### PR TITLE
[Store] Add log-structured local SSD backend

### DIFF
--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -875,6 +875,9 @@ void PrintBackendStorageStats(
     std::cout << "  Compaction bytes: " << stats->compaction_input_bytes
               << " input, " << stats->compaction_output_bytes << " output, "
               << stats->compaction_reclaimed_bytes << " reclaimed\n";
+    std::cout << "  Compaction C/C/E: " << stats->compaction_conflicts << "/"
+              << stats->compaction_cancellations << "/"
+              << stats->compaction_errors << "\n";
     std::cout << "  WAL/checkpoint:   " << stats->wal_sequence << "/"
               << stats->checkpoint_sequence << "\n";
 }

--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -15,7 +15,7 @@
 /**
  * @file storage_backend_bench.cpp
  * @brief Comprehensive benchmark for storage backends (OffsetAllocator, Bucket,
- * FilePerKey)
+ * FilePerKey, LogStructured)
  *
  * TESTS AVAILABLE:
  *   - init: Backend initialization time
@@ -92,6 +92,7 @@
 
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#include "storage/local/log_structured/log_structured_backend.h"
 #include "storage_backend.h"
 
 namespace fs = std::filesystem;
@@ -101,8 +102,10 @@ namespace fs = std::filesystem;
 // ============================================================================
 
 // === Core Parameters ===
-DEFINE_string(backend, "offset_allocator",
-              "Backend type: offset_allocator, bucket, file_per_key, or all");
+DEFINE_string(
+    backend, "offset_allocator",
+    "Backend type: offset_allocator, bucket, file_per_key, log_structured, or "
+    "all");
 DEFINE_uint64(value_size, 128 * 1024, "Value size in bytes (default: 128KB)");
 DEFINE_uint64(batch_size, 32, "Batch size for operations (default: 32)");
 DEFINE_uint64(num_operations, 1000,
@@ -242,7 +245,12 @@ AccessPattern StringToAccessPattern(const std::string& str) {
 // Backend Types
 // ============================================================================
 
-enum class BackendType { OFFSET_ALLOCATOR, BUCKET, FILE_PER_KEY };
+enum class BackendType {
+    OFFSET_ALLOCATOR,
+    BUCKET,
+    FILE_PER_KEY,
+    LOG_STRUCTURED
+};
 
 std::string BackendTypeToString(BackendType type) {
     switch (type) {
@@ -252,6 +260,8 @@ std::string BackendTypeToString(BackendType type) {
             return "bucket";
         case BackendType::FILE_PER_KEY:
             return "file_per_key";
+        case BackendType::LOG_STRUCTURED:
+            return "log_structured";
     }
     return "unknown";
 }
@@ -260,6 +270,7 @@ BackendType StringToBackendType(const std::string& str) {
     if (str == "offset_allocator") return BackendType::OFFSET_ALLOCATOR;
     if (str == "bucket") return BackendType::BUCKET;
     if (str == "file_per_key") return BackendType::FILE_PER_KEY;
+    if (str == "log_structured") return BackendType::LOG_STRUCTURED;
     LOG(FATAL) << "Unknown backend type: " << str;
     return BackendType::OFFSET_ALLOCATOR;
 }
@@ -830,6 +841,12 @@ std::shared_ptr<mooncake::StorageBackendInterface> CreateBackend(
             fpk_config.enable_eviction = false;
             return std::make_shared<mooncake::StorageBackendAdaptor>(
                 config, fpk_config);
+        }
+        case BackendType::LOG_STRUCTURED: {
+            config.storage_backend_type =
+                mooncake::StorageBackendType::kLogStructured;
+            return std::make_shared<mooncake::LogStructuredStorageBackend>(
+                config);
         }
     }
     return nullptr;
@@ -2280,9 +2297,9 @@ struct BenchmarkResult {
 };
 
 void RunAllBenchmarks(const std::string& storage_path, size_t capacity) {
-    std::vector<BackendType> backends = {BackendType::OFFSET_ALLOCATOR,
-                                         BackendType::BUCKET,
-                                         BackendType::FILE_PER_KEY};
+    std::vector<BackendType> backends = {
+        BackendType::OFFSET_ALLOCATOR, BackendType::BUCKET,
+        BackendType::FILE_PER_KEY, BackendType::LOG_STRUCTURED};
 
     std::vector<BenchmarkResult> results;
 

--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -852,6 +852,33 @@ std::shared_ptr<mooncake::StorageBackendInterface> CreateBackend(
     return nullptr;
 }
 
+void PrintBackendStorageStats(
+    const std::shared_ptr<mooncake::StorageBackendInterface>& backend) {
+    const auto stats = backend->SnapshotStats();
+    if (!stats) return;
+    const double physical_amplification =
+        stats->logical_value_bytes == 0
+            ? 0.0
+            : static_cast<double>(stats->physical_bytes) /
+                  static_cast<double>(stats->logical_value_bytes);
+    std::cout << "\n  --- BACKEND STORAGE STATE ---\n";
+    std::cout << "  Physical bytes:   " << stats->physical_bytes << "\n";
+    std::cout << "  Live record bytes:" << stats->live_record_bytes << "\n";
+    std::cout << "  Logical bytes:    " << stats->logical_value_bytes << "\n";
+    std::cout << "  Reclaimable bytes:" << stats->reclaimable_bytes << "\n";
+    std::cout << "  Physical amp:     " << std::fixed << std::setprecision(2)
+              << physical_amplification << "x\n";
+    std::cout << "  Segments A/S/R:   " << stats->active_segments << "/"
+              << stats->sealed_segments << "/" << stats->retired_segments
+              << "\n";
+    std::cout << "  Compaction runs:  " << stats->compaction_runs << "\n";
+    std::cout << "  Compaction bytes: " << stats->compaction_input_bytes
+              << " input, " << stats->compaction_output_bytes << " output, "
+              << stats->compaction_reclaimed_bytes << " reclaimed\n";
+    std::cout << "  WAL/checkpoint:   " << stats->wal_sequence << "/"
+              << stats->checkpoint_sequence << "\n";
+}
+
 // ============================================================================
 // Utility Functions
 // ============================================================================
@@ -2147,6 +2174,7 @@ void BenchChurn(BackendType type, const std::string& storage_path,
     stats.StopTimer();
     stats.Finalize();
     stats.PrintStatistics("CHURN");
+    PrintBackendStorageStats(backend);
 }
 
 // ============================================================================
@@ -2280,6 +2308,7 @@ void BenchRestart(BackendType type, const std::string& storage_path,
     std::cout << "  Samples:          " << first_load_latencies.size() << "\n";
     std::cout << "  Average:          " << avg_first_load << " ms\n";
     std::cout << "  First:            " << first_load_latencies[0] << " ms\n";
+    PrintBackendStorageStats(backend);
 }
 
 // ============================================================================

--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -121,6 +121,7 @@ DEFINE_bool(run_all, false,
             "Run full benchmark suite with all parameter combinations");
 DEFINE_bool(skip_cleanup, false,
             "Skip cleanup after benchmark (for debugging)");
+DEFINE_bool(use_uring, false, "Enable io_uring for backends that support it");
 DEFINE_string(test, "all",
               "Test to run: init, offload, load, concurrent_load, exist, "
               "mixed_rw, churn, restart, all");
@@ -817,6 +818,7 @@ std::shared_ptr<mooncake::StorageBackendInterface> CreateBackend(
     config.storage_filepath = storage_path;
     config.total_size_limit = capacity_bytes;
     config.total_keys_limit = 10'000'000;
+    config.use_uring = FLAGS_use_uring;
 
     switch (type) {
         case BackendType::OFFSET_ALLOCATOR: {
@@ -967,6 +969,8 @@ void PrintBenchmarkConfig(BackendType backend, CacheMode cache_mode) {
     std::cout << "  Operations:   " << FLAGS_num_operations
               << " (warmup: " << FLAGS_warmup_operations << ")\n";
     std::cout << "  Threads:      " << FLAGS_num_threads << "\n";
+    std::cout << "  I/O requested:"
+              << (FLAGS_use_uring ? "io_uring" : "pwrite/pread") << "\n";
     std::cout << "  Fill ratio:   " << (FLAGS_fill_ratio * 100) << "%\n";
     std::cout << "\n  --- Cache & Verification ---\n";
     std::cout << "  Cache mode:   " << CacheModeToString(cache_mode) << "\n";

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -559,6 +559,35 @@ struct SsdMetric {
           backend_retired_segments(
               "mooncake_ssd_backend_retired_segments",
               "Number of retired backend segments pending cleanup", labels),
+          backend_compaction_runs("mooncake_ssd_backend_compaction_runs_total",
+                                  "Completed backend compaction transactions",
+                                  labels),
+          backend_compaction_input_bytes(
+              "mooncake_ssd_backend_compaction_input_bytes_total",
+              "Physical bytes selected by backend compaction", labels),
+          backend_compaction_output_bytes(
+              "mooncake_ssd_backend_compaction_output_bytes_total",
+              "Physical bytes written by backend compaction", labels),
+          backend_compaction_reclaimed_bytes(
+              "mooncake_ssd_backend_compaction_reclaimed_bytes_total",
+              "Physical bytes reclaimed by backend compaction", labels),
+          backend_compaction_conflicts(
+              "mooncake_ssd_backend_compaction_conflicts_total",
+              "Backend compactions aborted by concurrent mutations", labels),
+          backend_compaction_cancellations(
+              "mooncake_ssd_backend_compaction_cancellations_total",
+              "Cancelled backend compactions", labels),
+          backend_compaction_errors(
+              "mooncake_ssd_backend_compaction_errors_total",
+              "Failed backend compactions", labels),
+          backend_compaction_last_duration_us(
+              "mooncake_ssd_backend_compaction_last_duration_us",
+              "Duration of the latest backend compaction attempt", labels),
+          backend_wal_sequence("mooncake_ssd_backend_wal_sequence",
+                               "Latest backend WAL sequence", labels),
+          backend_checkpoint_sequence(
+              "mooncake_ssd_backend_checkpoint_sequence",
+              "Latest backend checkpoint sequence", labels),
           start_time_(std::chrono::steady_clock::now()) {}
 
     ylt::metric::counter_t ssd_read_bytes;
@@ -580,6 +609,16 @@ struct SsdMetric {
     ylt::metric::gauge_t backend_active_segments;
     ylt::metric::gauge_t backend_sealed_segments;
     ylt::metric::gauge_t backend_retired_segments;
+    ylt::metric::counter_t backend_compaction_runs;
+    ylt::metric::counter_t backend_compaction_input_bytes;
+    ylt::metric::counter_t backend_compaction_output_bytes;
+    ylt::metric::counter_t backend_compaction_reclaimed_bytes;
+    ylt::metric::counter_t backend_compaction_conflicts;
+    ylt::metric::counter_t backend_compaction_cancellations;
+    ylt::metric::counter_t backend_compaction_errors;
+    ylt::metric::gauge_t backend_compaction_last_duration_us;
+    ylt::metric::gauge_t backend_wal_sequence;
+    ylt::metric::gauge_t backend_checkpoint_sequence;
     std::chrono::steady_clock::time_point start_time_;
 
     void serialize(std::string& str) {
@@ -602,6 +641,16 @@ struct SsdMetric {
         backend_active_segments.serialize(str);
         backend_sealed_segments.serialize(str);
         backend_retired_segments.serialize(str);
+        backend_compaction_runs.serialize(str);
+        backend_compaction_input_bytes.serialize(str);
+        backend_compaction_output_bytes.serialize(str);
+        backend_compaction_reclaimed_bytes.serialize(str);
+        backend_compaction_conflicts.serialize(str);
+        backend_compaction_cancellations.serialize(str);
+        backend_compaction_errors.serialize(str);
+        backend_compaction_last_duration_us.serialize(str);
+        backend_wal_sequence.serialize(str);
+        backend_checkpoint_sequence.serialize(str);
     }
 
     std::string summary_metrics() {

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include <vector>
 #include <ylt/metric/counter.hpp>
+#include <ylt/metric/gauge.hpp>
 #include <ylt/metric/histogram.hpp>
 #include <ylt/metric/summary.hpp>
 #include "environ.h"
@@ -537,6 +538,27 @@ struct SsdMetric {
           ssd_total_latency_summary("mooncake_ssd_total_latency_summary_us",
                                     "SSD total latency quantiles (us)",
                                     {0.5, 0.9, 0.99}, labels),
+          backend_physical_bytes(
+              "mooncake_ssd_backend_physical_bytes",
+              "Physical bytes occupied by the selected SSD backend", labels),
+          backend_live_record_bytes(
+              "mooncake_ssd_backend_live_record_bytes",
+              "Physical record bytes referenced by the current backend index",
+              labels),
+          backend_logical_value_bytes(
+              "mooncake_ssd_backend_logical_value_bytes",
+              "Logical value bytes referenced by the current backend index",
+              labels),
+          backend_reclaimable_bytes(
+              "mooncake_ssd_backend_reclaimable_bytes",
+              "Physical backend bytes eligible for reclamation", labels),
+          backend_active_segments("mooncake_ssd_backend_active_segments",
+                                  "Number of active backend segments", labels),
+          backend_sealed_segments("mooncake_ssd_backend_sealed_segments",
+                                  "Number of sealed backend segments", labels),
+          backend_retired_segments(
+              "mooncake_ssd_backend_retired_segments",
+              "Number of retired backend segments pending cleanup", labels),
           start_time_(std::chrono::steady_clock::now()) {}
 
     ylt::metric::counter_t ssd_read_bytes;
@@ -551,6 +573,13 @@ struct SsdMetric {
     ylt::metric::summary_t ssd_read_latency_summary;
     ylt::metric::summary_t ssd_write_latency_summary;
     ylt::metric::summary_t ssd_total_latency_summary;
+    ylt::metric::gauge_t backend_physical_bytes;
+    ylt::metric::gauge_t backend_live_record_bytes;
+    ylt::metric::gauge_t backend_logical_value_bytes;
+    ylt::metric::gauge_t backend_reclaimable_bytes;
+    ylt::metric::gauge_t backend_active_segments;
+    ylt::metric::gauge_t backend_sealed_segments;
+    ylt::metric::gauge_t backend_retired_segments;
     std::chrono::steady_clock::time_point start_time_;
 
     void serialize(std::string& str) {
@@ -566,6 +595,13 @@ struct SsdMetric {
         ssd_read_latency_summary.serialize(str);
         ssd_write_latency_summary.serialize(str);
         ssd_total_latency_summary.serialize(str);
+        backend_physical_bytes.serialize(str);
+        backend_live_record_bytes.serialize(str);
+        backend_logical_value_bytes.serialize(str);
+        backend_reclaimable_bytes.serialize(str);
+        backend_active_segments.serialize(str);
+        backend_sealed_segments.serialize(str);
+        backend_retired_segments.serialize(str);
     }
 
     std::string summary_metrics() {

--- a/mooncake-store/include/storage/local/log_structured/index.h
+++ b/mooncake-store/include/storage/local/log_structured/index.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <shared_mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "storage/local/log_structured/record_format.h"
+#include "storage/local/log_structured/segment.h"
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+enum class VersionState : uint8_t {
+    kPrepared,
+    kCommitted,
+    kAborted,
+    kObsolete,
+    kTombstoned,
+    kReclaimable,
+};
+
+enum class IndexError {
+    kNotFound,
+    kInvalidTransition,
+    kStaleSequence,
+    kPhysicalMismatch,
+};
+
+struct VersionEntry {
+    PhysicalRecord physical;
+    VersionState state{VersionState::kPrepared};
+    uint64_t sequence{0};
+    uint64_t mutation_epoch{0};
+
+    bool operator==(const VersionEntry&) const = default;
+};
+
+struct IndexSnapshotEntry {
+    RecordIdentity identity;
+    VersionEntry version;
+};
+
+class VersionIndex {
+   public:
+    tl::expected<void, IndexError> Prepare(const RecordIdentity& identity,
+                                           const PhysicalRecord& physical,
+                                           uint64_t sequence);
+    tl::expected<void, IndexError> Commit(const RecordIdentity& identity,
+                                          uint64_t sequence);
+    tl::expected<void, IndexError> Abort(const RecordIdentity& identity,
+                                         uint64_t sequence);
+    tl::expected<void, IndexError> ApplyTombstone(
+        const RecordIdentity& identity, uint64_t delete_sequence);
+    tl::expected<void, IndexError> MarkReclaimable(
+        const RecordIdentity& identity, uint64_t sequence);
+
+    tl::expected<void, IndexError> InstallCompactionCopy(
+        const RecordIdentity& identity, const PhysicalRecord& expected_source,
+        uint64_t expected_epoch, const PhysicalRecord& target);
+
+    std::optional<VersionEntry> LookupCommitted(
+        const RecordIdentity& identity) const;
+    std::optional<VersionEntry> Lookup(const RecordIdentity& identity) const;
+    std::vector<IndexSnapshotEntry> Snapshot() const;
+    size_t size() const;
+
+   private:
+    struct IdentityHash {
+        size_t operator()(const RecordIdentity& identity) const;
+    };
+
+    struct LogicalKey {
+        std::string tenant_id;
+        std::string object_key;
+
+        bool operator==(const LogicalKey&) const = default;
+    };
+
+    struct LogicalKeyHash {
+        size_t operator()(const LogicalKey& key) const;
+    };
+
+    static LogicalKey ToLogicalKey(const RecordIdentity& identity);
+
+    mutable std::shared_mutex mutex_;
+    std::unordered_map<RecordIdentity, VersionEntry, IdentityHash> versions_;
+    std::unordered_map<LogicalKey, RecordIdentity, LogicalKeyHash> current_;
+};
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/index.h
+++ b/mooncake-store/include/storage/local/log_structured/index.h
@@ -65,6 +65,8 @@ class VersionIndex {
         const RecordIdentity& identity) const;
     std::optional<VersionEntry> Lookup(const RecordIdentity& identity) const;
     std::vector<IndexSnapshotEntry> Snapshot() const;
+    tl::expected<void, IndexError> Restore(
+        const std::vector<IndexSnapshotEntry>& snapshot);
     size_t size() const;
 
    private:

--- a/mooncake-store/include/storage/local/log_structured/index.h
+++ b/mooncake-store/include/storage/local/log_structured/index.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 #include <shared_mutex>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -63,8 +64,11 @@ class VersionIndex {
 
     std::optional<VersionEntry> LookupCommitted(
         const RecordIdentity& identity) const;
+    std::optional<IndexSnapshotEntry> LookupCurrent(
+        std::string_view tenant_id, std::string_view object_key) const;
     std::optional<VersionEntry> Lookup(const RecordIdentity& identity) const;
     std::vector<IndexSnapshotEntry> Snapshot() const;
+    std::vector<IndexSnapshotEntry> CurrentSnapshot() const;
     tl::expected<void, IndexError> Restore(
         const std::vector<IndexSnapshotEntry>& snapshot);
     size_t size() const;

--- a/mooncake-store/include/storage/local/log_structured/index.h
+++ b/mooncake-store/include/storage/local/log_structured/index.h
@@ -73,6 +73,7 @@ class VersionIndex {
         const std::vector<CompactionIndexUpdate>& updates);
     void ReclaimNonCurrentVersionsInSegments(
         const std::unordered_set<uint64_t>& segment_ids);
+    void ReclaimNonCommittedVersionsAfterRecovery();
 
     std::optional<VersionEntry> LookupCommitted(
         const RecordIdentity& identity) const;

--- a/mooncake-store/include/storage/local/log_structured/index.h
+++ b/mooncake-store/include/storage/local/log_structured/index.h
@@ -5,6 +5,7 @@
 #include <shared_mutex>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -44,6 +45,13 @@ struct IndexSnapshotEntry {
     VersionEntry version;
 };
 
+struct CompactionIndexUpdate {
+    RecordIdentity identity;
+    PhysicalRecord expected_source;
+    uint64_t expected_epoch{0};
+    PhysicalRecord target;
+};
+
 class VersionIndex {
    public:
     tl::expected<void, IndexError> Prepare(const RecordIdentity& identity,
@@ -61,6 +69,10 @@ class VersionIndex {
     tl::expected<void, IndexError> InstallCompactionCopy(
         const RecordIdentity& identity, const PhysicalRecord& expected_source,
         uint64_t expected_epoch, const PhysicalRecord& target);
+    tl::expected<void, IndexError> InstallCompactionCopies(
+        const std::vector<CompactionIndexUpdate>& updates);
+    void ReclaimNonCurrentVersionsInSegments(
+        const std::unordered_set<uint64_t>& segment_ids);
 
     std::optional<VersionEntry> LookupCommitted(
         const RecordIdentity& identity) const;

--- a/mooncake-store/include/storage/local/log_structured/index.h
+++ b/mooncake-store/include/storage/local/log_structured/index.h
@@ -82,6 +82,8 @@ class VersionIndex {
     std::optional<VersionEntry> Lookup(const RecordIdentity& identity) const;
     std::vector<IndexSnapshotEntry> Snapshot() const;
     std::vector<IndexSnapshotEntry> CurrentSnapshot() const;
+    std::vector<IndexSnapshotEntry> CheckpointSnapshot() const;
+    void PruneCheckpointedHistory();
     tl::expected<void, IndexError> Restore(
         const std::vector<IndexSnapshotEntry>& snapshot);
     size_t size() const;

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -27,6 +27,8 @@ struct LogStructuredBackendConfig {
     size_t compaction_max_sources{8};
     uint64_t compaction_max_bytes_per_round{1024ULL * 1024 * 1024};
     uint64_t compaction_max_target_bytes{4ULL * 1024 * 1024 * 1024};
+    uint64_t compaction_max_bytes_per_second{0};
+    uint64_t compaction_reserve_bytes{0};
     double compaction_min_reclaim_ratio{0.20};
 
     static LogStructuredBackendConfig FromEnvironment();
@@ -59,6 +61,9 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
     void SetTestFailurePredicate(
         std::function<bool(const std::string& key)> predicate) override;
     void RemoveAll() override;
+    tl::expected<std::vector<std::string>, ErrorCode> EvictAboveDiskWatermark(
+        double high_watermark_ratio, double low_watermark_ratio,
+        EvictionHandler eviction_handler = nullptr) override;
 
    private:
     static ErrorCode ToWriteError(logstructured::StoreError error);
@@ -66,6 +71,8 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
     static tl::expected<std::string, ErrorCode> ConcatSlices(
         const std::vector<Slice>& slices);
     void CompactionLoop(std::stop_token stop_token);
+    logstructured::CompactionOptions MakeCompactionOptions(
+        std::stop_token stop_token = {}) const;
 
     LogStructuredBackendConfig backend_config_;
     mutable std::mutex mutex_;

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include "storage/local/log_structured/store.h"
+#include "storage_backend.h"
+
+namespace mooncake {
+
+class LogStructuredStorageBackend final : public StorageBackendInterface {
+   public:
+    explicit LogStructuredStorageBackend(const FileStorageConfig& config);
+
+    tl::expected<void, ErrorCode> Init() override;
+    tl::expected<int64_t, ErrorCode> BatchOffload(
+        const std::unordered_map<std::string, std::vector<Slice>>& batch_object,
+        std::function<ErrorCode(const std::vector<std::string>& keys,
+                                std::vector<StorageObjectMetadata>& metadatas)>
+            complete_handler,
+        EvictionHandler eviction_handler = nullptr) override;
+    tl::expected<void, ErrorCode> BatchLoad(
+        std::unordered_map<std::string, Slice>& batched_slices) override;
+    tl::expected<bool, ErrorCode> IsExist(const std::string& key) override;
+    tl::expected<bool, ErrorCode> IsEnableOffloading() override;
+    tl::expected<void, ErrorCode> ScanMeta(
+        const std::function<ErrorCode(
+            const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metadatas)>& handler) override;
+    void SetTestFailurePredicate(
+        std::function<bool(const std::string& key)> predicate) override;
+
+   private:
+    static ErrorCode ToWriteError(logstructured::StoreError error);
+    static ErrorCode ToReadError(logstructured::StoreError error);
+    static tl::expected<std::string, ErrorCode> ConcatSlices(
+        const std::vector<Slice>& slices);
+
+    mutable std::mutex mutex_;
+    std::unique_ptr<logstructured::LogStructuredStore> store_;
+    std::function<bool(const std::string& key)> test_failure_predicate_;
+    std::atomic<bool> initialized_{false};
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
 
 #include "storage/local/log_structured/store.h"
@@ -79,7 +80,7 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
     RunCompaction(const logstructured::CompactionOptions& options);
 
     LogStructuredBackendConfig backend_config_;
-    mutable std::mutex mutex_;
+    mutable std::shared_mutex mutex_;
     std::condition_variable_any compaction_wakeup_;
     std::jthread compaction_thread_;
     uint64_t committed_since_checkpoint_{0};

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -64,6 +64,7 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
     tl::expected<std::vector<std::string>, ErrorCode> EvictAboveDiskWatermark(
         double high_watermark_ratio, double low_watermark_ratio,
         EvictionHandler eviction_handler = nullptr) override;
+    std::optional<StorageBackendStats> SnapshotStats() const override;
 
    private:
     static ErrorCode ToWriteError(logstructured::StoreError error);

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -74,6 +74,8 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
     void CompactionLoop(std::stop_token stop_token);
     logstructured::CompactionOptions MakeCompactionOptions(
         std::stop_token stop_token = {}) const;
+    tl::expected<logstructured::CompactionResult, logstructured::StoreError>
+    RunCompaction(const logstructured::CompactionOptions& options);
 
     LogStructuredBackendConfig backend_config_;
     mutable std::mutex mutex_;
@@ -82,6 +84,14 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
     uint64_t committed_since_checkpoint_{0};
     std::unique_ptr<logstructured::LogStructuredStore> store_;
     std::function<bool(const std::string& key)> test_failure_predicate_;
+    std::atomic<uint64_t> compaction_runs_{0};
+    std::atomic<uint64_t> compaction_input_bytes_{0};
+    std::atomic<uint64_t> compaction_output_bytes_{0};
+    std::atomic<uint64_t> compaction_reclaimed_bytes_{0};
+    std::atomic<uint64_t> compaction_conflicts_{0};
+    std::atomic<uint64_t> compaction_cancellations_{0};
+    std::atomic<uint64_t> compaction_errors_{0};
+    std::atomic<uint64_t> compaction_last_duration_us_{0};
     std::atomic<bool> initialized_{false};
 };
 

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -1,18 +1,45 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <thread>
 
 #include "storage/local/log_structured/store.h"
 #include "storage_backend.h"
 
 namespace mooncake {
 
+enum class LogStructuredSyncPolicy { kRecord, kBatch, kNone };
+enum class LogStructuredCompactionPolicy { kNone, kReclaimOnly, kTiered };
+
+struct LogStructuredBackendConfig {
+    uint64_t segment_size_bytes{256ULL * 1024 * 1024};
+    LogStructuredSyncPolicy sync_policy{LogStructuredSyncPolicy::kRecord};
+    uint64_t checkpoint_interval_records{10000};
+    LogStructuredCompactionPolicy compaction_policy{
+        LogStructuredCompactionPolicy::kNone};
+    uint64_t compaction_interval_ms{1000};
+    size_t compaction_fanout{4};
+    uint32_t compaction_max_levels{4};
+    size_t compaction_max_sources{8};
+    uint64_t compaction_max_bytes_per_round{1024ULL * 1024 * 1024};
+    uint64_t compaction_max_target_bytes{4ULL * 1024 * 1024 * 1024};
+    double compaction_min_reclaim_ratio{0.20};
+
+    static LogStructuredBackendConfig FromEnvironment();
+    bool Validate() const;
+};
+
 class LogStructuredStorageBackend final : public StorageBackendInterface {
    public:
-    explicit LogStructuredStorageBackend(const FileStorageConfig& config);
+    explicit LogStructuredStorageBackend(
+        const FileStorageConfig& config,
+        LogStructuredBackendConfig backend_config =
+            LogStructuredBackendConfig::FromEnvironment());
+    ~LogStructuredStorageBackend() override;
 
     tl::expected<void, ErrorCode> Init() override;
     tl::expected<int64_t, ErrorCode> BatchOffload(
@@ -31,14 +58,20 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
             std::vector<StorageObjectMetadata>& metadatas)>& handler) override;
     void SetTestFailurePredicate(
         std::function<bool(const std::string& key)> predicate) override;
+    void RemoveAll() override;
 
    private:
     static ErrorCode ToWriteError(logstructured::StoreError error);
     static ErrorCode ToReadError(logstructured::StoreError error);
     static tl::expected<std::string, ErrorCode> ConcatSlices(
         const std::vector<Slice>& slices);
+    void CompactionLoop(std::stop_token stop_token);
 
+    LogStructuredBackendConfig backend_config_;
     mutable std::mutex mutex_;
+    std::condition_variable_any compaction_wakeup_;
+    std::jthread compaction_thread_;
+    uint64_t committed_since_checkpoint_{0};
     std::unique_ptr<logstructured::LogStructuredStore> store_;
     std::function<bool(const std::string& key)> test_failure_predicate_;
     std::atomic<bool> initialized_{false};

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -25,7 +25,7 @@ struct LogStructuredBackendConfig {
     size_t compaction_fanout{4};
     uint32_t compaction_max_levels{4};
     size_t compaction_max_sources{8};
-    uint64_t compaction_max_bytes_per_round{1024ULL * 1024 * 1024};
+    uint64_t compaction_max_input_bytes{1024ULL * 1024 * 1024};
     uint64_t compaction_max_target_bytes{4ULL * 1024 * 1024 * 1024};
     uint64_t compaction_max_bytes_per_second{0};
     uint64_t compaction_reserve_bytes{0};

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -17,6 +17,7 @@ enum class LogStructuredCompactionPolicy { kNone, kReclaimOnly, kTiered };
 
 struct LogStructuredBackendConfig {
     uint64_t segment_size_bytes{256ULL * 1024 * 1024};
+    size_t payload_write_parallelism{4};
     LogStructuredSyncPolicy sync_policy{LogStructuredSyncPolicy::kRecord};
     uint64_t checkpoint_interval_records{10000};
     LogStructuredCompactionPolicy compaction_policy{

--- a/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
+++ b/mooncake-store/include/storage/local/log_structured/log_structured_backend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <functional>
@@ -81,9 +82,11 @@ class LogStructuredStorageBackend final : public StorageBackendInterface {
 
     LogStructuredBackendConfig backend_config_;
     mutable std::shared_mutex mutex_;
+    mutable std::shared_mutex publication_mutex_;
+    std::array<std::mutex, 256> key_mutexes_;
     std::condition_variable_any compaction_wakeup_;
     std::jthread compaction_thread_;
-    uint64_t committed_since_checkpoint_{0};
+    std::atomic<uint64_t> committed_since_checkpoint_{0};
     std::unique_ptr<logstructured::LogStructuredStore> store_;
     std::function<bool(const std::string& key)> test_failure_predicate_;
     std::atomic<uint64_t> compaction_runs_{0};

--- a/mooncake-store/include/storage/local/log_structured/metadata.h
+++ b/mooncake-store/include/storage/local/log_structured/metadata.h
@@ -56,6 +56,7 @@ struct ManifestState {
 enum class MetadataError {
     kInvalidArgument,
     kIoError,
+    kPublicationUncertain,
     kCorruptData,
     kNotFound,
 };
@@ -67,7 +68,8 @@ tl::expected<CheckpointState, MetadataError> LoadCheckpoint(
     const std::string& root_path, const std::string& checkpoint_file);
 tl::expected<void, MetadataError> PublishManifest(
     const std::string& root_path, const ManifestState& manifest,
-    std::function<bool()> fail_before_current = {});
+    std::function<bool()> fail_before_current = {},
+    std::function<bool()> fail_after_current_rename = {});
 tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
     const std::string& root_path);
 tl::expected<void, MetadataError> RemoveFileDurably(

--- a/mooncake-store/include/storage/local/log_structured/metadata.h
+++ b/mooncake-store/include/storage/local/log_structured/metadata.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -65,10 +66,14 @@ tl::expected<std::string, MetadataError> WriteCheckpoint(
 tl::expected<CheckpointState, MetadataError> LoadCheckpoint(
     const std::string& root_path, const std::string& checkpoint_file);
 tl::expected<void, MetadataError> PublishManifest(
-    const std::string& root_path, const ManifestState& manifest);
+    const std::string& root_path, const ManifestState& manifest,
+    std::function<bool()> fail_before_current = {});
 tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
     const std::string& root_path);
 tl::expected<void, MetadataError> RemoveFileDurably(
     const std::string& root_path, const std::string& filename);
+tl::expected<void, MetadataError> CleanupMetadataArtifacts(
+    const std::string& root_path, uint64_t current_generation,
+    const std::string& current_wal_file);
 
 }  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/metadata.h
+++ b/mooncake-store/include/storage/local/log_structured/metadata.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "storage/local/log_structured/index.h"
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+enum class SegmentLifecycle : uint8_t {
+    kCreating,
+    kActive,
+    kSealing,
+    kSealed,
+    kCompacting,
+    kRetired,
+};
+
+struct SegmentMetadata {
+    uint64_t segment_id{0};
+    uint32_t level{0};
+    SegmentLifecycle state{SegmentLifecycle::kCreating};
+    uint64_t valid_bytes{0};
+    uint64_t live_bytes{0};
+    uint64_t record_count{0};
+    uint64_t mutation_epoch{0};
+
+    bool operator==(const SegmentMetadata&) const = default;
+};
+
+struct CheckpointState {
+    uint32_t format_version{1};
+    uint64_t checkpoint_sequence{0};
+    uint64_t next_sequence{1};
+    uint64_t next_segment_id{1};
+    uint64_t applied_delete_watermark{0};
+    std::vector<IndexSnapshotEntry> index;
+    std::vector<SegmentMetadata> segments;
+};
+
+struct ManifestState {
+    uint32_t format_version{1};
+    uint64_t generation{0};
+    uint64_t checkpoint_sequence{0};
+    uint64_t next_sequence{1};
+    uint64_t next_segment_id{1};
+    uint64_t active_segment_id{0};
+    std::string checkpoint_file;
+    std::string wal_file;
+    std::vector<SegmentMetadata> segments;
+};
+
+enum class MetadataError {
+    kInvalidArgument,
+    kIoError,
+    kCorruptData,
+    kNotFound,
+};
+
+tl::expected<std::string, MetadataError> WriteCheckpoint(
+    const std::string& root_path, uint64_t generation,
+    const CheckpointState& checkpoint);
+tl::expected<CheckpointState, MetadataError> LoadCheckpoint(
+    const std::string& root_path, const std::string& checkpoint_file);
+tl::expected<void, MetadataError> PublishManifest(
+    const std::string& root_path, const ManifestState& manifest);
+tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
+    const std::string& root_path);
+tl::expected<void, MetadataError> RemoveFileDurably(
+    const std::string& root_path, const std::string& filename);
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/record_format.h
+++ b/mooncake-store/include/storage/local/log_structured/record_format.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+enum class RecordKind : uint16_t {
+    kValue = 1,
+    kTombstone = 2,
+    kCompactionCopy = 3,
+};
+
+enum class DecodeError {
+    kNeedMoreData,
+    kInvalidMagic,
+    kUnsupportedVersion,
+    kInvalidFlags,
+    kInvalidLength,
+    kHeaderChecksumMismatch,
+    kPayloadChecksumMismatch,
+    kFooterMismatch,
+};
+
+struct ObjectIncarnation {
+    uint64_t high{0};
+    uint64_t low{0};
+
+    bool operator==(const ObjectIncarnation&) const = default;
+};
+
+struct RecordIdentity {
+    std::string tenant_id;
+    std::string object_key;
+    ObjectIncarnation incarnation;
+
+    bool operator==(const RecordIdentity&) const = default;
+};
+
+struct RecordHeader {
+    RecordKind kind{RecordKind::kValue};
+    uint64_t total_length{0};
+    uint64_t sequence{0};
+    ObjectIncarnation incarnation;
+    uint32_t tenant_length{0};
+    uint32_t key_length{0};
+    uint64_t value_length{0};
+};
+
+struct EncodedRecordEnvelope {
+    std::array<char, 64> header{};
+    std::array<char, 24> footer{};
+    uint64_t total_length{0};
+    uint64_t padding_length{0};
+};
+
+struct DecodedRecord {
+    RecordIdentity identity;
+    RecordKind kind{RecordKind::kValue};
+    uint64_t sequence{0};
+    std::string value;
+    uint64_t total_length{0};
+};
+
+inline constexpr uint32_t kRecordMagic = 0x474C434D;
+inline constexpr uint64_t kRecordCommitMagic = 0x54494D4D4F43434DULL;
+inline constexpr uint16_t kRecordFormatVersion = 1;
+inline constexpr size_t kRecordHeaderSize = 64;
+inline constexpr size_t kRecordFooterSize = 24;
+inline constexpr size_t kRecordAlignment = 8;
+inline constexpr uint32_t kMaxTenantLength = 1U << 20;
+inline constexpr uint32_t kMaxKeyLength = 16U << 20;
+
+uint64_t AlignedRecordSize(uint32_t tenant_length, uint32_t key_length,
+                           uint64_t value_length);
+
+tl::expected<EncodedRecordEnvelope, DecodeError> EncodeRecordEnvelope(
+    const RecordIdentity& identity, std::string_view value, RecordKind kind,
+    uint64_t sequence);
+
+tl::expected<std::string, DecodeError> EncodeRecord(
+    const RecordIdentity& identity, std::string_view value, RecordKind kind,
+    uint64_t sequence);
+
+tl::expected<RecordHeader, DecodeError> DecodeRecordHeader(
+    std::span<const char> bytes);
+
+tl::expected<DecodedRecord, DecodeError> DecodeRecord(
+    std::span<const char> bytes);
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/segment.h
+++ b/mooncake-store/include/storage/local/log_structured/segment.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -50,6 +51,13 @@ struct SegmentScanResult {
     DecodeError decode_error{DecodeError::kNeedMoreData};
 };
 
+struct SegmentAppendRequest {
+    RecordIdentity identity;
+    std::string_view value;
+    RecordKind kind{RecordKind::kValue};
+    uint64_t sequence{0};
+};
+
 class SegmentWriter {
    public:
     static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> Create(
@@ -66,6 +74,9 @@ class SegmentWriter {
     tl::expected<PhysicalRecord, SegmentError> Append(
         const RecordIdentity& identity, std::string_view value, RecordKind kind,
         uint64_t sequence, bool sync);
+    tl::expected<std::vector<PhysicalRecord>, SegmentError> AppendBatch(
+        const std::vector<SegmentAppendRequest>& requests, bool sync,
+        size_t parallelism);
 
     tl::expected<void, SegmentError> Sync();
 
@@ -74,7 +85,7 @@ class SegmentWriter {
                            size_t length)>
             predicate);
 
-    uint64_t tail() const { return tail_; }
+    uint64_t tail() const;
     uint64_t segment_id() const { return segment_id_; }
     const std::string& path() const { return path_; }
 
@@ -87,6 +98,7 @@ class SegmentWriter {
     std::string path_;
     uint64_t segment_id_;
     int fd_;
+    mutable std::mutex append_mutex_;
     uint64_t tail_;
 };
 

--- a/mooncake-store/include/storage/local/log_structured/segment.h
+++ b/mooncake-store/include/storage/local/log_structured/segment.h
@@ -102,6 +102,33 @@ class SegmentWriter {
     uint64_t tail_;
 };
 
+class SegmentReader {
+   public:
+    static tl::expected<std::shared_ptr<SegmentReader>, SegmentError> Open(
+        std::string path, uint64_t segment_id);
+
+    ~SegmentReader();
+
+    SegmentReader(const SegmentReader&) = delete;
+    SegmentReader& operator=(const SegmentReader&) = delete;
+
+    tl::expected<DecodedRecord, SegmentError> Read(
+        const PhysicalRecord& physical) const;
+    tl::expected<void, SegmentError> ReadValue(const PhysicalRecord& physical,
+                                               char* value,
+                                               size_t value_size) const;
+
+    uint64_t segment_id() const { return segment_id_; }
+    const std::string& path() const { return path_; }
+
+   private:
+    SegmentReader(std::string path, uint64_t segment_id, int fd);
+
+    std::string path_;
+    uint64_t segment_id_;
+    int fd_;
+};
+
 tl::expected<SegmentScanResult, SegmentError> ScanSegment(
     const std::string& path, uint64_t segment_id);
 

--- a/mooncake-store/include/storage/local/log_structured/segment.h
+++ b/mooncake-store/include/storage/local/log_structured/segment.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -67,6 +68,11 @@ class SegmentWriter {
         uint64_t sequence, bool sync);
 
     tl::expected<void, SegmentError> Sync();
+
+    static void SetWriteFailurePredicateForTest(
+        std::function<bool(std::string_view path, uint64_t offset,
+                           size_t length)>
+            predicate);
 
     uint64_t tail() const { return tail_; }
     uint64_t segment_id() const { return segment_id_; }

--- a/mooncake-store/include/storage/local/log_structured/segment.h
+++ b/mooncake-store/include/storage/local/log_structured/segment.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "storage/local/log_structured/record_format.h"
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+enum class SegmentError {
+    kInvalidArgument,
+    kOpenFailed,
+    kIoError,
+    kSyncFailed,
+    kTruncateFailed,
+};
+
+enum class ScanTermination {
+    kCleanEof,
+    kIncompleteTail,
+    kCorruptRecord,
+};
+
+struct PhysicalRecord {
+    uint64_t segment_id{0};
+    uint64_t record_offset{0};
+    uint64_t value_offset{0};
+    uint64_t value_length{0};
+    uint64_t total_length{0};
+
+    bool operator==(const PhysicalRecord&) const = default;
+};
+
+struct ScannedRecord {
+    RecordIdentity identity;
+    RecordKind kind{RecordKind::kValue};
+    uint64_t sequence{0};
+    PhysicalRecord physical;
+};
+
+struct SegmentScanResult {
+    std::vector<ScannedRecord> records;
+    uint64_t valid_bytes{0};
+    ScanTermination termination{ScanTermination::kCleanEof};
+    DecodeError decode_error{DecodeError::kNeedMoreData};
+};
+
+class SegmentWriter {
+   public:
+    static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> Create(
+        std::string path, uint64_t segment_id);
+
+    static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
+    OpenForAppend(std::string path, uint64_t segment_id, uint64_t valid_bytes);
+
+    ~SegmentWriter();
+
+    SegmentWriter(const SegmentWriter&) = delete;
+    SegmentWriter& operator=(const SegmentWriter&) = delete;
+
+    tl::expected<PhysicalRecord, SegmentError> Append(
+        const RecordIdentity& identity, std::string_view value, RecordKind kind,
+        uint64_t sequence, bool sync);
+
+    tl::expected<void, SegmentError> Sync();
+
+    uint64_t tail() const { return tail_; }
+    uint64_t segment_id() const { return segment_id_; }
+    const std::string& path() const { return path_; }
+
+   private:
+    static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> Open(
+        std::string path, uint64_t segment_id, int flags, uint64_t tail);
+
+    SegmentWriter(std::string path, uint64_t segment_id, int fd, uint64_t tail);
+
+    std::string path_;
+    uint64_t segment_id_;
+    int fd_;
+    uint64_t tail_;
+};
+
+tl::expected<SegmentScanResult, SegmentError> ScanSegment(
+    const std::string& path, uint64_t segment_id);
+
+tl::expected<DecodedRecord, SegmentError> ReadRecord(
+    const std::string& path, const PhysicalRecord& physical);
+
+tl::expected<void, SegmentError> TruncateSegment(const std::string& path,
+                                                 uint64_t valid_bytes);
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/segment.h
+++ b/mooncake-store/include/storage/local/log_structured/segment.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -77,6 +78,13 @@ class SegmentWriter {
     tl::expected<std::vector<PhysicalRecord>, SegmentError> AppendBatch(
         const std::vector<SegmentAppendRequest>& requests, bool sync,
         size_t parallelism);
+    tl::expected<std::vector<PhysicalRecord>, SegmentError> ReserveBatch(
+        const std::vector<SegmentAppendRequest>& requests);
+    tl::expected<void, SegmentError> WriteReservedBatch(
+        const std::vector<SegmentAppendRequest>& requests,
+        const std::vector<PhysicalRecord>& physical_records, bool sync,
+        size_t parallelism);
+    void CancelReservedBatch();
 
     tl::expected<void, SegmentError> Sync();
 
@@ -95,11 +103,21 @@ class SegmentWriter {
 
     SegmentWriter(std::string path, uint64_t segment_id, int fd, uint64_t tail);
 
+    tl::expected<std::vector<PhysicalRecord>, SegmentError> ReserveBatchLocked(
+        const std::vector<SegmentAppendRequest>& requests);
+    tl::expected<void, SegmentError> WriteBatchAt(
+        const std::vector<SegmentAppendRequest>& requests,
+        const std::vector<PhysicalRecord>& physical_records, bool sync,
+        size_t parallelism);
+    void FinishReservedBatch();
+
     std::string path_;
     uint64_t segment_id_;
     int fd_;
     mutable std::mutex append_mutex_;
+    std::condition_variable append_cv_;
     uint64_t tail_;
+    size_t in_flight_batches_{0};
 };
 
 class SegmentReader {

--- a/mooncake-store/include/storage/local/log_structured/segment.h
+++ b/mooncake-store/include/storage/local/log_structured/segment.h
@@ -62,10 +62,11 @@ struct SegmentAppendRequest {
 class SegmentWriter {
    public:
     static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> Create(
-        std::string path, uint64_t segment_id);
+        std::string path, uint64_t segment_id, bool use_uring = true);
 
     static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
-    OpenForAppend(std::string path, uint64_t segment_id, uint64_t valid_bytes);
+    OpenForAppend(std::string path, uint64_t segment_id, uint64_t valid_bytes,
+                  bool use_uring = true);
 
     ~SegmentWriter();
 
@@ -99,9 +100,11 @@ class SegmentWriter {
 
    private:
     static tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> Open(
-        std::string path, uint64_t segment_id, int flags, uint64_t tail);
+        std::string path, uint64_t segment_id, int flags, uint64_t tail,
+        bool use_uring);
 
-    SegmentWriter(std::string path, uint64_t segment_id, int fd, uint64_t tail);
+    SegmentWriter(std::string path, uint64_t segment_id, int fd, uint64_t tail,
+                  bool use_uring);
 
     tl::expected<std::vector<PhysicalRecord>, SegmentError> ReserveBatchLocked(
         const std::vector<SegmentAppendRequest>& requests);
@@ -118,6 +121,7 @@ class SegmentWriter {
     std::condition_variable append_cv_;
     uint64_t tail_;
     size_t in_flight_batches_{0};
+    bool use_uring_{true};
 };
 
 class SegmentReader {

--- a/mooncake-store/include/storage/local/log_structured/storage_directory.h
+++ b/mooncake-store/include/storage/local/log_structured/storage_directory.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+struct StorageIdentity {
+    uint64_t high{0};
+    uint64_t low{0};
+
+    bool operator==(const StorageIdentity&) const = default;
+};
+
+enum class StorageDirectoryError {
+    kInvalidArgument,
+    kIoError,
+    kAlreadyMounted,
+    kUnrecognizedFormat,
+    kCorruptIdentity,
+};
+
+class StorageDirectory {
+   public:
+    static tl::expected<std::unique_ptr<StorageDirectory>,
+                        StorageDirectoryError>
+    Open(std::string root_path);
+
+    ~StorageDirectory();
+
+    StorageDirectory(const StorageDirectory&) = delete;
+    StorageDirectory& operator=(const StorageDirectory&) = delete;
+
+    const std::string& root_path() const { return root_path_; }
+    const StorageIdentity& identity() const { return identity_; }
+
+   private:
+    StorageDirectory(std::string root_path, int lock_fd,
+                     StorageIdentity identity);
+
+    std::string root_path_;
+    int lock_fd_{-1};
+    StorageIdentity identity_;
+};
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -28,12 +28,14 @@ enum class StoreError {
     kUnrecognizedFormat,
     kNotFound,
     kInvalidTransition,
+    kNoSpace,
     kCancelled,
 };
 
 struct LogStructuredStoreConfig {
     std::string root_path;
     uint64_t max_segment_bytes{256ULL * 1024 * 1024};
+    uint64_t max_physical_bytes{std::numeric_limits<uint64_t>::max()};
     bool sync_data{true};
     bool sync_wal{true};
 };

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <limits>
 #include <map>
@@ -76,6 +77,13 @@ struct CompactionResult {
     uint64_t reclaimed_bytes{0};
 };
 
+enum class CompactionCrashPoint {
+    kBeforeTargetSync,
+    kAfterTargetSync,
+    kAfterTargetRename,
+    kAfterManifestPublication,
+};
+
 class LogStructuredStore {
    public:
     static tl::expected<std::unique_ptr<LogStructuredStore>, StoreError> Open(
@@ -108,6 +116,9 @@ class LogStructuredStore {
     StoreStats SnapshotStats() const;
     uint64_t active_segment_id() const;
     uint64_t next_sequence() const;
+
+    static void SetCompactionCrashPredicateForTest(
+        std::function<bool(CompactionCrashPoint)> predicate);
 
    private:
     explicit LogStructuredStore(LogStructuredStoreConfig config);

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <map>
 #include <mutex>
+#include <stop_token>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -25,6 +26,7 @@ enum class StoreError {
     kUnrecognizedFormat,
     kNotFound,
     kInvalidTransition,
+    kCancelled,
 };
 
 struct LogStructuredStoreConfig {
@@ -47,7 +49,19 @@ struct CompactionOptions {
     size_t fanout{4};
     uint32_t max_levels{4};
     double min_reclaim_ratio{0.20};
+    uint64_t max_bytes_per_second{0};
     bool enable_tiering{false};
+    std::stop_token stop_token;
+};
+
+struct StoreStats {
+    uint64_t physical_bytes{0};
+    uint64_t live_record_bytes{0};
+    uint64_t logical_value_bytes{0};
+    uint64_t reclaimable_bytes{0};
+    size_t active_segments{0};
+    size_t sealed_segments{0};
+    size_t retired_segments{0};
 };
 
 struct CompactionResult {
@@ -87,6 +101,7 @@ class LogStructuredStore {
 
     std::vector<IndexSnapshotEntry> SnapshotIndex() const;
     std::vector<IndexSnapshotEntry> SnapshotCurrentIndex() const;
+    StoreStats SnapshotStats() const;
     uint64_t active_segment_id() const;
     uint64_t next_sequence() const;
 

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "storage/local/log_structured/index.h"
 #include "storage/local/log_structured/metadata.h"
@@ -39,6 +40,20 @@ struct PreparedWrite {
     PhysicalRecord physical;
 };
 
+struct CompactionOptions {
+    size_t max_source_segments{8};
+    uint64_t max_input_bytes{1024ULL * 1024 * 1024};
+    double min_reclaim_ratio{0.20};
+};
+
+struct CompactionResult {
+    size_t source_segments{0};
+    size_t target_segments{0};
+    uint64_t input_bytes{0};
+    uint64_t output_bytes{0};
+    uint64_t reclaimed_bytes{0};
+};
+
 class LogStructuredStore {
    public:
     static tl::expected<std::unique_ptr<LogStructuredStore>, StoreError> Open(
@@ -55,6 +70,8 @@ class LogStructuredStore {
                                             uint64_t sequence);
     tl::expected<void, StoreError> Delete(const RecordIdentity& identity);
     tl::expected<void, StoreError> Checkpoint();
+    tl::expected<CompactionResult, StoreError> CompactOnce(
+        const CompactionOptions& options = {});
     tl::expected<std::string, StoreError> Get(
         const RecordIdentity& identity) const;
     tl::expected<std::string, StoreError> GetLatest(
@@ -84,12 +101,15 @@ class LogStructuredStore {
         const RecordIdentity& identity, std::string_view value);
     tl::expected<std::string, StoreError> ReadEntryLocked(
         const IndexSnapshotEntry& entry) const;
+    tl::expected<void, StoreError> CheckpointLocked();
+    void CleanupRetiredSegmentsLocked();
     std::string SegmentPath(uint64_t segment_id) const;
 
     LogStructuredStoreConfig config_;
     std::string segments_path_;
     std::string wal_path_;
     mutable std::mutex mutex_;
+    std::mutex compaction_mutex_;
     std::unique_ptr<StorageDirectory> directory_;
     VersionIndex index_;
     std::unordered_map<uint64_t, std::string> segment_paths_;

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "storage/local/log_structured/index.h"
+#include "storage/local/log_structured/segment.h"
+#include "storage/local/log_structured/wal.h"
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+enum class StoreError {
+    kInvalidArgument,
+    kIoError,
+    kCorruptData,
+    kNotFound,
+    kInvalidTransition,
+};
+
+struct LogStructuredStoreConfig {
+    std::string root_path;
+    uint64_t max_segment_bytes{256ULL * 1024 * 1024};
+    bool sync_data{true};
+    bool sync_wal{true};
+};
+
+struct PreparedWrite {
+    RecordIdentity identity;
+    uint64_t sequence{0};
+    PhysicalRecord physical;
+};
+
+class LogStructuredStore {
+   public:
+    static tl::expected<std::unique_ptr<LogStructuredStore>, StoreError> Open(
+        LogStructuredStoreConfig config);
+
+    tl::expected<PreparedWrite, StoreError> PreparePut(
+        const RecordIdentity& identity, std::string_view value);
+    tl::expected<void, StoreError> CommitPut(const RecordIdentity& identity,
+                                             uint64_t sequence);
+    tl::expected<void, StoreError> AbortPut(const RecordIdentity& identity,
+                                            uint64_t sequence);
+    tl::expected<void, StoreError> Delete(const RecordIdentity& identity);
+    tl::expected<std::string, StoreError> Get(
+        const RecordIdentity& identity) const;
+
+    std::vector<IndexSnapshotEntry> SnapshotIndex() const;
+    uint64_t active_segment_id() const;
+    uint64_t next_sequence() const;
+
+   private:
+    explicit LogStructuredStore(LogStructuredStoreConfig config);
+
+    tl::expected<void, StoreError> Recover();
+    tl::expected<void, StoreError> RotateSegmentIfNeeded(
+        uint64_t next_record_bytes);
+    std::string SegmentPath(uint64_t segment_id) const;
+
+    LogStructuredStoreConfig config_;
+    std::string segments_path_;
+    std::string wal_path_;
+    mutable std::mutex mutex_;
+    VersionIndex index_;
+    std::unordered_map<uint64_t, std::string> segment_paths_;
+    std::unique_ptr<SegmentWriter> active_segment_;
+    std::unique_ptr<WalWriter> wal_;
+    uint64_t next_sequence_{1};
+    uint64_t next_segment_id_{1};
+};
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -83,7 +83,10 @@ enum class CompactionCrashPoint {
     kBeforeTargetSync,
     kAfterTargetSync,
     kAfterTargetRename,
+    kBeforeManifestWrite,
+    kAfterManifestWrite,
     kAfterManifestPublication,
+    kAfterSourceUnlink,
 };
 
 class LogStructuredStore {

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -30,12 +30,14 @@ enum class StoreError {
     kInvalidTransition,
     kNoSpace,
     kCancelled,
+    kRecoveryRequired,
 };
 
 struct LogStructuredStoreConfig {
     std::string root_path;
     uint64_t max_segment_bytes{256ULL * 1024 * 1024};
     uint64_t max_physical_bytes{std::numeric_limits<uint64_t>::max()};
+    uint64_t max_total_physical_bytes{std::numeric_limits<uint64_t>::max()};
     bool sync_data{true};
     bool sync_wal{true};
 };
@@ -85,6 +87,7 @@ enum class CompactionCrashPoint {
     kAfterTargetRename,
     kBeforeManifestWrite,
     kAfterManifestWrite,
+    kAfterCurrentRenameBeforeDirectorySync,
     kAfterManifestPublication,
     kAfterSourceUnlink,
 };
@@ -136,6 +139,7 @@ class LogStructuredStore {
         const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
             scanned_segments) const;
     void RefreshSegmentLiveBytes();
+    uint64_t PhysicalBytesLocked() const;
     tl::expected<void, StoreError> RotateSegmentIfNeeded(
         uint64_t next_record_bytes);
     tl::expected<void, StoreError> RotateActiveSegmentLocked();
@@ -164,6 +168,8 @@ class LogStructuredStore {
     uint64_t wal_generation_{1};
     uint64_t checkpoint_sequence_{0};
     uint64_t applied_delete_watermark_{0};
+    uint64_t compaction_reserved_bytes_{0};
+    bool recovery_required_{false};
 };
 
 }  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -2,12 +2,15 @@
 
 #include <cstdint>
 #include <memory>
+#include <map>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
 #include "storage/local/log_structured/index.h"
+#include "storage/local/log_structured/metadata.h"
 #include "storage/local/log_structured/segment.h"
+#include "storage/local/log_structured/storage_directory.h"
 #include "storage/local/log_structured/wal.h"
 #include "ylt/util/tl/expected.hpp"
 
@@ -17,6 +20,8 @@ enum class StoreError {
     kInvalidArgument,
     kIoError,
     kCorruptData,
+    kAlreadyMounted,
+    kUnrecognizedFormat,
     kNotFound,
     kInvalidTransition,
 };
@@ -46,6 +51,7 @@ class LogStructuredStore {
     tl::expected<void, StoreError> AbortPut(const RecordIdentity& identity,
                                             uint64_t sequence);
     tl::expected<void, StoreError> Delete(const RecordIdentity& identity);
+    tl::expected<void, StoreError> Checkpoint();
     tl::expected<std::string, StoreError> Get(
         const RecordIdentity& identity) const;
 
@@ -57,6 +63,13 @@ class LogStructuredStore {
     explicit LogStructuredStore(LogStructuredStoreConfig config);
 
     tl::expected<void, StoreError> Recover();
+    tl::expected<void, StoreError> RecoverSegments(
+        const std::vector<SegmentMetadata>& expected_segments,
+        uint64_t active_segment_id);
+    tl::expected<void, StoreError> ValidateIndexRecords(
+        const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
+            scanned_segments) const;
+    void RefreshSegmentLiveBytes();
     tl::expected<void, StoreError> RotateSegmentIfNeeded(
         uint64_t next_record_bytes);
     std::string SegmentPath(uint64_t segment_id) const;
@@ -65,12 +78,18 @@ class LogStructuredStore {
     std::string segments_path_;
     std::string wal_path_;
     mutable std::mutex mutex_;
+    std::unique_ptr<StorageDirectory> directory_;
     VersionIndex index_;
     std::unordered_map<uint64_t, std::string> segment_paths_;
+    std::map<uint64_t, SegmentMetadata> segments_;
     std::unique_ptr<SegmentWriter> active_segment_;
     std::unique_ptr<WalWriter> wal_;
     uint64_t next_sequence_{1};
     uint64_t next_segment_id_{1};
+    uint64_t manifest_generation_{0};
+    uint64_t wal_generation_{1};
+    uint64_t checkpoint_sequence_{0};
+    uint64_t applied_delete_watermark_{0};
 };
 
 }  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <limits>
@@ -129,6 +130,10 @@ class LogStructuredStore {
         const RecordIdentity& identity) const;
     tl::expected<std::string, StoreError> GetLatest(
         std::string_view tenant_id, std::string_view object_key) const;
+    tl::expected<void, StoreError> GetLatestInto(std::string_view tenant_id,
+                                                 std::string_view object_key,
+                                                 char* value,
+                                                 size_t value_size) const;
     bool ContainsLatest(std::string_view tenant_id,
                         std::string_view object_key) const;
 
@@ -142,6 +147,11 @@ class LogStructuredStore {
         std::function<bool(CompactionCrashPoint)> predicate);
 
    private:
+    struct PinnedEntry {
+        IndexSnapshotEntry entry;
+        std::shared_ptr<SegmentReader> reader;
+    };
+
     explicit LogStructuredStore(LogStructuredStoreConfig config);
 
     tl::expected<void, StoreError> Recover();
@@ -162,8 +172,15 @@ class LogStructuredStore {
     tl::expected<void, StoreError> RotateActiveSegmentLocked();
     tl::expected<PreparedWrite, StoreError> PreparePutLocked(
         const RecordIdentity& identity, std::string_view value);
-    tl::expected<std::string, StoreError> ReadEntryLocked(
-        const IndexSnapshotEntry& entry) const;
+    tl::expected<PinnedEntry, StoreError> PinEntryLocked(
+        IndexSnapshotEntry entry) const;
+    tl::expected<std::shared_ptr<SegmentReader>, StoreError>
+    GetSegmentReaderLocked(uint64_t segment_id) const;
+    void ForgetSegmentReaderLocked(uint64_t segment_id);
+    static tl::expected<std::string, StoreError> ReadPinnedEntry(
+        const PinnedEntry& pinned);
+    static tl::expected<void, StoreError> ReadPinnedEntryInto(
+        const PinnedEntry& pinned, char* value, size_t value_size);
     tl::expected<void, StoreError> CheckpointLocked();
     void CleanupRetiredSegmentsLocked();
     std::string SegmentPath(uint64_t segment_id) const;
@@ -176,6 +193,10 @@ class LogStructuredStore {
     std::unique_ptr<StorageDirectory> directory_;
     VersionIndex index_;
     std::unordered_map<uint64_t, std::string> segment_paths_;
+    mutable std::unordered_map<uint64_t, std::weak_ptr<SegmentReader>>
+        segment_readers_;
+    mutable std::deque<std::pair<uint64_t, std::shared_ptr<SegmentReader>>>
+        reader_cache_;
     std::map<uint64_t, SegmentMetadata> segments_;
     std::unique_ptr<SegmentWriter> active_segment_;
     std::unique_ptr<WalWriter> wal_;

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <stop_token>
@@ -46,6 +47,7 @@ struct CompactionOptions {
     size_t max_source_segments{8};
     uint64_t max_input_bytes{1024ULL * 1024 * 1024};
     uint64_t max_target_bytes{4ULL * 1024 * 1024 * 1024};
+    uint64_t max_temporary_bytes{std::numeric_limits<uint64_t>::max()};
     size_t fanout{4};
     uint32_t max_levels{4};
     double min_reclaim_ratio{0.20};

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -46,6 +46,9 @@ class LogStructuredStore {
 
     tl::expected<PreparedWrite, StoreError> PreparePut(
         const RecordIdentity& identity, std::string_view value);
+    tl::expected<PreparedWrite, StoreError> PreparePut(std::string tenant_id,
+                                                       std::string object_key,
+                                                       std::string_view value);
     tl::expected<void, StoreError> CommitPut(const RecordIdentity& identity,
                                              uint64_t sequence);
     tl::expected<void, StoreError> AbortPut(const RecordIdentity& identity,
@@ -54,8 +57,13 @@ class LogStructuredStore {
     tl::expected<void, StoreError> Checkpoint();
     tl::expected<std::string, StoreError> Get(
         const RecordIdentity& identity) const;
+    tl::expected<std::string, StoreError> GetLatest(
+        std::string_view tenant_id, std::string_view object_key) const;
+    bool ContainsLatest(std::string_view tenant_id,
+                        std::string_view object_key) const;
 
     std::vector<IndexSnapshotEntry> SnapshotIndex() const;
+    std::vector<IndexSnapshotEntry> SnapshotCurrentIndex() const;
     uint64_t active_segment_id() const;
     uint64_t next_sequence() const;
 
@@ -72,6 +80,10 @@ class LogStructuredStore {
     void RefreshSegmentLiveBytes();
     tl::expected<void, StoreError> RotateSegmentIfNeeded(
         uint64_t next_record_bytes);
+    tl::expected<PreparedWrite, StoreError> PreparePutLocked(
+        const RecordIdentity& identity, std::string_view value);
+    tl::expected<std::string, StoreError> ReadEntryLocked(
+        const IndexSnapshotEntry& entry) const;
     std::string SegmentPath(uint64_t segment_id) const;
 
     LogStructuredStoreConfig config_;

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -139,6 +139,10 @@ class LogStructuredStore {
         const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
             scanned_segments) const;
     void RefreshSegmentLiveBytes();
+    tl::expected<void, StoreError> AddLiveRecordLocked(
+        const PhysicalRecord& physical);
+    tl::expected<void, StoreError> RemoveLiveRecordLocked(
+        const PhysicalRecord& physical);
     uint64_t PhysicalBytesLocked() const;
     tl::expected<void, StoreError> RotateSegmentIfNeeded(
         uint64_t next_record_bytes);

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -40,6 +40,13 @@ struct LogStructuredStoreConfig {
     uint64_t max_total_physical_bytes{std::numeric_limits<uint64_t>::max()};
     bool sync_data{true};
     bool sync_wal{true};
+    size_t payload_write_parallelism{4};
+};
+
+struct PutRequest {
+    std::string tenant_id;
+    std::string object_key;
+    std::string_view value;
 };
 
 struct PreparedWrite {
@@ -102,10 +109,16 @@ class LogStructuredStore {
     tl::expected<PreparedWrite, StoreError> PreparePut(std::string tenant_id,
                                                        std::string object_key,
                                                        std::string_view value);
+    tl::expected<std::vector<PreparedWrite>, StoreError> PreparePutBatch(
+        const std::vector<PutRequest>& requests);
     tl::expected<void, StoreError> CommitPut(const RecordIdentity& identity,
                                              uint64_t sequence);
+    tl::expected<void, StoreError> CommitPuts(
+        const std::vector<PreparedWrite>& writes);
     tl::expected<void, StoreError> AbortPut(const RecordIdentity& identity,
                                             uint64_t sequence);
+    tl::expected<void, StoreError> AbortPuts(
+        const std::vector<PreparedWrite>& writes);
     tl::expected<void, StoreError> Delete(const RecordIdentity& identity);
     tl::expected<void, StoreError> Sync();
     tl::expected<void, StoreError> SealActiveSegment();

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -64,6 +64,8 @@ struct StoreStats {
     size_t active_segments{0};
     size_t sealed_segments{0};
     size_t retired_segments{0};
+    uint64_t wal_sequence{0};
+    uint64_t checkpoint_sequence{0};
 };
 
 struct CompactionResult {

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -43,7 +43,11 @@ struct PreparedWrite {
 struct CompactionOptions {
     size_t max_source_segments{8};
     uint64_t max_input_bytes{1024ULL * 1024 * 1024};
+    uint64_t max_target_bytes{4ULL * 1024 * 1024 * 1024};
+    size_t fanout{4};
+    uint32_t max_levels{4};
     double min_reclaim_ratio{0.20};
+    bool enable_tiering{false};
 };
 
 struct CompactionResult {
@@ -69,6 +73,8 @@ class LogStructuredStore {
     tl::expected<void, StoreError> AbortPut(const RecordIdentity& identity,
                                             uint64_t sequence);
     tl::expected<void, StoreError> Delete(const RecordIdentity& identity);
+    tl::expected<void, StoreError> Sync();
+    tl::expected<void, StoreError> SealActiveSegment();
     tl::expected<void, StoreError> Checkpoint();
     tl::expected<CompactionResult, StoreError> CompactOnce(
         const CompactionOptions& options = {});
@@ -97,6 +103,7 @@ class LogStructuredStore {
     void RefreshSegmentLiveBytes();
     tl::expected<void, StoreError> RotateSegmentIfNeeded(
         uint64_t next_record_bytes);
+    tl::expected<void, StoreError> RotateActiveSegmentLocked();
     tl::expected<PreparedWrite, StoreError> PreparePutLocked(
         const RecordIdentity& identity, std::string_view value);
     tl::expected<std::string, StoreError> ReadEntryLocked(

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <map>
 #include <mutex>
+#include <shared_mutex>
 #include <stop_token>
 #include <string>
 #include <unordered_map>
@@ -158,9 +159,7 @@ class LogStructuredStore {
     tl::expected<void, StoreError> RecoverSegments(
         const std::vector<SegmentMetadata>& expected_segments,
         uint64_t active_segment_id);
-    tl::expected<void, StoreError> ValidateIndexRecords(
-        const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
-            scanned_segments) const;
+    tl::expected<void, StoreError> ValidateIndexRecords() const;
     void RefreshSegmentLiveBytes();
     tl::expected<void, StoreError> AddLiveRecordLocked(
         const PhysicalRecord& physical);
@@ -189,6 +188,7 @@ class LogStructuredStore {
     std::string segments_path_;
     std::string wal_path_;
     mutable std::mutex mutex_;
+    mutable std::shared_mutex mutation_mutex_;
     std::mutex compaction_mutex_;
     std::unique_ptr<StorageDirectory> directory_;
     VersionIndex index_;
@@ -198,7 +198,9 @@ class LogStructuredStore {
     mutable std::deque<std::pair<uint64_t, std::shared_ptr<SegmentReader>>>
         reader_cache_;
     std::map<uint64_t, SegmentMetadata> segments_;
-    std::unique_ptr<SegmentWriter> active_segment_;
+    std::unordered_map<uint64_t, size_t> pending_segment_writes_;
+    std::shared_ptr<SegmentWriter> active_segment_;
+    std::vector<std::shared_ptr<SegmentWriter>> sealed_writers_;
     std::unique_ptr<WalWriter> wal_;
     uint64_t next_sequence_{1};
     uint64_t next_segment_id_{1};

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -42,6 +42,7 @@ struct LogStructuredStoreConfig {
     uint64_t max_total_physical_bytes{std::numeric_limits<uint64_t>::max()};
     bool sync_data{true};
     bool sync_wal{true};
+    bool use_uring{true};
     size_t payload_write_parallelism{4};
 };
 
@@ -166,6 +167,8 @@ class LogStructuredStore {
     tl::expected<void, StoreError> RemoveLiveRecordLocked(
         const PhysicalRecord& physical);
     uint64_t PhysicalBytesLocked() const;
+    tl::expected<void, StoreError> EnsureForegroundCapacityLocked(
+        uint64_t requested_bytes);
     tl::expected<void, StoreError> RotateSegmentIfNeeded(
         uint64_t next_record_bytes);
     tl::expected<void, StoreError> RotateActiveSegmentLocked();

--- a/mooncake-store/include/storage/local/log_structured/store.h
+++ b/mooncake-store/include/storage/local/log_structured/store.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <memory>
@@ -11,6 +12,7 @@
 #include <stop_token>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "storage/local/log_structured/index.h"
@@ -80,6 +82,10 @@ struct StoreStats {
     size_t sealed_segments{0};
     size_t retired_segments{0};
     uint64_t wal_sequence{0};
+    uint64_t wal_append_requests{0};
+    uint64_t wal_write_groups{0};
+    uint64_t wal_sync_groups{0};
+    uint64_t wal_max_group_requests{0};
     uint64_t checkpoint_sequence{0};
 };
 
@@ -149,6 +155,17 @@ class LogStructuredStore {
         std::function<bool(CompactionCrashPoint)> predicate);
 
    private:
+    struct TransitionKey {
+        std::string tenant_id;
+        std::string object_key;
+
+        bool operator==(const TransitionKey&) const = default;
+    };
+
+    struct TransitionKeyHash {
+        size_t operator()(const TransitionKey& key) const;
+    };
+
     struct PinnedEntry {
         IndexSnapshotEntry entry;
         std::shared_ptr<SegmentReader> reader;
@@ -183,6 +200,9 @@ class LogStructuredStore {
         const PinnedEntry& pinned);
     static tl::expected<void, StoreError> ReadPinnedEntryInto(
         const PinnedEntry& pinned, char* value, size_t value_size);
+    bool AcquireTransitionKeysLocked(std::unique_lock<std::mutex>& lock,
+                                     const std::vector<TransitionKey>& keys);
+    void ReleaseTransitionKeysLocked(const std::vector<TransitionKey>& keys);
     tl::expected<void, StoreError> CheckpointLocked();
     void CleanupRetiredSegmentsLocked();
     std::string SegmentPath(uint64_t segment_id) const;
@@ -191,6 +211,8 @@ class LogStructuredStore {
     std::string segments_path_;
     std::string wal_path_;
     mutable std::mutex mutex_;
+    std::condition_variable transition_cv_;
+    std::unordered_set<TransitionKey, TransitionKeyHash> transitions_in_flight_;
     mutable std::shared_mutex mutation_mutex_;
     std::mutex compaction_mutex_;
     std::unique_ptr<StorageDirectory> directory_;

--- a/mooncake-store/include/storage/local/log_structured/uring_batch_io.h
+++ b/mooncake-store/include/storage/local/log_structured/uring_batch_io.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace mooncake::logstructured {
+
+struct UringWriteRequest {
+    const char* data = nullptr;
+    size_t length = 0;
+    uint64_t offset = 0;
+};
+
+enum class UringBatchWriteResult {
+    kSuccess,
+    kUnavailable,
+    kIoError,
+};
+
+UringBatchWriteResult UringBatchWrite(
+    int fd, std::span<const UringWriteRequest> requests, size_t max_in_flight);
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/wal.h
+++ b/mooncake-store/include/storage/local/log_structured/wal.h
@@ -15,7 +15,6 @@ enum class WalRecordType : uint16_t {
     kCommitValue = 2,
     kAbortValue = 3,
     kApplyTombstone = 4,
-    kCheckpoint = 5,
 };
 
 enum class WalError {

--- a/mooncake-store/include/storage/local/log_structured/wal.h
+++ b/mooncake-store/include/storage/local/log_structured/wal.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "storage/local/log_structured/index.h"
+#include "ylt/util/tl/expected.hpp"
+
+namespace mooncake::logstructured {
+
+enum class WalRecordType : uint16_t {
+    kPrepareValue = 1,
+    kCommitValue = 2,
+    kAbortValue = 3,
+    kApplyTombstone = 4,
+    kCheckpoint = 5,
+};
+
+enum class WalError {
+    kInvalidArgument,
+    kOpenFailed,
+    kIoError,
+    kSyncFailed,
+    kTruncateFailed,
+    kCorruptRecord,
+    kReplayFailed,
+};
+
+struct WalRecord {
+    WalRecordType type{WalRecordType::kPrepareValue};
+    uint64_t sequence{0};
+    RecordIdentity identity;
+    PhysicalRecord physical;
+
+    bool operator==(const WalRecord&) const = default;
+};
+
+enum class WalScanTermination {
+    kCleanEof,
+    kIncompleteTail,
+    kCorruptRecord,
+};
+
+struct WalScanResult {
+    std::vector<WalRecord> records;
+    uint64_t valid_bytes{0};
+    WalScanTermination termination{WalScanTermination::kCleanEof};
+};
+
+class WalWriter {
+   public:
+    static tl::expected<std::unique_ptr<WalWriter>, WalError> Create(
+        std::string path);
+    static tl::expected<std::unique_ptr<WalWriter>, WalError> OpenForAppend(
+        std::string path, uint64_t valid_bytes);
+
+    ~WalWriter();
+
+    WalWriter(const WalWriter&) = delete;
+    WalWriter& operator=(const WalWriter&) = delete;
+
+    tl::expected<void, WalError> Append(const WalRecord& record, bool sync);
+    tl::expected<void, WalError> Sync();
+
+    uint64_t tail() const { return tail_; }
+    const std::string& path() const { return path_; }
+
+   private:
+    WalWriter(std::string path, int fd, uint64_t tail);
+
+    std::string path_;
+    int fd_;
+    uint64_t tail_;
+};
+
+tl::expected<WalScanResult, WalError> ScanWal(const std::string& path);
+tl::expected<void, WalError> ReplayWal(const std::vector<WalRecord>& records,
+                                       VersionIndex& index);
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/include/storage/local/log_structured/wal.h
+++ b/mooncake-store/include/storage/local/log_structured/wal.h
@@ -61,6 +61,8 @@ class WalWriter {
     WalWriter& operator=(const WalWriter&) = delete;
 
     tl::expected<void, WalError> Append(const WalRecord& record, bool sync);
+    tl::expected<void, WalError> AppendBatch(
+        const std::vector<WalRecord>& records, bool sync);
     tl::expected<void, WalError> Sync();
 
     uint64_t tail() const { return tail_; }

--- a/mooncake-store/include/storage/local/log_structured/wal.h
+++ b/mooncake-store/include/storage/local/log_structured/wal.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <condition_variable>
 #include <cstdint>
+#include <deque>
+#include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -48,6 +53,16 @@ struct WalScanResult {
     WalScanTermination termination{WalScanTermination::kCleanEof};
 };
 
+struct WalWriterStats {
+    uint64_t append_requests{0};
+    uint64_t appended_records{0};
+    uint64_t write_groups{0};
+    uint64_t sync_groups{0};
+    uint64_t grouped_requests{0};
+    uint64_t max_group_requests{0};
+    uint64_t appended_bytes{0};
+};
+
 class WalWriter {
    public:
     static tl::expected<std::unique_ptr<WalWriter>, WalError> Create(
@@ -65,15 +80,38 @@ class WalWriter {
         const std::vector<WalRecord>& records, bool sync);
     tl::expected<void, WalError> Sync();
 
-    uint64_t tail() const { return tail_; }
+    uint64_t tail() const;
+    WalWriterStats SnapshotStats() const;
     const std::string& path() const { return path_; }
 
+    static void SetBeforeWriteHookForTest(std::function<void()> hook);
+
    private:
+    struct PendingAppend {
+        std::string encoded;
+        size_t record_count{0};
+        bool sync{false};
+        bool leader{false};
+        bool done{false};
+        std::optional<WalError> error;
+    };
+
     WalWriter(std::string path, int fd, uint64_t tail);
+
+    tl::expected<void, WalError> Submit(PendingAppend& request);
+    void RunWriter();
+    void CompleteGroup(const std::vector<PendingAppend*>& group,
+                       std::optional<WalError> error);
 
     std::string path_;
     int fd_;
+    mutable std::mutex mutex_;
+    std::condition_variable completion_cv_;
+    std::deque<PendingAppend*> pending_;
+    bool writer_active_{false};
+    std::optional<WalError> terminal_error_;
     uint64_t tail_;
+    WalWriterStats stats_;
 };
 
 tl::expected<WalScanResult, WalError> ScanWal(const std::string& path);

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -156,6 +157,16 @@ struct OffloadMetadata {
     int64_t total_size;
     OffloadMetadata(std::size_t keys, int64_t size)
         : total_keys(keys), total_size(size) {}
+};
+
+struct StorageBackendStats {
+    uint64_t physical_bytes{0};
+    uint64_t live_record_bytes{0};
+    uint64_t logical_value_bytes{0};
+    uint64_t reclaimable_bytes{0};
+    uint64_t active_segments{0};
+    uint64_t sealed_segments{0};
+    uint64_t retired_segments{0};
 };
 
 enum class FileMode { Read, Write };
@@ -382,6 +393,10 @@ class StorageBackendInterface {
                             double /* low_watermark_ratio */,
                             EvictionHandler /* eviction_handler */ = nullptr) {
         return std::vector<std::string>{};
+    }
+
+    virtual std::optional<StorageBackendStats> SnapshotStats() const {
+        return std::nullopt;
     }
 
     FileStorageConfig file_storage_config_;

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -167,6 +167,16 @@ struct StorageBackendStats {
     uint64_t active_segments{0};
     uint64_t sealed_segments{0};
     uint64_t retired_segments{0};
+    uint64_t compaction_runs{0};
+    uint64_t compaction_input_bytes{0};
+    uint64_t compaction_output_bytes{0};
+    uint64_t compaction_reclaimed_bytes{0};
+    uint64_t compaction_conflicts{0};
+    uint64_t compaction_cancellations{0};
+    uint64_t compaction_errors{0};
+    uint64_t compaction_last_duration_us{0};
+    uint64_t wal_sequence{0};
+    uint64_t checkpoint_sequence{0};
 };
 
 enum class FileMode { Read, Write };

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -165,7 +165,8 @@ enum class StorageBackendType {
     kBucket,
     kOffsetAllocator,
     kDistributed,
-    kNvmeKv
+    kNvmeKv,
+    kLogStructured
 };
 
 static constexpr size_t kKB = 1024;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -77,6 +77,7 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     client_metric.cpp
     master_client.cpp
     storage_backend.cpp
+    storage/local/log_structured/log_structured_backend.cpp
     nvme_kv_backend.cpp
     nvme_kv_connector.cpp
     nvme_kv_executor_io_uring.cpp
@@ -543,6 +544,8 @@ if(TARGET Mooncake::liburing)
   target_compile_definitions(mooncake_store PUBLIC USE_URING)
   target_link_libraries(mooncake_store PUBLIC Mooncake::liburing)
 endif()
+target_link_libraries(mooncake_store PRIVATE mooncake_log_structured_storage)
+
 if(USE_CUDA)
   target_link_libraries(mooncake_store PRIVATE CUDA::cudart)
 elseif(USE_HIP)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(cachelib_memory_allocator)
 add_subdirectory(local_ssd)
+add_subdirectory(storage/local/log_structured)
 
 set(MOONCAKE_STORE_SHARED_SOURCES
     types.cpp

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -518,7 +518,8 @@ add_library(
   mooncake_store
   $<TARGET_OBJECTS:mooncake_store_shared_objects>
   $<TARGET_OBJECTS:mooncake_store_master_objects>
-  $<TARGET_OBJECTS:mooncake_store_client_objects>)
+  $<TARGET_OBJECTS:mooncake_store_client_objects>
+  $<TARGET_OBJECTS:mooncake_log_structured_storage_objects>)
 target_include_directories(mooncake_store PUBLIC ${MOONCAKE_STORE_INCLUDE_DIRS})
 target_link_libraries(
   mooncake_store
@@ -544,8 +545,6 @@ if(TARGET Mooncake::liburing)
   target_compile_definitions(mooncake_store PUBLIC USE_URING)
   target_link_libraries(mooncake_store PUBLIC Mooncake::liburing)
 endif()
-target_link_libraries(mooncake_store PRIVATE mooncake_log_structured_storage)
-
 if(USE_CUDA)
   target_link_libraries(mooncake_store PRIVATE CUDA::cudart)
 elseif(USE_HIP)

--- a/mooncake-store/src/config/file_storage_config.cpp
+++ b/mooncake-store/src/config/file_storage_config.cpp
@@ -64,6 +64,8 @@ FileStorageConfig FileStorageConfig::FromEnvironment() {
         config.enable_dfs = true;
     } else if (storage_backend_descriptor == "nvme_kv_storage_backend") {
         config.storage_backend_type = StorageBackendType::kNvmeKv;
+    } else if (storage_backend_descriptor == "log_structured_storage_backend") {
+        config.storage_backend_type = StorageBackendType::kLogStructured;
     } else {
         LOG(ERROR) << "Unknown storage backend.";
     }

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -795,6 +795,25 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         LOG(WARNING) << "Disk watermark eviction failed: "
                      << disk_eviction_result.error();
     }
+
+    if (ssd_metric_) {
+        if (const auto stats = storage_backend_->SnapshotStats()) {
+            ssd_metric_->backend_physical_bytes.update(
+                static_cast<int64_t>(stats->physical_bytes));
+            ssd_metric_->backend_live_record_bytes.update(
+                static_cast<int64_t>(stats->live_record_bytes));
+            ssd_metric_->backend_logical_value_bytes.update(
+                static_cast<int64_t>(stats->logical_value_bytes));
+            ssd_metric_->backend_reclaimable_bytes.update(
+                static_cast<int64_t>(stats->reclaimable_bytes));
+            ssd_metric_->backend_active_segments.update(
+                static_cast<int64_t>(stats->active_segments));
+            ssd_metric_->backend_sealed_segments.update(
+                static_cast<int64_t>(stats->sealed_segments));
+            ssd_metric_->backend_retired_segments.update(
+                static_cast<int64_t>(stats->retired_segments));
+        }
+    }
     return {};
 }
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -812,6 +812,26 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                 static_cast<int64_t>(stats->sealed_segments));
             ssd_metric_->backend_retired_segments.update(
                 static_cast<int64_t>(stats->retired_segments));
+            ssd_metric_->backend_compaction_runs.update(
+                static_cast<int64_t>(stats->compaction_runs));
+            ssd_metric_->backend_compaction_input_bytes.update(
+                static_cast<int64_t>(stats->compaction_input_bytes));
+            ssd_metric_->backend_compaction_output_bytes.update(
+                static_cast<int64_t>(stats->compaction_output_bytes));
+            ssd_metric_->backend_compaction_reclaimed_bytes.update(
+                static_cast<int64_t>(stats->compaction_reclaimed_bytes));
+            ssd_metric_->backend_compaction_conflicts.update(
+                static_cast<int64_t>(stats->compaction_conflicts));
+            ssd_metric_->backend_compaction_cancellations.update(
+                static_cast<int64_t>(stats->compaction_cancellations));
+            ssd_metric_->backend_compaction_errors.update(
+                static_cast<int64_t>(stats->compaction_errors));
+            ssd_metric_->backend_compaction_last_duration_us.update(
+                static_cast<int64_t>(stats->compaction_last_duration_us));
+            ssd_metric_->backend_wal_sequence.update(
+                static_cast<int64_t>(stats->wal_sequence));
+            ssd_metric_->backend_checkpoint_sequence.update(
+                static_cast<int64_t>(stats->checkpoint_sequence));
         }
     }
     return {};

--- a/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
+++ b/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(mooncake_log_structured_storage STATIC record_format.cpp segment.cpp
-                                                     index.cpp wal.cpp metadata.cpp storage_directory.cpp store.cpp)
+                                                     uring_batch_io.cpp index.cpp wal.cpp metadata.cpp storage_directory.cpp store.cpp)
 
 target_include_directories(
   mooncake_log_structured_storage
@@ -8,3 +8,11 @@ target_include_directories(
 
 target_link_libraries(mooncake_log_structured_storage
                       PUBLIC yalantinglibs::yalantinglibs)
+
+if(TARGET Mooncake::liburing)
+  target_compile_definitions(mooncake_log_structured_storage PRIVATE USE_URING)
+  target_include_directories(mooncake_log_structured_storage
+                             PRIVATE ${PROJECT_SOURCE_DIR}/src)
+  target_link_libraries(mooncake_log_structured_storage
+                        PRIVATE Mooncake::liburing)
+endif()

--- a/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
+++ b/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(mooncake_log_structured_storage STATIC record_format.cpp segment.cpp
-                                                     index.cpp wal.cpp store.cpp)
+                                                     index.cpp wal.cpp metadata.cpp storage_directory.cpp store.cpp)
 
 target_include_directories(
   mooncake_log_structured_storage

--- a/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
+++ b/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(mooncake_log_structured_storage STATIC record_format.cpp segment.cpp
+                                                     index.cpp wal.cpp store.cpp)
+
+target_include_directories(
+  mooncake_log_structured_storage
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+target_link_libraries(mooncake_log_structured_storage
+                      PUBLIC yalantinglibs::yalantinglibs)

--- a/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
+++ b/mooncake-store/src/storage/local/log_structured/CMakeLists.txt
@@ -1,18 +1,44 @@
-add_library(mooncake_log_structured_storage STATIC record_format.cpp segment.cpp
-                                                     uring_batch_io.cpp index.cpp wal.cpp metadata.cpp storage_directory.cpp store.cpp)
+set(MOONCAKE_LOG_STRUCTURED_STORAGE_SOURCES
+    record_format.cpp
+    segment.cpp
+    uring_batch_io.cpp
+    index.cpp
+    wal.cpp
+    metadata.cpp
+    storage_directory.cpp
+    store.cpp)
 
+add_library(mooncake_log_structured_storage_objects OBJECT
+            ${MOONCAKE_LOG_STRUCTURED_STORAGE_SOURCES})
+set_target_properties(mooncake_log_structured_storage_objects
+                      PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(
+  mooncake_log_structured_storage_objects
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+target_link_libraries(mooncake_log_structured_storage_objects
+                      PUBLIC yalantinglibs::yalantinglibs)
+
+if(TARGET Mooncake::liburing)
+  target_compile_definitions(mooncake_log_structured_storage_objects
+                             PRIVATE USE_URING)
+  target_include_directories(mooncake_log_structured_storage_objects
+                             PRIVATE ${PROJECT_SOURCE_DIR}/src)
+endif()
+
+add_library(
+  mooncake_log_structured_storage STATIC
+  $<TARGET_OBJECTS:mooncake_log_structured_storage_objects>)
 target_include_directories(
   mooncake_log_structured_storage
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
-
 target_link_libraries(mooncake_log_structured_storage
                       PUBLIC yalantinglibs::yalantinglibs)
 
 if(TARGET Mooncake::liburing)
-  target_compile_definitions(mooncake_log_structured_storage PRIVATE USE_URING)
-  target_include_directories(mooncake_log_structured_storage
-                             PRIVATE ${PROJECT_SOURCE_DIR}/src)
   target_link_libraries(mooncake_log_structured_storage
                         PRIVATE Mooncake::liburing)
 endif()

--- a/mooncake-store/src/storage/local/log_structured/index.cpp
+++ b/mooncake-store/src/storage/local/log_structured/index.cpp
@@ -226,6 +226,36 @@ std::vector<IndexSnapshotEntry> VersionIndex::Snapshot() const {
     return snapshot;
 }
 
+tl::expected<void, IndexError> VersionIndex::Restore(
+    const std::vector<IndexSnapshotEntry>& snapshot) {
+    std::unique_lock lock(mutex_);
+    std::unordered_map<RecordIdentity, VersionEntry, IdentityHash> versions;
+    std::unordered_map<LogicalKey, RecordIdentity, LogicalKeyHash> current;
+    for (const auto& item : snapshot) {
+        if (!versions.emplace(item.identity, item.version).second) {
+            return tl::unexpected(IndexError::kInvalidTransition);
+        }
+        if (item.version.state != VersionState::kCommitted) continue;
+        const auto logical_key = ToLogicalKey(item.identity);
+        auto current_it = current.find(logical_key);
+        if (current_it == current.end()) {
+            current.emplace(logical_key, item.identity);
+            continue;
+        }
+        const auto old = versions.find(current_it->second);
+        if (old == versions.end() ||
+            old->second.sequence == item.version.sequence) {
+            return tl::unexpected(IndexError::kInvalidTransition);
+        }
+        if (old->second.sequence < item.version.sequence) {
+            current_it->second = item.identity;
+        }
+    }
+    versions_ = std::move(versions);
+    current_ = std::move(current);
+    return {};
+}
+
 size_t VersionIndex::size() const {
     std::shared_lock lock(mutex_);
     return versions_.size();

--- a/mooncake-store/src/storage/local/log_structured/index.cpp
+++ b/mooncake-store/src/storage/local/log_structured/index.cpp
@@ -205,6 +205,22 @@ std::optional<VersionEntry> VersionIndex::LookupCommitted(
     return it->second;
 }
 
+std::optional<IndexSnapshotEntry> VersionIndex::LookupCurrent(
+    std::string_view tenant_id, std::string_view object_key) const {
+    std::shared_lock lock(mutex_);
+    LogicalKey key{.tenant_id = std::string(tenant_id),
+                   .object_key = std::string(object_key)};
+    auto current = current_.find(key);
+    if (current == current_.end()) return std::nullopt;
+    auto version = versions_.find(current->second);
+    if (version == versions_.end() ||
+        version->second.state != VersionState::kCommitted) {
+        return std::nullopt;
+    }
+    return IndexSnapshotEntry{.identity = version->first,
+                              .version = version->second};
+}
+
 std::optional<VersionEntry> VersionIndex::Lookup(
     const RecordIdentity& identity) const {
     std::shared_lock lock(mutex_);
@@ -222,6 +238,22 @@ std::vector<IndexSnapshotEntry> VersionIndex::Snapshot() const {
     for (const auto& [identity, version] : versions_) {
         snapshot.push_back(
             IndexSnapshotEntry{.identity = identity, .version = version});
+    }
+    return snapshot;
+}
+
+std::vector<IndexSnapshotEntry> VersionIndex::CurrentSnapshot() const {
+    std::shared_lock lock(mutex_);
+    std::vector<IndexSnapshotEntry> snapshot;
+    snapshot.reserve(current_.size());
+    for (const auto& [logical_key, identity] : current_) {
+        static_cast<void>(logical_key);
+        auto version = versions_.find(identity);
+        if (version != versions_.end() &&
+            version->second.state == VersionState::kCommitted) {
+            snapshot.push_back(IndexSnapshotEntry{.identity = version->first,
+                                                  .version = version->second});
+        }
     }
     return snapshot;
 }

--- a/mooncake-store/src/storage/local/log_structured/index.cpp
+++ b/mooncake-store/src/storage/local/log_structured/index.cpp
@@ -10,6 +10,27 @@ size_t HashCombine(size_t seed, size_t value) {
     return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
 }
 
+bool IsKnownVersionState(VersionState state) {
+    switch (state) {
+        case VersionState::kPrepared:
+        case VersionState::kCommitted:
+        case VersionState::kAborted:
+        case VersionState::kObsolete:
+        case VersionState::kTombstoned:
+        case VersionState::kReclaimable:
+            return true;
+    }
+    return false;
+}
+
+bool IsValidPhysicalRecord(const PhysicalRecord& physical) {
+    const bool empty = physical.total_length == 0;
+    if (empty) return physical == PhysicalRecord{};
+    return physical.segment_id != 0 &&
+           physical.value_offset >= physical.record_offset &&
+           physical.value_length <= physical.total_length;
+}
+
 }  // namespace
 
 size_t VersionIndex::IdentityHash::operator()(
@@ -216,9 +237,21 @@ void VersionIndex::ReclaimNonCurrentVersionsInSegments(
         static_cast<void>(identity);
         if (version.physical.total_length == 0 ||
             !segment_ids.contains(version.physical.segment_id) ||
-            version.state == VersionState::kCommitted) {
+            version.state == VersionState::kCommitted ||
+            version.state == VersionState::kPrepared) {
             continue;
         }
+        version.physical = {};
+        version.state = VersionState::kReclaimable;
+        ++version.mutation_epoch;
+    }
+}
+
+void VersionIndex::ReclaimNonCommittedVersionsAfterRecovery() {
+    std::unique_lock lock(mutex_);
+    for (auto& [identity, version] : versions_) {
+        static_cast<void>(identity);
+        if (version.state == VersionState::kCommitted) continue;
         version.physical = {};
         version.state = VersionState::kReclaimable;
         ++version.mutation_epoch;
@@ -294,6 +327,14 @@ tl::expected<void, IndexError> VersionIndex::Restore(
     std::unordered_map<RecordIdentity, VersionEntry, IdentityHash> versions;
     std::unordered_map<LogicalKey, RecordIdentity, LogicalKeyHash> current;
     for (const auto& item : snapshot) {
+        if (!IsKnownVersionState(item.version.state) ||
+            item.version.sequence == 0 || item.version.mutation_epoch == 0 ||
+            !IsValidPhysicalRecord(item.version.physical) ||
+            ((item.version.state == VersionState::kPrepared ||
+              item.version.state == VersionState::kCommitted) &&
+             item.version.physical.total_length == 0)) {
+            return tl::unexpected(IndexError::kInvalidTransition);
+        }
         if (!versions.emplace(item.identity, item.version).second) {
             return tl::unexpected(IndexError::kInvalidTransition);
         }
@@ -304,14 +345,7 @@ tl::expected<void, IndexError> VersionIndex::Restore(
             current.emplace(logical_key, item.identity);
             continue;
         }
-        const auto old = versions.find(current_it->second);
-        if (old == versions.end() ||
-            old->second.sequence == item.version.sequence) {
-            return tl::unexpected(IndexError::kInvalidTransition);
-        }
-        if (old->second.sequence < item.version.sequence) {
-            current_it->second = item.identity;
-        }
+        return tl::unexpected(IndexError::kInvalidTransition);
     }
     versions_ = std::move(versions);
     current_ = std::move(current);

--- a/mooncake-store/src/storage/local/log_structured/index.cpp
+++ b/mooncake-store/src/storage/local/log_structured/index.cpp
@@ -1,0 +1,234 @@
+#include "storage/local/log_structured/index.h"
+
+#include <functional>
+#include <mutex>
+
+namespace mooncake::logstructured {
+namespace {
+
+size_t HashCombine(size_t seed, size_t value) {
+    return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
+}
+
+}  // namespace
+
+size_t VersionIndex::IdentityHash::operator()(
+    const RecordIdentity& identity) const {
+    size_t hash = std::hash<std::string>{}(identity.tenant_id);
+    hash = HashCombine(hash, std::hash<std::string>{}(identity.object_key));
+    hash = HashCombine(hash, std::hash<uint64_t>{}(identity.incarnation.high));
+    return HashCombine(hash, std::hash<uint64_t>{}(identity.incarnation.low));
+}
+
+size_t VersionIndex::LogicalKeyHash::operator()(const LogicalKey& key) const {
+    return HashCombine(std::hash<std::string>{}(key.tenant_id),
+                       std::hash<std::string>{}(key.object_key));
+}
+
+VersionIndex::LogicalKey VersionIndex::ToLogicalKey(
+    const RecordIdentity& identity) {
+    return LogicalKey{.tenant_id = identity.tenant_id,
+                      .object_key = identity.object_key};
+}
+
+tl::expected<void, IndexError> VersionIndex::Prepare(
+    const RecordIdentity& identity, const PhysicalRecord& physical,
+    uint64_t sequence) {
+    std::unique_lock lock(mutex_);
+    auto [it, inserted] = versions_.try_emplace(
+        identity, VersionEntry{.physical = physical,
+                               .state = VersionState::kPrepared,
+                               .sequence = sequence,
+                               .mutation_epoch = 1});
+    if (inserted) {
+        return {};
+    }
+    if (it->second.state == VersionState::kPrepared &&
+        it->second.sequence == sequence && it->second.physical == physical) {
+        return {};
+    }
+    if (sequence < it->second.sequence) {
+        return tl::unexpected(IndexError::kStaleSequence);
+    }
+    return tl::unexpected(IndexError::kInvalidTransition);
+}
+
+tl::expected<void, IndexError> VersionIndex::Commit(
+    const RecordIdentity& identity, uint64_t sequence) {
+    std::unique_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end()) {
+        return tl::unexpected(IndexError::kNotFound);
+    }
+    if (sequence < it->second.sequence) {
+        return tl::unexpected(IndexError::kStaleSequence);
+    }
+    if (it->second.state == VersionState::kCommitted &&
+        it->second.sequence == sequence) {
+        return {};
+    }
+    if (it->second.state != VersionState::kPrepared ||
+        it->second.sequence != sequence) {
+        return tl::unexpected(IndexError::kInvalidTransition);
+    }
+
+    const auto logical_key = ToLogicalKey(identity);
+    auto current = current_.find(logical_key);
+    if (current != current_.end() && current->second != identity) {
+        auto old = versions_.find(current->second);
+        if (old != versions_.end()) {
+            if (old->second.sequence >= sequence) {
+                return tl::unexpected(IndexError::kStaleSequence);
+            }
+            old->second.state = VersionState::kObsolete;
+            ++old->second.mutation_epoch;
+        }
+    }
+
+    it->second.state = VersionState::kCommitted;
+    ++it->second.mutation_epoch;
+    current_.insert_or_assign(logical_key, identity);
+    return {};
+}
+
+tl::expected<void, IndexError> VersionIndex::Abort(
+    const RecordIdentity& identity, uint64_t sequence) {
+    std::unique_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end()) {
+        return tl::unexpected(IndexError::kNotFound);
+    }
+    if (sequence < it->second.sequence) {
+        return tl::unexpected(IndexError::kStaleSequence);
+    }
+    if (it->second.state == VersionState::kAborted &&
+        it->second.sequence == sequence) {
+        return {};
+    }
+    if (it->second.state != VersionState::kPrepared ||
+        it->second.sequence != sequence) {
+        return tl::unexpected(IndexError::kInvalidTransition);
+    }
+    it->second.state = VersionState::kAborted;
+    ++it->second.mutation_epoch;
+    return {};
+}
+
+tl::expected<void, IndexError> VersionIndex::ApplyTombstone(
+    const RecordIdentity& identity, uint64_t delete_sequence) {
+    std::unique_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end()) {
+        versions_.emplace(identity,
+                          VersionEntry{.physical = {},
+                                       .state = VersionState::kTombstoned,
+                                       .sequence = delete_sequence,
+                                       .mutation_epoch = 1});
+        return {};
+    }
+    if (delete_sequence < it->second.sequence) {
+        return tl::unexpected(IndexError::kStaleSequence);
+    }
+    if (it->second.state == VersionState::kTombstoned &&
+        it->second.sequence == delete_sequence) {
+        return {};
+    }
+    if (it->second.state == VersionState::kReclaimable) {
+        return tl::unexpected(IndexError::kInvalidTransition);
+    }
+
+    const auto logical_key = ToLogicalKey(identity);
+    auto current = current_.find(logical_key);
+    if (current != current_.end() && current->second == identity) {
+        current_.erase(current);
+    }
+    it->second.physical = {};
+    it->second.state = VersionState::kTombstoned;
+    it->second.sequence = delete_sequence;
+    ++it->second.mutation_epoch;
+    return {};
+}
+
+tl::expected<void, IndexError> VersionIndex::MarkReclaimable(
+    const RecordIdentity& identity, uint64_t sequence) {
+    std::unique_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end()) {
+        return tl::unexpected(IndexError::kNotFound);
+    }
+    if (sequence < it->second.sequence) {
+        return tl::unexpected(IndexError::kStaleSequence);
+    }
+    if (it->second.state == VersionState::kReclaimable) {
+        return {};
+    }
+    if (it->second.state != VersionState::kAborted &&
+        it->second.state != VersionState::kObsolete &&
+        it->second.state != VersionState::kTombstoned) {
+        return tl::unexpected(IndexError::kInvalidTransition);
+    }
+    it->second.state = VersionState::kReclaimable;
+    it->second.sequence = sequence;
+    ++it->second.mutation_epoch;
+    return {};
+}
+
+tl::expected<void, IndexError> VersionIndex::InstallCompactionCopy(
+    const RecordIdentity& identity, const PhysicalRecord& expected_source,
+    uint64_t expected_epoch, const PhysicalRecord& target) {
+    std::unique_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end()) {
+        return tl::unexpected(IndexError::kNotFound);
+    }
+    if (it->second.state != VersionState::kCommitted) {
+        return tl::unexpected(IndexError::kInvalidTransition);
+    }
+    if (it->second.mutation_epoch != expected_epoch) {
+        return tl::unexpected(IndexError::kStaleSequence);
+    }
+    if (it->second.physical != expected_source) {
+        return tl::unexpected(IndexError::kPhysicalMismatch);
+    }
+    it->second.physical = target;
+    ++it->second.mutation_epoch;
+    return {};
+}
+
+std::optional<VersionEntry> VersionIndex::LookupCommitted(
+    const RecordIdentity& identity) const {
+    std::shared_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end() || it->second.state != VersionState::kCommitted) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<VersionEntry> VersionIndex::Lookup(
+    const RecordIdentity& identity) const {
+    std::shared_lock lock(mutex_);
+    auto it = versions_.find(identity);
+    if (it == versions_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::vector<IndexSnapshotEntry> VersionIndex::Snapshot() const {
+    std::shared_lock lock(mutex_);
+    std::vector<IndexSnapshotEntry> snapshot;
+    snapshot.reserve(versions_.size());
+    for (const auto& [identity, version] : versions_) {
+        snapshot.push_back(
+            IndexSnapshotEntry{.identity = identity, .version = version});
+    }
+    return snapshot;
+}
+
+size_t VersionIndex::size() const {
+    std::shared_lock lock(mutex_);
+    return versions_.size();
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/index.cpp
+++ b/mooncake-store/src/storage/local/log_structured/index.cpp
@@ -176,23 +176,53 @@ tl::expected<void, IndexError> VersionIndex::MarkReclaimable(
 tl::expected<void, IndexError> VersionIndex::InstallCompactionCopy(
     const RecordIdentity& identity, const PhysicalRecord& expected_source,
     uint64_t expected_epoch, const PhysicalRecord& target) {
+    return InstallCompactionCopies(
+        {CompactionIndexUpdate{.identity = identity,
+                               .expected_source = expected_source,
+                               .expected_epoch = expected_epoch,
+                               .target = target}});
+}
+
+tl::expected<void, IndexError> VersionIndex::InstallCompactionCopies(
+    const std::vector<CompactionIndexUpdate>& updates) {
     std::unique_lock lock(mutex_);
-    auto it = versions_.find(identity);
-    if (it == versions_.end()) {
-        return tl::unexpected(IndexError::kNotFound);
+    for (const auto& update : updates) {
+        auto it = versions_.find(update.identity);
+        if (it == versions_.end()) {
+            return tl::unexpected(IndexError::kNotFound);
+        }
+        if (it->second.state != VersionState::kCommitted) {
+            return tl::unexpected(IndexError::kInvalidTransition);
+        }
+        if (it->second.mutation_epoch != update.expected_epoch) {
+            return tl::unexpected(IndexError::kStaleSequence);
+        }
+        if (it->second.physical != update.expected_source) {
+            return tl::unexpected(IndexError::kPhysicalMismatch);
+        }
     }
-    if (it->second.state != VersionState::kCommitted) {
-        return tl::unexpected(IndexError::kInvalidTransition);
+    for (const auto& update : updates) {
+        auto& version = versions_.at(update.identity);
+        version.physical = update.target;
+        ++version.mutation_epoch;
     }
-    if (it->second.mutation_epoch != expected_epoch) {
-        return tl::unexpected(IndexError::kStaleSequence);
-    }
-    if (it->second.physical != expected_source) {
-        return tl::unexpected(IndexError::kPhysicalMismatch);
-    }
-    it->second.physical = target;
-    ++it->second.mutation_epoch;
     return {};
+}
+
+void VersionIndex::ReclaimNonCurrentVersionsInSegments(
+    const std::unordered_set<uint64_t>& segment_ids) {
+    std::unique_lock lock(mutex_);
+    for (auto& [identity, version] : versions_) {
+        static_cast<void>(identity);
+        if (version.physical.total_length == 0 ||
+            !segment_ids.contains(version.physical.segment_id) ||
+            version.state == VersionState::kCommitted) {
+            continue;
+        }
+        version.physical = {};
+        version.state = VersionState::kReclaimable;
+        ++version.mutation_epoch;
+    }
 }
 
 std::optional<VersionEntry> VersionIndex::LookupCommitted(

--- a/mooncake-store/src/storage/local/log_structured/index.cpp
+++ b/mooncake-store/src/storage/local/log_structured/index.cpp
@@ -321,6 +321,39 @@ std::vector<IndexSnapshotEntry> VersionIndex::CurrentSnapshot() const {
     return snapshot;
 }
 
+std::vector<IndexSnapshotEntry> VersionIndex::CheckpointSnapshot() const {
+    std::shared_lock lock(mutex_);
+    std::vector<IndexSnapshotEntry> snapshot;
+    snapshot.reserve(current_.size());
+    for (const auto& [identity, version] : versions_) {
+        if (version.state == VersionState::kPrepared) {
+            snapshot.push_back({.identity = identity, .version = version});
+            continue;
+        }
+        if (version.state != VersionState::kCommitted) continue;
+        const auto current = current_.find(ToLogicalKey(identity));
+        if (current != current_.end() && current->second == identity) {
+            snapshot.push_back({.identity = identity, .version = version});
+        }
+    }
+    return snapshot;
+}
+
+void VersionIndex::PruneCheckpointedHistory() {
+    std::unique_lock lock(mutex_);
+    for (auto it = versions_.begin(); it != versions_.end();) {
+        const auto current = current_.find(ToLogicalKey(it->first));
+        const bool keep_current =
+            it->second.state == VersionState::kCommitted &&
+            current != current_.end() && current->second == it->first;
+        if (keep_current || it->second.state == VersionState::kPrepared) {
+            ++it;
+        } else {
+            it = versions_.erase(it);
+        }
+    }
+}
+
 tl::expected<void, IndexError> VersionIndex::Restore(
     const std::vector<IndexSnapshotEntry>& snapshot) {
     std::unique_lock lock(mutex_);

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -386,12 +386,11 @@ LogStructuredStorageBackend::RunCompaction(
     if (!result) {
         if (result.error() == logstructured::StoreError::kCancelled) {
             compaction_cancellations_.fetch_add(1, std::memory_order_relaxed);
+        } else if (result.error() ==
+                   logstructured::StoreError::kInvalidTransition) {
+            compaction_conflicts_.fetch_add(1, std::memory_order_relaxed);
         } else {
             compaction_errors_.fetch_add(1, std::memory_order_relaxed);
-            if (result.error() ==
-                logstructured::StoreError::kInvalidTransition) {
-                compaction_conflicts_.fetch_add(1, std::memory_order_relaxed);
-            }
         }
         return result;
     }
@@ -418,7 +417,9 @@ void LogStructuredStorageBackend::CompactionLoop(std::stop_token stop_token) {
         if (stop_token.stop_requested()) break;
         auto compacted = RunCompaction(MakeCompactionOptions(stop_token));
         if (!compacted &&
-            compacted.error() != logstructured::StoreError::kCancelled) {
+            compacted.error() != logstructured::StoreError::kCancelled &&
+            compacted.error() !=
+                logstructured::StoreError::kInvalidTransition) {
             LOG(ERROR) << "Log-structured compaction failed";
         }
     }

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -303,6 +303,7 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
 
 tl::expected<void, ErrorCode> LogStructuredStorageBackend::BatchLoad(
     std::unordered_map<std::string, Slice>& batched_slices) {
+    std::shared_lock lock(mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -59,6 +59,12 @@ LogStructuredBackendConfig LogStructuredBackendConfig::FromEnvironment() {
     config.compaction_max_target_bytes =
         Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES",
                            config.compaction_max_target_bytes);
+    config.compaction_max_bytes_per_second =
+        Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_SEC",
+                           config.compaction_max_bytes_per_second);
+    config.compaction_reserve_bytes =
+        Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_RESERVE_BYTES",
+                           config.compaction_reserve_bytes);
     config.compaction_min_reclaim_ratio = ParseRatio(
         Environ::GetString("MOONCAKE_LOG_COMPACTION_MIN_RECLAIM_RATIO", ""),
         config.compaction_min_reclaim_ratio);
@@ -294,15 +300,20 @@ LogStructuredStorageBackend::IsEnableOffloading() {
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
-    const auto entries = store_->SnapshotCurrentIndex();
-    uint64_t total_size = 0;
-    for (const auto& entry : entries) {
-        total_size += entry.version.physical.value_length;
+    if (file_storage_config_.total_keys_limit <= 0 ||
+        file_storage_config_.total_size_limit <= 0) {
+        return false;
     }
+    const auto entries = store_->SnapshotCurrentIndex();
+    const auto stats = store_->SnapshotStats();
+    const uint64_t capacity =
+        static_cast<uint64_t>(file_storage_config_.total_size_limit);
+    if (backend_config_.compaction_reserve_bytes >= capacity) return false;
+    const uint64_t usable_capacity =
+        capacity - backend_config_.compaction_reserve_bytes;
     return entries.size() <
                static_cast<size_t>(file_storage_config_.total_keys_limit) &&
-           total_size <
-               static_cast<uint64_t>(file_storage_config_.total_size_limit);
+           stats.physical_bytes < usable_capacity;
 }
 
 tl::expected<void, ErrorCode> LogStructuredStorageBackend::ScanMeta(
@@ -336,6 +347,22 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::ScanMeta(
     return {};
 }
 
+logstructured::CompactionOptions
+LogStructuredStorageBackend::MakeCompactionOptions(
+    std::stop_token stop_token) const {
+    return {
+        .max_source_segments = backend_config_.compaction_max_sources,
+        .max_input_bytes = backend_config_.compaction_max_bytes_per_round,
+        .max_target_bytes = backend_config_.compaction_max_target_bytes,
+        .fanout = backend_config_.compaction_fanout,
+        .max_levels = backend_config_.compaction_max_levels,
+        .min_reclaim_ratio = backend_config_.compaction_min_reclaim_ratio,
+        .max_bytes_per_second = backend_config_.compaction_max_bytes_per_second,
+        .enable_tiering = backend_config_.compaction_policy ==
+                          LogStructuredCompactionPolicy::kTiered,
+        .stop_token = stop_token};
+}
+
 void LogStructuredStorageBackend::CompactionLoop(std::stop_token stop_token) {
     std::mutex wait_mutex;
     std::unique_lock wait_lock(wait_mutex);
@@ -345,19 +372,70 @@ void LogStructuredStorageBackend::CompactionLoop(std::stop_token stop_token) {
             std::chrono::milliseconds(backend_config_.compaction_interval_ms),
             [] { return false; });
         if (stop_token.stop_requested()) break;
-        auto compacted = store_->CompactOnce(
-            {.max_source_segments = backend_config_.compaction_max_sources,
-             .max_input_bytes = backend_config_.compaction_max_bytes_per_round,
-             .max_target_bytes = backend_config_.compaction_max_target_bytes,
-             .fanout = backend_config_.compaction_fanout,
-             .max_levels = backend_config_.compaction_max_levels,
-             .min_reclaim_ratio = backend_config_.compaction_min_reclaim_ratio,
-             .enable_tiering = backend_config_.compaction_policy ==
-                               LogStructuredCompactionPolicy::kTiered});
-        if (!compacted) {
+        auto compacted = store_->CompactOnce(MakeCompactionOptions(stop_token));
+        if (!compacted &&
+            compacted.error() != logstructured::StoreError::kCancelled) {
             LOG(ERROR) << "Log-structured compaction failed";
         }
     }
+}
+
+tl::expected<std::vector<std::string>, ErrorCode>
+LogStructuredStorageBackend::EvictAboveDiskWatermark(
+    double high_watermark_ratio, double low_watermark_ratio,
+    EvictionHandler eviction_handler) {
+    static_cast<void>(eviction_handler);
+    if (!std::isfinite(high_watermark_ratio) ||
+        !std::isfinite(low_watermark_ratio) || low_watermark_ratio < 0.0 ||
+        high_watermark_ratio > 1.0 ||
+        low_watermark_ratio > high_watermark_ratio) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (!initialized_.load(std::memory_order_acquire) || !store_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (file_storage_config_.total_size_limit <= 0) {
+        return std::vector<std::string>{};
+    }
+
+    const uint64_t capacity =
+        static_cast<uint64_t>(file_storage_config_.total_size_limit);
+    if (backend_config_.compaction_reserve_bytes >= capacity) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    const uint64_t usable_capacity =
+        capacity - backend_config_.compaction_reserve_bytes;
+    const uint64_t high_watermark_bytes = static_cast<uint64_t>(
+        static_cast<double>(usable_capacity) * high_watermark_ratio);
+    const uint64_t low_watermark_bytes = static_cast<uint64_t>(
+        static_cast<double>(usable_capacity) * low_watermark_ratio);
+
+    auto stats = store_->SnapshotStats();
+    if (stats.physical_bytes <= high_watermark_bytes) {
+        return std::vector<std::string>{};
+    }
+    if (stats.reclaimable_bytes == 0) {
+        return std::vector<std::string>{};
+    }
+    auto sealed = store_->SealActiveSegment();
+    if (!sealed) return tl::make_unexpected(ToWriteError(sealed.error()));
+
+    auto options = MakeCompactionOptions();
+    options.min_reclaim_ratio = 0.0;
+    options.enable_tiering = false;
+    while (stats.physical_bytes > low_watermark_bytes &&
+           stats.reclaimable_bytes != 0) {
+        auto compacted = store_->CompactOnce(options);
+        if (!compacted) {
+            return tl::make_unexpected(ToWriteError(compacted.error()));
+        }
+        if (compacted->source_segments == 0 ||
+            compacted->reclaimed_bytes == 0) {
+            break;
+        }
+        stats = store_->SnapshotStats();
+    }
+    return std::vector<std::string>{};
 }
 
 void LogStructuredStorageBackend::RemoveAll() {
@@ -384,7 +462,8 @@ void LogStructuredStorageBackend::RemoveAll() {
         .fanout = backend_config_.compaction_fanout,
         .max_levels = backend_config_.compaction_max_levels,
         .min_reclaim_ratio = 0.0,
-        .enable_tiering = false};
+        .enable_tiering = false,
+        .stop_token = {}};
     while (true) {
         auto compacted = store_->CompactOnce(options);
         if (!compacted) {

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -121,6 +121,9 @@ ErrorCode LogStructuredStorageBackend::ToWriteError(
     if (error == logstructured::StoreError::kNotFound) {
         return ErrorCode::OBJECT_NOT_FOUND;
     }
+    if (error == logstructured::StoreError::kNoSpace) {
+        return ErrorCode::KEYS_ULTRA_LIMIT;
+    }
     return ErrorCode::FILE_WRITE_FAIL;
 }
 
@@ -161,12 +164,23 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::Init() {
     if (!backend_config_.Validate()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
+    uint64_t max_physical_bytes = std::numeric_limits<uint64_t>::max();
+    if (file_storage_config_.total_size_limit > 0) {
+        const uint64_t capacity =
+            static_cast<uint64_t>(file_storage_config_.total_size_limit);
+        if (backend_config_.compaction_reserve_bytes >= capacity) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        max_physical_bytes =
+            capacity - backend_config_.compaction_reserve_bytes;
+    }
     const std::filesystem::path root =
         std::filesystem::path(file_storage_config_.storage_filepath) /
         "log_structured";
     auto store = logstructured::LogStructuredStore::Open(
         {.root_path = root.string(),
          .max_segment_bytes = backend_config_.segment_size_bytes,
+         .max_physical_bytes = max_physical_bytes,
          .sync_data =
              backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
          .sync_wal =
@@ -200,19 +214,29 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
     }
 
     std::vector<logstructured::PreparedWrite> prepared;
+    std::optional<ErrorCode> first_prepare_error;
     std::vector<std::string> keys;
     std::vector<StorageObjectMetadata> metadatas;
     prepared.reserve(batch_object.size());
     keys.reserve(batch_object.size());
     metadatas.reserve(batch_object.size());
     for (const auto& [key, slices] : batch_object) {
-        if (test_failure_predicate_ && test_failure_predicate_(key)) continue;
+        if (test_failure_predicate_ && test_failure_predicate_(key)) {
+            first_prepare_error = ErrorCode::FILE_WRITE_FAIL;
+            continue;
+        }
         auto value = ConcatSlices(slices);
-        if (!value) continue;
+        if (!value) {
+            first_prepare_error = value.error();
+            continue;
+        }
         auto [tenant_id, object_key] = SplitStorageKey(key);
         auto write = store_->PreparePut(std::move(tenant_id),
                                         std::move(object_key), *value);
-        if (!write) continue;
+        if (!write) {
+            first_prepare_error = ToWriteError(write.error());
+            continue;
+        }
         metadatas.push_back(StorageObjectMetadata{
             -1, 0, static_cast<int64_t>(key.size()),
             static_cast<int64_t>(write->physical.value_length), ""});
@@ -220,7 +244,8 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
         prepared.push_back(std::move(write.value()));
     }
     if (prepared.empty()) {
-        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        return tl::make_unexpected(
+            first_prepare_error.value_or(ErrorCode::FILE_WRITE_FAIL));
     }
     if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
         !store_->Sync()) {

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -350,10 +350,19 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::ScanMeta(
 logstructured::CompactionOptions
 LogStructuredStorageBackend::MakeCompactionOptions(
     std::stop_token stop_token) const {
+    uint64_t max_temporary_bytes = std::numeric_limits<uint64_t>::max();
+    if (store_ && file_storage_config_.total_size_limit > 0) {
+        const uint64_t capacity =
+            static_cast<uint64_t>(file_storage_config_.total_size_limit);
+        const uint64_t physical_bytes = store_->SnapshotStats().physical_bytes;
+        max_temporary_bytes =
+            physical_bytes < capacity ? capacity - physical_bytes : 0;
+    }
     return {
         .max_source_segments = backend_config_.compaction_max_sources,
         .max_input_bytes = backend_config_.compaction_max_bytes_per_round,
         .max_target_bytes = backend_config_.compaction_max_target_bytes,
+        .max_temporary_bytes = max_temporary_bytes,
         .fanout = backend_config_.compaction_fanout,
         .max_levels = backend_config_.compaction_max_levels,
         .min_reclaim_ratio = backend_config_.compaction_min_reclaim_ratio,
@@ -459,6 +468,7 @@ void LogStructuredStorageBackend::RemoveAll() {
         .max_source_segments = std::numeric_limits<size_t>::max(),
         .max_input_bytes = std::numeric_limits<uint64_t>::max(),
         .max_target_bytes = backend_config_.compaction_max_target_bytes,
+        .max_temporary_bytes = std::numeric_limits<uint64_t>::max(),
         .fanout = backend_config_.compaction_fanout,
         .max_levels = backend_config_.compaction_max_levels,
         .min_reclaim_ratio = 0.0,

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -53,9 +53,9 @@ LogStructuredBackendConfig LogStructuredBackendConfig::FromEnvironment() {
         "MOONCAKE_LOG_COMPACTION_MAX_LEVELS", config.compaction_max_levels));
     config.compaction_max_sources = static_cast<size_t>(Environ::GetUInt64(
         "MOONCAKE_LOG_COMPACTION_MAX_SOURCES", config.compaction_max_sources));
-    config.compaction_max_bytes_per_round =
-        Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND",
-                           config.compaction_max_bytes_per_round);
+    config.compaction_max_input_bytes =
+        Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_INPUT_BYTES",
+                           config.compaction_max_input_bytes);
     config.compaction_max_target_bytes =
         Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES",
                            config.compaction_max_target_bytes);
@@ -94,7 +94,7 @@ LogStructuredBackendConfig LogStructuredBackendConfig::FromEnvironment() {
 bool LogStructuredBackendConfig::Validate() const {
     return segment_size_bytes > 0 && compaction_interval_ms > 0 &&
            compaction_fanout >= 2 && compaction_max_levels > 0 &&
-           compaction_max_sources > 0 && compaction_max_bytes_per_round > 0 &&
+           compaction_max_sources > 0 && compaction_max_input_bytes > 0 &&
            compaction_max_target_bytes >= segment_size_bytes &&
            compaction_min_reclaim_ratio >= 0.0 &&
            compaction_min_reclaim_ratio <= 1.0;
@@ -181,6 +181,10 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::Init() {
         {.root_path = root.string(),
          .max_segment_bytes = backend_config_.segment_size_bytes,
          .max_physical_bytes = max_physical_bytes,
+         .max_total_physical_bytes =
+             file_storage_config_.total_size_limit > 0
+                 ? static_cast<uint64_t>(file_storage_config_.total_size_limit)
+                 : std::numeric_limits<uint64_t>::max(),
          .sync_data =
              backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
          .sync_wal =
@@ -385,7 +389,7 @@ LogStructuredStorageBackend::MakeCompactionOptions(
     }
     return {
         .max_source_segments = backend_config_.compaction_max_sources,
-        .max_input_bytes = backend_config_.compaction_max_bytes_per_round,
+        .max_input_bytes = backend_config_.compaction_max_input_bytes,
         .max_target_bytes = backend_config_.compaction_max_target_bytes,
         .max_temporary_bytes = max_temporary_bytes,
         .fanout = backend_config_.compaction_fanout,

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -303,21 +303,17 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
 
 tl::expected<void, ErrorCode> LogStructuredStorageBackend::BatchLoad(
     std::unordered_map<std::string, Slice>& batched_slices) {
-    std::lock_guard lock(mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
     for (const auto& [key, slice] : batched_slices) {
-        const auto [tenant_id, object_key] = SplitStorageKey(key);
-        auto value = store_->GetLatest(tenant_id, object_key);
-        if (!value) return tl::make_unexpected(ToReadError(value.error()));
-        if (value->size() != slice.size ||
-            (slice.size != 0 && slice.ptr == nullptr)) {
+        if (slice.size != 0 && slice.ptr == nullptr) {
             return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
         }
-        if (!value->empty()) {
-            std::memcpy(slice.ptr, value->data(), value->size());
-        }
+        const auto [tenant_id, object_key] = SplitStorageKey(key);
+        auto read = store_->GetLatestInto(
+            tenant_id, object_key, static_cast<char*>(slice.ptr), slice.size);
+        if (!read) return tl::make_unexpected(ToReadError(read.error()));
     }
     return {};
 }

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -372,6 +372,41 @@ LogStructuredStorageBackend::MakeCompactionOptions(
         .stop_token = stop_token};
 }
 
+tl::expected<logstructured::CompactionResult, logstructured::StoreError>
+LogStructuredStorageBackend::RunCompaction(
+    const logstructured::CompactionOptions& options) {
+    const auto started = std::chrono::steady_clock::now();
+    auto result = store_->CompactOnce(options);
+    const auto duration_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - started)
+            .count();
+    compaction_last_duration_us_.store(static_cast<uint64_t>(duration_us),
+                                       std::memory_order_relaxed);
+    if (!result) {
+        if (result.error() == logstructured::StoreError::kCancelled) {
+            compaction_cancellations_.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            compaction_errors_.fetch_add(1, std::memory_order_relaxed);
+            if (result.error() ==
+                logstructured::StoreError::kInvalidTransition) {
+                compaction_conflicts_.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+        return result;
+    }
+    if (result->source_segments != 0) {
+        compaction_runs_.fetch_add(1, std::memory_order_relaxed);
+        compaction_input_bytes_.fetch_add(result->input_bytes,
+                                          std::memory_order_relaxed);
+        compaction_output_bytes_.fetch_add(result->output_bytes,
+                                           std::memory_order_relaxed);
+        compaction_reclaimed_bytes_.fetch_add(result->reclaimed_bytes,
+                                              std::memory_order_relaxed);
+    }
+    return result;
+}
+
 void LogStructuredStorageBackend::CompactionLoop(std::stop_token stop_token) {
     std::mutex wait_mutex;
     std::unique_lock wait_lock(wait_mutex);
@@ -381,7 +416,7 @@ void LogStructuredStorageBackend::CompactionLoop(std::stop_token stop_token) {
             std::chrono::milliseconds(backend_config_.compaction_interval_ms),
             [] { return false; });
         if (stop_token.stop_requested()) break;
-        auto compacted = store_->CompactOnce(MakeCompactionOptions(stop_token));
+        auto compacted = RunCompaction(MakeCompactionOptions(stop_token));
         if (!compacted &&
             compacted.error() != logstructured::StoreError::kCancelled) {
             LOG(ERROR) << "Log-structured compaction failed";
@@ -434,7 +469,7 @@ LogStructuredStorageBackend::EvictAboveDiskWatermark(
     options.enable_tiering = false;
     while (stats.physical_bytes > low_watermark_bytes &&
            stats.reclaimable_bytes != 0) {
-        auto compacted = store_->CompactOnce(options);
+        auto compacted = RunCompaction(options);
         if (!compacted) {
             return tl::make_unexpected(ToWriteError(compacted.error()));
         }
@@ -475,7 +510,7 @@ void LogStructuredStorageBackend::RemoveAll() {
         .enable_tiering = false,
         .stop_token = {}};
     while (true) {
-        auto compacted = store_->CompactOnce(options);
+        auto compacted = RunCompaction(options);
         if (!compacted) {
             LOG(ERROR) << "Failed to reclaim segments during RemoveAll";
             return;
@@ -495,13 +530,30 @@ std::optional<StorageBackendStats> LogStructuredStorageBackend::SnapshotStats()
     std::lock_guard lock(mutex_);
     if (!store_) return std::nullopt;
     const auto stats = store_->SnapshotStats();
-    return StorageBackendStats{.physical_bytes = stats.physical_bytes,
-                               .live_record_bytes = stats.live_record_bytes,
-                               .logical_value_bytes = stats.logical_value_bytes,
-                               .reclaimable_bytes = stats.reclaimable_bytes,
-                               .active_segments = stats.active_segments,
-                               .sealed_segments = stats.sealed_segments,
-                               .retired_segments = stats.retired_segments};
+    return StorageBackendStats{
+        .physical_bytes = stats.physical_bytes,
+        .live_record_bytes = stats.live_record_bytes,
+        .logical_value_bytes = stats.logical_value_bytes,
+        .reclaimable_bytes = stats.reclaimable_bytes,
+        .active_segments = stats.active_segments,
+        .sealed_segments = stats.sealed_segments,
+        .retired_segments = stats.retired_segments,
+        .compaction_runs = compaction_runs_.load(std::memory_order_relaxed),
+        .compaction_input_bytes =
+            compaction_input_bytes_.load(std::memory_order_relaxed),
+        .compaction_output_bytes =
+            compaction_output_bytes_.load(std::memory_order_relaxed),
+        .compaction_reclaimed_bytes =
+            compaction_reclaimed_bytes_.load(std::memory_order_relaxed),
+        .compaction_conflicts =
+            compaction_conflicts_.load(std::memory_order_relaxed),
+        .compaction_cancellations =
+            compaction_cancellations_.load(std::memory_order_relaxed),
+        .compaction_errors = compaction_errors_.load(std::memory_order_relaxed),
+        .compaction_last_duration_us =
+            compaction_last_duration_us_.load(std::memory_order_relaxed),
+        .wal_sequence = stats.wal_sequence,
+        .checkpoint_sequence = stats.checkpoint_sequence};
 }
 
 void LogStructuredStorageBackend::SetTestFailurePredicate(

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -1,18 +1,35 @@
 #include "storage/local/log_structured/log_structured_backend.h"
 
 #include <algorithm>
+#include <chrono>
+#include <cerrno>
+#include <cstdlib>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <limits>
+#include <string_view>
 
 #include <glog/logging.h>
 
+#include "environ.h"
 #include "tenant_id.h"
 
 namespace mooncake {
 namespace {
 
-constexpr uint64_t kDefaultSegmentBytes = 256ULL * 1024 * 1024;
+double ParseRatio(std::string_view value, double fallback) {
+    if (value.empty()) return fallback;
+    std::string owned(value);
+    char* end = nullptr;
+    errno = 0;
+    const double parsed = std::strtod(owned.c_str(), &end);
+    if (errno != 0 || end != owned.c_str() + owned.size() ||
+        !std::isfinite(parsed)) {
+        return fallback;
+    }
+    return parsed;
+}
 
 std::pair<std::string, std::string> SplitStorageKey(
     std::string_view storage_key) {
@@ -22,9 +39,73 @@ std::pair<std::string, std::string> SplitStorageKey(
 
 }  // namespace
 
+LogStructuredBackendConfig LogStructuredBackendConfig::FromEnvironment() {
+    LogStructuredBackendConfig config;
+    config.segment_size_bytes = Environ::GetUInt64(
+        "MOONCAKE_LOG_SEGMENT_SIZE_BYTES", config.segment_size_bytes);
+    config.checkpoint_interval_records = Environ::GetUInt64(
+        "MOONCAKE_LOG_CHECKPOINT_INTERVAL", config.checkpoint_interval_records);
+    config.compaction_interval_ms = Environ::GetUInt64(
+        "MOONCAKE_LOG_COMPACTION_INTERVAL_MS", config.compaction_interval_ms);
+    config.compaction_fanout = static_cast<size_t>(Environ::GetUInt64(
+        "MOONCAKE_LOG_COMPACTION_FANOUT", config.compaction_fanout));
+    config.compaction_max_levels = static_cast<uint32_t>(Environ::GetUInt64(
+        "MOONCAKE_LOG_COMPACTION_MAX_LEVELS", config.compaction_max_levels));
+    config.compaction_max_sources = static_cast<size_t>(Environ::GetUInt64(
+        "MOONCAKE_LOG_COMPACTION_MAX_SOURCES", config.compaction_max_sources));
+    config.compaction_max_bytes_per_round =
+        Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND",
+                           config.compaction_max_bytes_per_round);
+    config.compaction_max_target_bytes =
+        Environ::GetUInt64("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES",
+                           config.compaction_max_target_bytes);
+    config.compaction_min_reclaim_ratio = ParseRatio(
+        Environ::GetString("MOONCAKE_LOG_COMPACTION_MIN_RECLAIM_RATIO", ""),
+        config.compaction_min_reclaim_ratio);
+
+    const auto sync_policy =
+        Environ::GetString("MOONCAKE_LOG_SYNC_POLICY", "record");
+    if (sync_policy == "batch") {
+        config.sync_policy = LogStructuredSyncPolicy::kBatch;
+    } else if (sync_policy == "none") {
+        config.sync_policy = LogStructuredSyncPolicy::kNone;
+    } else {
+        config.sync_policy = LogStructuredSyncPolicy::kRecord;
+    }
+
+    const auto compaction_policy =
+        Environ::GetString("MOONCAKE_LOG_COMPACTION_POLICY", "none");
+    if (compaction_policy == "reclaim_only") {
+        config.compaction_policy = LogStructuredCompactionPolicy::kReclaimOnly;
+    } else if (compaction_policy == "tiered") {
+        config.compaction_policy = LogStructuredCompactionPolicy::kTiered;
+    } else {
+        config.compaction_policy = LogStructuredCompactionPolicy::kNone;
+    }
+    return config;
+}
+
+bool LogStructuredBackendConfig::Validate() const {
+    return segment_size_bytes > 0 && compaction_interval_ms > 0 &&
+           compaction_fanout >= 2 && compaction_max_levels > 0 &&
+           compaction_max_sources > 0 && compaction_max_bytes_per_round > 0 &&
+           compaction_max_target_bytes >= segment_size_bytes &&
+           compaction_min_reclaim_ratio >= 0.0 &&
+           compaction_min_reclaim_ratio <= 1.0;
+}
+
 LogStructuredStorageBackend::LogStructuredStorageBackend(
-    const FileStorageConfig& config)
-    : StorageBackendInterface(config) {}
+    const FileStorageConfig& config, LogStructuredBackendConfig backend_config)
+    : StorageBackendInterface(config),
+      backend_config_(std::move(backend_config)) {}
+
+LogStructuredStorageBackend::~LogStructuredStorageBackend() {
+    if (compaction_thread_.joinable()) {
+        compaction_thread_.request_stop();
+        compaction_wakeup_.notify_all();
+        compaction_thread_.join();
+    }
+}
 
 ErrorCode LogStructuredStorageBackend::ToWriteError(
     logstructured::StoreError error) {
@@ -71,20 +152,30 @@ tl::expected<std::string, ErrorCode> LogStructuredStorageBackend::ConcatSlices(
 tl::expected<void, ErrorCode> LogStructuredStorageBackend::Init() {
     std::lock_guard lock(mutex_);
     if (initialized_.load(std::memory_order_acquire)) return {};
+    if (!backend_config_.Validate()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
     const std::filesystem::path root =
         std::filesystem::path(file_storage_config_.storage_filepath) /
         "log_structured";
     auto store = logstructured::LogStructuredStore::Open(
         {.root_path = root.string(),
-         .max_segment_bytes = kDefaultSegmentBytes,
-         .sync_data = true,
-         .sync_wal = true});
+         .max_segment_bytes = backend_config_.segment_size_bytes,
+         .sync_data =
+             backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
+         .sync_wal =
+             backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord});
     if (!store) {
         LOG(ERROR) << "Failed to initialize log-structured backend at " << root;
         return tl::make_unexpected(ToWriteError(store.error()));
     }
     store_ = std::move(store.value());
     initialized_.store(true, std::memory_order_release);
+    if (backend_config_.compaction_policy !=
+        LogStructuredCompactionPolicy::kNone) {
+        compaction_thread_ = std::jthread(
+            [this](std::stop_token token) { CompactionLoop(token); });
+    }
     return {};
 }
 
@@ -125,6 +216,13 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
     if (prepared.empty()) {
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
+    if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
+        !store_->Sync()) {
+        for (const auto& write : prepared) {
+            static_cast<void>(store_->AbortPut(write.identity, write.sequence));
+        }
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
 
     if (complete_handler) {
         const auto result = complete_handler(keys, metadatas);
@@ -139,6 +237,21 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
         auto committed = store_->CommitPut(write.identity, write.sequence);
         if (!committed) {
             return tl::make_unexpected(ToWriteError(committed.error()));
+        }
+    }
+    if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
+        !store_->Sync()) {
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+    committed_since_checkpoint_ += prepared.size();
+    if (backend_config_.checkpoint_interval_records != 0 &&
+        committed_since_checkpoint_ >=
+            backend_config_.checkpoint_interval_records) {
+        auto checkpointed = store_->Checkpoint();
+        if (!checkpointed) {
+            LOG(ERROR) << "Failed to checkpoint log-structured backend";
+        } else {
+            committed_since_checkpoint_ = 0;
         }
     }
     return static_cast<int64_t>(prepared.size());
@@ -221,6 +334,68 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::ScanMeta(
         if (result != ErrorCode::OK) return tl::make_unexpected(result);
     }
     return {};
+}
+
+void LogStructuredStorageBackend::CompactionLoop(std::stop_token stop_token) {
+    std::mutex wait_mutex;
+    std::unique_lock wait_lock(wait_mutex);
+    while (!stop_token.stop_requested()) {
+        compaction_wakeup_.wait_for(
+            wait_lock, stop_token,
+            std::chrono::milliseconds(backend_config_.compaction_interval_ms),
+            [] { return false; });
+        if (stop_token.stop_requested()) break;
+        auto compacted = store_->CompactOnce(
+            {.max_source_segments = backend_config_.compaction_max_sources,
+             .max_input_bytes = backend_config_.compaction_max_bytes_per_round,
+             .max_target_bytes = backend_config_.compaction_max_target_bytes,
+             .fanout = backend_config_.compaction_fanout,
+             .max_levels = backend_config_.compaction_max_levels,
+             .min_reclaim_ratio = backend_config_.compaction_min_reclaim_ratio,
+             .enable_tiering = backend_config_.compaction_policy ==
+                               LogStructuredCompactionPolicy::kTiered});
+        if (!compacted) {
+            LOG(ERROR) << "Log-structured compaction failed";
+        }
+    }
+}
+
+void LogStructuredStorageBackend::RemoveAll() {
+    std::lock_guard lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !store_) return;
+
+    for (const auto& entry : store_->SnapshotCurrentIndex()) {
+        auto deleted = store_->Delete(entry.identity);
+        if (!deleted) {
+            LOG(ERROR) << "Failed to tombstone object during RemoveAll: "
+                       << entry.identity.object_key;
+            return;
+        }
+    }
+    if (!store_->SealActiveSegment()) {
+        LOG(ERROR) << "Failed to seal active segment during RemoveAll";
+        return;
+    }
+
+    const logstructured::CompactionOptions options{
+        .max_source_segments = std::numeric_limits<size_t>::max(),
+        .max_input_bytes = std::numeric_limits<uint64_t>::max(),
+        .max_target_bytes = backend_config_.compaction_max_target_bytes,
+        .fanout = backend_config_.compaction_fanout,
+        .max_levels = backend_config_.compaction_max_levels,
+        .min_reclaim_ratio = 0.0,
+        .enable_tiering = false};
+    while (true) {
+        auto compacted = store_->CompactOnce(options);
+        if (!compacted) {
+            LOG(ERROR) << "Failed to reclaim segments during RemoveAll";
+            return;
+        }
+        if (compacted->source_segments == 0) break;
+    }
+    if (!store_->Checkpoint()) {
+        LOG(ERROR) << "Failed to checkpoint RemoveAll";
+    }
 }
 
 void LogStructuredStorageBackend::SetTestFailurePredicate(

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -487,6 +487,23 @@ void LogStructuredStorageBackend::RemoveAll() {
     }
 }
 
+std::optional<StorageBackendStats> LogStructuredStorageBackend::SnapshotStats()
+    const {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return std::nullopt;
+    }
+    std::lock_guard lock(mutex_);
+    if (!store_) return std::nullopt;
+    const auto stats = store_->SnapshotStats();
+    return StorageBackendStats{.physical_bytes = stats.physical_bytes,
+                               .live_record_bytes = stats.live_record_bytes,
+                               .logical_value_bytes = stats.logical_value_bytes,
+                               .reclaimable_bytes = stats.reclaimable_bytes,
+                               .active_segments = stats.active_segments,
+                               .sealed_segments = stats.sealed_segments,
+                               .retired_segments = stats.retired_segments};
+}
+
 void LogStructuredStorageBackend::SetTestFailurePredicate(
     std::function<bool(const std::string& key)> predicate) {
     std::lock_guard lock(mutex_);

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -43,6 +43,8 @@ LogStructuredBackendConfig LogStructuredBackendConfig::FromEnvironment() {
     LogStructuredBackendConfig config;
     config.segment_size_bytes = Environ::GetUInt64(
         "MOONCAKE_LOG_SEGMENT_SIZE_BYTES", config.segment_size_bytes);
+    config.payload_write_parallelism = static_cast<size_t>(Environ::GetUInt64(
+        "MOONCAKE_LOG_WRITE_PARALLELISM", config.payload_write_parallelism));
     config.checkpoint_interval_records = Environ::GetUInt64(
         "MOONCAKE_LOG_CHECKPOINT_INTERVAL", config.checkpoint_interval_records);
     config.compaction_interval_ms = Environ::GetUInt64(
@@ -92,9 +94,10 @@ LogStructuredBackendConfig LogStructuredBackendConfig::FromEnvironment() {
 }
 
 bool LogStructuredBackendConfig::Validate() const {
-    return segment_size_bytes > 0 && compaction_interval_ms > 0 &&
-           compaction_fanout >= 2 && compaction_max_levels > 0 &&
-           compaction_max_sources > 0 && compaction_max_input_bytes > 0 &&
+    return segment_size_bytes > 0 && payload_write_parallelism > 0 &&
+           compaction_interval_ms > 0 && compaction_fanout >= 2 &&
+           compaction_max_levels > 0 && compaction_max_sources > 0 &&
+           compaction_max_input_bytes > 0 &&
            compaction_max_target_bytes >= segment_size_bytes &&
            compaction_min_reclaim_ratio >= 0.0 &&
            compaction_min_reclaim_ratio <= 1.0;
@@ -188,7 +191,9 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::Init() {
          .sync_data =
              backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
          .sync_wal =
-             backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord});
+             backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
+         .payload_write_parallelism =
+             backend_config_.payload_write_parallelism});
     if (!store) {
         LOG(ERROR) << "Failed to initialize log-structured backend at " << root;
         return tl::make_unexpected(ToWriteError(store.error()));
@@ -220,9 +225,10 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
     std::vector<logstructured::PreparedWrite> prepared;
     std::optional<ErrorCode> first_prepare_error;
     std::vector<std::string> keys;
+    std::vector<std::string> values;
     std::vector<StorageObjectMetadata> metadatas;
-    prepared.reserve(batch_object.size());
     keys.reserve(batch_object.size());
+    values.reserve(batch_object.size());
     metadatas.reserve(batch_object.size());
     for (const auto& [key, slices] : batch_object) {
         if (test_failure_predicate_ && test_failure_predicate_(key)) {
@@ -234,45 +240,48 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
             first_prepare_error = value.error();
             continue;
         }
-        auto [tenant_id, object_key] = SplitStorageKey(key);
-        auto write = store_->PreparePut(std::move(tenant_id),
-                                        std::move(object_key), *value);
-        if (!write) {
-            first_prepare_error = ToWriteError(write.error());
-            continue;
-        }
-        metadatas.push_back(StorageObjectMetadata{
-            -1, 0, static_cast<int64_t>(key.size()),
-            static_cast<int64_t>(write->physical.value_length), ""});
         keys.push_back(key);
-        prepared.push_back(std::move(write.value()));
+        values.push_back(std::move(value.value()));
     }
-    if (prepared.empty()) {
+    if (keys.empty()) {
         return tl::make_unexpected(
             first_prepare_error.value_or(ErrorCode::FILE_WRITE_FAIL));
     }
+
+    std::vector<logstructured::PutRequest> requests;
+    requests.reserve(keys.size());
+    for (size_t index = 0; index < keys.size(); ++index) {
+        auto [tenant_id, object_key] = SplitStorageKey(keys[index]);
+        requests.push_back({.tenant_id = std::move(tenant_id),
+                            .object_key = std::move(object_key),
+                            .value = values[index]});
+    }
+    auto batch = store_->PreparePutBatch(requests);
+    if (!batch) {
+        return tl::make_unexpected(ToWriteError(batch.error()));
+    }
+    prepared = std::move(batch.value());
+    for (size_t index = 0; index < prepared.size(); ++index) {
+        metadatas.push_back(StorageObjectMetadata{
+            -1, 0, static_cast<int64_t>(keys[index].size()),
+            static_cast<int64_t>(prepared[index].physical.value_length), ""});
+    }
     if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
         !store_->Sync()) {
-        for (const auto& write : prepared) {
-            static_cast<void>(store_->AbortPut(write.identity, write.sequence));
-        }
+        static_cast<void>(store_->AbortPuts(prepared));
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
 
     if (complete_handler) {
         const auto result = complete_handler(keys, metadatas);
         if (result != ErrorCode::OK) {
-            for (const auto& write : prepared) {
-                store_->AbortPut(write.identity, write.sequence);
-            }
+            static_cast<void>(store_->AbortPuts(prepared));
             return tl::make_unexpected(result);
         }
     }
-    for (const auto& write : prepared) {
-        auto committed = store_->CommitPut(write.identity, write.sequence);
-        if (!committed) {
-            return tl::make_unexpected(ToWriteError(committed.error()));
-        }
+    auto committed = store_->CommitPuts(prepared);
+    if (!committed) {
+        return tl::make_unexpected(ToWriteError(committed.error()));
     }
     if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
         !store_->Sync()) {

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -1,0 +1,232 @@
+#include "storage/local/log_structured/log_structured_backend.h"
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+
+#include <glog/logging.h>
+
+#include "tenant_id.h"
+
+namespace mooncake {
+namespace {
+
+constexpr uint64_t kDefaultSegmentBytes = 256ULL * 1024 * 1024;
+
+std::pair<std::string, std::string> SplitStorageKey(
+    std::string_view storage_key) {
+    auto [tenant_id, object_key] = TenantId::ParseScopedKey(storage_key);
+    return {tenant_id.value(), std::move(object_key)};
+}
+
+}  // namespace
+
+LogStructuredStorageBackend::LogStructuredStorageBackend(
+    const FileStorageConfig& config)
+    : StorageBackendInterface(config) {}
+
+ErrorCode LogStructuredStorageBackend::ToWriteError(
+    logstructured::StoreError error) {
+    if (error == logstructured::StoreError::kInvalidArgument) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (error == logstructured::StoreError::kNotFound) {
+        return ErrorCode::OBJECT_NOT_FOUND;
+    }
+    return ErrorCode::FILE_WRITE_FAIL;
+}
+
+ErrorCode LogStructuredStorageBackend::ToReadError(
+    logstructured::StoreError error) {
+    if (error == logstructured::StoreError::kNotFound) {
+        return ErrorCode::OBJECT_NOT_FOUND;
+    }
+    if (error == logstructured::StoreError::kInvalidArgument) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    return ErrorCode::FILE_READ_FAIL;
+}
+
+tl::expected<std::string, ErrorCode> LogStructuredStorageBackend::ConcatSlices(
+    const std::vector<Slice>& slices) {
+    size_t total_size = 0;
+    for (const auto& slice : slices) {
+        if (slice.size > std::numeric_limits<size_t>::max() - total_size) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        total_size += slice.size;
+    }
+    std::string value;
+    value.reserve(total_size);
+    for (const auto& slice : slices) {
+        if (slice.size != 0 && slice.ptr == nullptr) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        value.append(static_cast<const char*>(slice.ptr), slice.size);
+    }
+    return value;
+}
+
+tl::expected<void, ErrorCode> LogStructuredStorageBackend::Init() {
+    std::lock_guard lock(mutex_);
+    if (initialized_.load(std::memory_order_acquire)) return {};
+    const std::filesystem::path root =
+        std::filesystem::path(file_storage_config_.storage_filepath) /
+        "log_structured";
+    auto store = logstructured::LogStructuredStore::Open(
+        {.root_path = root.string(),
+         .max_segment_bytes = kDefaultSegmentBytes,
+         .sync_data = true,
+         .sync_wal = true});
+    if (!store) {
+        LOG(ERROR) << "Failed to initialize log-structured backend at " << root;
+        return tl::make_unexpected(ToWriteError(store.error()));
+    }
+    store_ = std::move(store.value());
+    initialized_.store(true, std::memory_order_release);
+    return {};
+}
+
+tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
+    const std::unordered_map<std::string, std::vector<Slice>>& batch_object,
+    std::function<ErrorCode(const std::vector<std::string>&,
+                            std::vector<StorageObjectMetadata>&)>
+        complete_handler,
+    EvictionHandler) {
+    std::lock_guard lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !store_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (batch_object.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_KEY);
+    }
+
+    std::vector<logstructured::PreparedWrite> prepared;
+    std::vector<std::string> keys;
+    std::vector<StorageObjectMetadata> metadatas;
+    prepared.reserve(batch_object.size());
+    keys.reserve(batch_object.size());
+    metadatas.reserve(batch_object.size());
+    for (const auto& [key, slices] : batch_object) {
+        if (test_failure_predicate_ && test_failure_predicate_(key)) continue;
+        auto value = ConcatSlices(slices);
+        if (!value) continue;
+        auto [tenant_id, object_key] = SplitStorageKey(key);
+        auto write = store_->PreparePut(std::move(tenant_id),
+                                        std::move(object_key), *value);
+        if (!write) continue;
+        metadatas.push_back(StorageObjectMetadata{
+            -1, 0, static_cast<int64_t>(key.size()),
+            static_cast<int64_t>(write->physical.value_length), ""});
+        keys.push_back(key);
+        prepared.push_back(std::move(write.value()));
+    }
+    if (prepared.empty()) {
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+
+    if (complete_handler) {
+        const auto result = complete_handler(keys, metadatas);
+        if (result != ErrorCode::OK) {
+            for (const auto& write : prepared) {
+                store_->AbortPut(write.identity, write.sequence);
+            }
+            return tl::make_unexpected(result);
+        }
+    }
+    for (const auto& write : prepared) {
+        auto committed = store_->CommitPut(write.identity, write.sequence);
+        if (!committed) {
+            return tl::make_unexpected(ToWriteError(committed.error()));
+        }
+    }
+    return static_cast<int64_t>(prepared.size());
+}
+
+tl::expected<void, ErrorCode> LogStructuredStorageBackend::BatchLoad(
+    std::unordered_map<std::string, Slice>& batched_slices) {
+    std::lock_guard lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !store_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    for (const auto& [key, slice] : batched_slices) {
+        const auto [tenant_id, object_key] = SplitStorageKey(key);
+        auto value = store_->GetLatest(tenant_id, object_key);
+        if (!value) return tl::make_unexpected(ToReadError(value.error()));
+        if (value->size() != slice.size ||
+            (slice.size != 0 && slice.ptr == nullptr)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        if (!value->empty()) {
+            std::memcpy(slice.ptr, value->data(), value->size());
+        }
+    }
+    return {};
+}
+
+tl::expected<bool, ErrorCode> LogStructuredStorageBackend::IsExist(
+    const std::string& key) {
+    std::lock_guard lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !store_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    const auto [tenant_id, object_key] = SplitStorageKey(key);
+    return store_->ContainsLatest(tenant_id, object_key);
+}
+
+tl::expected<bool, ErrorCode>
+LogStructuredStorageBackend::IsEnableOffloading() {
+    std::lock_guard lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !store_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    const auto entries = store_->SnapshotCurrentIndex();
+    uint64_t total_size = 0;
+    for (const auto& entry : entries) {
+        total_size += entry.version.physical.value_length;
+    }
+    return entries.size() <
+               static_cast<size_t>(file_storage_config_.total_keys_limit) &&
+           total_size <
+               static_cast<uint64_t>(file_storage_config_.total_size_limit);
+}
+
+tl::expected<void, ErrorCode> LogStructuredStorageBackend::ScanMeta(
+    const std::function<ErrorCode(const std::vector<std::string>&,
+                                  std::vector<StorageObjectMetadata>&)>&
+        handler) {
+    std::lock_guard lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !store_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    std::vector<std::string> keys;
+    std::vector<StorageObjectMetadata> metadatas;
+    const size_t batch_limit = static_cast<size_t>(std::max<int64_t>(
+        1, file_storage_config_.scanmeta_iterator_keys_limit));
+    for (const auto& entry : store_->SnapshotCurrentIndex()) {
+        keys.push_back(TenantId(entry.identity.tenant_id)
+                           .MakeScopedKey(entry.identity.object_key));
+        metadatas.push_back(StorageObjectMetadata{
+            -1, 0, static_cast<int64_t>(keys.back().size()),
+            static_cast<int64_t>(entry.version.physical.value_length), ""});
+        if (keys.size() < batch_limit) continue;
+        const auto result = handler(keys, metadatas);
+        if (result != ErrorCode::OK) return tl::make_unexpected(result);
+        keys.clear();
+        metadatas.clear();
+    }
+    if (!keys.empty()) {
+        const auto result = handler(keys, metadatas);
+        if (result != ErrorCode::OK) return tl::make_unexpected(result);
+    }
+    return {};
+}
+
+void LogStructuredStorageBackend::SetTestFailurePredicate(
+    std::function<bool(const std::string& key)> predicate) {
+    std::lock_guard lock(mutex_);
+    test_failure_predicate_ = std::move(predicate);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -214,12 +214,28 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
                             std::vector<StorageObjectMetadata>&)>
         complete_handler,
     EvictionHandler) {
-    std::lock_guard lock(mutex_);
+    std::shared_lock lock(mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
     if (batch_object.empty()) {
         return tl::make_unexpected(ErrorCode::INVALID_KEY);
+    }
+
+    std::vector<size_t> key_stripes;
+    key_stripes.reserve(batch_object.size());
+    for (const auto& [key, slices] : batch_object) {
+        static_cast<void>(slices);
+        key_stripes.push_back(std::hash<std::string>{}(key) %
+                              key_mutexes_.size());
+    }
+    std::sort(key_stripes.begin(), key_stripes.end());
+    key_stripes.erase(std::unique(key_stripes.begin(), key_stripes.end()),
+                      key_stripes.end());
+    std::vector<std::unique_lock<std::mutex>> key_locks;
+    key_locks.reserve(key_stripes.size());
+    for (const size_t stripe : key_stripes) {
+        key_locks.emplace_back(key_mutexes_[stripe]);
     }
 
     std::vector<logstructured::PreparedWrite> prepared;
@@ -272,30 +288,34 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
 
-    if (complete_handler) {
-        const auto result = complete_handler(keys, metadatas);
-        if (result != ErrorCode::OK) {
-            static_cast<void>(store_->AbortPuts(prepared));
-            return tl::make_unexpected(result);
+    {
+        std::lock_guard publication_lock(publication_mutex_);
+        if (complete_handler) {
+            const auto result = complete_handler(keys, metadatas);
+            if (result != ErrorCode::OK) {
+                static_cast<void>(store_->AbortPuts(prepared));
+                return tl::make_unexpected(result);
+            }
         }
-    }
-    auto committed = store_->CommitPuts(prepared);
-    if (!committed) {
-        return tl::make_unexpected(ToWriteError(committed.error()));
+        auto committed = store_->CommitPuts(prepared);
+        if (!committed) {
+            return tl::make_unexpected(ToWriteError(committed.error()));
+        }
     }
     if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
         !store_->Sync()) {
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
-    committed_since_checkpoint_ += prepared.size();
+    const uint64_t committed = committed_since_checkpoint_.fetch_add(
+                                   prepared.size(), std::memory_order_relaxed) +
+                               prepared.size();
     if (backend_config_.checkpoint_interval_records != 0 &&
-        committed_since_checkpoint_ >=
-            backend_config_.checkpoint_interval_records) {
+        committed >= backend_config_.checkpoint_interval_records) {
         auto checkpointed = store_->Checkpoint();
         if (!checkpointed) {
             LOG(ERROR) << "Failed to checkpoint log-structured backend";
         } else {
-            committed_since_checkpoint_ = 0;
+            committed_since_checkpoint_.store(0, std::memory_order_relaxed);
         }
     }
     return static_cast<int64_t>(prepared.size());
@@ -304,6 +324,7 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
 tl::expected<void, ErrorCode> LogStructuredStorageBackend::BatchLoad(
     std::unordered_map<std::string, Slice>& batched_slices) {
     std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
@@ -321,7 +342,8 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::BatchLoad(
 
 tl::expected<bool, ErrorCode> LogStructuredStorageBackend::IsExist(
     const std::string& key) {
-    std::lock_guard lock(mutex_);
+    std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
@@ -331,7 +353,8 @@ tl::expected<bool, ErrorCode> LogStructuredStorageBackend::IsExist(
 
 tl::expected<bool, ErrorCode>
 LogStructuredStorageBackend::IsEnableOffloading() {
-    std::lock_guard lock(mutex_);
+    std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
@@ -355,7 +378,8 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::ScanMeta(
     const std::function<ErrorCode(const std::vector<std::string>&,
                                   std::vector<StorageObjectMetadata>&)>&
         handler) {
-    std::lock_guard lock(mutex_);
+    std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
     if (!initialized_.load(std::memory_order_acquire) || !store_) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
@@ -563,7 +587,7 @@ std::optional<StorageBackendStats> LogStructuredStorageBackend::SnapshotStats()
     if (!initialized_.load(std::memory_order_acquire)) {
         return std::nullopt;
     }
-    std::lock_guard lock(mutex_);
+    std::shared_lock lock(mutex_);
     if (!store_) return std::nullopt;
     const auto stats = store_->SnapshotStats();
     return StorageBackendStats{

--- a/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
+++ b/mooncake-store/src/storage/local/log_structured/log_structured_backend.cpp
@@ -97,6 +97,8 @@ bool LogStructuredBackendConfig::Validate() const {
     return segment_size_bytes > 0 && payload_write_parallelism > 0 &&
            compaction_interval_ms > 0 && compaction_fanout >= 2 &&
            compaction_max_levels > 0 && compaction_max_sources > 0 &&
+           (compaction_policy != LogStructuredCompactionPolicy::kTiered ||
+            compaction_max_sources >= compaction_fanout) &&
            compaction_max_input_bytes > 0 &&
            compaction_max_target_bytes >= segment_size_bytes &&
            compaction_min_reclaim_ratio >= 0.0 &&
@@ -192,6 +194,7 @@ tl::expected<void, ErrorCode> LogStructuredStorageBackend::Init() {
              backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
          .sync_wal =
              backend_config_.sync_policy == LogStructuredSyncPolicy::kRecord,
+         .use_uring = file_storage_config_.use_uring,
          .payload_write_parallelism =
              backend_config_.payload_write_parallelism});
     if (!store) {
@@ -277,6 +280,15 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
         return tl::make_unexpected(ToWriteError(batch.error()));
     }
     prepared = std::move(batch.value());
+    struct PreparedBatchGuard {
+        logstructured::LogStructuredStore* store;
+        const std::vector<logstructured::PreparedWrite>* writes;
+        bool active{true};
+
+        ~PreparedBatchGuard() {
+            if (active) static_cast<void>(store->AbortPuts(*writes));
+        }
+    } prepared_guard{store_.get(), &prepared};
     for (size_t index = 0; index < prepared.size(); ++index) {
         metadatas.push_back(StorageObjectMetadata{
             -1, 0, static_cast<int64_t>(keys[index].size()),
@@ -284,7 +296,6 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
     }
     if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
         !store_->Sync()) {
-        static_cast<void>(store_->AbortPuts(prepared));
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
 
@@ -293,7 +304,6 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
         if (complete_handler) {
             const auto result = complete_handler(keys, metadatas);
             if (result != ErrorCode::OK) {
-                static_cast<void>(store_->AbortPuts(prepared));
                 return tl::make_unexpected(result);
             }
         }
@@ -301,6 +311,7 @@ tl::expected<int64_t, ErrorCode> LogStructuredStorageBackend::BatchOffload(
         if (!committed) {
             return tl::make_unexpected(ToWriteError(committed.error()));
         }
+        prepared_guard.active = false;
     }
     if (backend_config_.sync_policy == LogStructuredSyncPolicy::kBatch &&
         !store_->Sync()) {

--- a/mooncake-store/src/storage/local/log_structured/metadata.cpp
+++ b/mooncake-store/src/storage/local/log_structured/metadata.cpp
@@ -1,0 +1,281 @@
+#include "storage/local/log_structured/metadata.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string_view>
+#include <type_traits>
+
+#include <ylt/struct_pack.hpp>
+
+#include "crc32c.h"
+
+namespace mooncake::logstructured {
+namespace {
+
+constexpr uint32_t kMetadataMagic = 0x444D434D;
+constexpr uint16_t kMetadataVersion = 1;
+constexpr uint64_t kMetadataCommitMagic = 0x54494D4D4F434D4DULL;
+constexpr size_t kHeaderSize = 24;
+constexpr size_t kFooterSize = 8;
+constexpr size_t kMagicOffset = 0;
+constexpr size_t kVersionOffset = 4;
+constexpr size_t kKindOffset = 6;
+constexpr size_t kPayloadLengthOffset = 8;
+constexpr size_t kPayloadChecksumOffset = 16;
+constexpr size_t kHeaderChecksumOffset = 20;
+constexpr size_t kHeaderChecksumInputSize = kHeaderChecksumOffset;
+
+enum class ArtifactKind : uint16_t {
+    kCheckpoint = 1,
+    kManifest = 2,
+};
+
+template <typename T>
+void WriteLittleEndian(char* output, T value) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned unsigned_value = static_cast<Unsigned>(value);
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        output[i] = static_cast<char>((unsigned_value >> (i * 8)) & 0xff);
+    }
+}
+
+template <typename T>
+T ReadLittleEndian(const char* input) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        value |= static_cast<Unsigned>(static_cast<unsigned char>(input[i]))
+                 << (i * 8);
+    }
+    return static_cast<T>(value);
+}
+
+bool WriteAll(int fd, const char* data, size_t length) {
+    size_t written = 0;
+    while (written < length) {
+        const ssize_t result = write(fd, data + written, length - written);
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (result == 0) return false;
+        written += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+tl::expected<void, MetadataError> SyncDirectory(const std::string& path) {
+    const int fd = open(path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd < 0) return tl::unexpected(MetadataError::kIoError);
+    const int result = fsync(fd);
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    if (result != 0) return tl::unexpected(MetadataError::kIoError);
+    return {};
+}
+
+bool IsSafeFilename(std::string_view filename) {
+    return !filename.empty() && filename != "." && filename != ".." &&
+           filename.find('/') == std::string_view::npos;
+}
+
+std::string NumberedFilename(std::string_view prefix, uint64_t generation) {
+    std::ostringstream stream;
+    stream << prefix << '-' << std::setw(20) << std::setfill('0') << generation;
+    return stream.str();
+}
+
+template <typename T>
+std::string EncodeArtifact(ArtifactKind kind, const T& value) {
+    auto payload = struct_pack::serialize<std::vector<char>>(value);
+    std::string encoded(kHeaderSize + payload.size() + kFooterSize, '\0');
+    WriteLittleEndian<uint32_t>(encoded.data() + kMagicOffset, kMetadataMagic);
+    WriteLittleEndian<uint16_t>(encoded.data() + kVersionOffset,
+                                kMetadataVersion);
+    WriteLittleEndian<uint16_t>(encoded.data() + kKindOffset,
+                                static_cast<uint16_t>(kind));
+    WriteLittleEndian<uint64_t>(encoded.data() + kPayloadLengthOffset,
+                                payload.size());
+    WriteLittleEndian<uint32_t>(encoded.data() + kPayloadChecksumOffset,
+                                Crc32cValue(payload.data(), payload.size()));
+    WriteLittleEndian<uint32_t>(
+        encoded.data() + kHeaderChecksumOffset,
+        Crc32cValue(encoded.data(), kHeaderChecksumInputSize));
+    std::copy(payload.begin(), payload.end(), encoded.begin() + kHeaderSize);
+    WriteLittleEndian<uint64_t>(encoded.data() + encoded.size() - kFooterSize,
+                                kMetadataCommitMagic);
+    return encoded;
+}
+
+template <typename T>
+tl::expected<T, MetadataError> DecodeArtifact(std::span<const char> encoded,
+                                              ArtifactKind expected_kind) {
+    if (encoded.size() < kHeaderSize + kFooterSize ||
+        ReadLittleEndian<uint32_t>(encoded.data() + kMagicOffset) !=
+            kMetadataMagic ||
+        ReadLittleEndian<uint16_t>(encoded.data() + kVersionOffset) !=
+            kMetadataVersion ||
+        ReadLittleEndian<uint16_t>(encoded.data() + kKindOffset) !=
+            static_cast<uint16_t>(expected_kind) ||
+        Crc32cValue(encoded.data(), kHeaderChecksumInputSize) !=
+            ReadLittleEndian<uint32_t>(encoded.data() +
+                                       kHeaderChecksumOffset)) {
+        return tl::unexpected(MetadataError::kCorruptData);
+    }
+    const uint64_t payload_length =
+        ReadLittleEndian<uint64_t>(encoded.data() + kPayloadLengthOffset);
+    if (payload_length != encoded.size() - kHeaderSize - kFooterSize ||
+        ReadLittleEndian<uint64_t>(encoded.data() + encoded.size() -
+                                   kFooterSize) != kMetadataCommitMagic ||
+        Crc32cValue(encoded.data() + kHeaderSize, payload_length) !=
+            ReadLittleEndian<uint32_t>(encoded.data() +
+                                       kPayloadChecksumOffset)) {
+        return tl::unexpected(MetadataError::kCorruptData);
+    }
+    T result;
+    std::span<const char> payload(encoded.data() + kHeaderSize,
+                                  static_cast<size_t>(payload_length));
+    if (struct_pack::deserialize_to(result, payload) != struct_pack::errc::ok) {
+        return tl::unexpected(MetadataError::kCorruptData);
+    }
+    return result;
+}
+
+tl::expected<std::string, MetadataError> ReadFile(const std::string& path) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input.is_open()) return tl::unexpected(MetadataError::kNotFound);
+    const auto end = input.tellg();
+    if (end < 0 ||
+        static_cast<uint64_t>(end) >
+            static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        return tl::unexpected(MetadataError::kIoError);
+    }
+    std::string contents(static_cast<size_t>(end), '\0');
+    input.seekg(0);
+    if (!contents.empty() &&
+        !input.read(contents.data(),
+                    static_cast<std::streamsize>(contents.size()))) {
+        return tl::unexpected(MetadataError::kIoError);
+    }
+    return contents;
+}
+
+tl::expected<void, MetadataError> AtomicWrite(const std::string& root_path,
+                                              const std::string& filename,
+                                              std::string_view contents) {
+    if (!IsSafeFilename(filename)) {
+        return tl::unexpected(MetadataError::kInvalidArgument);
+    }
+    const std::string final_path = root_path + "/" + filename;
+    const std::string temporary_path = final_path + ".tmp";
+    const int fd = open(temporary_path.c_str(),
+                        O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
+    if (fd < 0) return tl::unexpected(MetadataError::kIoError);
+    bool success = WriteAll(fd, contents.data(), contents.size()) &&
+                   fsync(fd) == 0 && close(fd) == 0;
+    if (!success) {
+        const int saved_errno = errno;
+        close(fd);
+        unlink(temporary_path.c_str());
+        errno = saved_errno;
+        return tl::unexpected(MetadataError::kIoError);
+    }
+    if (rename(temporary_path.c_str(), final_path.c_str()) != 0) {
+        unlink(temporary_path.c_str());
+        return tl::unexpected(MetadataError::kIoError);
+    }
+    return SyncDirectory(root_path);
+}
+
+}  // namespace
+
+tl::expected<std::string, MetadataError> WriteCheckpoint(
+    const std::string& root_path, uint64_t generation,
+    const CheckpointState& checkpoint) {
+    if (checkpoint.format_version != 1) {
+        return tl::unexpected(MetadataError::kInvalidArgument);
+    }
+    const std::string filename = NumberedFilename("CHECKPOINT", generation);
+    auto written =
+        AtomicWrite(root_path, filename,
+                    EncodeArtifact(ArtifactKind::kCheckpoint, checkpoint));
+    if (!written) return tl::unexpected(written.error());
+    return filename;
+}
+
+tl::expected<CheckpointState, MetadataError> LoadCheckpoint(
+    const std::string& root_path, const std::string& checkpoint_file) {
+    if (!IsSafeFilename(checkpoint_file)) {
+        return tl::unexpected(MetadataError::kInvalidArgument);
+    }
+    auto contents = ReadFile(root_path + "/" + checkpoint_file);
+    if (!contents) return tl::unexpected(contents.error());
+    auto checkpoint = DecodeArtifact<CheckpointState>(
+        std::span<const char>(contents->data(), contents->size()),
+        ArtifactKind::kCheckpoint);
+    if (!checkpoint || checkpoint->format_version != 1) {
+        return tl::unexpected(MetadataError::kCorruptData);
+    }
+    return checkpoint.value();
+}
+
+tl::expected<void, MetadataError> PublishManifest(
+    const std::string& root_path, const ManifestState& manifest) {
+    if (manifest.format_version != 1 || manifest.generation == 0 ||
+        !IsSafeFilename(manifest.checkpoint_file) ||
+        !IsSafeFilename(manifest.wal_file)) {
+        return tl::unexpected(MetadataError::kInvalidArgument);
+    }
+    const std::string manifest_file =
+        NumberedFilename("MANIFEST", manifest.generation);
+    auto written =
+        AtomicWrite(root_path, manifest_file,
+                    EncodeArtifact(ArtifactKind::kManifest, manifest));
+    if (!written) return written;
+    return AtomicWrite(root_path, "CURRENT", manifest_file + "\n");
+}
+
+tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
+    const std::string& root_path) {
+    auto current = ReadFile(root_path + "/CURRENT");
+    if (!current) return tl::unexpected(current.error());
+    while (!current->empty() &&
+           (current->back() == '\n' || current->back() == '\r')) {
+        current->pop_back();
+    }
+    if (!IsSafeFilename(*current) ||
+        !std::string_view(*current).starts_with("MANIFEST-")) {
+        return tl::unexpected(MetadataError::kCorruptData);
+    }
+    auto contents = ReadFile(root_path + "/" + *current);
+    if (!contents) return tl::unexpected(contents.error());
+    auto manifest = DecodeArtifact<ManifestState>(
+        std::span<const char>(contents->data(), contents->size()),
+        ArtifactKind::kManifest);
+    if (!manifest || manifest->format_version != 1) {
+        return tl::unexpected(MetadataError::kCorruptData);
+    }
+    return manifest.value();
+}
+
+tl::expected<void, MetadataError> RemoveFileDurably(
+    const std::string& root_path, const std::string& filename) {
+    if (!IsSafeFilename(filename)) {
+        return tl::unexpected(MetadataError::kInvalidArgument);
+    }
+    if (unlink((root_path + "/" + filename).c_str()) != 0 && errno != ENOENT) {
+        return tl::unexpected(MetadataError::kIoError);
+    }
+    return SyncDirectory(root_path);
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/metadata.cpp
+++ b/mooncake-store/src/storage/local/log_structured/metadata.cpp
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <filesystem>
@@ -86,6 +87,15 @@ tl::expected<void, MetadataError> SyncDirectory(const std::string& path) {
 bool IsSafeFilename(std::string_view filename) {
     return !filename.empty() && filename != "." && filename != ".." &&
            filename.find('/') == std::string_view::npos;
+}
+
+bool IsNumberedArtifact(std::string_view filename, std::string_view prefix) {
+    if (!filename.starts_with(prefix) || filename.size() == prefix.size()) {
+        return false;
+    }
+    filename.remove_prefix(prefix.size());
+    return std::all_of(filename.begin(), filename.end(),
+                       [](char value) { return value >= '0' && value <= '9'; });
 }
 
 std::string NumberedFilename(std::string_view prefix, uint64_t generation) {
@@ -229,7 +239,8 @@ tl::expected<CheckpointState, MetadataError> LoadCheckpoint(
 }
 
 tl::expected<void, MetadataError> PublishManifest(
-    const std::string& root_path, const ManifestState& manifest) {
+    const std::string& root_path, const ManifestState& manifest,
+    std::function<bool()> fail_before_current) {
     if (manifest.format_version != 1 || manifest.generation == 0 ||
         !IsSafeFilename(manifest.checkpoint_file) ||
         !IsSafeFilename(manifest.wal_file)) {
@@ -241,6 +252,9 @@ tl::expected<void, MetadataError> PublishManifest(
         AtomicWrite(root_path, manifest_file,
                     EncodeArtifact(ArtifactKind::kManifest, manifest));
     if (!written) return written;
+    if (fail_before_current && fail_before_current()) {
+        return tl::unexpected(MetadataError::kIoError);
+    }
     return AtomicWrite(root_path, "CURRENT", manifest_file + "\n");
 }
 
@@ -265,6 +279,52 @@ tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
         return tl::unexpected(MetadataError::kCorruptData);
     }
     return manifest.value();
+}
+
+tl::expected<void, MetadataError> CleanupMetadataArtifacts(
+    const std::string& root_path, uint64_t current_generation,
+    const std::string& current_wal_file) {
+    if (!IsSafeFilename(current_wal_file)) {
+        return tl::unexpected(MetadataError::kInvalidArgument);
+    }
+    const std::string current_manifest =
+        current_generation == 0
+            ? std::string{}
+            : NumberedFilename("MANIFEST", current_generation);
+    const std::string current_checkpoint =
+        current_generation == 0
+            ? std::string{}
+            : NumberedFilename("CHECKPOINT", current_generation);
+    std::error_code error;
+    bool removed_any = false;
+    for (const auto& entry :
+         std::filesystem::directory_iterator(root_path, error)) {
+        if (error) return tl::unexpected(MetadataError::kIoError);
+        if (!entry.is_regular_file(error)) {
+            error.clear();
+            continue;
+        }
+        const std::string filename = entry.path().filename().string();
+        const bool temporary = filename.ends_with(".tmp");
+        std::string_view stable_name = filename;
+        if (temporary && stable_name.ends_with(".tmp")) {
+            stable_name.remove_suffix(4);
+        }
+        const bool managed = IsNumberedArtifact(stable_name, "MANIFEST-") ||
+                             IsNumberedArtifact(stable_name, "CHECKPOINT-") ||
+                             IsNumberedArtifact(stable_name, "WAL-") ||
+                             filename == "CURRENT.tmp";
+        if (!managed || filename == "CURRENT" || filename == current_manifest ||
+            filename == current_checkpoint || filename == current_wal_file) {
+            continue;
+        }
+        if (unlink(entry.path().c_str()) != 0 && errno != ENOENT) {
+            return tl::unexpected(MetadataError::kIoError);
+        }
+        removed_any = true;
+    }
+    if (!removed_any) return {};
+    return SyncDirectory(root_path);
 }
 
 tl::expected<void, MetadataError> RemoveFileDurably(

--- a/mooncake-store/src/storage/local/log_structured/metadata.cpp
+++ b/mooncake-store/src/storage/local/log_structured/metadata.cpp
@@ -179,9 +179,10 @@ tl::expected<std::string, MetadataError> ReadFile(const std::string& path) {
     return contents;
 }
 
-tl::expected<void, MetadataError> AtomicWrite(const std::string& root_path,
-                                              const std::string& filename,
-                                              std::string_view contents) {
+tl::expected<void, MetadataError> AtomicWrite(
+    const std::string& root_path, const std::string& filename,
+    std::string_view contents, bool publication_pointer = false,
+    std::function<bool()> fail_after_rename = {}) {
     if (!IsSafeFilename(filename)) {
         return tl::unexpected(MetadataError::kInvalidArgument);
     }
@@ -190,11 +191,11 @@ tl::expected<void, MetadataError> AtomicWrite(const std::string& root_path,
     const int fd = open(temporary_path.c_str(),
                         O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
     if (fd < 0) return tl::unexpected(MetadataError::kIoError);
-    bool success = WriteAll(fd, contents.data(), contents.size()) &&
-                   fsync(fd) == 0 && close(fd) == 0;
-    if (!success) {
+    const bool data_written = WriteAll(fd, contents.data(), contents.size());
+    const bool data_synced = data_written && fsync(fd) == 0;
+    const int close_result = close(fd);
+    if (!data_synced || close_result != 0) {
         const int saved_errno = errno;
-        close(fd);
         unlink(temporary_path.c_str());
         errno = saved_errno;
         return tl::unexpected(MetadataError::kIoError);
@@ -203,7 +204,16 @@ tl::expected<void, MetadataError> AtomicWrite(const std::string& root_path,
         unlink(temporary_path.c_str());
         return tl::unexpected(MetadataError::kIoError);
     }
-    return SyncDirectory(root_path);
+    if (fail_after_rename && fail_after_rename()) {
+        return tl::unexpected(publication_pointer
+                                  ? MetadataError::kPublicationUncertain
+                                  : MetadataError::kIoError);
+    }
+    auto synced = SyncDirectory(root_path);
+    if (!synced && publication_pointer) {
+        return tl::unexpected(MetadataError::kPublicationUncertain);
+    }
+    return synced;
 }
 
 }  // namespace
@@ -211,7 +221,7 @@ tl::expected<void, MetadataError> AtomicWrite(const std::string& root_path,
 tl::expected<std::string, MetadataError> WriteCheckpoint(
     const std::string& root_path, uint64_t generation,
     const CheckpointState& checkpoint) {
-    if (checkpoint.format_version != 1) {
+    if (checkpoint.format_version != 1 || generation == 0) {
         return tl::unexpected(MetadataError::kInvalidArgument);
     }
     const std::string filename = NumberedFilename("CHECKPOINT", generation);
@@ -240,10 +250,14 @@ tl::expected<CheckpointState, MetadataError> LoadCheckpoint(
 
 tl::expected<void, MetadataError> PublishManifest(
     const std::string& root_path, const ManifestState& manifest,
-    std::function<bool()> fail_before_current) {
+    std::function<bool()> fail_before_current,
+    std::function<bool()> fail_after_current_rename) {
     if (manifest.format_version != 1 || manifest.generation == 0 ||
         !IsSafeFilename(manifest.checkpoint_file) ||
-        !IsSafeFilename(manifest.wal_file)) {
+        !IsSafeFilename(manifest.wal_file) ||
+        manifest.checkpoint_file !=
+            NumberedFilename("CHECKPOINT", manifest.generation) ||
+        !IsNumberedArtifact(manifest.wal_file, "WAL-")) {
         return tl::unexpected(MetadataError::kInvalidArgument);
     }
     const std::string manifest_file =
@@ -255,7 +269,8 @@ tl::expected<void, MetadataError> PublishManifest(
     if (fail_before_current && fail_before_current()) {
         return tl::unexpected(MetadataError::kIoError);
     }
-    return AtomicWrite(root_path, "CURRENT", manifest_file + "\n");
+    return AtomicWrite(root_path, "CURRENT", manifest_file + "\n", true,
+                       std::move(fail_after_current_rename));
 }
 
 tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
@@ -275,7 +290,12 @@ tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
     auto manifest = DecodeArtifact<ManifestState>(
         std::span<const char>(contents->data(), contents->size()),
         ArtifactKind::kManifest);
-    if (!manifest || manifest->format_version != 1) {
+    if (!manifest || manifest->format_version != 1 ||
+        manifest->generation == 0 ||
+        *current != NumberedFilename("MANIFEST", manifest->generation) ||
+        manifest->checkpoint_file !=
+            NumberedFilename("CHECKPOINT", manifest->generation) ||
+        !IsNumberedArtifact(manifest->wal_file, "WAL-")) {
         return tl::unexpected(MetadataError::kCorruptData);
     }
     return manifest.value();
@@ -284,7 +304,8 @@ tl::expected<ManifestState, MetadataError> LoadCurrentManifest(
 tl::expected<void, MetadataError> CleanupMetadataArtifacts(
     const std::string& root_path, uint64_t current_generation,
     const std::string& current_wal_file) {
-    if (!IsSafeFilename(current_wal_file)) {
+    if (!IsSafeFilename(current_wal_file) ||
+        !IsNumberedArtifact(current_wal_file, "WAL-")) {
         return tl::unexpected(MetadataError::kInvalidArgument);
     }
     const std::string current_manifest =

--- a/mooncake-store/src/storage/local/log_structured/record_format.cpp
+++ b/mooncake-store/src/storage/local/log_structured/record_format.cpp
@@ -203,6 +203,9 @@ tl::expected<RecordHeader, DecodeError> DecodeRecordHeader(
         expected_header_checksum) {
         return tl::unexpected(DecodeError::kHeaderChecksumMismatch);
     }
+    if (ReadLittleEndian<uint32_t>(bytes.data() + kHeaderReservedOffset) != 0) {
+        return tl::unexpected(DecodeError::kInvalidFlags);
+    }
 
     RecordHeader header;
     header.kind = kind;

--- a/mooncake-store/src/storage/local/log_structured/record_format.cpp
+++ b/mooncake-store/src/storage/local/log_structured/record_format.cpp
@@ -1,0 +1,285 @@
+#include "storage/local/log_structured/record_format.h"
+
+#include <array>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "crc32c.h"
+
+namespace mooncake::logstructured {
+namespace {
+
+constexpr size_t kMagicOffset = 0;
+constexpr size_t kVersionOffset = 4;
+constexpr size_t kKindOffset = 6;
+constexpr size_t kTotalLengthOffset = 8;
+constexpr size_t kSequenceOffset = 16;
+constexpr size_t kIncarnationHighOffset = 24;
+constexpr size_t kIncarnationLowOffset = 32;
+constexpr size_t kTenantLengthOffset = 40;
+constexpr size_t kKeyLengthOffset = 44;
+constexpr size_t kValueLengthOffset = 48;
+constexpr size_t kHeaderChecksumOffset = 56;
+constexpr size_t kHeaderReservedOffset = 60;
+constexpr size_t kHeaderChecksumInputSize = kHeaderChecksumOffset;
+
+constexpr size_t kFooterLengthOffset = 0;
+constexpr size_t kFooterPayloadChecksumOffset = 8;
+constexpr size_t kFooterChecksumOffset = 12;
+constexpr size_t kFooterMagicOffset = 16;
+constexpr size_t kFooterChecksumInputSize = kFooterChecksumOffset;
+
+template <typename T>
+void WriteLittleEndian(char* output, T value) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned unsigned_value = static_cast<Unsigned>(value);
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        output[i] = static_cast<char>((unsigned_value >> (i * 8)) & 0xff);
+    }
+}
+
+template <typename T>
+T ReadLittleEndian(const char* input) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        value |= static_cast<Unsigned>(static_cast<unsigned char>(input[i]))
+                 << (i * 8);
+    }
+    return static_cast<T>(value);
+}
+
+bool IsKnownKind(RecordKind kind) {
+    return kind == RecordKind::kValue || kind == RecordKind::kTombstone ||
+           kind == RecordKind::kCompactionCopy;
+}
+
+tl::expected<uint64_t, DecodeError> CheckedRecordSize(uint32_t tenant_length,
+                                                      uint32_t key_length,
+                                                      uint64_t value_length) {
+    constexpr uint64_t kFixedSize = kRecordHeaderSize + kRecordFooterSize;
+    if (value_length > std::numeric_limits<uint64_t>::max() - kFixedSize ||
+        tenant_length >
+            std::numeric_limits<uint64_t>::max() - kFixedSize - value_length ||
+        key_length > std::numeric_limits<uint64_t>::max() - kFixedSize -
+                         value_length - tenant_length) {
+        return tl::unexpected(DecodeError::kInvalidLength);
+    }
+    const uint64_t unaligned =
+        kRecordHeaderSize + tenant_length + key_length + value_length;
+    if (unaligned > std::numeric_limits<uint64_t>::max() -
+                        (kRecordAlignment - 1) - kRecordFooterSize) {
+        return tl::unexpected(DecodeError::kInvalidLength);
+    }
+    const uint64_t aligned =
+        (unaligned + kRecordAlignment - 1) & ~(kRecordAlignment - 1);
+    return aligned + kRecordFooterSize;
+}
+
+}  // namespace
+
+uint64_t AlignedRecordSize(uint32_t tenant_length, uint32_t key_length,
+                           uint64_t value_length) {
+    auto result = CheckedRecordSize(tenant_length, key_length, value_length);
+    return result ? result.value() : 0;
+}
+
+tl::expected<EncodedRecordEnvelope, DecodeError> EncodeRecordEnvelope(
+    const RecordIdentity& identity, std::string_view value, RecordKind kind,
+    uint64_t sequence) {
+    if (!IsKnownKind(kind)) {
+        return tl::unexpected(DecodeError::kInvalidFlags);
+    }
+    if (identity.tenant_id.size() > kMaxTenantLength ||
+        identity.object_key.size() > kMaxKeyLength ||
+        (kind == RecordKind::kTombstone && !value.empty())) {
+        return tl::unexpected(DecodeError::kInvalidLength);
+    }
+
+    const uint32_t tenant_length =
+        static_cast<uint32_t>(identity.tenant_id.size());
+    const uint32_t key_length =
+        static_cast<uint32_t>(identity.object_key.size());
+    auto size_result =
+        CheckedRecordSize(tenant_length, key_length, value.size());
+    if (!size_result) {
+        return tl::unexpected(size_result.error());
+    }
+
+    EncodedRecordEnvelope envelope;
+    envelope.total_length = size_result.value();
+    envelope.padding_length =
+        envelope.total_length - kRecordHeaderSize - identity.tenant_id.size() -
+        identity.object_key.size() - value.size() - kRecordFooterSize;
+
+    char* header = envelope.header.data();
+    WriteLittleEndian<uint32_t>(header + kMagicOffset, kRecordMagic);
+    WriteLittleEndian<uint16_t>(header + kVersionOffset, kRecordFormatVersion);
+    WriteLittleEndian<uint16_t>(header + kKindOffset,
+                                static_cast<uint16_t>(kind));
+    WriteLittleEndian<uint64_t>(header + kTotalLengthOffset,
+                                envelope.total_length);
+    WriteLittleEndian<uint64_t>(header + kSequenceOffset, sequence);
+    WriteLittleEndian<uint64_t>(header + kIncarnationHighOffset,
+                                identity.incarnation.high);
+    WriteLittleEndian<uint64_t>(header + kIncarnationLowOffset,
+                                identity.incarnation.low);
+    WriteLittleEndian<uint32_t>(header + kTenantLengthOffset, tenant_length);
+    WriteLittleEndian<uint32_t>(header + kKeyLengthOffset, key_length);
+    WriteLittleEndian<uint64_t>(header + kValueLengthOffset, value.size());
+    WriteLittleEndian<uint32_t>(header + kHeaderChecksumOffset,
+                                Crc32cValue(header, kHeaderChecksumInputSize));
+    WriteLittleEndian<uint32_t>(header + kHeaderReservedOffset, 0);
+
+    Crc32c payload_crc;
+    payload_crc.Extend(identity.tenant_id.data(), identity.tenant_id.size());
+    payload_crc.Extend(identity.object_key.data(), identity.object_key.size());
+    payload_crc.Extend(value.data(), value.size());
+
+    char* footer = envelope.footer.data();
+    WriteLittleEndian<uint64_t>(footer + kFooterLengthOffset,
+                                envelope.total_length);
+    WriteLittleEndian<uint32_t>(footer + kFooterPayloadChecksumOffset,
+                                payload_crc.Final());
+    WriteLittleEndian<uint32_t>(footer + kFooterChecksumOffset,
+                                Crc32cValue(footer, kFooterChecksumInputSize));
+    WriteLittleEndian<uint64_t>(footer + kFooterMagicOffset,
+                                kRecordCommitMagic);
+    return envelope;
+}
+
+tl::expected<std::string, DecodeError> EncodeRecord(
+    const RecordIdentity& identity, std::string_view value, RecordKind kind,
+    uint64_t sequence) {
+    auto envelope = EncodeRecordEnvelope(identity, value, kind, sequence);
+    if (!envelope) {
+        return tl::unexpected(envelope.error());
+    }
+    if (envelope->total_length >
+        static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        return tl::unexpected(DecodeError::kInvalidLength);
+    }
+
+    std::string encoded(static_cast<size_t>(envelope->total_length), '\0');
+    size_t cursor = 0;
+    std::memcpy(encoded.data() + cursor, envelope->header.data(),
+                envelope->header.size());
+    cursor += envelope->header.size();
+    std::memcpy(encoded.data() + cursor, identity.tenant_id.data(),
+                identity.tenant_id.size());
+    cursor += identity.tenant_id.size();
+    std::memcpy(encoded.data() + cursor, identity.object_key.data(),
+                identity.object_key.size());
+    cursor += identity.object_key.size();
+    std::memcpy(encoded.data() + cursor, value.data(), value.size());
+    std::memcpy(encoded.data() + encoded.size() - envelope->footer.size(),
+                envelope->footer.data(), envelope->footer.size());
+    return encoded;
+}
+
+tl::expected<RecordHeader, DecodeError> DecodeRecordHeader(
+    std::span<const char> bytes) {
+    if (bytes.size() < kRecordHeaderSize) {
+        return tl::unexpected(DecodeError::kNeedMoreData);
+    }
+    if (ReadLittleEndian<uint32_t>(bytes.data() + kMagicOffset) !=
+        kRecordMagic) {
+        return tl::unexpected(DecodeError::kInvalidMagic);
+    }
+    if (ReadLittleEndian<uint16_t>(bytes.data() + kVersionOffset) !=
+        kRecordFormatVersion) {
+        return tl::unexpected(DecodeError::kUnsupportedVersion);
+    }
+
+    const auto kind = static_cast<RecordKind>(
+        ReadLittleEndian<uint16_t>(bytes.data() + kKindOffset));
+    if (!IsKnownKind(kind)) {
+        return tl::unexpected(DecodeError::kInvalidFlags);
+    }
+    const uint32_t expected_header_checksum =
+        ReadLittleEndian<uint32_t>(bytes.data() + kHeaderChecksumOffset);
+    if (Crc32cValue(bytes.data(), kHeaderChecksumInputSize) !=
+        expected_header_checksum) {
+        return tl::unexpected(DecodeError::kHeaderChecksumMismatch);
+    }
+
+    RecordHeader header;
+    header.kind = kind;
+    header.total_length =
+        ReadLittleEndian<uint64_t>(bytes.data() + kTotalLengthOffset);
+    header.sequence =
+        ReadLittleEndian<uint64_t>(bytes.data() + kSequenceOffset);
+    header.incarnation.high =
+        ReadLittleEndian<uint64_t>(bytes.data() + kIncarnationHighOffset);
+    header.incarnation.low =
+        ReadLittleEndian<uint64_t>(bytes.data() + kIncarnationLowOffset);
+    header.tenant_length =
+        ReadLittleEndian<uint32_t>(bytes.data() + kTenantLengthOffset);
+    header.key_length =
+        ReadLittleEndian<uint32_t>(bytes.data() + kKeyLengthOffset);
+    header.value_length =
+        ReadLittleEndian<uint64_t>(bytes.data() + kValueLengthOffset);
+
+    if (header.tenant_length > kMaxTenantLength ||
+        header.key_length > kMaxKeyLength) {
+        return tl::unexpected(DecodeError::kInvalidLength);
+    }
+    auto expected_size = CheckedRecordSize(
+        header.tenant_length, header.key_length, header.value_length);
+    if (!expected_size || expected_size.value() != header.total_length ||
+        (header.kind == RecordKind::kTombstone && header.value_length != 0)) {
+        return tl::unexpected(DecodeError::kInvalidLength);
+    }
+    return header;
+}
+
+tl::expected<DecodedRecord, DecodeError> DecodeRecord(
+    std::span<const char> bytes) {
+    auto header_result = DecodeRecordHeader(bytes);
+    if (!header_result) {
+        return tl::unexpected(header_result.error());
+    }
+    const RecordHeader& header = header_result.value();
+    if (header.total_length > bytes.size()) {
+        return tl::unexpected(DecodeError::kNeedMoreData);
+    }
+
+    const char* footer = bytes.data() + header.total_length - kRecordFooterSize;
+    if (ReadLittleEndian<uint64_t>(footer + kFooterLengthOffset) !=
+            header.total_length ||
+        ReadLittleEndian<uint64_t>(footer + kFooterMagicOffset) !=
+            kRecordCommitMagic ||
+        Crc32cValue(footer, kFooterChecksumInputSize) !=
+            ReadLittleEndian<uint32_t>(footer + kFooterChecksumOffset)) {
+        return tl::unexpected(DecodeError::kFooterMismatch);
+    }
+
+    size_t cursor = kRecordHeaderSize;
+    DecodedRecord record;
+    record.identity.tenant_id.assign(bytes.data() + cursor,
+                                     header.tenant_length);
+    cursor += header.tenant_length;
+    record.identity.object_key.assign(bytes.data() + cursor, header.key_length);
+    cursor += header.key_length;
+    record.value.assign(bytes.data() + cursor,
+                        static_cast<size_t>(header.value_length));
+    record.identity.incarnation = header.incarnation;
+    record.kind = header.kind;
+    record.sequence = header.sequence;
+    record.total_length = header.total_length;
+
+    Crc32c payload_crc;
+    payload_crc.Extend(record.identity.tenant_id.data(),
+                       record.identity.tenant_id.size());
+    payload_crc.Extend(record.identity.object_key.data(),
+                       record.identity.object_key.size());
+    payload_crc.Extend(record.value.data(), record.value.size());
+    if (payload_crc.Final() !=
+        ReadLittleEndian<uint32_t>(footer + kFooterPayloadChecksumOffset)) {
+        return tl::unexpected(DecodeError::kPayloadChecksumMismatch);
+    }
+    return record;
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -98,6 +98,25 @@ SegmentWriter::~SegmentWriter() {
     }
 }
 
+SegmentReader::SegmentReader(std::string path, uint64_t segment_id, int fd)
+    : path_(std::move(path)), segment_id_(segment_id), fd_(fd) {}
+
+SegmentReader::~SegmentReader() {
+    if (fd_ >= 0) {
+        close(fd_);
+    }
+}
+
+tl::expected<std::shared_ptr<SegmentReader>, SegmentError> SegmentReader::Open(
+    std::string path, uint64_t segment_id) {
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return tl::unexpected(SegmentError::kOpenFailed);
+    }
+    return std::shared_ptr<SegmentReader>(
+        new SegmentReader(std::move(path), segment_id, fd));
+}
+
 void SegmentWriter::SetWriteFailurePredicateForTest(
     std::function<bool(std::string_view, uint64_t, size_t)> predicate) {
     std::lock_guard lock(write_failure_mutex);
@@ -454,6 +473,16 @@ tl::expected<SegmentScanResult, SegmentError> ScanSegment(
 
 tl::expected<DecodedRecord, SegmentError> ReadRecord(
     const std::string& path, const PhysicalRecord& physical) {
+    auto reader = SegmentReader::Open(path, physical.segment_id);
+    if (!reader) return tl::unexpected(reader.error());
+    return reader.value()->Read(physical);
+}
+
+tl::expected<DecodedRecord, SegmentError> SegmentReader::Read(
+    const PhysicalRecord& physical) const {
+    if (physical.segment_id != segment_id_) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
     if (physical.total_length < kRecordHeaderSize + kRecordFooterSize ||
         physical.total_length >
             static_cast<uint64_t>(std::numeric_limits<size_t>::max()) ||
@@ -462,17 +491,9 @@ tl::expected<DecodedRecord, SegmentError> ReadRecord(
                 physical.total_length) {
         return tl::unexpected(SegmentError::kInvalidArgument);
     }
-    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
-    if (fd < 0) {
-        return tl::unexpected(SegmentError::kOpenFailed);
-    }
-    struct FdGuard {
-        int fd;
-        ~FdGuard() { close(fd); }
-    } fd_guard{fd};
-
     std::string encoded(static_cast<size_t>(physical.total_length), '\0');
-    if (!PreadAll(fd, encoded.data(), encoded.size(), physical.record_offset)) {
+    if (!PreadAll(fd_, encoded.data(), encoded.size(),
+                  physical.record_offset)) {
         return tl::unexpected(SegmentError::kIoError);
     }
     auto decoded = DecodeRecord(encoded);
@@ -489,6 +510,31 @@ tl::expected<DecodedRecord, SegmentError> ReadRecord(
         return tl::unexpected(SegmentError::kInvalidArgument);
     }
     return decoded.value();
+}
+
+tl::expected<void, SegmentError> SegmentReader::ReadValue(
+    const PhysicalRecord& physical, char* value, size_t value_size) const {
+    if (physical.segment_id != segment_id_ ||
+        physical.total_length < kRecordHeaderSize + kRecordFooterSize ||
+        physical.value_length != value_size ||
+        (value_size != 0 && value == nullptr) ||
+        physical.record_offset >
+            static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+                physical.total_length ||
+        physical.value_offset < physical.record_offset + kRecordHeaderSize ||
+        physical.value_offset >
+            physical.record_offset + physical.total_length -
+                kRecordFooterSize ||
+        physical.value_length >
+            physical.record_offset + physical.total_length -
+                kRecordFooterSize - physical.value_offset) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    if (value_size != 0 &&
+        !PreadAll(fd_, value, value_size, physical.value_offset)) {
+        return tl::unexpected(SegmentError::kIoError);
+    }
+    return {};
 }
 
 tl::expected<void, SegmentError> TruncateSegment(const std::string& path,

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -5,10 +5,12 @@
 #include <unistd.h>
 
 #include <array>
+#include <atomic>
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <functional>
+#include <future>
 #include <limits>
 #include <mutex>
 #include <type_traits>
@@ -141,6 +143,7 @@ SegmentWriter::OpenForAppend(std::string path, uint64_t segment_id,
 tl::expected<PhysicalRecord, SegmentError> SegmentWriter::Append(
     const RecordIdentity& identity, std::string_view value, RecordKind kind,
     uint64_t sequence, bool sync) {
+    std::lock_guard lock(append_mutex_);
     auto envelope = EncodeRecordEnvelope(identity, value, kind, sequence);
     if (!envelope) {
         return tl::unexpected(SegmentError::kInvalidArgument);
@@ -192,11 +195,99 @@ tl::expected<PhysicalRecord, SegmentError> SegmentWriter::Append(
     return physical;
 }
 
+tl::expected<std::vector<PhysicalRecord>, SegmentError>
+SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
+                           bool sync, size_t parallelism) {
+    std::lock_guard lock(append_mutex_);
+    if (requests.empty() || parallelism == 0) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+
+    std::vector<PhysicalRecord> physical_records;
+    physical_records.reserve(requests.size());
+    uint64_t next_offset = tail_;
+    for (const auto& request : requests) {
+        const uint64_t record_size = AlignedRecordSize(
+            static_cast<uint32_t>(request.identity.tenant_id.size()),
+            static_cast<uint32_t>(request.identity.object_key.size()),
+            request.value.size());
+        if (record_size == 0 ||
+            next_offset >
+                static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+                    record_size) {
+            return tl::unexpected(SegmentError::kInvalidArgument);
+        }
+        physical_records.push_back(
+            {.segment_id = segment_id_,
+             .record_offset = next_offset,
+             .value_offset = next_offset + kRecordHeaderSize +
+                             request.identity.tenant_id.size() +
+                             request.identity.object_key.size(),
+             .value_length = request.value.size(),
+             .total_length = record_size});
+        next_offset += record_size;
+    }
+
+    std::atomic<size_t> next_index{0};
+    std::atomic<int> failure{0};
+    const size_t worker_count = std::min(parallelism, requests.size());
+    auto write_records = [&] {
+        while (failure.load(std::memory_order_relaxed) == 0) {
+            const size_t index =
+                next_index.fetch_add(1, std::memory_order_relaxed);
+            if (index >= requests.size()) break;
+            const auto& request = requests[index];
+            auto encoded = EncodeRecord(request.identity, request.value,
+                                        request.kind, request.sequence);
+            if (!encoded) {
+                failure.store(1, std::memory_order_relaxed);
+                break;
+            }
+            const uint64_t offset = physical_records[index].record_offset;
+            if (ShouldFailWrite(path_, offset, encoded->size()) ||
+                !PwriteAll(fd_, encoded->data(), encoded->size(), offset)) {
+                failure.store(2, std::memory_order_relaxed);
+                break;
+            }
+        }
+    };
+    if (worker_count == 1) {
+        write_records();
+    } else {
+        std::vector<std::future<void>> workers;
+        workers.reserve(worker_count);
+        for (size_t worker = 0; worker < worker_count; ++worker) {
+            workers.push_back(std::async(std::launch::async, write_records));
+        }
+        for (auto& worker : workers) worker.get();
+    }
+
+    const int failure_code = failure.load(std::memory_order_relaxed);
+    if (failure_code != 0) {
+        if (ftruncate(fd_, static_cast<off_t>(tail_)) != 0) {
+            return tl::unexpected(SegmentError::kTruncateFailed);
+        }
+        return tl::unexpected(failure_code == 1 ? SegmentError::kInvalidArgument
+                                                : SegmentError::kIoError);
+    }
+    if (sync && fdatasync(fd_) != 0) {
+        return tl::unexpected(SegmentError::kSyncFailed);
+    }
+    tail_ = next_offset;
+    return physical_records;
+}
+
 tl::expected<void, SegmentError> SegmentWriter::Sync() {
+    std::lock_guard lock(append_mutex_);
     if (fdatasync(fd_) != 0) {
         return tl::unexpected(SegmentError::kSyncFailed);
     }
     return {};
+}
+
+uint64_t SegmentWriter::tail() const {
+    std::lock_guard lock(append_mutex_);
+    return tail_;
 }
 
 tl::expected<SegmentScanResult, SegmentError> ScanSegment(

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 
 #include "crc32c.h"
+#include "storage/local/log_structured/uring_batch_io.h"
 
 namespace mooncake::logstructured {
 namespace {
@@ -228,11 +229,12 @@ SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
         next_offset += record_size;
     }
 
+    std::vector<std::string> encoded_records(requests.size());
     std::atomic<size_t> next_index{0};
-    std::atomic<int> failure{0};
+    std::atomic<bool> encode_failed{false};
     const size_t worker_count = std::min(parallelism, requests.size());
-    auto write_records = [&] {
-        while (failure.load(std::memory_order_relaxed) == 0) {
+    auto encode_records = [&] {
+        while (!encode_failed.load(std::memory_order_relaxed)) {
             const size_t index =
                 next_index.fetch_add(1, std::memory_order_relaxed);
             if (index >= requests.size()) break;
@@ -240,35 +242,58 @@ SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
             auto encoded = EncodeRecord(request.identity, request.value,
                                         request.kind, request.sequence);
             if (!encoded) {
-                failure.store(1, std::memory_order_relaxed);
+                encode_failed.store(true, std::memory_order_relaxed);
                 break;
             }
-            const uint64_t offset = physical_records[index].record_offset;
-            if (ShouldFailWrite(path_, offset, encoded->size()) ||
-                !PwriteAll(fd_, encoded->data(), encoded->size(), offset)) {
-                failure.store(2, std::memory_order_relaxed);
-                break;
-            }
+            encoded_records[index] = std::move(*encoded);
         }
     };
     if (worker_count == 1) {
-        write_records();
+        encode_records();
     } else {
         std::vector<std::future<void>> workers;
         workers.reserve(worker_count);
         for (size_t worker = 0; worker < worker_count; ++worker) {
-            workers.push_back(std::async(std::launch::async, write_records));
+            workers.push_back(std::async(std::launch::async, encode_records));
         }
         for (auto& worker : workers) worker.get();
     }
 
-    const int failure_code = failure.load(std::memory_order_relaxed);
-    if (failure_code != 0) {
+    if (encode_failed.load(std::memory_order_relaxed)) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+
+    std::vector<UringWriteRequest> write_requests;
+    write_requests.reserve(requests.size());
+    bool injected_failure = false;
+    for (size_t index = 0; index < requests.size(); ++index) {
+        const uint64_t offset = physical_records[index].record_offset;
+        if (ShouldFailWrite(path_, offset, encoded_records[index].size())) {
+            injected_failure = true;
+            break;
+        }
+        write_requests.push_back({.data = encoded_records[index].data(),
+                                  .length = encoded_records[index].size(),
+                                  .offset = offset});
+    }
+
+    auto write_result = injected_failure
+                            ? UringBatchWriteResult::kIoError
+                            : UringBatchWrite(fd_, write_requests, parallelism);
+    if (write_result == UringBatchWriteResult::kUnavailable) {
+        write_result = UringBatchWriteResult::kSuccess;
+        for (const auto& request : write_requests) {
+            if (!PwriteAll(fd_, request.data, request.length, request.offset)) {
+                write_result = UringBatchWriteResult::kIoError;
+                break;
+            }
+        }
+    }
+    if (write_result != UringBatchWriteResult::kSuccess) {
         if (ftruncate(fd_, static_cast<off_t>(tail_)) != 0) {
             return tl::unexpected(SegmentError::kTruncateFailed);
         }
-        return tl::unexpected(failure_code == 1 ? SegmentError::kInvalidArgument
-                                                : SegmentError::kIoError);
+        return tl::unexpected(SegmentError::kIoError);
     }
     if (sync && fdatasync(fd_) != 0) {
         return tl::unexpected(SegmentError::kSyncFailed);

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -8,7 +8,9 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <functional>
 #include <limits>
+#include <mutex>
 #include <type_traits>
 
 #include "crc32c.h"
@@ -22,6 +24,15 @@ constexpr size_t kFooterPayloadChecksumOffset = 8;
 constexpr size_t kFooterChecksumOffset = 12;
 constexpr size_t kFooterMagicOffset = 16;
 constexpr size_t kFooterChecksumInputSize = kFooterChecksumOffset;
+
+std::mutex write_failure_mutex;
+std::function<bool(std::string_view, uint64_t, size_t)> write_failure_predicate;
+
+bool ShouldFailWrite(std::string_view path, uint64_t offset, size_t length) {
+    std::lock_guard lock(write_failure_mutex);
+    return write_failure_predicate &&
+           write_failure_predicate(path, offset, length);
+}
 
 template <typename T>
 T ReadLittleEndian(const char* input) {
@@ -84,6 +95,12 @@ SegmentWriter::~SegmentWriter() {
     }
 }
 
+void SegmentWriter::SetWriteFailurePredicateForTest(
+    std::function<bool(std::string_view, uint64_t, size_t)> predicate) {
+    std::lock_guard lock(write_failure_mutex);
+    write_failure_predicate = std::move(predicate);
+}
+
 tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
 SegmentWriter::Create(std::string path, uint64_t segment_id) {
     return Open(std::move(path), segment_id,
@@ -139,20 +156,23 @@ tl::expected<PhysicalRecord, SegmentError> SegmentWriter::Append(
         identity.tenant_id, identity.object_key, value};
     for (const auto part : payload_parts) {
         if (!part.empty() &&
-            !PwriteAll(fd_, part.data(), part.size(), cursor)) {
+            (ShouldFailWrite(path_, cursor, part.size()) ||
+             !PwriteAll(fd_, part.data(), part.size(), cursor))) {
             return tl::unexpected(SegmentError::kIoError);
         }
         cursor += part.size();
     }
     if (envelope->padding_length > 0) {
         static constexpr std::array<char, kRecordAlignment> kZeroPadding{};
-        if (!PwriteAll(fd_, kZeroPadding.data(), envelope->padding_length,
+        if (ShouldFailWrite(path_, cursor, envelope->padding_length) ||
+            !PwriteAll(fd_, kZeroPadding.data(), envelope->padding_length,
                        cursor)) {
             return tl::unexpected(SegmentError::kIoError);
         }
         cursor += envelope->padding_length;
     }
-    if (!PwriteAll(fd_, envelope->footer.data(), envelope->footer.size(),
+    if (ShouldFailWrite(path_, cursor, envelope->footer.size()) ||
+        !PwriteAll(fd_, envelope->footer.data(), envelope->footer.size(),
                    cursor)) {
         return tl::unexpected(SegmentError::kIoError);
     }

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -1,0 +1,369 @@
+#include "storage/local/log_structured/segment.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "crc32c.h"
+
+namespace mooncake::logstructured {
+namespace {
+
+constexpr size_t kScanBufferSize = 64 * 1024;
+constexpr size_t kFooterLengthOffset = 0;
+constexpr size_t kFooterPayloadChecksumOffset = 8;
+constexpr size_t kFooterChecksumOffset = 12;
+constexpr size_t kFooterMagicOffset = 16;
+constexpr size_t kFooterChecksumInputSize = kFooterChecksumOffset;
+
+template <typename T>
+T ReadLittleEndian(const char* input) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        value |= static_cast<Unsigned>(static_cast<unsigned char>(input[i]))
+                 << (i * 8);
+    }
+    return static_cast<T>(value);
+}
+
+bool PwriteAll(int fd, const char* data, size_t length, uint64_t offset) {
+    size_t written = 0;
+    while (written < length) {
+        const ssize_t result =
+            pwrite(fd, data + written, length - written, offset + written);
+        if (result < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (result == 0) {
+            return false;
+        }
+        written += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+bool PreadAll(int fd, char* data, size_t length, uint64_t offset) {
+    size_t read_bytes = 0;
+    while (read_bytes < length) {
+        const ssize_t result = pread(fd, data + read_bytes, length - read_bytes,
+                                     offset + read_bytes);
+        if (result < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (result == 0) {
+            return false;
+        }
+        read_bytes += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+}  // namespace
+
+SegmentWriter::SegmentWriter(std::string path, uint64_t segment_id, int fd,
+                             uint64_t tail)
+    : path_(std::move(path)), segment_id_(segment_id), fd_(fd), tail_(tail) {}
+
+SegmentWriter::~SegmentWriter() {
+    if (fd_ >= 0) {
+        close(fd_);
+    }
+}
+
+tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
+SegmentWriter::Create(std::string path, uint64_t segment_id) {
+    return Open(std::move(path), segment_id,
+                O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0);
+}
+
+tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> SegmentWriter::Open(
+    std::string path, uint64_t segment_id, int flags, uint64_t tail) {
+    const int fd = open(path.c_str(), flags, 0644);
+    if (fd < 0) {
+        return tl::unexpected(SegmentError::kOpenFailed);
+    }
+    return std::unique_ptr<SegmentWriter>(
+        new SegmentWriter(std::move(path), segment_id, fd, tail));
+}
+
+tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
+SegmentWriter::OpenForAppend(std::string path, uint64_t segment_id,
+                             uint64_t valid_bytes) {
+    const int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+        return tl::unexpected(SegmentError::kOpenFailed);
+    }
+    struct stat file_stat{};
+    if (fstat(fd, &file_stat) != 0 || file_stat.st_size < 0 ||
+        valid_bytes > static_cast<uint64_t>(file_stat.st_size)) {
+        close(fd);
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    if (ftruncate(fd, static_cast<off_t>(valid_bytes)) != 0) {
+        close(fd);
+        return tl::unexpected(SegmentError::kTruncateFailed);
+    }
+    return std::unique_ptr<SegmentWriter>(
+        new SegmentWriter(std::move(path), segment_id, fd, valid_bytes));
+}
+
+tl::expected<PhysicalRecord, SegmentError> SegmentWriter::Append(
+    const RecordIdentity& identity, std::string_view value, RecordKind kind,
+    uint64_t sequence, bool sync) {
+    auto envelope = EncodeRecordEnvelope(identity, value, kind, sequence);
+    if (!envelope) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    if (tail_ > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+                    envelope->total_length) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+
+    uint64_t cursor = tail_;
+    const std::array<std::string_view, 4> payload_parts = {
+        std::string_view(envelope->header.data(), envelope->header.size()),
+        identity.tenant_id, identity.object_key, value};
+    for (const auto part : payload_parts) {
+        if (!part.empty() &&
+            !PwriteAll(fd_, part.data(), part.size(), cursor)) {
+            return tl::unexpected(SegmentError::kIoError);
+        }
+        cursor += part.size();
+    }
+    if (envelope->padding_length > 0) {
+        static constexpr std::array<char, kRecordAlignment> kZeroPadding{};
+        if (!PwriteAll(fd_, kZeroPadding.data(), envelope->padding_length,
+                       cursor)) {
+            return tl::unexpected(SegmentError::kIoError);
+        }
+        cursor += envelope->padding_length;
+    }
+    if (!PwriteAll(fd_, envelope->footer.data(), envelope->footer.size(),
+                   cursor)) {
+        return tl::unexpected(SegmentError::kIoError);
+    }
+    if (sync && fdatasync(fd_) != 0) {
+        return tl::unexpected(SegmentError::kSyncFailed);
+    }
+
+    PhysicalRecord physical{
+        .segment_id = segment_id_,
+        .record_offset = tail_,
+        .value_offset = tail_ + kRecordHeaderSize + identity.tenant_id.size() +
+                        identity.object_key.size(),
+        .value_length = value.size(),
+        .total_length = envelope->total_length,
+    };
+    tail_ += envelope->total_length;
+    return physical;
+}
+
+tl::expected<void, SegmentError> SegmentWriter::Sync() {
+    if (fdatasync(fd_) != 0) {
+        return tl::unexpected(SegmentError::kSyncFailed);
+    }
+    return {};
+}
+
+tl::expected<SegmentScanResult, SegmentError> ScanSegment(
+    const std::string& path, uint64_t segment_id) {
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return tl::unexpected(SegmentError::kOpenFailed);
+    }
+
+    struct FdGuard {
+        int fd;
+        ~FdGuard() { close(fd); }
+    } fd_guard{fd};
+
+    struct stat file_stat{};
+    if (fstat(fd, &file_stat) != 0 || file_stat.st_size < 0) {
+        return tl::unexpected(SegmentError::kIoError);
+    }
+    const uint64_t file_size = static_cast<uint64_t>(file_stat.st_size);
+
+    SegmentScanResult result;
+    uint64_t offset = 0;
+    std::array<char, kRecordHeaderSize> header_bytes{};
+    std::array<char, kRecordFooterSize> footer_bytes{};
+    std::array<char, kScanBufferSize> scan_buffer{};
+
+    while (offset < file_size) {
+        const uint64_t remaining = file_size - offset;
+        if (remaining < kRecordHeaderSize) {
+            result.valid_bytes = offset;
+            result.termination = ScanTermination::kIncompleteTail;
+            return result;
+        }
+        if (!PreadAll(fd, header_bytes.data(), header_bytes.size(), offset)) {
+            return tl::unexpected(SegmentError::kIoError);
+        }
+        auto header_result = DecodeRecordHeader(header_bytes);
+        if (!header_result) {
+            result.valid_bytes = offset;
+            result.termination = ScanTermination::kCorruptRecord;
+            result.decode_error = header_result.error();
+            return result;
+        }
+        const RecordHeader& header = header_result.value();
+        if (header.total_length > remaining) {
+            result.valid_bytes = offset;
+            result.termination = ScanTermination::kIncompleteTail;
+            return result;
+        }
+        if (header.total_length > std::numeric_limits<off_t>::max()) {
+            return tl::unexpected(SegmentError::kInvalidArgument);
+        }
+
+        const uint64_t footer_offset =
+            offset + header.total_length - kRecordFooterSize;
+        if (!PreadAll(fd, footer_bytes.data(), footer_bytes.size(),
+                      footer_offset)) {
+            return tl::unexpected(SegmentError::kIoError);
+        }
+        if (ReadLittleEndian<uint64_t>(footer_bytes.data() +
+                                       kFooterLengthOffset) !=
+                header.total_length ||
+            ReadLittleEndian<uint64_t>(footer_bytes.data() +
+                                       kFooterMagicOffset) !=
+                kRecordCommitMagic ||
+            Crc32cValue(footer_bytes.data(), kFooterChecksumInputSize) !=
+                ReadLittleEndian<uint32_t>(footer_bytes.data() +
+                                           kFooterChecksumOffset)) {
+            result.valid_bytes = offset;
+            result.termination = ScanTermination::kCorruptRecord;
+            result.decode_error = DecodeError::kFooterMismatch;
+            return result;
+        }
+
+        RecordIdentity identity;
+        identity.incarnation = header.incarnation;
+        identity.tenant_id.resize(header.tenant_length);
+        identity.object_key.resize(header.key_length);
+        uint64_t cursor = offset + kRecordHeaderSize;
+        if (!identity.tenant_id.empty() &&
+            !PreadAll(fd, identity.tenant_id.data(), identity.tenant_id.size(),
+                      cursor)) {
+            return tl::unexpected(SegmentError::kIoError);
+        }
+        cursor += identity.tenant_id.size();
+        if (!identity.object_key.empty() &&
+            !PreadAll(fd, identity.object_key.data(),
+                      identity.object_key.size(), cursor)) {
+            return tl::unexpected(SegmentError::kIoError);
+        }
+        cursor += identity.object_key.size();
+
+        Crc32c payload_crc;
+        payload_crc.Extend(identity.tenant_id.data(),
+                           identity.tenant_id.size());
+        payload_crc.Extend(identity.object_key.data(),
+                           identity.object_key.size());
+        uint64_t value_remaining = header.value_length;
+        uint64_t value_cursor = cursor;
+        while (value_remaining > 0) {
+            const size_t chunk = static_cast<size_t>(
+                std::min<uint64_t>(value_remaining, scan_buffer.size()));
+            if (!PreadAll(fd, scan_buffer.data(), chunk, value_cursor)) {
+                return tl::unexpected(SegmentError::kIoError);
+            }
+            payload_crc.Extend(scan_buffer.data(), chunk);
+            value_remaining -= chunk;
+            value_cursor += chunk;
+        }
+        if (payload_crc.Final() !=
+            ReadLittleEndian<uint32_t>(footer_bytes.data() +
+                                       kFooterPayloadChecksumOffset)) {
+            result.valid_bytes = offset;
+            result.termination = ScanTermination::kCorruptRecord;
+            result.decode_error = DecodeError::kPayloadChecksumMismatch;
+            return result;
+        }
+
+        result.records.push_back(ScannedRecord{
+            .identity = std::move(identity),
+            .kind = header.kind,
+            .sequence = header.sequence,
+            .physical =
+                PhysicalRecord{
+                    .segment_id = segment_id,
+                    .record_offset = offset,
+                    .value_offset = cursor,
+                    .value_length = header.value_length,
+                    .total_length = header.total_length,
+                },
+        });
+        offset += header.total_length;
+    }
+
+    result.valid_bytes = offset;
+    result.termination = ScanTermination::kCleanEof;
+    return result;
+}
+
+tl::expected<DecodedRecord, SegmentError> ReadRecord(
+    const std::string& path, const PhysicalRecord& physical) {
+    if (physical.total_length < kRecordHeaderSize + kRecordFooterSize ||
+        physical.total_length >
+            static_cast<uint64_t>(std::numeric_limits<size_t>::max()) ||
+        physical.record_offset >
+            static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+                physical.total_length) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return tl::unexpected(SegmentError::kOpenFailed);
+    }
+    struct FdGuard {
+        int fd;
+        ~FdGuard() { close(fd); }
+    } fd_guard{fd};
+
+    std::string encoded(static_cast<size_t>(physical.total_length), '\0');
+    if (!PreadAll(fd, encoded.data(), encoded.size(), physical.record_offset)) {
+        return tl::unexpected(SegmentError::kIoError);
+    }
+    auto decoded = DecodeRecord(encoded);
+    if (!decoded) {
+        return tl::unexpected(SegmentError::kIoError);
+    }
+    const uint64_t expected_value_offset = physical.record_offset +
+                                           kRecordHeaderSize +
+                                           decoded->identity.tenant_id.size() +
+                                           decoded->identity.object_key.size();
+    if (decoded->total_length != physical.total_length ||
+        decoded->value.size() != physical.value_length ||
+        expected_value_offset != physical.value_offset) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    return decoded.value();
+}
+
+tl::expected<void, SegmentError> TruncateSegment(const std::string& path,
+                                                 uint64_t valid_bytes) {
+    if (valid_bytes > std::numeric_limits<off_t>::max()) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    if (truncate(path.c_str(), static_cast<off_t>(valid_bytes)) != 0) {
+        return tl::unexpected(SegmentError::kTruncateFailed);
+    }
+    return {};
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -32,9 +32,12 @@ std::mutex write_failure_mutex;
 std::function<bool(std::string_view, uint64_t, size_t)> write_failure_predicate;
 
 bool ShouldFailWrite(std::string_view path, uint64_t offset, size_t length) {
-    std::lock_guard lock(write_failure_mutex);
-    return write_failure_predicate &&
-           write_failure_predicate(path, offset, length);
+    std::function<bool(std::string_view, uint64_t, size_t)> predicate;
+    {
+        std::lock_guard lock(write_failure_mutex);
+        predicate = write_failure_predicate;
+    }
+    return predicate && predicate(path, offset, length);
 }
 
 template <typename T>
@@ -219,7 +222,32 @@ tl::expected<std::vector<PhysicalRecord>, SegmentError>
 SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
                            bool sync, size_t parallelism) {
     std::lock_guard lock(append_mutex_);
-    if (requests.empty() || parallelism == 0) {
+    const uint64_t original_tail = tail_;
+    auto physical_records = ReserveBatchLocked(requests);
+    if (!physical_records) return tl::unexpected(physical_records.error());
+    auto written = WriteBatchAt(requests, *physical_records, sync, parallelism);
+    if (!written) {
+        tail_ = original_tail;
+        if (ftruncate(fd_, static_cast<off_t>(original_tail)) != 0) {
+            return tl::unexpected(SegmentError::kTruncateFailed);
+        }
+        return tl::unexpected(written.error());
+    }
+    return physical_records;
+}
+
+tl::expected<std::vector<PhysicalRecord>, SegmentError>
+SegmentWriter::ReserveBatch(const std::vector<SegmentAppendRequest>& requests) {
+    std::lock_guard lock(append_mutex_);
+    auto reserved = ReserveBatchLocked(requests);
+    if (reserved) ++in_flight_batches_;
+    return reserved;
+}
+
+tl::expected<std::vector<PhysicalRecord>, SegmentError>
+SegmentWriter::ReserveBatchLocked(
+    const std::vector<SegmentAppendRequest>& requests) {
+    if (requests.empty()) {
         return tl::unexpected(SegmentError::kInvalidArgument);
     }
 
@@ -246,6 +274,50 @@ SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
              .value_length = request.value.size(),
              .total_length = record_size});
         next_offset += record_size;
+    }
+    tail_ = next_offset;
+    return physical_records;
+}
+
+tl::expected<void, SegmentError> SegmentWriter::WriteReservedBatch(
+    const std::vector<SegmentAppendRequest>& requests,
+    const std::vector<PhysicalRecord>& physical_records, bool sync,
+    size_t parallelism) {
+    if (requests.empty() || requests.size() != physical_records.size()) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
+    }
+    for (size_t index = 0; index < requests.size(); ++index) {
+        const uint64_t expected_size = AlignedRecordSize(
+            static_cast<uint32_t>(requests[index].identity.tenant_id.size()),
+            static_cast<uint32_t>(requests[index].identity.object_key.size()),
+            requests[index].value.size());
+        const auto& physical = physical_records[index];
+        if (expected_size == 0 || physical.segment_id != segment_id_ ||
+            physical.total_length != expected_size) {
+            return tl::unexpected(SegmentError::kInvalidArgument);
+        }
+    }
+    struct ReservationGuard {
+        SegmentWriter* writer;
+        ~ReservationGuard() { writer->FinishReservedBatch(); }
+    } guard{this};
+    return WriteBatchAt(requests, physical_records, sync, parallelism);
+}
+
+void SegmentWriter::CancelReservedBatch() { FinishReservedBatch(); }
+
+void SegmentWriter::FinishReservedBatch() {
+    std::lock_guard lock(append_mutex_);
+    if (in_flight_batches_ > 0) --in_flight_batches_;
+    append_cv_.notify_all();
+}
+
+tl::expected<void, SegmentError> SegmentWriter::WriteBatchAt(
+    const std::vector<SegmentAppendRequest>& requests,
+    const std::vector<PhysicalRecord>& physical_records, bool sync,
+    size_t parallelism) {
+    if (parallelism == 0) {
+        return tl::unexpected(SegmentError::kInvalidArgument);
     }
 
     std::vector<std::string> encoded_records(requests.size());
@@ -284,21 +356,17 @@ SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
 
     std::vector<UringWriteRequest> write_requests;
     write_requests.reserve(requests.size());
-    bool injected_failure = false;
     for (size_t index = 0; index < requests.size(); ++index) {
         const uint64_t offset = physical_records[index].record_offset;
         if (ShouldFailWrite(path_, offset, encoded_records[index].size())) {
-            injected_failure = true;
-            break;
+            return tl::unexpected(SegmentError::kIoError);
         }
         write_requests.push_back({.data = encoded_records[index].data(),
                                   .length = encoded_records[index].size(),
                                   .offset = offset});
     }
 
-    auto write_result = injected_failure
-                            ? UringBatchWriteResult::kIoError
-                            : UringBatchWrite(fd_, write_requests, parallelism);
+    auto write_result = UringBatchWrite(fd_, write_requests, parallelism);
     if (write_result == UringBatchWriteResult::kUnavailable) {
         write_result = UringBatchWriteResult::kSuccess;
         for (const auto& request : write_requests) {
@@ -309,21 +377,18 @@ SegmentWriter::AppendBatch(const std::vector<SegmentAppendRequest>& requests,
         }
     }
     if (write_result != UringBatchWriteResult::kSuccess) {
-        if (ftruncate(fd_, static_cast<off_t>(tail_)) != 0) {
-            return tl::unexpected(SegmentError::kTruncateFailed);
-        }
         return tl::unexpected(SegmentError::kIoError);
     }
     if (sync && fdatasync(fd_) != 0) {
         return tl::unexpected(SegmentError::kSyncFailed);
     }
-    tail_ = next_offset;
-    return physical_records;
+    return {};
 }
 
 tl::expected<void, SegmentError> SegmentWriter::Sync() {
-    std::lock_guard lock(append_mutex_);
-    if (fdatasync(fd_) != 0) {
+    std::unique_lock lock(append_mutex_);
+    append_cv_.wait(lock, [this] { return in_flight_batches_ == 0; });
+    if (ftruncate(fd_, static_cast<off_t>(tail_)) != 0 || fdatasync(fd_) != 0) {
         return tl::unexpected(SegmentError::kSyncFailed);
     }
     return {};
@@ -522,12 +587,10 @@ tl::expected<void, SegmentError> SegmentReader::ReadValue(
             static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
                 physical.total_length ||
         physical.value_offset < physical.record_offset + kRecordHeaderSize ||
-        physical.value_offset >
-            physical.record_offset + physical.total_length -
-                kRecordFooterSize ||
-        physical.value_length >
-            physical.record_offset + physical.total_length -
-                kRecordFooterSize - physical.value_offset) {
+        physical.value_offset > physical.record_offset + physical.total_length -
+                                    kRecordFooterSize ||
+        physical.value_length > physical.record_offset + physical.total_length -
+                                    kRecordFooterSize - physical.value_offset) {
         return tl::unexpected(SegmentError::kInvalidArgument);
     }
     if (value_size != 0 &&

--- a/mooncake-store/src/storage/local/log_structured/segment.cpp
+++ b/mooncake-store/src/storage/local/log_structured/segment.cpp
@@ -92,8 +92,12 @@ bool PreadAll(int fd, char* data, size_t length, uint64_t offset) {
 }  // namespace
 
 SegmentWriter::SegmentWriter(std::string path, uint64_t segment_id, int fd,
-                             uint64_t tail)
-    : path_(std::move(path)), segment_id_(segment_id), fd_(fd), tail_(tail) {}
+                             uint64_t tail, bool use_uring)
+    : path_(std::move(path)),
+      segment_id_(segment_id),
+      fd_(fd),
+      tail_(tail),
+      use_uring_(use_uring) {}
 
 SegmentWriter::~SegmentWriter() {
     if (fd_ >= 0) {
@@ -127,24 +131,25 @@ void SegmentWriter::SetWriteFailurePredicateForTest(
 }
 
 tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
-SegmentWriter::Create(std::string path, uint64_t segment_id) {
+SegmentWriter::Create(std::string path, uint64_t segment_id, bool use_uring) {
     return Open(std::move(path), segment_id,
-                O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0);
+                O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0, use_uring);
 }
 
 tl::expected<std::unique_ptr<SegmentWriter>, SegmentError> SegmentWriter::Open(
-    std::string path, uint64_t segment_id, int flags, uint64_t tail) {
+    std::string path, uint64_t segment_id, int flags, uint64_t tail,
+    bool use_uring) {
     const int fd = open(path.c_str(), flags, 0644);
     if (fd < 0) {
         return tl::unexpected(SegmentError::kOpenFailed);
     }
     return std::unique_ptr<SegmentWriter>(
-        new SegmentWriter(std::move(path), segment_id, fd, tail));
+        new SegmentWriter(std::move(path), segment_id, fd, tail, use_uring));
 }
 
 tl::expected<std::unique_ptr<SegmentWriter>, SegmentError>
 SegmentWriter::OpenForAppend(std::string path, uint64_t segment_id,
-                             uint64_t valid_bytes) {
+                             uint64_t valid_bytes, bool use_uring) {
     const int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
     if (fd < 0) {
         return tl::unexpected(SegmentError::kOpenFailed);
@@ -159,8 +164,8 @@ SegmentWriter::OpenForAppend(std::string path, uint64_t segment_id,
         close(fd);
         return tl::unexpected(SegmentError::kTruncateFailed);
     }
-    return std::unique_ptr<SegmentWriter>(
-        new SegmentWriter(std::move(path), segment_id, fd, valid_bytes));
+    return std::unique_ptr<SegmentWriter>(new SegmentWriter(
+        std::move(path), segment_id, fd, valid_bytes, use_uring));
 }
 
 tl::expected<PhysicalRecord, SegmentError> SegmentWriter::Append(
@@ -366,7 +371,9 @@ tl::expected<void, SegmentError> SegmentWriter::WriteBatchAt(
                                   .offset = offset});
     }
 
-    auto write_result = UringBatchWrite(fd_, write_requests, parallelism);
+    auto write_result = use_uring_
+                            ? UringBatchWrite(fd_, write_requests, parallelism)
+                            : UringBatchWriteResult::kUnavailable;
     if (write_result == UringBatchWriteResult::kUnavailable) {
         write_result = UringBatchWriteResult::kSuccess;
         for (const auto& request : write_requests) {

--- a/mooncake-store/src/storage/local/log_structured/storage_directory.cpp
+++ b/mooncake-store/src/storage/local/log_structured/storage_directory.cpp
@@ -1,0 +1,223 @@
+#include "storage/local/log_structured/storage_directory.h"
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <filesystem>
+#include <limits>
+#include <string_view>
+#include <type_traits>
+
+#include "crc32c.h"
+#include "random.h"
+
+namespace mooncake::logstructured {
+namespace {
+
+constexpr uint32_t kIdentityMagic = 0x494C434D;
+constexpr uint16_t kIdentityVersion = 1;
+constexpr uint64_t kIdentityCommitMagic = 0x54494D4D4F434449ULL;
+constexpr size_t kIdentitySize = 40;
+constexpr size_t kMagicOffset = 0;
+constexpr size_t kVersionOffset = 4;
+constexpr size_t kHighOffset = 8;
+constexpr size_t kLowOffset = 16;
+constexpr size_t kChecksumOffset = 24;
+constexpr size_t kChecksumInputSize = kChecksumOffset;
+constexpr size_t kCommitMagicOffset = 32;
+
+template <typename T>
+void WriteLittleEndian(char* output, T value) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned unsigned_value = static_cast<Unsigned>(value);
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        output[i] = static_cast<char>((unsigned_value >> (i * 8)) & 0xff);
+    }
+}
+
+template <typename T>
+T ReadLittleEndian(const char* input) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        value |= static_cast<Unsigned>(static_cast<unsigned char>(input[i]))
+                 << (i * 8);
+    }
+    return static_cast<T>(value);
+}
+
+bool WriteAll(int fd, const char* data, size_t length) {
+    size_t written = 0;
+    while (written < length) {
+        const ssize_t result = write(fd, data + written, length - written);
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (result == 0) return false;
+        written += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+bool ReadAll(int fd, char* data, size_t length) {
+    size_t read_bytes = 0;
+    while (read_bytes < length) {
+        const ssize_t result = read(fd, data + read_bytes, length - read_bytes);
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (result == 0) return false;
+        read_bytes += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+bool DirectoryHasUserData(const std::string& root_path) {
+    std::error_code error;
+    for (const auto& entry :
+         std::filesystem::directory_iterator(root_path, error)) {
+        if (error) return true;
+        const std::string name = entry.path().filename().string();
+        if (name != "LOCK" && name != "IDENTITY.tmp") return true;
+    }
+    return error.operator bool();
+}
+
+tl::expected<StorageIdentity, StorageDirectoryError> ReadIdentity(
+    const std::string& path) {
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return tl::unexpected(StorageDirectoryError::kIoError);
+    std::array<char, kIdentitySize> bytes{};
+    const bool read = ReadAll(fd, bytes.data(), bytes.size());
+    char extra = 0;
+    const ssize_t extra_read = ::read(fd, &extra, 1);
+    close(fd);
+    if (!read || extra_read != 0 ||
+        ReadLittleEndian<uint32_t>(bytes.data() + kMagicOffset) !=
+            kIdentityMagic ||
+        ReadLittleEndian<uint16_t>(bytes.data() + kVersionOffset) !=
+            kIdentityVersion ||
+        Crc32cValue(bytes.data(), kChecksumInputSize) !=
+            ReadLittleEndian<uint32_t>(bytes.data() + kChecksumOffset) ||
+        ReadLittleEndian<uint64_t>(bytes.data() + kCommitMagicOffset) !=
+            kIdentityCommitMagic) {
+        return tl::unexpected(StorageDirectoryError::kCorruptIdentity);
+    }
+    StorageIdentity identity{
+        .high = ReadLittleEndian<uint64_t>(bytes.data() + kHighOffset),
+        .low = ReadLittleEndian<uint64_t>(bytes.data() + kLowOffset)};
+    if (identity == StorageIdentity{}) {
+        return tl::unexpected(StorageDirectoryError::kCorruptIdentity);
+    }
+    return identity;
+}
+
+tl::expected<StorageIdentity, StorageDirectoryError> CreateIdentity(
+    const std::string& root_path) {
+    StorageIdentity identity{.high = randomUniform<uint64_t>(
+                                 0, std::numeric_limits<uint64_t>::max()),
+                             .low = randomUniform<uint64_t>(
+                                 0, std::numeric_limits<uint64_t>::max())};
+    if (identity == StorageIdentity{}) identity.low = 1;
+
+    std::array<char, kIdentitySize> bytes{};
+    WriteLittleEndian<uint32_t>(bytes.data() + kMagicOffset, kIdentityMagic);
+    WriteLittleEndian<uint16_t>(bytes.data() + kVersionOffset,
+                                kIdentityVersion);
+    WriteLittleEndian<uint64_t>(bytes.data() + kHighOffset, identity.high);
+    WriteLittleEndian<uint64_t>(bytes.data() + kLowOffset, identity.low);
+    WriteLittleEndian<uint32_t>(bytes.data() + kChecksumOffset,
+                                Crc32cValue(bytes.data(), kChecksumInputSize));
+    WriteLittleEndian<uint64_t>(bytes.data() + kCommitMagicOffset,
+                                kIdentityCommitMagic);
+
+    const std::string temporary_path = root_path + "/IDENTITY.tmp";
+    const std::string final_path = root_path + "/IDENTITY";
+    const int fd = open(temporary_path.c_str(),
+                        O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0644);
+    if (fd < 0) return tl::unexpected(StorageDirectoryError::kIoError);
+    const bool data_written = WriteAll(fd, bytes.data(), bytes.size());
+    const bool data_synced = data_written && fsync(fd) == 0;
+    const int close_result = close(fd);
+    if (!data_synced || close_result != 0) {
+        unlink(temporary_path.c_str());
+        return tl::unexpected(StorageDirectoryError::kIoError);
+    }
+    if (rename(temporary_path.c_str(), final_path.c_str()) != 0) {
+        unlink(temporary_path.c_str());
+        return tl::unexpected(StorageDirectoryError::kIoError);
+    }
+    const int directory_fd =
+        open(root_path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (directory_fd < 0) {
+        return tl::unexpected(StorageDirectoryError::kIoError);
+    }
+    const int sync_result = fsync(directory_fd);
+    close(directory_fd);
+    if (sync_result != 0) {
+        return tl::unexpected(StorageDirectoryError::kIoError);
+    }
+    return identity;
+}
+
+}  // namespace
+
+StorageDirectory::StorageDirectory(std::string root_path, int lock_fd,
+                                   StorageIdentity identity)
+    : root_path_(std::move(root_path)),
+      lock_fd_(lock_fd),
+      identity_(identity) {}
+
+StorageDirectory::~StorageDirectory() {
+    if (lock_fd_ >= 0) {
+        flock(lock_fd_, LOCK_UN);
+        close(lock_fd_);
+    }
+}
+
+tl::expected<std::unique_ptr<StorageDirectory>, StorageDirectoryError>
+StorageDirectory::Open(std::string root_path) {
+    if (root_path.empty()) {
+        return tl::unexpected(StorageDirectoryError::kInvalidArgument);
+    }
+    std::error_code error;
+    std::filesystem::create_directories(root_path, error);
+    if (error) return tl::unexpected(StorageDirectoryError::kIoError);
+
+    const std::string lock_path = root_path + "/LOCK";
+    const int lock_fd =
+        open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0644);
+    if (lock_fd < 0) return tl::unexpected(StorageDirectoryError::kIoError);
+    if (flock(lock_fd, LOCK_EX | LOCK_NB) != 0) {
+        const auto result = errno == EWOULDBLOCK
+                                ? StorageDirectoryError::kAlreadyMounted
+                                : StorageDirectoryError::kIoError;
+        close(lock_fd);
+        return tl::unexpected(result);
+    }
+
+    const std::string identity_path = root_path + "/IDENTITY";
+    tl::expected<StorageIdentity, StorageDirectoryError> identity =
+        tl::unexpected(StorageDirectoryError::kIoError);
+    if (std::filesystem::exists(identity_path, error)) {
+        if (!error) identity = ReadIdentity(identity_path);
+    } else if (!error && !DirectoryHasUserData(root_path)) {
+        identity = CreateIdentity(root_path);
+    } else if (!error) {
+        identity = tl::unexpected(StorageDirectoryError::kUnrecognizedFormat);
+    }
+    if (!identity) {
+        flock(lock_fd, LOCK_UN);
+        close(lock_fd);
+        return tl::unexpected(identity.error());
+    }
+    return std::unique_ptr<StorageDirectory>(
+        new StorageDirectory(std::move(root_path), lock_fd, identity.value()));
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/storage_directory.cpp
+++ b/mooncake-store/src/storage/local/log_structured/storage_directory.cpp
@@ -139,13 +139,15 @@ tl::expected<StorageIdentity, StorageDirectoryError> CreateIdentity(
     const std::string temporary_path = root_path + "/IDENTITY.tmp";
     const std::string final_path = root_path + "/IDENTITY";
     const int fd = open(temporary_path.c_str(),
-                        O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0644);
+                        O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
     if (fd < 0) return tl::unexpected(StorageDirectoryError::kIoError);
     const bool data_written = WriteAll(fd, bytes.data(), bytes.size());
     const bool data_synced = data_written && fsync(fd) == 0;
     const int close_result = close(fd);
     if (!data_synced || close_result != 0) {
+        const int saved_errno = errno;
         unlink(temporary_path.c_str());
+        errno = saved_errno;
         return tl::unexpected(StorageDirectoryError::kIoError);
     }
     if (rename(temporary_path.c_str(), final_path.c_str()) != 0) {

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -687,7 +687,9 @@ void LogStructuredStore::CleanupRetiredSegmentsLocked() {
 tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
     const CompactionOptions& options) {
     if (options.max_source_segments == 0 || options.max_input_bytes == 0 ||
-        options.min_reclaim_ratio < 0.0 || options.min_reclaim_ratio > 1.0) {
+        options.max_target_bytes == 0 || options.fanout == 0 ||
+        options.max_levels == 0 || options.min_reclaim_ratio < 0.0 ||
+        options.min_reclaim_ratio > 1.0) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
     if (options.stop_token.stop_requested()) {
@@ -755,24 +757,27 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 break;
             }
         }
-        if (sources.size() > options.max_source_segments) {
-            sources.resize(options.max_source_segments);
-        }
+        std::vector<SegmentMetadata> bounded_sources;
+        bounded_sources.reserve(
+            std::min(sources.size(), options.max_source_segments));
         uint64_t selected_bytes = 0;
-        size_t selected_count = 0;
-        for (; selected_count < sources.size(); ++selected_count) {
-            const auto bytes = sources[selected_count].valid_bytes;
-            if (selected_count != 0 &&
-                bytes > options.max_input_bytes - selected_bytes) {
+        uint64_t selected_live_bytes = 0;
+        for (const auto& source : sources) {
+            if (bounded_sources.size() == options.max_source_segments) break;
+            if (!bounded_sources.empty() &&
+                source.valid_bytes > options.max_input_bytes - selected_bytes) {
                 break;
             }
-            selected_bytes += bytes;
-            if (selected_bytes >= options.max_input_bytes) {
-                ++selected_count;
-                break;
+            if (source.live_bytes >
+                options.max_temporary_bytes - selected_live_bytes) {
+                continue;
             }
+            bounded_sources.push_back(source);
+            selected_bytes += source.valid_bytes;
+            selected_live_bytes += source.live_bytes;
+            if (selected_bytes >= options.max_input_bytes) break;
         }
-        sources.resize(selected_count);
+        sources = std::move(bounded_sources);
         if (sources.empty()) return CompactionResult{};
 
         std::unordered_set<uint64_t> source_ids;

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -1,0 +1,321 @@
+#include "storage/local/log_structured/store.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <limits>
+#include <map>
+#include <string_view>
+
+namespace mooncake::logstructured {
+namespace {
+
+constexpr std::string_view kSegmentPrefix = "segment-";
+constexpr std::string_view kSegmentSuffix = ".log";
+constexpr std::string_view kWalFile = "WAL-000001";
+
+std::optional<uint64_t> ParseSegmentId(std::string_view name) {
+    if (!name.starts_with(kSegmentPrefix) || !name.ends_with(kSegmentSuffix)) {
+        return std::nullopt;
+    }
+    name.remove_prefix(kSegmentPrefix.size());
+    name.remove_suffix(kSegmentSuffix.size());
+    if (name.empty()) return std::nullopt;
+    uint64_t id = 0;
+    for (const char ch : name) {
+        if (ch < '0' || ch > '9' ||
+            id > (std::numeric_limits<uint64_t>::max() - (ch - '0')) / 10) {
+            return std::nullopt;
+        }
+        id = id * 10 + static_cast<uint64_t>(ch - '0');
+    }
+    return id;
+}
+
+std::string FormatSegmentName(uint64_t segment_id) {
+    std::string digits = std::to_string(segment_id);
+    if (digits.size() < 20) digits.insert(0, 20 - digits.size(), '0');
+    return std::string(kSegmentPrefix) + digits + std::string(kSegmentSuffix);
+}
+
+StoreError MapIndexError(IndexError error) {
+    if (error == IndexError::kNotFound) return StoreError::kNotFound;
+    return StoreError::kInvalidTransition;
+}
+
+}  // namespace
+
+LogStructuredStore::LogStructuredStore(LogStructuredStoreConfig config)
+    : config_(std::move(config)),
+      segments_path_(config_.root_path + "/segments"),
+      wal_path_(config_.root_path + "/" + std::string(kWalFile)) {}
+
+tl::expected<std::unique_ptr<LogStructuredStore>, StoreError>
+LogStructuredStore::Open(LogStructuredStoreConfig config) {
+    if (config.root_path.empty() || config.max_segment_bytes == 0) {
+        return tl::unexpected(StoreError::kInvalidArgument);
+    }
+    auto store = std::unique_ptr<LogStructuredStore>(
+        new LogStructuredStore(std::move(config)));
+    auto recovered = store->Recover();
+    if (!recovered) return tl::unexpected(recovered.error());
+    return store;
+}
+
+std::string LogStructuredStore::SegmentPath(uint64_t segment_id) const {
+    return segments_path_ + "/" + FormatSegmentName(segment_id);
+}
+
+tl::expected<void, StoreError> LogStructuredStore::Recover() {
+    namespace fs = std::filesystem;
+    std::error_code error;
+    fs::create_directories(segments_path_, error);
+    if (error) return tl::unexpected(StoreError::kIoError);
+
+    std::map<uint64_t, std::string> ordered_segments;
+    for (const auto& entry : fs::directory_iterator(segments_path_, error)) {
+        if (error) return tl::unexpected(StoreError::kIoError);
+        if (!entry.is_regular_file(error) || error) {
+            error.clear();
+            continue;
+        }
+        auto id = ParseSegmentId(entry.path().filename().string());
+        if (id) ordered_segments.emplace(*id, entry.path().string());
+    }
+
+    std::unordered_map<uint64_t, std::vector<ScannedRecord>> scanned_segments;
+    uint64_t max_sequence = 0;
+    for (auto it = ordered_segments.begin(); it != ordered_segments.end();
+         ++it) {
+        auto scan = ScanSegment(it->second, it->first);
+        if (!scan) return tl::unexpected(StoreError::kIoError);
+        const bool is_last = std::next(it) == ordered_segments.end();
+        if (scan->termination == ScanTermination::kCorruptRecord ||
+            (scan->termination == ScanTermination::kIncompleteTail &&
+             !is_last)) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        if (scan->termination == ScanTermination::kIncompleteTail) {
+            auto truncated = TruncateSegment(it->second, scan->valid_bytes);
+            if (!truncated) return tl::unexpected(StoreError::kIoError);
+        }
+        for (const auto& record : scan->records) {
+            max_sequence = std::max(max_sequence, record.sequence);
+        }
+        scanned_segments.emplace(it->first, std::move(scan->records));
+        segment_paths_.emplace(it->first, it->second);
+        next_segment_id_ = std::max(next_segment_id_, it->first + 1);
+    }
+
+    if (fs::exists(wal_path_, error)) {
+        if (error) return tl::unexpected(StoreError::kIoError);
+        auto scan = ScanWal(wal_path_);
+        if (!scan) return tl::unexpected(StoreError::kIoError);
+        if (scan->termination == WalScanTermination::kCorruptRecord) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        auto replayed = ReplayWal(scan->records, index_);
+        if (!replayed) return tl::unexpected(StoreError::kCorruptData);
+        for (const auto& record : scan->records) {
+            max_sequence = std::max(max_sequence, record.sequence);
+        }
+        auto opened = WalWriter::OpenForAppend(wal_path_, scan->valid_bytes);
+        if (!opened) return tl::unexpected(StoreError::kIoError);
+        wal_ = std::move(opened.value());
+    } else {
+        if (error) return tl::unexpected(StoreError::kIoError);
+        auto created = WalWriter::Create(wal_path_);
+        if (!created) return tl::unexpected(StoreError::kIoError);
+        wal_ = std::move(created.value());
+    }
+
+    for (const auto& snapshot : index_.Snapshot()) {
+        if (snapshot.version.physical.total_length == 0) continue;
+        auto segment =
+            scanned_segments.find(snapshot.version.physical.segment_id);
+        if (segment == scanned_segments.end()) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        const auto record = std::find_if(
+            segment->second.begin(), segment->second.end(),
+            [&](const ScannedRecord& candidate) {
+                return candidate.identity == snapshot.identity &&
+                       candidate.sequence == snapshot.version.sequence &&
+                       candidate.physical == snapshot.version.physical;
+            });
+        if (record == segment->second.end()) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+    }
+
+    next_sequence_ = max_sequence + 1;
+    if (ordered_segments.empty()) {
+        const uint64_t segment_id = next_segment_id_++;
+        const std::string path = SegmentPath(segment_id);
+        auto created = SegmentWriter::Create(path, segment_id);
+        if (!created) return tl::unexpected(StoreError::kIoError);
+        segment_paths_.emplace(segment_id, path);
+        active_segment_ = std::move(created.value());
+    } else {
+        const auto& [segment_id, path] = *ordered_segments.rbegin();
+        auto scan = ScanSegment(path, segment_id);
+        if (!scan) return tl::unexpected(StoreError::kIoError);
+        auto opened =
+            SegmentWriter::OpenForAppend(path, segment_id, scan->valid_bytes);
+        if (!opened) return tl::unexpected(StoreError::kIoError);
+        active_segment_ = std::move(opened.value());
+    }
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
+    uint64_t next_record_bytes) {
+    if (active_segment_->tail() == 0 ||
+        active_segment_->tail() + next_record_bytes <=
+            config_.max_segment_bytes) {
+        return {};
+    }
+    auto synced = active_segment_->Sync();
+    if (!synced) return tl::unexpected(StoreError::kIoError);
+    const uint64_t segment_id = next_segment_id_++;
+    const std::string path = SegmentPath(segment_id);
+    auto created = SegmentWriter::Create(path, segment_id);
+    if (!created) return tl::unexpected(StoreError::kIoError);
+    segment_paths_.emplace(segment_id, path);
+    active_segment_ = std::move(created.value());
+    return {};
+}
+
+tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
+    const RecordIdentity& identity, std::string_view value) {
+    std::lock_guard lock(mutex_);
+    const uint64_t record_bytes = AlignedRecordSize(
+        identity.tenant_id.size(), identity.object_key.size(), value.size());
+    if (record_bytes == 0) {
+        return tl::unexpected(StoreError::kInvalidArgument);
+    }
+    auto rotated = RotateSegmentIfNeeded(record_bytes);
+    if (!rotated) return tl::unexpected(rotated.error());
+
+    const uint64_t sequence = next_sequence_++;
+    auto appended = active_segment_->Append(identity, value, RecordKind::kValue,
+                                            sequence, config_.sync_data);
+    if (!appended) return tl::unexpected(StoreError::kIoError);
+    WalRecord transition{.type = WalRecordType::kPrepareValue,
+                         .sequence = sequence,
+                         .identity = identity,
+                         .physical = appended.value()};
+    auto wal_result = wal_->Append(transition, config_.sync_wal);
+    if (!wal_result) return tl::unexpected(StoreError::kIoError);
+    auto prepared = index_.Prepare(identity, appended.value(), sequence);
+    if (!prepared) return tl::unexpected(MapIndexError(prepared.error()));
+    return PreparedWrite{.identity = identity,
+                         .sequence = sequence,
+                         .physical = appended.value()};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::CommitPut(
+    const RecordIdentity& identity, uint64_t sequence) {
+    std::lock_guard lock(mutex_);
+    auto current = index_.Lookup(identity);
+    if (!current) return tl::unexpected(StoreError::kNotFound);
+    if (current->state == VersionState::kCommitted &&
+        current->sequence == sequence) {
+        return {};
+    }
+    if (current->state != VersionState::kPrepared ||
+        current->sequence != sequence) {
+        return tl::unexpected(StoreError::kInvalidTransition);
+    }
+    auto persisted = wal_->Append(WalRecord{.type = WalRecordType::kCommitValue,
+                                            .sequence = sequence,
+                                            .identity = identity,
+                                            .physical = {}},
+                                  config_.sync_wal);
+    if (!persisted) return tl::unexpected(StoreError::kIoError);
+    auto committed = index_.Commit(identity, sequence);
+    if (!committed) return tl::unexpected(MapIndexError(committed.error()));
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::AbortPut(
+    const RecordIdentity& identity, uint64_t sequence) {
+    std::lock_guard lock(mutex_);
+    auto current = index_.Lookup(identity);
+    if (!current) return tl::unexpected(StoreError::kNotFound);
+    if (current->state == VersionState::kAborted &&
+        current->sequence == sequence) {
+        return {};
+    }
+    if (current->state != VersionState::kPrepared ||
+        current->sequence != sequence) {
+        return tl::unexpected(StoreError::kInvalidTransition);
+    }
+    auto persisted = wal_->Append(WalRecord{.type = WalRecordType::kAbortValue,
+                                            .sequence = sequence,
+                                            .identity = identity,
+                                            .physical = {}},
+                                  config_.sync_wal);
+    if (!persisted) return tl::unexpected(StoreError::kIoError);
+    auto aborted = index_.Abort(identity, sequence);
+    if (!aborted) return tl::unexpected(MapIndexError(aborted.error()));
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::Delete(
+    const RecordIdentity& identity) {
+    std::lock_guard lock(mutex_);
+    const uint64_t record_bytes = AlignedRecordSize(
+        identity.tenant_id.size(), identity.object_key.size(), 0);
+    auto rotated = RotateSegmentIfNeeded(record_bytes);
+    if (!rotated) return tl::unexpected(rotated.error());
+    const uint64_t sequence = next_sequence_++;
+    auto appended = active_segment_->Append(
+        identity, "", RecordKind::kTombstone, sequence, config_.sync_data);
+    if (!appended) return tl::unexpected(StoreError::kIoError);
+    auto persisted =
+        wal_->Append(WalRecord{.type = WalRecordType::kApplyTombstone,
+                               .sequence = sequence,
+                               .identity = identity,
+                               .physical = {}},
+                     config_.sync_wal);
+    if (!persisted) return tl::unexpected(StoreError::kIoError);
+    auto tombstoned = index_.ApplyTombstone(identity, sequence);
+    if (!tombstoned) {
+        return tl::unexpected(MapIndexError(tombstoned.error()));
+    }
+    return {};
+}
+
+tl::expected<std::string, StoreError> LogStructuredStore::Get(
+    const RecordIdentity& identity) const {
+    std::lock_guard lock(mutex_);
+    auto entry = index_.LookupCommitted(identity);
+    if (!entry) return tl::unexpected(StoreError::kNotFound);
+    auto path = segment_paths_.find(entry->physical.segment_id);
+    if (path == segment_paths_.end()) {
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    auto record = ReadRecord(path->second, entry->physical);
+    if (!record || record->identity != identity ||
+        record->kind == RecordKind::kTombstone) {
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    return std::move(record->value);
+}
+
+std::vector<IndexSnapshotEntry> LogStructuredStore::SnapshotIndex() const {
+    std::lock_guard lock(mutex_);
+    return index_.Snapshot();
+}
+
+uint64_t LogStructuredStore::active_segment_id() const {
+    std::lock_guard lock(mutex_);
+    return active_segment_->segment_id();
+}
+
+uint64_t LogStructuredStore::next_sequence() const {
+    std::lock_guard lock(mutex_);
+    return next_sequence_;
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -488,6 +488,17 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
     if (record_bytes == 0) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
+    uint64_t physical_bytes = 0;
+    for (const auto& [segment_id, segment] : segments_) {
+        static_cast<void>(segment_id);
+        if (segment.valid_bytes > config_.max_physical_bytes - physical_bytes) {
+            return tl::unexpected(StoreError::kNoSpace);
+        }
+        physical_bytes += segment.valid_bytes;
+    }
+    if (record_bytes > config_.max_physical_bytes - physical_bytes) {
+        return tl::unexpected(StoreError::kNoSpace);
+    }
     auto rotated = RotateSegmentIfNeeded(record_bytes);
     if (!rotated) return tl::unexpected(rotated.error());
 

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -619,12 +619,134 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
 
 tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
     std::string tenant_id, std::string object_key, std::string_view value) {
+    std::vector<PutRequest> requests;
+    requests.push_back({.tenant_id = std::move(tenant_id),
+                        .object_key = std::move(object_key),
+                        .value = value});
+    auto prepared = PreparePutBatch(requests);
+    if (!prepared) return tl::unexpected(prepared.error());
+    return std::move(prepared->front());
+}
+
+tl::expected<std::vector<PreparedWrite>, StoreError>
+LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
     std::lock_guard lock(mutex_);
-    RecordIdentity identity{.tenant_id = std::move(tenant_id),
-                            .object_key = std::move(object_key),
-                            .incarnation = {.high = directory_->identity().high,
-                                            .low = next_sequence_}};
-    return PreparePutLocked(identity, value);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    if (requests.empty()) {
+        return tl::unexpected(StoreError::kInvalidArgument);
+    }
+
+    uint64_t total_record_bytes = 0;
+    std::vector<uint64_t> record_sizes;
+    record_sizes.reserve(requests.size());
+    for (const auto& request : requests) {
+        if (request.tenant_id.size() > kMaxTenantLength ||
+            request.object_key.size() > kMaxKeyLength) {
+            return tl::unexpected(StoreError::kInvalidArgument);
+        }
+        const uint64_t record_bytes =
+            AlignedRecordSize(static_cast<uint32_t>(request.tenant_id.size()),
+                              static_cast<uint32_t>(request.object_key.size()),
+                              request.value.size());
+        if (record_bytes == 0 ||
+            total_record_bytes >
+                std::numeric_limits<uint64_t>::max() - record_bytes) {
+            return tl::unexpected(StoreError::kInvalidArgument);
+        }
+        total_record_bytes += record_bytes;
+        record_sizes.push_back(record_bytes);
+    }
+
+    const uint64_t physical_bytes = PhysicalBytesLocked();
+    if (physical_bytes > config_.max_physical_bytes ||
+        total_record_bytes > config_.max_physical_bytes - physical_bytes ||
+        physical_bytes > config_.max_total_physical_bytes ||
+        compaction_reserved_bytes_ >
+            config_.max_total_physical_bytes - physical_bytes ||
+        total_record_bytes > config_.max_total_physical_bytes - physical_bytes -
+                                 compaction_reserved_bytes_) {
+        return tl::unexpected(StoreError::kNoSpace);
+    }
+
+    std::vector<PreparedWrite> prepared;
+    prepared.reserve(requests.size());
+    size_t begin = 0;
+    while (begin < requests.size()) {
+        auto rotated = RotateSegmentIfNeeded(record_sizes[begin]);
+        if (!rotated) return tl::unexpected(rotated.error());
+
+        const uint64_t segment_tail = active_segment_->tail();
+        uint64_t chunk_bytes = 0;
+        size_t end = begin;
+        while (end < requests.size()) {
+            const uint64_t next_bytes = record_sizes[end];
+            if (end != begin &&
+                (chunk_bytes > config_.max_segment_bytes - segment_tail ||
+                 next_bytes >
+                     config_.max_segment_bytes - segment_tail - chunk_bytes)) {
+                break;
+            }
+            chunk_bytes += next_bytes;
+            ++end;
+            if (segment_tail + chunk_bytes >= config_.max_segment_bytes) break;
+        }
+
+        std::vector<SegmentAppendRequest> appends;
+        std::vector<WalRecord> wal_records;
+        appends.reserve(end - begin);
+        wal_records.reserve(end - begin);
+        for (size_t index = begin; index < end; ++index) {
+            const uint64_t sequence = next_sequence_++;
+            RecordIdentity identity{
+                .tenant_id = requests[index].tenant_id,
+                .object_key = requests[index].object_key,
+                .incarnation = {.high = directory_->identity().high,
+                                .low = sequence}};
+            appends.push_back({.identity = std::move(identity),
+                               .value = requests[index].value,
+                               .kind = RecordKind::kValue,
+                               .sequence = sequence});
+        }
+
+        auto physical_records = active_segment_->AppendBatch(
+            appends, config_.sync_data, config_.payload_write_parallelism);
+        if (!physical_records) {
+            return tl::unexpected(StoreError::kIoError);
+        }
+        auto& segment = segments_.at(active_segment_->segment_id());
+        segment.valid_bytes = active_segment_->tail();
+        segment.record_count += appends.size();
+        ++segment.mutation_epoch;
+
+        for (size_t index = 0; index < appends.size(); ++index) {
+            wal_records.push_back({.type = WalRecordType::kPrepareValue,
+                                   .sequence = appends[index].sequence,
+                                   .identity = appends[index].identity,
+                                   .physical = (*physical_records)[index]});
+        }
+        if (!wal_->AppendBatch(wal_records, config_.sync_wal)) {
+            return tl::unexpected(StoreError::kIoError);
+        }
+
+        for (size_t index = 0; index < appends.size(); ++index) {
+            auto indexed = index_.Prepare(appends[index].identity,
+                                          (*physical_records)[index],
+                                          appends[index].sequence);
+            if (!indexed) {
+                recovery_required_ = true;
+                return tl::unexpected(StoreError::kRecoveryRequired);
+            }
+            auto live = AddLiveRecordLocked((*physical_records)[index]);
+            if (!live) return tl::unexpected(live.error());
+            prepared.push_back({.identity = appends[index].identity,
+                                .sequence = appends[index].sequence,
+                                .physical = (*physical_records)[index]});
+        }
+        begin = end;
+    }
+    return prepared;
 }
 
 tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
@@ -715,6 +837,48 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
     return {};
 }
 
+tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
+    const std::vector<PreparedWrite>& writes) {
+    std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    if (writes.empty()) return {};
+
+    std::vector<WalRecord> records;
+    records.reserve(writes.size());
+    for (const auto& write : writes) {
+        auto current = index_.Lookup(write.identity);
+        if (!current || current->state != VersionState::kPrepared ||
+            current->sequence != write.sequence) {
+            return tl::unexpected(current ? StoreError::kInvalidTransition
+                                          : StoreError::kNotFound);
+        }
+        records.push_back({.type = WalRecordType::kCommitValue,
+                           .sequence = write.sequence,
+                           .identity = write.identity,
+                           .physical = {}});
+    }
+    if (!wal_->AppendBatch(records, config_.sync_wal)) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+    for (const auto& write : writes) {
+        auto previous_current = index_.LookupCurrent(write.identity.tenant_id,
+                                                     write.identity.object_key);
+        auto committed = index_.Commit(write.identity, write.sequence);
+        if (!committed) {
+            recovery_required_ = true;
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        if (previous_current && previous_current->identity != write.identity) {
+            auto removed =
+                RemoveLiveRecordLocked(previous_current->version.physical);
+            if (!removed) return tl::unexpected(removed.error());
+        }
+    }
+    return {};
+}
+
 tl::expected<void, StoreError> LogStructuredStore::AbortPut(
     const RecordIdentity& identity, uint64_t sequence) {
     std::lock_guard lock(mutex_);
@@ -744,6 +908,44 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
     return {};
 }
 
+tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
+    const std::vector<PreparedWrite>& writes) {
+    std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    if (writes.empty()) return {};
+
+    std::vector<WalRecord> records;
+    records.reserve(writes.size());
+    for (const auto& write : writes) {
+        auto current = index_.Lookup(write.identity);
+        if (!current || current->state != VersionState::kPrepared ||
+            current->sequence != write.sequence) {
+            return tl::unexpected(current ? StoreError::kInvalidTransition
+                                          : StoreError::kNotFound);
+        }
+        records.push_back({.type = WalRecordType::kAbortValue,
+                           .sequence = write.sequence,
+                           .identity = write.identity,
+                           .physical = {}});
+    }
+    if (!wal_->AppendBatch(records, config_.sync_wal)) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+    for (const auto& write : writes) {
+        auto current = index_.Lookup(write.identity);
+        auto aborted = index_.Abort(write.identity, write.sequence);
+        if (!aborted) {
+            recovery_required_ = true;
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        auto removed = RemoveLiveRecordLocked(current->physical);
+        if (!removed) return tl::unexpected(removed.error());
+    }
+    return {};
+}
+
 tl::expected<void, StoreError> LogStructuredStore::Delete(
     const RecordIdentity& identity) {
     std::lock_guard lock(mutex_);
@@ -755,28 +957,7 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
         return tl::unexpected(StoreError::kInvalidArgument);
     }
     const auto existing = index_.Lookup(identity);
-    const uint64_t record_bytes =
-        AlignedRecordSize(static_cast<uint32_t>(identity.tenant_id.size()),
-                          static_cast<uint32_t>(identity.object_key.size()), 0);
-    const uint64_t physical_bytes = PhysicalBytesLocked();
-    if (record_bytes == 0 ||
-        physical_bytes > config_.max_total_physical_bytes ||
-        compaction_reserved_bytes_ >
-            config_.max_total_physical_bytes - physical_bytes ||
-        record_bytes > config_.max_total_physical_bytes - physical_bytes -
-                           compaction_reserved_bytes_) {
-        return tl::unexpected(StoreError::kNoSpace);
-    }
-    auto rotated = RotateSegmentIfNeeded(record_bytes);
-    if (!rotated) return tl::unexpected(rotated.error());
     const uint64_t sequence = next_sequence_++;
-    auto appended = active_segment_->Append(
-        identity, "", RecordKind::kTombstone, sequence, config_.sync_data);
-    if (!appended) return tl::unexpected(StoreError::kIoError);
-    auto& segment = segments_.at(active_segment_->segment_id());
-    segment.valid_bytes = active_segment_->tail();
-    ++segment.record_count;
-    ++segment.mutation_epoch;
     auto persisted =
         wal_->Append(WalRecord{.type = WalRecordType::kApplyTombstone,
                                .sequence = sequence,

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -415,6 +415,10 @@ tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
             config_.max_segment_bytes) {
         return {};
     }
+    return RotateActiveSegmentLocked();
+}
+
+tl::expected<void, StoreError> LogStructuredStore::RotateActiveSegmentLocked() {
     auto synced = active_segment_->Sync();
     if (!synced) return tl::unexpected(StoreError::kIoError);
     auto old_metadata = segments_.find(active_segment_->segment_id());
@@ -577,6 +581,20 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
     return {};
 }
 
+tl::expected<void, StoreError> LogStructuredStore::Sync() {
+    std::lock_guard lock(mutex_);
+    if (!active_segment_->Sync() || !wal_->Sync()) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::SealActiveSegment() {
+    std::lock_guard lock(mutex_);
+    if (active_segment_->tail() == 0) return {};
+    return RotateActiveSegmentLocked();
+}
+
 tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
     std::lock_guard lock(mutex_);
     return CheckpointLocked();
@@ -683,6 +701,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         std::lock_guard lock(mutex_);
         CleanupRetiredSegmentsLocked();
         RefreshSegmentLiveBytes();
+        std::vector<SegmentMetadata> sealed;
         for (const auto& [segment_id, segment] : segments_) {
             static_cast<void>(segment_id);
             if (segment.state != SegmentLifecycle::kSealed ||
@@ -690,16 +709,16 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 segment.live_bytes > segment.valid_bytes) {
                 continue;
             }
+            sealed.push_back(segment);
             const uint64_t reclaimable =
                 segment.valid_bytes - segment.live_bytes;
             const double reclaim_ratio =
                 static_cast<double>(reclaimable) / segment.valid_bytes;
-            if (reclaimable == 0 ||
-                (segment.live_bytes != 0 &&
-                 reclaim_ratio < options.min_reclaim_ratio)) {
-                continue;
+            if (reclaimable != 0 &&
+                (segment.live_bytes == 0 ||
+                 reclaim_ratio >= options.min_reclaim_ratio)) {
+                sources.push_back(segment);
             }
-            sources.push_back(segment);
         }
         std::sort(
             sources.begin(), sources.end(),
@@ -713,6 +732,24 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 }
                 return left.segment_id < right.segment_id;
             });
+        if (sources.empty() && options.enable_tiering) {
+            for (uint32_t level = 0; level + 1 < options.max_levels; ++level) {
+                std::vector<SegmentMetadata> level_segments;
+                for (const auto& segment : sealed) {
+                    if (segment.level == level)
+                        level_segments.push_back(segment);
+                }
+                if (level_segments.size() < options.fanout) continue;
+                std::sort(level_segments.begin(), level_segments.end(),
+                          [](const SegmentMetadata& left,
+                             const SegmentMetadata& right) {
+                              return left.segment_id < right.segment_id;
+                          });
+                level_segments.resize(options.fanout);
+                sources = std::move(level_segments);
+                break;
+            }
+        }
         if (sources.size() > options.max_source_segments) {
             sources.resize(options.max_source_segments);
         }
@@ -737,7 +774,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         for (auto& source : sources) {
             source_ids.insert(source.segment_id);
             input_bytes += source.valid_bytes;
-            target_level = std::max(target_level, source.level + 1);
+            const uint32_t next_level =
+                source.level + static_cast<uint32_t>(source.level + 1 != 0);
+            target_level = std::max(target_level, next_level);
             auto path = segment_paths_.find(source.segment_id);
             if (path == segment_paths_.end()) {
                 return tl::unexpected(StoreError::kCorruptData);
@@ -758,6 +797,17 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             reserved_target_ids.push_back(next_segment_id_++);
         }
     }
+
+    target_level = std::min(target_level, options.max_levels - 1);
+    uint64_t target_bytes = config_.max_segment_bytes;
+    for (uint32_t level = 0; level < target_level; ++level) {
+        if (target_bytes > options.max_target_bytes / options.fanout) {
+            target_bytes = options.max_target_bytes;
+            break;
+        }
+        target_bytes *= options.fanout;
+    }
+    target_bytes = std::min(target_bytes, options.max_target_bytes);
 
     struct TargetOutput {
         uint64_t segment_id{0};
@@ -807,8 +857,8 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             return tl::unexpected(StoreError::kCorruptData);
         }
         const uint64_t record_bytes = entry.version.physical.total_length;
-        if (!writer || (writer->tail() != 0 && writer->tail() + record_bytes >
-                                                   config_.max_segment_bytes)) {
+        if (!writer || (writer->tail() != 0 &&
+                        writer->tail() + record_bytes > target_bytes)) {
             if (writer && !writer->Sync()) {
                 cleanup_targets();
                 reset_sources();

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -547,6 +547,31 @@ void LogStructuredStore::RefreshSegmentLiveBytes() {
     }
 }
 
+tl::expected<void, StoreError> LogStructuredStore::AddLiveRecordLocked(
+    const PhysicalRecord& physical) {
+    auto segment = segments_.find(physical.segment_id);
+    if (physical.total_length == 0 || segment == segments_.end() ||
+        segment->second.live_bytes >
+            std::numeric_limits<uint64_t>::max() - physical.total_length) {
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    segment->second.live_bytes += physical.total_length;
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::RemoveLiveRecordLocked(
+    const PhysicalRecord& physical) {
+    auto segment = segments_.find(physical.segment_id);
+    if (physical.total_length == 0 || segment == segments_.end() ||
+        segment->second.live_bytes < physical.total_length) {
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    segment->second.live_bytes -= physical.total_length;
+    return {};
+}
+
 tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
     uint64_t next_record_bytes) {
     if (active_segment_->tail() == 0 ||
@@ -611,6 +636,9 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
         identity.object_key.size() > kMaxKeyLength) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
+    if (index_.Lookup(identity)) {
+        return tl::unexpected(StoreError::kInvalidTransition);
+    }
     const uint64_t record_bytes = AlignedRecordSize(
         static_cast<uint32_t>(identity.tenant_id.size()),
         static_cast<uint32_t>(identity.object_key.size()), value.size());
@@ -634,6 +662,10 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
     auto appended = active_segment_->Append(identity, value, RecordKind::kValue,
                                             sequence, config_.sync_data);
     if (!appended) return tl::unexpected(StoreError::kIoError);
+    auto& segment = segments_.at(active_segment_->segment_id());
+    segment.valid_bytes = active_segment_->tail();
+    ++segment.record_count;
+    ++segment.mutation_epoch;
     WalRecord transition{.type = WalRecordType::kPrepareValue,
                          .sequence = sequence,
                          .identity = identity,
@@ -642,10 +674,8 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
     if (!wal_result) return tl::unexpected(StoreError::kIoError);
     auto prepared = index_.Prepare(identity, appended.value(), sequence);
     if (!prepared) return tl::unexpected(MapIndexError(prepared.error()));
-    auto& segment = segments_.at(active_segment_->segment_id());
-    segment.valid_bytes = active_segment_->tail();
-    ++segment.record_count;
-    ++segment.mutation_epoch;
+    auto live = AddLiveRecordLocked(appended.value());
+    if (!live) return tl::unexpected(live.error());
     return PreparedWrite{.identity = identity,
                          .sequence = sequence,
                          .physical = appended.value()};
@@ -667,6 +697,8 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
         current->sequence != sequence) {
         return tl::unexpected(StoreError::kInvalidTransition);
     }
+    auto previous_current =
+        index_.LookupCurrent(identity.tenant_id, identity.object_key);
     auto persisted = wal_->Append(WalRecord{.type = WalRecordType::kCommitValue,
                                             .sequence = sequence,
                                             .identity = identity,
@@ -675,7 +707,11 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
     if (!persisted) return tl::unexpected(StoreError::kIoError);
     auto committed = index_.Commit(identity, sequence);
     if (!committed) return tl::unexpected(MapIndexError(committed.error()));
-    RefreshSegmentLiveBytes();
+    if (previous_current && previous_current->identity != identity) {
+        auto removed =
+            RemoveLiveRecordLocked(previous_current->version.physical);
+        if (!removed) return tl::unexpected(removed.error());
+    }
     return {};
 }
 
@@ -703,6 +739,8 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
     if (!persisted) return tl::unexpected(StoreError::kIoError);
     auto aborted = index_.Abort(identity, sequence);
     if (!aborted) return tl::unexpected(MapIndexError(aborted.error()));
+    auto removed = RemoveLiveRecordLocked(current->physical);
+    if (!removed) return tl::unexpected(removed.error());
     return {};
 }
 
@@ -716,6 +754,7 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
         identity.object_key.size() > kMaxKeyLength) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
+    const auto existing = index_.Lookup(identity);
     const uint64_t record_bytes =
         AlignedRecordSize(static_cast<uint32_t>(identity.tenant_id.size()),
                           static_cast<uint32_t>(identity.object_key.size()), 0);
@@ -734,6 +773,10 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
     auto appended = active_segment_->Append(
         identity, "", RecordKind::kTombstone, sequence, config_.sync_data);
     if (!appended) return tl::unexpected(StoreError::kIoError);
+    auto& segment = segments_.at(active_segment_->segment_id());
+    segment.valid_bytes = active_segment_->tail();
+    ++segment.record_count;
+    ++segment.mutation_epoch;
     auto persisted =
         wal_->Append(WalRecord{.type = WalRecordType::kApplyTombstone,
                                .sequence = sequence,
@@ -745,12 +788,12 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
     if (!tombstoned) {
         return tl::unexpected(MapIndexError(tombstoned.error()));
     }
-    auto& segment = segments_.at(active_segment_->segment_id());
-    segment.valid_bytes = active_segment_->tail();
-    ++segment.record_count;
-    ++segment.mutation_epoch;
+    if (existing && (existing->state == VersionState::kPrepared ||
+                     existing->state == VersionState::kCommitted)) {
+        auto removed = RemoveLiveRecordLocked(existing->physical);
+        if (!removed) return tl::unexpected(removed.error());
+    }
     applied_delete_watermark_ = sequence;
-    RefreshSegmentLiveBytes();
     return {};
 }
 
@@ -786,7 +829,6 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     if (!active_segment_->Sync() || !wal_->Sync()) {
         return tl::unexpected(StoreError::kIoError);
     }
-    RefreshSegmentLiveBytes();
     const uint64_t generation = manifest_generation_ + 1;
     const uint64_t checkpoint_sequence = next_sequence_ - 1;
     std::vector<SegmentMetadata> segment_snapshot;
@@ -916,7 +958,6 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             return tl::unexpected(StoreError::kRecoveryRequired);
         }
         CleanupRetiredSegmentsLocked();
-        RefreshSegmentLiveBytes();
         std::unordered_set<uint64_t> prepared_segments;
         for (const auto& entry : index_.Snapshot()) {
             if (entry.version.state == VersionState::kPrepared &&
@@ -1213,6 +1254,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 auto current = segments_.find(source.segment_id);
                 if (current != segments_.end()) {
                     current->second.state = SegmentLifecycle::kSealed;
+                    current->second.live_bytes = source.live_bytes;
                     ++current->second.mutation_epoch;
                 }
             }
@@ -1236,9 +1278,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         for (const auto& source : sources) {
             auto& current = segments_.at(source.segment_id);
             current.state = SegmentLifecycle::kRetired;
+            current.live_bytes = 0;
             ++current.mutation_epoch;
         }
-        RefreshSegmentLiveBytes();
         auto checkpointed = CheckpointLocked();
         if (!checkpointed) {
             if (checkpointed.error() == StoreError::kRecoveryRequired) {
@@ -1253,6 +1295,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 auto current = segments_.find(source.segment_id);
                 if (current != segments_.end()) {
                     current->second.state = SegmentLifecycle::kSealed;
+                    current->second.live_bytes = source.live_bytes;
                     ++current->second.mutation_epoch;
                 }
             }
@@ -1264,7 +1307,6 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             return tl::unexpected(StoreError::kIoError);
         }
         CleanupRetiredSegmentsLocked();
-        RefreshSegmentLiveBytes();
         if (HitCompactionCrashPoint(CompactionCrashPoint::kAfterSourceUnlink)) {
             return tl::unexpected(StoreError::kIoError);
         }

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -19,6 +19,14 @@ constexpr std::string_view kSegmentPrefix = "segment-";
 constexpr std::string_view kSegmentSuffix = ".log";
 constexpr std::string_view kInitialWalFile = "WAL-00000000000000000001";
 
+std::mutex compaction_crash_mutex;
+std::function<bool(CompactionCrashPoint)> compaction_crash_predicate;
+
+bool HitCompactionCrashPoint(CompactionCrashPoint point) {
+    std::lock_guard lock(compaction_crash_mutex);
+    return compaction_crash_predicate && compaction_crash_predicate(point);
+}
+
 std::optional<uint64_t> ParseSegmentId(std::string_view name) {
     if (!name.starts_with(kSegmentPrefix) || !name.ends_with(kSegmentSuffix)) {
         return std::nullopt;
@@ -91,6 +99,12 @@ LogStructuredStore::LogStructuredStore(LogStructuredStoreConfig config)
     : config_(std::move(config)),
       segments_path_(config_.root_path + "/segments"),
       wal_path_(config_.root_path + "/" + std::string(kInitialWalFile)) {}
+
+void LogStructuredStore::SetCompactionCrashPredicateForTest(
+    std::function<bool(CompactionCrashPoint)> predicate) {
+    std::lock_guard lock(compaction_crash_mutex);
+    compaction_crash_predicate = std::move(predicate);
+}
 
 tl::expected<std::unique_ptr<LogStructuredStore>, StoreError>
 LogStructuredStore::Open(LogStructuredStoreConfig config) {
@@ -934,9 +948,15 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         reset_sources();
         return tl::unexpected(StoreError::kCancelled);
     }
+    if (HitCompactionCrashPoint(CompactionCrashPoint::kBeforeTargetSync)) {
+        return tl::unexpected(StoreError::kIoError);
+    }
     if (writer && !writer->Sync()) {
         cleanup_targets();
         reset_sources();
+        return tl::unexpected(StoreError::kIoError);
+    }
+    if (HitCompactionCrashPoint(CompactionCrashPoint::kAfterTargetSync)) {
         return tl::unexpected(StoreError::kIoError);
     }
     if (options.stop_token.stop_requested()) {
@@ -957,6 +977,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
     if (!targets.empty() && !SyncDirectory(segments_path_)) {
         cleanup_targets();
         reset_sources();
+        return tl::unexpected(StoreError::kIoError);
+    }
+    if (HitCompactionCrashPoint(CompactionCrashPoint::kAfterTargetRename)) {
         return tl::unexpected(StoreError::kIoError);
     }
 
@@ -1012,6 +1035,10 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             }
             cleanup_targets();
             return tl::unexpected(checkpointed.error());
+        }
+        if (HitCompactionCrashPoint(
+                CompactionCrashPoint::kAfterManifestPublication)) {
+            return tl::unexpected(StoreError::kIoError);
         }
         CleanupRetiredSegmentsLocked();
         RefreshSegmentLiveBytes();

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -1,10 +1,14 @@
 #include "storage/local/log_structured/store.h"
 
 #include <algorithm>
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <filesystem>
 #include <limits>
 #include <map>
 #include <string_view>
+#include <unordered_set>
 
 namespace mooncake::logstructured {
 namespace {
@@ -63,6 +67,22 @@ StoreError MapIndexError(IndexError error) {
     return StoreError::kInvalidTransition;
 }
 
+bool SyncDirectory(const std::string& path) {
+    const int fd = open(path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd < 0) return false;
+    const bool synced = fsync(fd) == 0;
+    const bool closed = close(fd) == 0;
+    return synced && closed;
+}
+
+bool IsCompactionOnly(const SegmentScanResult& scan) {
+    return !scan.records.empty() &&
+           std::all_of(scan.records.begin(), scan.records.end(),
+                       [](const ScannedRecord& record) {
+                           return record.kind == RecordKind::kCompactionCopy;
+                       });
+}
+
 }  // namespace
 
 LogStructuredStore::LogStructuredStore(LogStructuredStoreConfig config)
@@ -105,6 +125,14 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
     std::error_code error;
     fs::create_directories(segments_path_, error);
     if (error) return tl::unexpected(StoreError::kIoError);
+    fs::create_directories(config_.root_path + "/tmp", error);
+    if (error) return tl::unexpected(StoreError::kIoError);
+    for (const auto& entry :
+         fs::directory_iterator(config_.root_path + "/tmp", error)) {
+        if (error) return tl::unexpected(StoreError::kIoError);
+        fs::remove_all(entry.path(), error);
+        if (error) return tl::unexpected(StoreError::kIoError);
+    }
 
     std::vector<SegmentMetadata> expected_segments;
     uint64_t expected_active_segment = 0;
@@ -193,8 +221,11 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
 
     for (const auto& segment : expected_segments) {
         if (segment.segment_id == 0 ||
-            !segments_.emplace(segment.segment_id, segment).second ||
-            !ordered_segments.contains(segment.segment_id)) {
+            !segments_.emplace(segment.segment_id, segment).second) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        if (!ordered_segments.contains(segment.segment_id) &&
+            segment.state != SegmentLifecycle::kRetired) {
             return tl::unexpected(StoreError::kCorruptData);
         }
     }
@@ -206,13 +237,35 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
         }
     }
 
-    uint64_t active_segment_id = checkpoint_active_segment_id;
-    if (!ordered_segments.empty() &&
-        ordered_segments.rbegin()->first > active_segment_id) {
-        active_segment_id = ordered_segments.rbegin()->first;
+    for (auto it = ordered_segments.begin(); it != ordered_segments.end();) {
+        if (segments_.contains(it->first) ||
+            it->first < post_checkpoint_segment_floor) {
+            ++it;
+            continue;
+        }
+        auto scan = ScanSegment(it->second, it->first);
+        if (!scan) return tl::unexpected(StoreError::kCorruptData);
+        if (scan->termination != ScanTermination::kCleanEof ||
+            !IsCompactionOnly(*scan)) {
+            ++it;
+            continue;
+        }
+        const auto filename = fs::path(it->second).filename().string();
+        auto removed = RemoveFileDurably(segments_path_, filename);
+        if (!removed) return tl::unexpected(StoreError::kIoError);
+        it = ordered_segments.erase(it);
     }
+
+    uint64_t active_segment_id = checkpoint_active_segment_id;
     if (expected_segments.empty() && !ordered_segments.empty()) {
         active_segment_id = ordered_segments.rbegin()->first;
+    } else {
+        for (const auto& [segment_id, path] : ordered_segments) {
+            static_cast<void>(path);
+            if (!segments_.contains(segment_id)) {
+                active_segment_id = std::max(active_segment_id, segment_id);
+            }
+        }
     }
 
     std::unordered_map<uint64_t, std::vector<ScannedRecord>> scanned_segments;
@@ -268,6 +321,21 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
 
     auto validated = ValidateIndexRecords(scanned_segments);
     if (!validated) return validated;
+
+    for (auto it = segments_.begin(); it != segments_.end();) {
+        if (it->second.state != SegmentLifecycle::kRetired) {
+            ++it;
+            continue;
+        }
+        auto path = segment_paths_.find(it->first);
+        if (path != segment_paths_.end()) {
+            const auto filename = fs::path(path->second).filename().string();
+            auto removed = RemoveFileDurably(segments_path_, filename);
+            if (!removed) return tl::unexpected(StoreError::kIoError);
+            segment_paths_.erase(path);
+        }
+        it = segments_.erase(it);
+    }
 
     if (active_segment_id == 0) {
         const uint64_t segment_id = next_segment_id_++;
@@ -511,6 +579,10 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
 
 tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
     std::lock_guard lock(mutex_);
+    return CheckpointLocked();
+}
+
+tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     if (!active_segment_->Sync() || !wal_->Sync()) {
         return tl::unexpected(StoreError::kIoError);
     }
@@ -567,10 +639,298 @@ tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
     manifest_generation_ = generation;
     checkpoint_sequence_ = checkpoint_sequence;
     if (old_wal_file != next_wal_file) {
-        auto removed = RemoveFileDurably(config_.root_path, old_wal_file);
-        if (!removed) return tl::unexpected(StoreError::kIoError);
+        static_cast<void>(RemoveFileDurably(config_.root_path, old_wal_file));
     }
     return {};
+}
+
+void LogStructuredStore::CleanupRetiredSegmentsLocked() {
+    namespace fs = std::filesystem;
+    for (auto it = segments_.begin(); it != segments_.end();) {
+        if (it->second.state != SegmentLifecycle::kRetired) {
+            ++it;
+            continue;
+        }
+        auto path = segment_paths_.find(it->first);
+        if (path != segment_paths_.end()) {
+            const auto filename = fs::path(path->second).filename().string();
+            if (!RemoveFileDurably(segments_path_, filename)) {
+                ++it;
+                continue;
+            }
+            segment_paths_.erase(path);
+        }
+        it = segments_.erase(it);
+    }
+}
+
+tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
+    const CompactionOptions& options) {
+    if (options.max_source_segments == 0 || options.max_input_bytes == 0 ||
+        options.min_reclaim_ratio < 0.0 || options.min_reclaim_ratio > 1.0) {
+        return tl::unexpected(StoreError::kInvalidArgument);
+    }
+
+    std::lock_guard compaction_lock(compaction_mutex_);
+    std::vector<SegmentMetadata> sources;
+    std::unordered_map<uint64_t, std::string> source_paths;
+    std::vector<IndexSnapshotEntry> live_entries;
+    std::vector<uint64_t> reserved_target_ids;
+    uint32_t target_level = 1;
+    uint64_t input_bytes = 0;
+
+    {
+        std::lock_guard lock(mutex_);
+        CleanupRetiredSegmentsLocked();
+        RefreshSegmentLiveBytes();
+        for (const auto& [segment_id, segment] : segments_) {
+            static_cast<void>(segment_id);
+            if (segment.state != SegmentLifecycle::kSealed ||
+                segment.valid_bytes == 0 ||
+                segment.live_bytes > segment.valid_bytes) {
+                continue;
+            }
+            const uint64_t reclaimable =
+                segment.valid_bytes - segment.live_bytes;
+            const double reclaim_ratio =
+                static_cast<double>(reclaimable) / segment.valid_bytes;
+            if (reclaimable == 0 ||
+                (segment.live_bytes != 0 &&
+                 reclaim_ratio < options.min_reclaim_ratio)) {
+                continue;
+            }
+            sources.push_back(segment);
+        }
+        std::sort(
+            sources.begin(), sources.end(),
+            [](const SegmentMetadata& left, const SegmentMetadata& right) {
+                const uint64_t left_reclaim =
+                    left.valid_bytes - left.live_bytes;
+                const uint64_t right_reclaim =
+                    right.valid_bytes - right.live_bytes;
+                if (left_reclaim != right_reclaim) {
+                    return left_reclaim > right_reclaim;
+                }
+                return left.segment_id < right.segment_id;
+            });
+        if (sources.size() > options.max_source_segments) {
+            sources.resize(options.max_source_segments);
+        }
+        uint64_t selected_bytes = 0;
+        size_t selected_count = 0;
+        for (; selected_count < sources.size(); ++selected_count) {
+            const auto bytes = sources[selected_count].valid_bytes;
+            if (selected_count != 0 &&
+                bytes > options.max_input_bytes - selected_bytes) {
+                break;
+            }
+            selected_bytes += bytes;
+            if (selected_bytes >= options.max_input_bytes) {
+                ++selected_count;
+                break;
+            }
+        }
+        sources.resize(selected_count);
+        if (sources.empty()) return CompactionResult{};
+
+        std::unordered_set<uint64_t> source_ids;
+        for (auto& source : sources) {
+            source_ids.insert(source.segment_id);
+            input_bytes += source.valid_bytes;
+            target_level = std::max(target_level, source.level + 1);
+            auto path = segment_paths_.find(source.segment_id);
+            if (path == segment_paths_.end()) {
+                return tl::unexpected(StoreError::kCorruptData);
+            }
+            source_paths.emplace(source.segment_id, path->second);
+            auto& current = segments_.at(source.segment_id);
+            current.state = SegmentLifecycle::kCompacting;
+            ++current.mutation_epoch;
+            source = current;
+        }
+        for (const auto& entry : index_.CurrentSnapshot()) {
+            if (source_ids.contains(entry.version.physical.segment_id)) {
+                live_entries.push_back(entry);
+            }
+        }
+        reserved_target_ids.reserve(std::max<size_t>(1, live_entries.size()));
+        for (size_t i = 0; i < std::max<size_t>(1, live_entries.size()); ++i) {
+            reserved_target_ids.push_back(next_segment_id_++);
+        }
+    }
+
+    struct TargetOutput {
+        uint64_t segment_id{0};
+        std::string temporary_path;
+        std::string final_path;
+        uint64_t valid_bytes{0};
+        uint64_t record_count{0};
+    };
+    std::vector<TargetOutput> targets;
+    std::vector<CompactionIndexUpdate> updates;
+    std::unique_ptr<SegmentWriter> writer;
+
+    const auto cleanup_targets = [&]() {
+        writer.reset();
+        std::error_code error;
+        for (const auto& target : targets) {
+            std::filesystem::remove(target.temporary_path, error);
+            error.clear();
+            std::filesystem::remove(target.final_path, error);
+            error.clear();
+        }
+    };
+    const auto reset_sources = [&]() {
+        std::lock_guard lock(mutex_);
+        for (const auto& source : sources) {
+            auto current = segments_.find(source.segment_id);
+            if (current != segments_.end() &&
+                current->second.state == SegmentLifecycle::kCompacting) {
+                current->second.state = SegmentLifecycle::kSealed;
+                ++current->second.mutation_epoch;
+            }
+        }
+    };
+
+    for (const auto& entry : live_entries) {
+        const auto path = source_paths.find(entry.version.physical.segment_id);
+        if (path == source_paths.end()) {
+            cleanup_targets();
+            reset_sources();
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        auto record = ReadRecord(path->second, entry.version.physical);
+        if (!record || record->identity != entry.identity ||
+            record->kind == RecordKind::kTombstone) {
+            cleanup_targets();
+            reset_sources();
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        const uint64_t record_bytes = entry.version.physical.total_length;
+        if (!writer || (writer->tail() != 0 && writer->tail() + record_bytes >
+                                                   config_.max_segment_bytes)) {
+            if (writer && !writer->Sync()) {
+                cleanup_targets();
+                reset_sources();
+                return tl::unexpected(StoreError::kIoError);
+            }
+            writer.reset();
+            const uint64_t segment_id = reserved_target_ids[targets.size()];
+            const std::string temporary_path =
+                config_.root_path + "/tmp/" + FormatSegmentName(segment_id);
+            const std::string final_path = SegmentPath(segment_id);
+            auto created = SegmentWriter::Create(temporary_path, segment_id);
+            if (!created) {
+                cleanup_targets();
+                reset_sources();
+                return tl::unexpected(StoreError::kIoError);
+            }
+            writer = std::move(created.value());
+            targets.push_back(TargetOutput{.segment_id = segment_id,
+                                           .temporary_path = temporary_path,
+                                           .final_path = final_path});
+        }
+        auto appended = writer->Append(entry.identity, record->value,
+                                       RecordKind::kCompactionCopy,
+                                       entry.version.sequence, false);
+        if (!appended) {
+            cleanup_targets();
+            reset_sources();
+            return tl::unexpected(StoreError::kIoError);
+        }
+        targets.back().valid_bytes = writer->tail();
+        ++targets.back().record_count;
+        updates.push_back(CompactionIndexUpdate{
+            .identity = entry.identity,
+            .expected_source = entry.version.physical,
+            .expected_epoch = entry.version.mutation_epoch,
+            .target = *appended});
+    }
+    if (writer && !writer->Sync()) {
+        cleanup_targets();
+        reset_sources();
+        return tl::unexpected(StoreError::kIoError);
+    }
+    writer.reset();
+
+    for (const auto& target : targets) {
+        if (rename(target.temporary_path.c_str(), target.final_path.c_str()) !=
+            0) {
+            cleanup_targets();
+            reset_sources();
+            return tl::unexpected(StoreError::kIoError);
+        }
+    }
+    if (!targets.empty() && !SyncDirectory(segments_path_)) {
+        cleanup_targets();
+        reset_sources();
+        return tl::unexpected(StoreError::kIoError);
+    }
+
+    {
+        std::lock_guard lock(mutex_);
+        const auto index_before = index_.Snapshot();
+        auto installed = index_.InstallCompactionCopies(updates);
+        if (!installed) {
+            cleanup_targets();
+            for (const auto& source : sources) {
+                auto current = segments_.find(source.segment_id);
+                if (current != segments_.end()) {
+                    current->second.state = SegmentLifecycle::kSealed;
+                    ++current->second.mutation_epoch;
+                }
+            }
+            return tl::unexpected(MapIndexError(installed.error()));
+        }
+        std::unordered_set<uint64_t> source_ids;
+        for (const auto& source : sources) source_ids.insert(source.segment_id);
+        index_.ReclaimNonCurrentVersionsInSegments(source_ids);
+        for (const auto& target : targets) {
+            segment_paths_.emplace(target.segment_id, target.final_path);
+            segments_.emplace(
+                target.segment_id,
+                SegmentMetadata{.segment_id = target.segment_id,
+                                .level = target_level,
+                                .state = SegmentLifecycle::kSealed,
+                                .valid_bytes = target.valid_bytes,
+                                .live_bytes = target.valid_bytes,
+                                .record_count = target.record_count,
+                                .mutation_epoch = 1});
+        }
+        for (const auto& source : sources) {
+            auto& current = segments_.at(source.segment_id);
+            current.state = SegmentLifecycle::kRetired;
+            ++current.mutation_epoch;
+        }
+        RefreshSegmentLiveBytes();
+        auto checkpointed = CheckpointLocked();
+        if (!checkpointed) {
+            static_cast<void>(index_.Restore(index_before));
+            for (const auto& target : targets) {
+                segment_paths_.erase(target.segment_id);
+                segments_.erase(target.segment_id);
+            }
+            for (const auto& source : sources) {
+                auto current = segments_.find(source.segment_id);
+                if (current != segments_.end()) {
+                    current->second.state = SegmentLifecycle::kSealed;
+                    ++current->second.mutation_epoch;
+                }
+            }
+            cleanup_targets();
+            return tl::unexpected(checkpointed.error());
+        }
+        CleanupRetiredSegmentsLocked();
+        RefreshSegmentLiveBytes();
+    }
+
+    uint64_t output_bytes = 0;
+    for (const auto& target : targets) output_bytes += target.valid_bytes;
+    return CompactionResult{.source_segments = sources.size(),
+                            .target_segments = targets.size(),
+                            .input_bytes = input_bytes,
+                            .output_bytes = output_bytes,
+                            .reclaimed_bytes = input_bytes - output_bytes};
 }
 
 tl::expected<std::string, StoreError> LogStructuredStore::ReadEntryLocked(

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -1093,6 +1093,8 @@ StoreStats LogStructuredStore::SnapshotStats() const {
         stats.logical_value_bytes += entry.version.physical.value_length;
     }
     stats.reclaimable_bytes = stats.physical_bytes - stats.live_record_bytes;
+    stats.wal_sequence = next_sequence_ - 1;
+    stats.checkpoint_sequence = checkpoint_sequence_;
     return stats;
 }
 

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -450,6 +450,7 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
             auto removed = RemoveFileDurably(segments_path_, filename);
             if (!removed) return tl::unexpected(StoreError::kIoError);
             segment_paths_.erase(path);
+            ForgetSegmentReaderLocked(it->first);
         }
         it = segments_.erase(it);
     }
@@ -1108,6 +1109,7 @@ void LogStructuredStore::CleanupRetiredSegmentsLocked() {
                 continue;
             }
             segment_paths_.erase(path);
+            ForgetSegmentReaderLocked(it->first);
         }
         it = segments_.erase(it);
     }
@@ -1470,6 +1472,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             static_cast<void>(index_.Restore(index_before));
             for (const auto& target : targets) {
                 segment_paths_.erase(target.segment_id);
+                ForgetSegmentReaderLocked(target.segment_id);
                 segments_.erase(target.segment_id);
             }
             for (const auto& source : sources) {
@@ -1502,41 +1505,112 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                             .reclaimed_bytes = input_bytes - output_bytes};
 }
 
-tl::expected<std::string, StoreError> LogStructuredStore::ReadEntryLocked(
-    const IndexSnapshotEntry& entry) const {
-    auto path = segment_paths_.find(entry.version.physical.segment_id);
+tl::expected<std::shared_ptr<SegmentReader>, StoreError>
+LogStructuredStore::GetSegmentReaderLocked(uint64_t segment_id) const {
+    auto cached = segment_readers_.find(segment_id);
+    if (cached != segment_readers_.end()) {
+        auto reader = cached->second.lock();
+        if (reader) return reader;
+    }
+    auto path = segment_paths_.find(segment_id);
     if (path == segment_paths_.end()) {
         return tl::unexpected(StoreError::kCorruptData);
     }
-    auto record = ReadRecord(path->second, entry.version.physical);
-    if (!record || record->identity != entry.identity ||
-        record->kind == RecordKind::kTombstone) {
+    auto opened = SegmentReader::Open(path->second, segment_id);
+    if (!opened) return tl::unexpected(StoreError::kIoError);
+    constexpr size_t kReaderCacheCapacity = 128;
+    if (reader_cache_.size() >= kReaderCacheCapacity) {
+        reader_cache_.pop_front();
+    }
+    segment_readers_[segment_id] = *opened;
+    reader_cache_.emplace_back(segment_id, *opened);
+    return *opened;
+}
+
+void LogStructuredStore::ForgetSegmentReaderLocked(uint64_t segment_id) {
+    segment_readers_.erase(segment_id);
+    std::erase_if(reader_cache_, [segment_id](const auto& cached) {
+        return cached.first == segment_id;
+    });
+}
+
+tl::expected<LogStructuredStore::PinnedEntry, StoreError>
+LogStructuredStore::PinEntryLocked(IndexSnapshotEntry entry) const {
+    auto reader = GetSegmentReaderLocked(entry.version.physical.segment_id);
+    if (!reader) return tl::unexpected(reader.error());
+    return PinnedEntry{.entry = std::move(entry), .reader = std::move(*reader)};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::ReadPinnedEntryInto(
+    const PinnedEntry& pinned, char* value, size_t value_size) {
+    auto read = pinned.reader->ReadValue(pinned.entry.version.physical, value,
+                                         value_size);
+    if (!read) {
+        return tl::unexpected(read.error() == SegmentError::kIoError
+                                  ? StoreError::kIoError
+                                  : StoreError::kCorruptData);
+    }
+    return {};
+}
+
+tl::expected<std::string, StoreError> LogStructuredStore::ReadPinnedEntry(
+    const PinnedEntry& pinned) {
+    const uint64_t value_length = pinned.entry.version.physical.value_length;
+    if (value_length >
+        static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
         return tl::unexpected(StoreError::kCorruptData);
     }
-    return std::move(record->value);
+    std::string value(static_cast<size_t>(value_length), '\0');
+    auto read = ReadPinnedEntryInto(pinned, value.data(), value.size());
+    if (!read) return tl::unexpected(read.error());
+    return value;
 }
 
 tl::expected<std::string, StoreError> LogStructuredStore::Get(
     const RecordIdentity& identity) const {
-    std::lock_guard lock(mutex_);
-    if (recovery_required_) {
-        return tl::unexpected(StoreError::kRecoveryRequired);
-    }
-    auto version = index_.LookupCommitted(identity);
-    if (!version) return tl::unexpected(StoreError::kNotFound);
-    return ReadEntryLocked(
-        IndexSnapshotEntry{.identity = identity, .version = *version});
+    auto pinned = [&]() -> tl::expected<PinnedEntry, StoreError> {
+        std::lock_guard lock(mutex_);
+        if (recovery_required_) {
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        auto version = index_.LookupCommitted(identity);
+        if (!version) return tl::unexpected(StoreError::kNotFound);
+        return PinEntryLocked(
+            IndexSnapshotEntry{.identity = identity, .version = *version});
+    }();
+    if (!pinned) return tl::unexpected(pinned.error());
+    return ReadPinnedEntry(*pinned);
 }
 
 tl::expected<std::string, StoreError> LogStructuredStore::GetLatest(
     std::string_view tenant_id, std::string_view object_key) const {
-    std::lock_guard lock(mutex_);
-    if (recovery_required_) {
-        return tl::unexpected(StoreError::kRecoveryRequired);
-    }
-    auto entry = index_.LookupCurrent(tenant_id, object_key);
-    if (!entry) return tl::unexpected(StoreError::kNotFound);
-    return ReadEntryLocked(*entry);
+    auto pinned = [&]() -> tl::expected<PinnedEntry, StoreError> {
+        std::lock_guard lock(mutex_);
+        if (recovery_required_) {
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        auto entry = index_.LookupCurrent(tenant_id, object_key);
+        if (!entry) return tl::unexpected(StoreError::kNotFound);
+        return PinEntryLocked(std::move(*entry));
+    }();
+    if (!pinned) return tl::unexpected(pinned.error());
+    return ReadPinnedEntry(*pinned);
+}
+
+tl::expected<void, StoreError> LogStructuredStore::GetLatestInto(
+    std::string_view tenant_id, std::string_view object_key, char* value,
+    size_t value_size) const {
+    auto pinned = [&]() -> tl::expected<PinnedEntry, StoreError> {
+        std::lock_guard lock(mutex_);
+        if (recovery_required_) {
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        auto entry = index_.LookupCurrent(tenant_id, object_key);
+        if (!entry) return tl::unexpected(StoreError::kNotFound);
+        return PinEntryLocked(std::move(*entry));
+    }();
+    if (!pinned) return tl::unexpected(pinned.error());
+    return ReadPinnedEntryInto(*pinned, value, value_size);
 }
 
 bool LogStructuredStore::ContainsLatest(std::string_view tenant_id,

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -375,8 +375,28 @@ tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
 tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
     const RecordIdentity& identity, std::string_view value) {
     std::lock_guard lock(mutex_);
+    return PreparePutLocked(identity, value);
+}
+
+tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
+    std::string tenant_id, std::string object_key, std::string_view value) {
+    std::lock_guard lock(mutex_);
+    RecordIdentity identity{.tenant_id = std::move(tenant_id),
+                            .object_key = std::move(object_key),
+                            .incarnation = {.high = directory_->identity().high,
+                                            .low = next_sequence_}};
+    return PreparePutLocked(identity, value);
+}
+
+tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
+    const RecordIdentity& identity, std::string_view value) {
+    if (identity.tenant_id.size() > kMaxTenantLength ||
+        identity.object_key.size() > kMaxKeyLength) {
+        return tl::unexpected(StoreError::kInvalidArgument);
+    }
     const uint64_t record_bytes = AlignedRecordSize(
-        identity.tenant_id.size(), identity.object_key.size(), value.size());
+        static_cast<uint32_t>(identity.tenant_id.size()),
+        static_cast<uint32_t>(identity.object_key.size()), value.size());
     if (record_bytes == 0) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
@@ -553,26 +573,52 @@ tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
     return {};
 }
 
-tl::expected<std::string, StoreError> LogStructuredStore::Get(
-    const RecordIdentity& identity) const {
-    std::lock_guard lock(mutex_);
-    auto entry = index_.LookupCommitted(identity);
-    if (!entry) return tl::unexpected(StoreError::kNotFound);
-    auto path = segment_paths_.find(entry->physical.segment_id);
+tl::expected<std::string, StoreError> LogStructuredStore::ReadEntryLocked(
+    const IndexSnapshotEntry& entry) const {
+    auto path = segment_paths_.find(entry.version.physical.segment_id);
     if (path == segment_paths_.end()) {
         return tl::unexpected(StoreError::kCorruptData);
     }
-    auto record = ReadRecord(path->second, entry->physical);
-    if (!record || record->identity != identity ||
+    auto record = ReadRecord(path->second, entry.version.physical);
+    if (!record || record->identity != entry.identity ||
         record->kind == RecordKind::kTombstone) {
         return tl::unexpected(StoreError::kCorruptData);
     }
     return std::move(record->value);
 }
 
+tl::expected<std::string, StoreError> LogStructuredStore::Get(
+    const RecordIdentity& identity) const {
+    std::lock_guard lock(mutex_);
+    auto version = index_.LookupCommitted(identity);
+    if (!version) return tl::unexpected(StoreError::kNotFound);
+    return ReadEntryLocked(
+        IndexSnapshotEntry{.identity = identity, .version = *version});
+}
+
+tl::expected<std::string, StoreError> LogStructuredStore::GetLatest(
+    std::string_view tenant_id, std::string_view object_key) const {
+    std::lock_guard lock(mutex_);
+    auto entry = index_.LookupCurrent(tenant_id, object_key);
+    if (!entry) return tl::unexpected(StoreError::kNotFound);
+    return ReadEntryLocked(*entry);
+}
+
+bool LogStructuredStore::ContainsLatest(std::string_view tenant_id,
+                                        std::string_view object_key) const {
+    std::lock_guard lock(mutex_);
+    return index_.LookupCurrent(tenant_id, object_key).has_value();
+}
+
 std::vector<IndexSnapshotEntry> LogStructuredStore::SnapshotIndex() const {
     std::lock_guard lock(mutex_);
     return index_.Snapshot();
+}
+
+std::vector<IndexSnapshotEntry> LogStructuredStore::SnapshotCurrentIndex()
+    const {
+    std::lock_guard lock(mutex_);
+    return index_.CurrentSnapshot();
 }
 
 uint64_t LogStructuredStore::active_segment_id() const {

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -23,8 +23,12 @@ std::mutex compaction_crash_mutex;
 std::function<bool(CompactionCrashPoint)> compaction_crash_predicate;
 
 bool HitCompactionCrashPoint(CompactionCrashPoint point) {
-    std::lock_guard lock(compaction_crash_mutex);
-    return compaction_crash_predicate && compaction_crash_predicate(point);
+    std::function<bool(CompactionCrashPoint)> predicate;
+    {
+        std::lock_guard lock(compaction_crash_mutex);
+        predicate = compaction_crash_predicate;
+    }
+    return predicate && predicate(point);
 }
 
 std::optional<uint64_t> ParseSegmentId(std::string_view name) {
@@ -85,12 +89,83 @@ bool SyncDirectory(const std::string& path) {
     return synced && closed;
 }
 
+class ScopeExit {
+   public:
+    explicit ScopeExit(std::function<void()> callback)
+        : callback_(std::move(callback)) {}
+    ~ScopeExit() { callback_(); }
+
+    ScopeExit(const ScopeExit&) = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+   private:
+    std::function<void()> callback_;
+};
+
 bool IsCompactionOnly(const SegmentScanResult& scan) {
     return !scan.records.empty() &&
            std::all_of(scan.records.begin(), scan.records.end(),
                        [](const ScannedRecord& record) {
                            return record.kind == RecordKind::kCompactionCopy;
                        });
+}
+
+bool IsKnownSegmentLifecycle(SegmentLifecycle state) {
+    switch (state) {
+        case SegmentLifecycle::kCreating:
+        case SegmentLifecycle::kActive:
+        case SegmentLifecycle::kSealing:
+        case SegmentLifecycle::kSealed:
+        case SegmentLifecycle::kCompacting:
+        case SegmentLifecycle::kRetired:
+            return true;
+    }
+    return false;
+}
+
+bool ValidatePersistentMetadata(const CheckpointState& checkpoint,
+                                const ManifestState& manifest) {
+    if (checkpoint.next_sequence == 0 || checkpoint.next_segment_id == 0 ||
+        checkpoint.checkpoint_sequence != checkpoint.next_sequence - 1 ||
+        checkpoint.applied_delete_watermark > checkpoint.checkpoint_sequence ||
+        manifest.active_segment_id == 0) {
+        return false;
+    }
+
+    std::unordered_set<uint64_t> segment_ids;
+    size_t active_segments = 0;
+    bool declared_active_found = false;
+    for (const auto& segment : checkpoint.segments) {
+        if (!IsKnownSegmentLifecycle(segment.state) ||
+            segment.segment_id == 0 ||
+            segment.segment_id >= checkpoint.next_segment_id ||
+            segment.state == SegmentLifecycle::kCreating ||
+            segment.live_bytes > segment.valid_bytes ||
+            segment.mutation_epoch == 0 ||
+            !segment_ids.insert(segment.segment_id).second) {
+            return false;
+        }
+        if (segment.state == SegmentLifecycle::kActive) {
+            ++active_segments;
+            if (segment.segment_id != manifest.active_segment_id) return false;
+        }
+        if (segment.segment_id == manifest.active_segment_id) {
+            declared_active_found = true;
+            if (segment.state != SegmentLifecycle::kActive &&
+                segment.state != SegmentLifecycle::kSealing) {
+                return false;
+            }
+        }
+    }
+    if (!declared_active_found || active_segments > 1) return false;
+
+    for (const auto& item : checkpoint.index) {
+        if (item.version.sequence == 0 ||
+            item.version.sequence > checkpoint.checkpoint_sequence) {
+            return false;
+        }
+    }
+    return true;
 }
 
 }  // namespace
@@ -108,7 +183,8 @@ void LogStructuredStore::SetCompactionCrashPredicateForTest(
 
 tl::expected<std::unique_ptr<LogStructuredStore>, StoreError>
 LogStructuredStore::Open(LogStructuredStoreConfig config) {
-    if (config.root_path.empty() || config.max_segment_bytes == 0) {
+    if (config.root_path.empty() || config.max_segment_bytes == 0 ||
+        config.max_physical_bytes > config.max_total_physical_bytes) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
     auto store = std::unique_ptr<LogStructuredStore>(
@@ -162,7 +238,8 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
             checkpoint->checkpoint_sequence != manifest->checkpoint_sequence ||
             checkpoint->next_sequence != manifest->next_sequence ||
             checkpoint->next_segment_id != manifest->next_segment_id ||
-            checkpoint->segments != manifest->segments) {
+            checkpoint->segments != manifest->segments ||
+            !ValidatePersistentMetadata(*checkpoint, *manifest)) {
             return tl::unexpected(StoreError::kCorruptData);
         }
         auto restored = index_.Restore(checkpoint->index);
@@ -175,7 +252,9 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
         expected_segments = manifest->segments;
         expected_active_segment = manifest->active_segment_id;
         auto wal_generation = ParseNumberedName(manifest->wal_file, "WAL-");
-        if (!wal_generation) return tl::unexpected(StoreError::kCorruptData);
+        if (!wal_generation || *wal_generation == 0) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
         wal_generation_ = *wal_generation;
         wal_path_ = config_.root_path + "/" + manifest->wal_file;
     } else if (error) {
@@ -198,6 +277,7 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
         }
         auto replayed = ReplayWal(scan->records, index_);
         if (!replayed) return tl::unexpected(StoreError::kCorruptData);
+        index_.ReclaimNonCommittedVersionsAfterRecovery();
         auto opened = WalWriter::OpenForAppend(wal_path_, scan->valid_bytes);
         if (!opened) return tl::unexpected(StoreError::kIoError);
         wal_ = std::move(opened.value());
@@ -206,7 +286,10 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
             return tl::unexpected(StoreError::kCorruptData);
         }
         auto created = WalWriter::Create(wal_path_);
-        if (!created) return tl::unexpected(StoreError::kIoError);
+        if (!created || !(*created)->Sync() ||
+            !SyncDirectory(config_.root_path)) {
+            return tl::unexpected(StoreError::kIoError);
+        }
         wal_ = std::move(created.value());
     }
 
@@ -242,7 +325,19 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
 
     for (const auto& segment : expected_segments) {
         if (segment.segment_id == 0 ||
-            !segments_.emplace(segment.segment_id, segment).second) {
+            segment.state == SegmentLifecycle::kCreating) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        auto recovered_segment = segment;
+        if (recovered_segment.state == SegmentLifecycle::kSealing ||
+            recovered_segment.state == SegmentLifecycle::kCompacting) {
+            recovered_segment.state = SegmentLifecycle::kSealed;
+            ++recovered_segment.mutation_epoch;
+        }
+        if (!segments_
+                 .emplace(recovered_segment.segment_id,
+                          std::move(recovered_segment))
+                 .second) {
             return tl::unexpected(StoreError::kCorruptData);
         }
         if (!ordered_segments.contains(segment.segment_id) &&
@@ -250,31 +345,26 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
             return tl::unexpected(StoreError::kCorruptData);
         }
     }
-    for (const auto& [segment_id, path] : ordered_segments) {
-        static_cast<void>(path);
-        if (!expected_segments.empty() && !segments_.contains(segment_id) &&
-            segment_id < post_checkpoint_segment_floor) {
-            return tl::unexpected(StoreError::kCorruptData);
-        }
-    }
-
     for (auto it = ordered_segments.begin(); it != ordered_segments.end();) {
-        if (segments_.contains(it->first) ||
-            it->first < post_checkpoint_segment_floor) {
+        if (segments_.contains(it->first)) {
             ++it;
             continue;
         }
         auto scan = ScanSegment(it->second, it->first);
         if (!scan) return tl::unexpected(StoreError::kCorruptData);
-        if (scan->termination != ScanTermination::kCleanEof ||
-            !IsCompactionOnly(*scan)) {
-            ++it;
+        if (scan->termination == ScanTermination::kCleanEof &&
+            IsCompactionOnly(*scan)) {
+            const auto filename = fs::path(it->second).filename().string();
+            auto removed = RemoveFileDurably(segments_path_, filename);
+            if (!removed) return tl::unexpected(StoreError::kIoError);
+            it = ordered_segments.erase(it);
             continue;
         }
-        const auto filename = fs::path(it->second).filename().string();
-        auto removed = RemoveFileDurably(segments_path_, filename);
-        if (!removed) return tl::unexpected(StoreError::kIoError);
-        it = ordered_segments.erase(it);
+        if (!expected_segments.empty() &&
+            it->first < post_checkpoint_segment_floor) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        ++it;
     }
 
     uint64_t active_segment_id = checkpoint_active_segment_id;
@@ -291,6 +381,12 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
 
     std::unordered_map<uint64_t, std::vector<ScannedRecord>> scanned_segments;
     for (const auto& [segment_id, path] : ordered_segments) {
+        auto metadata = segments_.find(segment_id);
+        if (metadata != segments_.end() &&
+            metadata->second.state == SegmentLifecycle::kRetired) {
+            segment_paths_.emplace(segment_id, path);
+            continue;
+        }
         auto scan = ScanSegment(path, segment_id);
         if (!scan) return tl::unexpected(StoreError::kCorruptData);
         if (scan->termination == ScanTermination::kCorruptRecord ||
@@ -303,7 +399,7 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
             if (!truncated) return tl::unexpected(StoreError::kIoError);
         }
 
-        auto metadata = segments_.find(segment_id);
+        metadata = segments_.find(segment_id);
         if (metadata == segments_.end()) {
             segments_.emplace(
                 segment_id,
@@ -359,10 +455,13 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
     }
 
     if (active_segment_id == 0) {
-        const uint64_t segment_id = next_segment_id_++;
+        const uint64_t segment_id = next_segment_id_;
         const std::string path = SegmentPath(segment_id);
         auto created = SegmentWriter::Create(path, segment_id);
-        if (!created) return tl::unexpected(StoreError::kIoError);
+        if (!created || !SyncDirectory(segments_path_)) {
+            return tl::unexpected(StoreError::kIoError);
+        }
+        ++next_segment_id_;
         segment_paths_.emplace(segment_id, path);
         segments_.emplace(segment_id,
                           SegmentMetadata{.segment_id = segment_id,
@@ -395,7 +494,10 @@ tl::expected<void, StoreError> LogStructuredStore::ValidateIndexRecords(
     const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
         scanned_segments) const {
     for (const auto& snapshot : index_.Snapshot()) {
-        if (snapshot.version.physical.total_length == 0) continue;
+        if (snapshot.version.state != VersionState::kCommitted) continue;
+        if (snapshot.version.physical.total_length == 0) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
         auto segment =
             scanned_segments.find(snapshot.version.physical.segment_id);
         if (segment == scanned_segments.end()) {
@@ -415,13 +517,29 @@ tl::expected<void, StoreError> LogStructuredStore::ValidateIndexRecords(
     return {};
 }
 
+uint64_t LogStructuredStore::PhysicalBytesLocked() const {
+    uint64_t physical_bytes = 0;
+    for (const auto& [segment_id, segment] : segments_) {
+        static_cast<void>(segment_id);
+        if (segment.valid_bytes >
+            std::numeric_limits<uint64_t>::max() - physical_bytes) {
+            return std::numeric_limits<uint64_t>::max();
+        }
+        physical_bytes += segment.valid_bytes;
+    }
+    return physical_bytes;
+}
+
 void LogStructuredStore::RefreshSegmentLiveBytes() {
     for (auto& [segment_id, segment] : segments_) {
         static_cast<void>(segment_id);
         segment.live_bytes = 0;
     }
     for (const auto& item : index_.Snapshot()) {
-        if (item.version.state != VersionState::kCommitted) continue;
+        if (item.version.state != VersionState::kCommitted &&
+            item.version.state != VersionState::kPrepared) {
+            continue;
+        }
         auto segment = segments_.find(item.version.physical.segment_id);
         if (segment != segments_.end()) {
             segment->second.live_bytes += item.version.physical.total_length;
@@ -446,12 +564,15 @@ tl::expected<void, StoreError> LogStructuredStore::RotateActiveSegmentLocked() {
     if (old_metadata == segments_.end()) {
         return tl::unexpected(StoreError::kCorruptData);
     }
-    old_metadata->second.state = SegmentLifecycle::kSealed;
-    ++old_metadata->second.mutation_epoch;
-    const uint64_t segment_id = next_segment_id_++;
+    const uint64_t segment_id = next_segment_id_;
     const std::string path = SegmentPath(segment_id);
     auto created = SegmentWriter::Create(path, segment_id);
-    if (!created) return tl::unexpected(StoreError::kIoError);
+    if (!created || !SyncDirectory(segments_path_)) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+    old_metadata->second.state = SegmentLifecycle::kSealed;
+    ++old_metadata->second.mutation_epoch;
+    ++next_segment_id_;
     segment_paths_.emplace(segment_id, path);
     segments_.emplace(segment_id,
                       SegmentMetadata{.segment_id = segment_id,
@@ -483,6 +604,9 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
 
 tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
     const RecordIdentity& identity, std::string_view value) {
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     if (identity.tenant_id.size() > kMaxTenantLength ||
         identity.object_key.size() > kMaxKeyLength) {
         return tl::unexpected(StoreError::kInvalidArgument);
@@ -493,15 +617,14 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
     if (record_bytes == 0) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
-    uint64_t physical_bytes = 0;
-    for (const auto& [segment_id, segment] : segments_) {
-        static_cast<void>(segment_id);
-        if (segment.valid_bytes > config_.max_physical_bytes - physical_bytes) {
-            return tl::unexpected(StoreError::kNoSpace);
-        }
-        physical_bytes += segment.valid_bytes;
-    }
-    if (record_bytes > config_.max_physical_bytes - physical_bytes) {
+    const uint64_t physical_bytes = PhysicalBytesLocked();
+    if (physical_bytes > config_.max_physical_bytes ||
+        record_bytes > config_.max_physical_bytes - physical_bytes ||
+        physical_bytes > config_.max_total_physical_bytes ||
+        compaction_reserved_bytes_ >
+            config_.max_total_physical_bytes - physical_bytes ||
+        record_bytes > config_.max_total_physical_bytes - physical_bytes -
+                           compaction_reserved_bytes_) {
         return tl::unexpected(StoreError::kNoSpace);
     }
     auto rotated = RotateSegmentIfNeeded(record_bytes);
@@ -531,6 +654,9 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
 tl::expected<void, StoreError> LogStructuredStore::CommitPut(
     const RecordIdentity& identity, uint64_t sequence) {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto current = index_.Lookup(identity);
     if (!current) return tl::unexpected(StoreError::kNotFound);
     if (current->state == VersionState::kCommitted &&
@@ -556,6 +682,9 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
 tl::expected<void, StoreError> LogStructuredStore::AbortPut(
     const RecordIdentity& identity, uint64_t sequence) {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto current = index_.Lookup(identity);
     if (!current) return tl::unexpected(StoreError::kNotFound);
     if (current->state == VersionState::kAborted &&
@@ -580,6 +709,9 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
 tl::expected<void, StoreError> LogStructuredStore::Delete(
     const RecordIdentity& identity) {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     if (identity.tenant_id.size() > kMaxTenantLength ||
         identity.object_key.size() > kMaxKeyLength) {
         return tl::unexpected(StoreError::kInvalidArgument);
@@ -587,6 +719,15 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
     const uint64_t record_bytes =
         AlignedRecordSize(static_cast<uint32_t>(identity.tenant_id.size()),
                           static_cast<uint32_t>(identity.object_key.size()), 0);
+    const uint64_t physical_bytes = PhysicalBytesLocked();
+    if (record_bytes == 0 ||
+        physical_bytes > config_.max_total_physical_bytes ||
+        compaction_reserved_bytes_ >
+            config_.max_total_physical_bytes - physical_bytes ||
+        record_bytes > config_.max_total_physical_bytes - physical_bytes -
+                           compaction_reserved_bytes_) {
+        return tl::unexpected(StoreError::kNoSpace);
+    }
     auto rotated = RotateSegmentIfNeeded(record_bytes);
     if (!rotated) return tl::unexpected(rotated.error());
     const uint64_t sequence = next_sequence_++;
@@ -615,6 +756,9 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
 
 tl::expected<void, StoreError> LogStructuredStore::Sync() {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     if (!active_segment_->Sync() || !wal_->Sync()) {
         return tl::unexpected(StoreError::kIoError);
     }
@@ -623,6 +767,9 @@ tl::expected<void, StoreError> LogStructuredStore::Sync() {
 
 tl::expected<void, StoreError> LogStructuredStore::SealActiveSegment() {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     if (active_segment_->tail() == 0) return {};
     return RotateActiveSegmentLocked();
 }
@@ -633,6 +780,9 @@ tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
 }
 
 tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     if (!active_segment_->Sync() || !wal_->Sync()) {
         return tl::unexpected(StoreError::kIoError);
     }
@@ -643,7 +793,15 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     segment_snapshot.reserve(segments_.size());
     for (const auto& [segment_id, segment] : segments_) {
         static_cast<void>(segment_id);
-        segment_snapshot.push_back(segment);
+        if (segment.state == SegmentLifecycle::kCreating) {
+            return tl::unexpected(StoreError::kInvalidTransition);
+        }
+        auto stable_segment = segment;
+        if (stable_segment.state == SegmentLifecycle::kSealing ||
+            stable_segment.state == SegmentLifecycle::kCompacting) {
+            stable_segment.state = SegmentLifecycle::kSealed;
+        }
+        segment_snapshot.push_back(std::move(stable_segment));
     }
     CheckpointState checkpoint{
         .format_version = 1,
@@ -678,12 +836,22 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     if (HitCompactionCrashPoint(CompactionCrashPoint::kBeforeManifestWrite)) {
         return tl::unexpected(StoreError::kIoError);
     }
-    auto published = PublishManifest(config_.root_path, manifest, [] {
-        return HitCompactionCrashPoint(
-            CompactionCrashPoint::kAfterManifestWrite);
-    });
+    auto published = PublishManifest(
+        config_.root_path, manifest,
+        [] {
+            return HitCompactionCrashPoint(
+                CompactionCrashPoint::kAfterManifestWrite);
+        },
+        [] {
+            return HitCompactionCrashPoint(
+                CompactionCrashPoint::kAfterCurrentRenameBeforeDirectorySync);
+        });
     if (!published) {
-        RemoveFileDurably(config_.root_path, next_wal_file);
+        if (published.error() == MetadataError::kPublicationUncertain) {
+            recovery_required_ = true;
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        static_cast<void>(RemoveFileDurably(config_.root_path, next_wal_file));
         return tl::unexpected(StoreError::kIoError);
     }
 
@@ -744,14 +912,25 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
 
     {
         std::lock_guard lock(mutex_);
+        if (recovery_required_) {
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
         CleanupRetiredSegmentsLocked();
         RefreshSegmentLiveBytes();
+        std::unordered_set<uint64_t> prepared_segments;
+        for (const auto& entry : index_.Snapshot()) {
+            if (entry.version.state == VersionState::kPrepared &&
+                entry.version.physical.total_length != 0) {
+                prepared_segments.insert(entry.version.physical.segment_id);
+            }
+        }
         std::vector<SegmentMetadata> sealed;
         for (const auto& [segment_id, segment] : segments_) {
             static_cast<void>(segment_id);
             if (segment.state != SegmentLifecycle::kSealed ||
                 segment.valid_bytes == 0 ||
-                segment.live_bytes > segment.valid_bytes) {
+                segment.live_bytes > segment.valid_bytes ||
+                prepared_segments.contains(segment.segment_id)) {
                 continue;
             }
             sealed.push_back(segment);
@@ -795,6 +974,13 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 break;
             }
         }
+        const uint64_t physical_bytes = PhysicalBytesLocked();
+        const uint64_t available_total_bytes =
+            physical_bytes < config_.max_total_physical_bytes
+                ? config_.max_total_physical_bytes - physical_bytes
+                : 0;
+        const uint64_t temporary_budget =
+            std::min(options.max_temporary_bytes, available_total_bytes);
         std::vector<SegmentMetadata> bounded_sources;
         bounded_sources.reserve(
             std::min(sources.size(), options.max_source_segments));
@@ -808,9 +994,8 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                      options.max_input_bytes - selected_bytes)) {
                 break;
             }
-            if (selected_live_bytes > options.max_temporary_bytes ||
-                source.live_bytes >
-                    options.max_temporary_bytes - selected_live_bytes) {
+            if (selected_live_bytes > temporary_budget ||
+                source.live_bytes > temporary_budget - selected_live_bytes) {
                 continue;
             }
             bounded_sources.push_back(source);
@@ -822,7 +1007,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         if (sources.empty()) return CompactionResult{};
 
         std::unordered_set<uint64_t> source_ids;
-        for (auto& source : sources) {
+        for (const auto& source : sources) {
             source_ids.insert(source.segment_id);
             input_bytes += source.valid_bytes;
             const uint32_t next_level =
@@ -833,6 +1018,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 return tl::unexpected(StoreError::kCorruptData);
             }
             source_paths.emplace(source.segment_id, path->second);
+        }
+        compaction_reserved_bytes_ = selected_live_bytes;
+        for (auto& source : sources) {
             auto& current = segments_.at(source.segment_id);
             current.state = SegmentLifecycle::kCompacting;
             ++current.mutation_epoch;
@@ -848,6 +1036,11 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             reserved_target_ids.push_back(next_segment_id_++);
         }
     }
+
+    const ScopeExit release_reservation([this] {
+        std::lock_guard lock(mutex_);
+        compaction_reserved_bytes_ = 0;
+    });
 
     target_level = std::min(target_level, options.max_levels - 1);
     uint64_t target_bytes = config_.max_segment_bytes;
@@ -1048,6 +1241,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         RefreshSegmentLiveBytes();
         auto checkpointed = CheckpointLocked();
         if (!checkpointed) {
+            if (checkpointed.error() == StoreError::kRecoveryRequired) {
+                return tl::unexpected(StoreError::kRecoveryRequired);
+            }
             static_cast<void>(index_.Restore(index_before));
             for (const auto& target : targets) {
                 segment_paths_.erase(target.segment_id);
@@ -1100,6 +1296,9 @@ tl::expected<std::string, StoreError> LogStructuredStore::ReadEntryLocked(
 tl::expected<std::string, StoreError> LogStructuredStore::Get(
     const RecordIdentity& identity) const {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto version = index_.LookupCommitted(identity);
     if (!version) return tl::unexpected(StoreError::kNotFound);
     return ReadEntryLocked(
@@ -1109,6 +1308,9 @@ tl::expected<std::string, StoreError> LogStructuredStore::Get(
 tl::expected<std::string, StoreError> LogStructuredStore::GetLatest(
     std::string_view tenant_id, std::string_view object_key) const {
     std::lock_guard lock(mutex_);
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto entry = index_.LookupCurrent(tenant_id, object_key);
     if (!entry) return tl::unexpected(StoreError::kNotFound);
     return ReadEntryLocked(*entry);

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -1,6 +1,7 @@
 #include "storage/local/log_structured/store.h"
 
 #include <algorithm>
+#include <chrono>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -8,6 +9,7 @@
 #include <limits>
 #include <map>
 #include <string_view>
+#include <thread>
 #include <unordered_set>
 
 namespace mooncake::logstructured {
@@ -688,6 +690,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         options.min_reclaim_ratio < 0.0 || options.min_reclaim_ratio > 1.0) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
+    if (options.stop_token.stop_requested()) {
+        return tl::unexpected(StoreError::kCancelled);
+    }
 
     std::lock_guard compaction_lock(compaction_mutex_);
     std::vector<SegmentMetadata> sources;
@@ -842,7 +847,14 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         }
     };
 
+    const auto copy_started = std::chrono::steady_clock::now();
+    uint64_t copied_bytes = 0;
     for (const auto& entry : live_entries) {
+        if (options.stop_token.stop_requested()) {
+            cleanup_targets();
+            reset_sources();
+            return tl::unexpected(StoreError::kCancelled);
+        }
         const auto path = source_paths.find(entry.version.physical.segment_id);
         if (path == source_paths.end()) {
             cleanup_targets();
@@ -895,11 +907,37 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             .expected_source = entry.version.physical,
             .expected_epoch = entry.version.mutation_epoch,
             .target = *appended});
+        copied_bytes += record_bytes;
+        if (options.max_bytes_per_second != 0) {
+            const auto target_elapsed = std::chrono::duration<double>(
+                static_cast<double>(copied_bytes) /
+                options.max_bytes_per_second);
+            while (!options.stop_token.stop_requested() &&
+                   std::chrono::steady_clock::now() - copy_started <
+                       target_elapsed) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            if (options.stop_token.stop_requested()) {
+                cleanup_targets();
+                reset_sources();
+                return tl::unexpected(StoreError::kCancelled);
+            }
+        }
+    }
+    if (options.stop_token.stop_requested()) {
+        cleanup_targets();
+        reset_sources();
+        return tl::unexpected(StoreError::kCancelled);
     }
     if (writer && !writer->Sync()) {
         cleanup_targets();
         reset_sources();
         return tl::unexpected(StoreError::kIoError);
+    }
+    if (options.stop_token.stop_requested()) {
+        cleanup_targets();
+        reset_sources();
+        return tl::unexpected(StoreError::kCancelled);
     }
     writer.reset();
 
@@ -1029,6 +1067,28 @@ std::vector<IndexSnapshotEntry> LogStructuredStore::SnapshotCurrentIndex()
     const {
     std::lock_guard lock(mutex_);
     return index_.CurrentSnapshot();
+}
+
+StoreStats LogStructuredStore::SnapshotStats() const {
+    std::lock_guard lock(mutex_);
+    StoreStats stats;
+    for (const auto& [segment_id, segment] : segments_) {
+        static_cast<void>(segment_id);
+        stats.physical_bytes += segment.valid_bytes;
+        stats.live_record_bytes += segment.live_bytes;
+        if (segment.state == SegmentLifecycle::kActive) {
+            ++stats.active_segments;
+        } else if (segment.state == SegmentLifecycle::kRetired) {
+            ++stats.retired_segments;
+        } else {
+            ++stats.sealed_segments;
+        }
+    }
+    for (const auto& entry : index_.CurrentSnapshot()) {
+        stats.logical_value_bytes += entry.version.physical.value_length;
+    }
+    stats.reclaimable_bytes = stats.physical_bytes - stats.live_record_bytes;
+    return stats;
 }
 
 uint64_t LogStructuredStore::active_segment_id() const {

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -11,7 +11,7 @@ namespace {
 
 constexpr std::string_view kSegmentPrefix = "segment-";
 constexpr std::string_view kSegmentSuffix = ".log";
-constexpr std::string_view kWalFile = "WAL-000001";
+constexpr std::string_view kInitialWalFile = "WAL-00000000000000000001";
 
 std::optional<uint64_t> ParseSegmentId(std::string_view name) {
     if (!name.starts_with(kSegmentPrefix) || !name.ends_with(kSegmentSuffix)) {
@@ -31,10 +31,31 @@ std::optional<uint64_t> ParseSegmentId(std::string_view name) {
     return id;
 }
 
-std::string FormatSegmentName(uint64_t segment_id) {
-    std::string digits = std::to_string(segment_id);
+std::string FormatNumberedName(std::string_view prefix, uint64_t number,
+                               std::string_view suffix = {}) {
+    std::string digits = std::to_string(number);
     if (digits.size() < 20) digits.insert(0, 20 - digits.size(), '0');
-    return std::string(kSegmentPrefix) + digits + std::string(kSegmentSuffix);
+    return std::string(prefix) + digits + std::string(suffix);
+}
+
+std::string FormatSegmentName(uint64_t segment_id) {
+    return FormatNumberedName(kSegmentPrefix, segment_id, kSegmentSuffix);
+}
+
+std::optional<uint64_t> ParseNumberedName(std::string_view name,
+                                          std::string_view prefix) {
+    if (!name.starts_with(prefix)) return std::nullopt;
+    name.remove_prefix(prefix.size());
+    if (name.empty()) return std::nullopt;
+    uint64_t value = 0;
+    for (const char ch : name) {
+        if (ch < '0' || ch > '9' ||
+            value > (std::numeric_limits<uint64_t>::max() - (ch - '0')) / 10) {
+            return std::nullopt;
+        }
+        value = value * 10 + static_cast<uint64_t>(ch - '0');
+    }
+    return value;
 }
 
 StoreError MapIndexError(IndexError error) {
@@ -47,7 +68,7 @@ StoreError MapIndexError(IndexError error) {
 LogStructuredStore::LogStructuredStore(LogStructuredStoreConfig config)
     : config_(std::move(config)),
       segments_path_(config_.root_path + "/segments"),
-      wal_path_(config_.root_path + "/" + std::string(kWalFile)) {}
+      wal_path_(config_.root_path + "/" + std::string(kInitialWalFile)) {}
 
 tl::expected<std::unique_ptr<LogStructuredStore>, StoreError>
 LogStructuredStore::Open(LogStructuredStoreConfig config) {
@@ -56,6 +77,20 @@ LogStructuredStore::Open(LogStructuredStoreConfig config) {
     }
     auto store = std::unique_ptr<LogStructuredStore>(
         new LogStructuredStore(std::move(config)));
+    auto directory = StorageDirectory::Open(store->config_.root_path);
+    if (!directory) {
+        if (directory.error() == StorageDirectoryError::kAlreadyMounted) {
+            return tl::unexpected(StoreError::kAlreadyMounted);
+        }
+        if (directory.error() == StorageDirectoryError::kUnrecognizedFormat) {
+            return tl::unexpected(StoreError::kUnrecognizedFormat);
+        }
+        if (directory.error() == StorageDirectoryError::kInvalidArgument) {
+            return tl::unexpected(StoreError::kInvalidArgument);
+        }
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    store->directory_ = std::move(directory.value());
     auto recovered = store->Recover();
     if (!recovered) return tl::unexpected(recovered.error());
     return store;
@@ -71,6 +106,80 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
     fs::create_directories(segments_path_, error);
     if (error) return tl::unexpected(StoreError::kIoError);
 
+    std::vector<SegmentMetadata> expected_segments;
+    uint64_t expected_active_segment = 0;
+    if (fs::exists(config_.root_path + "/CURRENT", error)) {
+        if (error) return tl::unexpected(StoreError::kIoError);
+        auto manifest = LoadCurrentManifest(config_.root_path);
+        if (!manifest) return tl::unexpected(StoreError::kCorruptData);
+        auto checkpoint =
+            LoadCheckpoint(config_.root_path, manifest->checkpoint_file);
+        if (!checkpoint ||
+            checkpoint->checkpoint_sequence != manifest->checkpoint_sequence ||
+            checkpoint->next_sequence != manifest->next_sequence ||
+            checkpoint->next_segment_id != manifest->next_segment_id ||
+            checkpoint->segments != manifest->segments) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        auto restored = index_.Restore(checkpoint->index);
+        if (!restored) return tl::unexpected(StoreError::kCorruptData);
+        manifest_generation_ = manifest->generation;
+        checkpoint_sequence_ = manifest->checkpoint_sequence;
+        next_sequence_ = manifest->next_sequence;
+        next_segment_id_ = manifest->next_segment_id;
+        applied_delete_watermark_ = checkpoint->applied_delete_watermark;
+        expected_segments = manifest->segments;
+        expected_active_segment = manifest->active_segment_id;
+        auto wal_generation = ParseNumberedName(manifest->wal_file, "WAL-");
+        if (!wal_generation) return tl::unexpected(StoreError::kCorruptData);
+        wal_generation_ = *wal_generation;
+        wal_path_ = config_.root_path + "/" + manifest->wal_file;
+    } else if (error) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+
+    uint64_t max_sequence = checkpoint_sequence_;
+    if (fs::exists(wal_path_, error)) {
+        if (error) return tl::unexpected(StoreError::kIoError);
+        auto scan = ScanWal(wal_path_);
+        if (!scan) return tl::unexpected(StoreError::kIoError);
+        if (scan->termination == WalScanTermination::kCorruptRecord) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        for (const auto& record : scan->records) {
+            if (record.sequence <= checkpoint_sequence_) {
+                return tl::unexpected(StoreError::kCorruptData);
+            }
+            max_sequence = std::max(max_sequence, record.sequence);
+        }
+        auto replayed = ReplayWal(scan->records, index_);
+        if (!replayed) return tl::unexpected(StoreError::kCorruptData);
+        auto opened = WalWriter::OpenForAppend(wal_path_, scan->valid_bytes);
+        if (!opened) return tl::unexpected(StoreError::kIoError);
+        wal_ = std::move(opened.value());
+    } else {
+        if (error || manifest_generation_ != 0) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+        auto created = WalWriter::Create(wal_path_);
+        if (!created) return tl::unexpected(StoreError::kIoError);
+        wal_ = std::move(created.value());
+    }
+
+    auto recovered_segments =
+        RecoverSegments(expected_segments, expected_active_segment);
+    if (!recovered_segments) return recovered_segments;
+    next_sequence_ = std::max(next_sequence_, max_sequence + 1);
+    RefreshSegmentLiveBytes();
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
+    const std::vector<SegmentMetadata>& expected_segments,
+    uint64_t checkpoint_active_segment_id) {
+    namespace fs = std::filesystem;
+    std::error_code error;
+    const uint64_t post_checkpoint_segment_floor = next_segment_id_;
     std::map<uint64_t, std::string> ordered_segments;
     for (const auto& entry : fs::directory_iterator(segments_path_, error)) {
         if (error) return tl::unexpected(StoreError::kIoError);
@@ -82,52 +191,120 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
         if (id) ordered_segments.emplace(*id, entry.path().string());
     }
 
+    for (const auto& segment : expected_segments) {
+        if (segment.segment_id == 0 ||
+            !segments_.emplace(segment.segment_id, segment).second ||
+            !ordered_segments.contains(segment.segment_id)) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+    }
+    for (const auto& [segment_id, path] : ordered_segments) {
+        static_cast<void>(path);
+        if (!expected_segments.empty() && !segments_.contains(segment_id) &&
+            segment_id < post_checkpoint_segment_floor) {
+            return tl::unexpected(StoreError::kCorruptData);
+        }
+    }
+
+    uint64_t active_segment_id = checkpoint_active_segment_id;
+    if (!ordered_segments.empty() &&
+        ordered_segments.rbegin()->first > active_segment_id) {
+        active_segment_id = ordered_segments.rbegin()->first;
+    }
+    if (expected_segments.empty() && !ordered_segments.empty()) {
+        active_segment_id = ordered_segments.rbegin()->first;
+    }
+
     std::unordered_map<uint64_t, std::vector<ScannedRecord>> scanned_segments;
-    uint64_t max_sequence = 0;
-    for (auto it = ordered_segments.begin(); it != ordered_segments.end();
-         ++it) {
-        auto scan = ScanSegment(it->second, it->first);
-        if (!scan) return tl::unexpected(StoreError::kIoError);
-        const bool is_last = std::next(it) == ordered_segments.end();
+    for (const auto& [segment_id, path] : ordered_segments) {
+        auto scan = ScanSegment(path, segment_id);
+        if (!scan) return tl::unexpected(StoreError::kCorruptData);
         if (scan->termination == ScanTermination::kCorruptRecord ||
             (scan->termination == ScanTermination::kIncompleteTail &&
-             !is_last)) {
+             segment_id != active_segment_id)) {
             return tl::unexpected(StoreError::kCorruptData);
         }
         if (scan->termination == ScanTermination::kIncompleteTail) {
-            auto truncated = TruncateSegment(it->second, scan->valid_bytes);
+            auto truncated = TruncateSegment(path, scan->valid_bytes);
             if (!truncated) return tl::unexpected(StoreError::kIoError);
         }
-        for (const auto& record : scan->records) {
-            max_sequence = std::max(max_sequence, record.sequence);
+
+        auto metadata = segments_.find(segment_id);
+        if (metadata == segments_.end()) {
+            segments_.emplace(
+                segment_id,
+                SegmentMetadata{.segment_id = segment_id,
+                                .level = 0,
+                                .state = segment_id == active_segment_id
+                                             ? SegmentLifecycle::kActive
+                                             : SegmentLifecycle::kSealed,
+                                .valid_bytes = scan->valid_bytes,
+                                .live_bytes = 0,
+                                .record_count = scan->records.size(),
+                                .mutation_epoch = 1});
+        } else {
+            const bool was_checkpoint_active =
+                segment_id == checkpoint_active_segment_id;
+            if ((!was_checkpoint_active &&
+                 (metadata->second.valid_bytes != scan->valid_bytes ||
+                  metadata->second.record_count != scan->records.size())) ||
+                (was_checkpoint_active &&
+                 (metadata->second.valid_bytes > scan->valid_bytes ||
+                  metadata->second.record_count > scan->records.size()))) {
+                return tl::unexpected(StoreError::kCorruptData);
+            }
+            metadata->second.valid_bytes = scan->valid_bytes;
+            metadata->second.record_count = scan->records.size();
+            if (segment_id != active_segment_id &&
+                metadata->second.state == SegmentLifecycle::kActive) {
+                metadata->second.state = SegmentLifecycle::kSealed;
+                ++metadata->second.mutation_epoch;
+            }
         }
-        scanned_segments.emplace(it->first, std::move(scan->records));
-        segment_paths_.emplace(it->first, it->second);
-        next_segment_id_ = std::max(next_segment_id_, it->first + 1);
+        scanned_segments.emplace(segment_id, std::move(scan->records));
+        segment_paths_.emplace(segment_id, path);
+        next_segment_id_ = std::max(next_segment_id_, segment_id + 1);
     }
 
-    if (fs::exists(wal_path_, error)) {
-        if (error) return tl::unexpected(StoreError::kIoError);
-        auto scan = ScanWal(wal_path_);
-        if (!scan) return tl::unexpected(StoreError::kIoError);
-        if (scan->termination == WalScanTermination::kCorruptRecord) {
-            return tl::unexpected(StoreError::kCorruptData);
-        }
-        auto replayed = ReplayWal(scan->records, index_);
-        if (!replayed) return tl::unexpected(StoreError::kCorruptData);
-        for (const auto& record : scan->records) {
-            max_sequence = std::max(max_sequence, record.sequence);
-        }
-        auto opened = WalWriter::OpenForAppend(wal_path_, scan->valid_bytes);
-        if (!opened) return tl::unexpected(StoreError::kIoError);
-        wal_ = std::move(opened.value());
-    } else {
-        if (error) return tl::unexpected(StoreError::kIoError);
-        auto created = WalWriter::Create(wal_path_);
+    auto validated = ValidateIndexRecords(scanned_segments);
+    if (!validated) return validated;
+
+    if (active_segment_id == 0) {
+        const uint64_t segment_id = next_segment_id_++;
+        const std::string path = SegmentPath(segment_id);
+        auto created = SegmentWriter::Create(path, segment_id);
         if (!created) return tl::unexpected(StoreError::kIoError);
-        wal_ = std::move(created.value());
+        segment_paths_.emplace(segment_id, path);
+        segments_.emplace(segment_id,
+                          SegmentMetadata{.segment_id = segment_id,
+                                          .level = 0,
+                                          .state = SegmentLifecycle::kActive,
+                                          .valid_bytes = 0,
+                                          .live_bytes = 0,
+                                          .record_count = 0,
+                                          .mutation_epoch = 1});
+        active_segment_ = std::move(created.value());
+        return {};
     }
 
+    auto active_path = ordered_segments.find(active_segment_id);
+    auto active_metadata = segments_.find(active_segment_id);
+    if (active_path == ordered_segments.end() ||
+        active_metadata == segments_.end()) {
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    active_metadata->second.state = SegmentLifecycle::kActive;
+    auto opened =
+        SegmentWriter::OpenForAppend(active_path->second, active_segment_id,
+                                     active_metadata->second.valid_bytes);
+    if (!opened) return tl::unexpected(StoreError::kIoError);
+    active_segment_ = std::move(opened.value());
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::ValidateIndexRecords(
+    const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
+        scanned_segments) const {
     for (const auto& snapshot : index_.Snapshot()) {
         if (snapshot.version.physical.total_length == 0) continue;
         auto segment =
@@ -146,25 +323,21 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
             return tl::unexpected(StoreError::kCorruptData);
         }
     }
-
-    next_sequence_ = max_sequence + 1;
-    if (ordered_segments.empty()) {
-        const uint64_t segment_id = next_segment_id_++;
-        const std::string path = SegmentPath(segment_id);
-        auto created = SegmentWriter::Create(path, segment_id);
-        if (!created) return tl::unexpected(StoreError::kIoError);
-        segment_paths_.emplace(segment_id, path);
-        active_segment_ = std::move(created.value());
-    } else {
-        const auto& [segment_id, path] = *ordered_segments.rbegin();
-        auto scan = ScanSegment(path, segment_id);
-        if (!scan) return tl::unexpected(StoreError::kIoError);
-        auto opened =
-            SegmentWriter::OpenForAppend(path, segment_id, scan->valid_bytes);
-        if (!opened) return tl::unexpected(StoreError::kIoError);
-        active_segment_ = std::move(opened.value());
-    }
     return {};
+}
+
+void LogStructuredStore::RefreshSegmentLiveBytes() {
+    for (auto& [segment_id, segment] : segments_) {
+        static_cast<void>(segment_id);
+        segment.live_bytes = 0;
+    }
+    for (const auto& item : index_.Snapshot()) {
+        if (item.version.state != VersionState::kCommitted) continue;
+        auto segment = segments_.find(item.version.physical.segment_id);
+        if (segment != segments_.end()) {
+            segment->second.live_bytes += item.version.physical.total_length;
+        }
+    }
 }
 
 tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
@@ -176,11 +349,25 @@ tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
     }
     auto synced = active_segment_->Sync();
     if (!synced) return tl::unexpected(StoreError::kIoError);
+    auto old_metadata = segments_.find(active_segment_->segment_id());
+    if (old_metadata == segments_.end()) {
+        return tl::unexpected(StoreError::kCorruptData);
+    }
+    old_metadata->second.state = SegmentLifecycle::kSealed;
+    ++old_metadata->second.mutation_epoch;
     const uint64_t segment_id = next_segment_id_++;
     const std::string path = SegmentPath(segment_id);
     auto created = SegmentWriter::Create(path, segment_id);
     if (!created) return tl::unexpected(StoreError::kIoError);
     segment_paths_.emplace(segment_id, path);
+    segments_.emplace(segment_id,
+                      SegmentMetadata{.segment_id = segment_id,
+                                      .level = 0,
+                                      .state = SegmentLifecycle::kActive,
+                                      .valid_bytes = 0,
+                                      .live_bytes = 0,
+                                      .record_count = 0,
+                                      .mutation_epoch = 1});
     active_segment_ = std::move(created.value());
     return {};
 }
@@ -208,6 +395,10 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
     if (!wal_result) return tl::unexpected(StoreError::kIoError);
     auto prepared = index_.Prepare(identity, appended.value(), sequence);
     if (!prepared) return tl::unexpected(MapIndexError(prepared.error()));
+    auto& segment = segments_.at(active_segment_->segment_id());
+    segment.valid_bytes = active_segment_->tail();
+    ++segment.record_count;
+    ++segment.mutation_epoch;
     return PreparedWrite{.identity = identity,
                          .sequence = sequence,
                          .physical = appended.value()};
@@ -234,6 +425,7 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
     if (!persisted) return tl::unexpected(StoreError::kIoError);
     auto committed = index_.Commit(identity, sequence);
     if (!committed) return tl::unexpected(MapIndexError(committed.error()));
+    RefreshSegmentLiveBytes();
     return {};
 }
 
@@ -264,8 +456,13 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
 tl::expected<void, StoreError> LogStructuredStore::Delete(
     const RecordIdentity& identity) {
     std::lock_guard lock(mutex_);
-    const uint64_t record_bytes = AlignedRecordSize(
-        identity.tenant_id.size(), identity.object_key.size(), 0);
+    if (identity.tenant_id.size() > kMaxTenantLength ||
+        identity.object_key.size() > kMaxKeyLength) {
+        return tl::unexpected(StoreError::kInvalidArgument);
+    }
+    const uint64_t record_bytes =
+        AlignedRecordSize(static_cast<uint32_t>(identity.tenant_id.size()),
+                          static_cast<uint32_t>(identity.object_key.size()), 0);
     auto rotated = RotateSegmentIfNeeded(record_bytes);
     if (!rotated) return tl::unexpected(rotated.error());
     const uint64_t sequence = next_sequence_++;
@@ -282,6 +479,76 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
     auto tombstoned = index_.ApplyTombstone(identity, sequence);
     if (!tombstoned) {
         return tl::unexpected(MapIndexError(tombstoned.error()));
+    }
+    auto& segment = segments_.at(active_segment_->segment_id());
+    segment.valid_bytes = active_segment_->tail();
+    ++segment.record_count;
+    ++segment.mutation_epoch;
+    applied_delete_watermark_ = sequence;
+    RefreshSegmentLiveBytes();
+    return {};
+}
+
+tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
+    std::lock_guard lock(mutex_);
+    if (!active_segment_->Sync() || !wal_->Sync()) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+    RefreshSegmentLiveBytes();
+    const uint64_t generation = manifest_generation_ + 1;
+    const uint64_t checkpoint_sequence = next_sequence_ - 1;
+    std::vector<SegmentMetadata> segment_snapshot;
+    segment_snapshot.reserve(segments_.size());
+    for (const auto& [segment_id, segment] : segments_) {
+        static_cast<void>(segment_id);
+        segment_snapshot.push_back(segment);
+    }
+    CheckpointState checkpoint{
+        .format_version = 1,
+        .checkpoint_sequence = checkpoint_sequence,
+        .next_sequence = next_sequence_,
+        .next_segment_id = next_segment_id_,
+        .applied_delete_watermark = applied_delete_watermark_,
+        .index = index_.Snapshot(),
+        .segments = segment_snapshot};
+    auto checkpoint_file =
+        WriteCheckpoint(config_.root_path, generation, checkpoint);
+    if (!checkpoint_file) return tl::unexpected(StoreError::kIoError);
+
+    const uint64_t next_wal_generation = wal_generation_ + 1;
+    const std::string next_wal_file =
+        FormatNumberedName("WAL-", next_wal_generation);
+    const std::string next_wal_path = config_.root_path + "/" + next_wal_file;
+    auto next_wal = WalWriter::Create(next_wal_path);
+    if (!next_wal || !(*next_wal)->Sync()) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+
+    ManifestState manifest{.format_version = 1,
+                           .generation = generation,
+                           .checkpoint_sequence = checkpoint_sequence,
+                           .next_sequence = next_sequence_,
+                           .next_segment_id = next_segment_id_,
+                           .active_segment_id = active_segment_->segment_id(),
+                           .checkpoint_file = *checkpoint_file,
+                           .wal_file = next_wal_file,
+                           .segments = segment_snapshot};
+    auto published = PublishManifest(config_.root_path, manifest);
+    if (!published) {
+        RemoveFileDurably(config_.root_path, next_wal_file);
+        return tl::unexpected(StoreError::kIoError);
+    }
+
+    const std::string old_wal_file =
+        std::filesystem::path(wal_path_).filename().string();
+    wal_ = std::move(next_wal.value());
+    wal_path_ = next_wal_path;
+    wal_generation_ = next_wal_generation;
+    manifest_generation_ = generation;
+    checkpoint_sequence_ = checkpoint_sequence;
+    if (old_wal_file != next_wal_file) {
+        auto removed = RemoveFileDurably(config_.root_path, old_wal_file);
+        if (!removed) return tl::unexpected(StoreError::kIoError);
     }
     return {};
 }

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -215,6 +215,11 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
     if (!recovered_segments) return recovered_segments;
     next_sequence_ = std::max(next_sequence_, max_sequence + 1);
     RefreshSegmentLiveBytes();
+    const std::string wal_file =
+        std::filesystem::path(wal_path_).filename().string();
+    auto cleaned = CleanupMetadataArtifacts(config_.root_path,
+                                            manifest_generation_, wal_file);
+    if (!cleaned) return tl::unexpected(StoreError::kIoError);
     return {};
 }
 
@@ -670,7 +675,13 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
                            .checkpoint_file = *checkpoint_file,
                            .wal_file = next_wal_file,
                            .segments = segment_snapshot};
-    auto published = PublishManifest(config_.root_path, manifest);
+    if (HitCompactionCrashPoint(CompactionCrashPoint::kBeforeManifestWrite)) {
+        return tl::unexpected(StoreError::kIoError);
+    }
+    auto published = PublishManifest(config_.root_path, manifest, [] {
+        return HitCompactionCrashPoint(
+            CompactionCrashPoint::kAfterManifestWrite);
+    });
     if (!published) {
         RemoveFileDurably(config_.root_path, next_wal_file);
         return tl::unexpected(StoreError::kIoError);
@@ -686,6 +697,8 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     if (old_wal_file != next_wal_file) {
         static_cast<void>(RemoveFileDurably(config_.root_path, old_wal_file));
     }
+    static_cast<void>(
+        CleanupMetadataArtifacts(config_.root_path, generation, next_wal_file));
     return {};
 }
 
@@ -1056,6 +1069,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         }
         CleanupRetiredSegmentsLocked();
         RefreshSegmentLiveBytes();
+        if (HitCompactionCrashPoint(CompactionCrashPoint::kAfterSourceUnlink)) {
+            return tl::unexpected(StoreError::kIoError);
+        }
     }
 
     uint64_t output_bytes = 0;

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -779,11 +779,14 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
         for (const auto& source : sources) {
             if (bounded_sources.size() == options.max_source_segments) break;
             if (!bounded_sources.empty() &&
-                source.valid_bytes > options.max_input_bytes - selected_bytes) {
+                (selected_bytes >= options.max_input_bytes ||
+                 source.valid_bytes >
+                     options.max_input_bytes - selected_bytes)) {
                 break;
             }
-            if (source.live_bytes >
-                options.max_temporary_bytes - selected_live_bytes) {
+            if (selected_live_bytes > options.max_temporary_bytes ||
+                source.live_bytes >
+                    options.max_temporary_bytes - selected_live_bytes) {
                 continue;
             }
             bounded_sources.push_back(source);

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -345,6 +345,14 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
             return tl::unexpected(StoreError::kCorruptData);
         }
     }
+
+    std::unordered_map<uint64_t, uint64_t> referenced_records;
+    for (const auto& snapshot : index_.Snapshot()) {
+        if (snapshot.version.physical.total_length != 0) {
+            ++referenced_records[snapshot.version.physical.segment_id];
+        }
+    }
+
     for (auto it = ordered_segments.begin(); it != ordered_segments.end();) {
         if (segments_.contains(it->first)) {
             ++it;
@@ -360,26 +368,18 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
             it = ordered_segments.erase(it);
             continue;
         }
-        if (!expected_segments.empty() &&
-            it->first < post_checkpoint_segment_floor) {
+        if (it->first < post_checkpoint_segment_floor) {
             return tl::unexpected(StoreError::kCorruptData);
         }
         ++it;
     }
 
     uint64_t active_segment_id = checkpoint_active_segment_id;
-    if (expected_segments.empty() && !ordered_segments.empty()) {
-        active_segment_id = ordered_segments.rbegin()->first;
-    } else {
-        for (const auto& [segment_id, path] : ordered_segments) {
-            static_cast<void>(path);
-            if (!segments_.contains(segment_id)) {
-                active_segment_id = std::max(active_segment_id, segment_id);
-            }
-        }
+    if (!ordered_segments.empty()) {
+        active_segment_id =
+            std::max(active_segment_id, ordered_segments.rbegin()->first);
     }
 
-    std::unordered_map<uint64_t, std::vector<ScannedRecord>> scanned_segments;
     for (const auto& [segment_id, path] : ordered_segments) {
         auto metadata = segments_.find(segment_id);
         if (metadata != segments_.end() &&
@@ -387,19 +387,9 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
             segment_paths_.emplace(segment_id, path);
             continue;
         }
-        auto scan = ScanSegment(path, segment_id);
-        if (!scan) return tl::unexpected(StoreError::kCorruptData);
-        if (scan->termination == ScanTermination::kCorruptRecord ||
-            (scan->termination == ScanTermination::kIncompleteTail &&
-             segment_id != active_segment_id)) {
-            return tl::unexpected(StoreError::kCorruptData);
-        }
-        if (scan->termination == ScanTermination::kIncompleteTail) {
-            auto truncated = TruncateSegment(path, scan->valid_bytes);
-            if (!truncated) return tl::unexpected(StoreError::kIoError);
-        }
 
-        metadata = segments_.find(segment_id);
+        const uint64_t file_size = fs::file_size(path, error);
+        if (error) return tl::unexpected(StoreError::kIoError);
         if (metadata == segments_.end()) {
             segments_.emplace(
                 segment_id,
@@ -408,35 +398,31 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
                                 .state = segment_id == active_segment_id
                                              ? SegmentLifecycle::kActive
                                              : SegmentLifecycle::kSealed,
-                                .valid_bytes = scan->valid_bytes,
+                                .valid_bytes = file_size,
                                 .live_bytes = 0,
-                                .record_count = scan->records.size(),
+                                .record_count = referenced_records[segment_id],
                                 .mutation_epoch = 1});
         } else {
             const bool was_checkpoint_active =
                 segment_id == checkpoint_active_segment_id;
             if ((!was_checkpoint_active &&
-                 (metadata->second.valid_bytes != scan->valid_bytes ||
-                  metadata->second.record_count != scan->records.size())) ||
+                 metadata->second.valid_bytes != file_size) ||
                 (was_checkpoint_active &&
-                 (metadata->second.valid_bytes > scan->valid_bytes ||
-                  metadata->second.record_count > scan->records.size()))) {
+                 metadata->second.valid_bytes > file_size)) {
                 return tl::unexpected(StoreError::kCorruptData);
             }
-            metadata->second.valid_bytes = scan->valid_bytes;
-            metadata->second.record_count = scan->records.size();
+            metadata->second.valid_bytes = file_size;
             if (segment_id != active_segment_id &&
                 metadata->second.state == SegmentLifecycle::kActive) {
                 metadata->second.state = SegmentLifecycle::kSealed;
                 ++metadata->second.mutation_epoch;
             }
         }
-        scanned_segments.emplace(segment_id, std::move(scan->records));
         segment_paths_.emplace(segment_id, path);
         next_segment_id_ = std::max(next_segment_id_, segment_id + 1);
     }
 
-    auto validated = ValidateIndexRecords(scanned_segments);
+    auto validated = ValidateIndexRecords();
     if (!validated) return validated;
 
     for (auto it = segments_.begin(); it != segments_.end();) {
@@ -491,27 +477,20 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
     return {};
 }
 
-tl::expected<void, StoreError> LogStructuredStore::ValidateIndexRecords(
-    const std::unordered_map<uint64_t, std::vector<ScannedRecord>>&
-        scanned_segments) const {
+tl::expected<void, StoreError> LogStructuredStore::ValidateIndexRecords()
+    const {
     for (const auto& snapshot : index_.Snapshot()) {
         if (snapshot.version.state != VersionState::kCommitted) continue;
         if (snapshot.version.physical.total_length == 0) {
             return tl::unexpected(StoreError::kCorruptData);
         }
-        auto segment =
-            scanned_segments.find(snapshot.version.physical.segment_id);
-        if (segment == scanned_segments.end()) {
+        auto path = segment_paths_.find(snapshot.version.physical.segment_id);
+        if (path == segment_paths_.end()) {
             return tl::unexpected(StoreError::kCorruptData);
         }
-        const auto record = std::find_if(
-            segment->second.begin(), segment->second.end(),
-            [&](const ScannedRecord& candidate) {
-                return candidate.identity == snapshot.identity &&
-                       candidate.sequence == snapshot.version.sequence &&
-                       candidate.physical == snapshot.version.physical;
-            });
-        if (record == segment->second.end()) {
+        auto record = ReadRecord(path->second, snapshot.version.physical);
+        if (!record || record->identity != snapshot.identity ||
+            record->sequence != snapshot.version.sequence) {
             return tl::unexpected(StoreError::kCorruptData);
         }
     }
@@ -584,8 +563,6 @@ tl::expected<void, StoreError> LogStructuredStore::RotateSegmentIfNeeded(
 }
 
 tl::expected<void, StoreError> LogStructuredStore::RotateActiveSegmentLocked() {
-    auto synced = active_segment_->Sync();
-    if (!synced) return tl::unexpected(StoreError::kIoError);
     auto old_metadata = segments_.find(active_segment_->segment_id());
     if (old_metadata == segments_.end()) {
         return tl::unexpected(StoreError::kCorruptData);
@@ -596,8 +573,12 @@ tl::expected<void, StoreError> LogStructuredStore::RotateActiveSegmentLocked() {
     if (!created || !SyncDirectory(segments_path_)) {
         return tl::unexpected(StoreError::kIoError);
     }
-    old_metadata->second.state = SegmentLifecycle::kSealed;
+    old_metadata->second.state =
+        pending_segment_writes_[active_segment_->segment_id()] != 0
+            ? SegmentLifecycle::kSealing
+            : SegmentLifecycle::kSealed;
     ++old_metadata->second.mutation_epoch;
+    sealed_writers_.push_back(active_segment_);
     ++next_segment_id_;
     segment_paths_.emplace(segment_id, path);
     segments_.emplace(segment_id,
@@ -614,6 +595,7 @@ tl::expected<void, StoreError> LogStructuredStore::RotateActiveSegmentLocked() {
 
 tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
     const RecordIdentity& identity, std::string_view value) {
+    std::shared_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     return PreparePutLocked(identity, value);
 }
@@ -631,10 +613,7 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePut(
 
 tl::expected<std::vector<PreparedWrite>, StoreError>
 LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
-    std::lock_guard lock(mutex_);
-    if (recovery_required_) {
-        return tl::unexpected(StoreError::kRecoveryRequired);
-    }
+    std::shared_lock mutation_lock(mutation_mutex_);
     if (requests.empty()) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
@@ -660,93 +639,161 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
         record_sizes.push_back(record_bytes);
     }
 
-    const uint64_t physical_bytes = PhysicalBytesLocked();
-    if (physical_bytes > config_.max_physical_bytes ||
-        total_record_bytes > config_.max_physical_bytes - physical_bytes ||
-        physical_bytes > config_.max_total_physical_bytes ||
-        compaction_reserved_bytes_ >
-            config_.max_total_physical_bytes - physical_bytes ||
-        total_record_bytes > config_.max_total_physical_bytes - physical_bytes -
-                                 compaction_reserved_bytes_) {
-        return tl::unexpected(StoreError::kNoSpace);
+    struct ReservedChunk {
+        std::shared_ptr<SegmentWriter> writer;
+        std::vector<SegmentAppendRequest> appends;
+        std::vector<PhysicalRecord> physical_records;
+    };
+    std::vector<ReservedChunk> chunks;
+
+    {
+        std::lock_guard lock(mutex_);
+        if (recovery_required_) {
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
+        const uint64_t physical_bytes = PhysicalBytesLocked();
+        if (physical_bytes > config_.max_physical_bytes ||
+            total_record_bytes > config_.max_physical_bytes - physical_bytes ||
+            physical_bytes > config_.max_total_physical_bytes ||
+            compaction_reserved_bytes_ >
+                config_.max_total_physical_bytes - physical_bytes ||
+            total_record_bytes > config_.max_total_physical_bytes -
+                                     physical_bytes -
+                                     compaction_reserved_bytes_) {
+            return tl::unexpected(StoreError::kNoSpace);
+        }
+
+        size_t begin = 0;
+        while (begin < requests.size()) {
+            auto rotated = RotateSegmentIfNeeded(record_sizes[begin]);
+            if (!rotated) return tl::unexpected(rotated.error());
+
+            const uint64_t segment_tail = active_segment_->tail();
+            uint64_t chunk_bytes = 0;
+            size_t end = begin;
+            while (end < requests.size()) {
+                const uint64_t next_bytes = record_sizes[end];
+                if (end != begin &&
+                    (chunk_bytes > config_.max_segment_bytes - segment_tail ||
+                     next_bytes > config_.max_segment_bytes - segment_tail -
+                                      chunk_bytes)) {
+                    break;
+                }
+                chunk_bytes += next_bytes;
+                ++end;
+                if (segment_tail + chunk_bytes >= config_.max_segment_bytes) {
+                    break;
+                }
+            }
+
+            ReservedChunk chunk;
+            chunk.writer = active_segment_;
+            chunk.appends.reserve(end - begin);
+            for (size_t index = begin; index < end; ++index) {
+                const uint64_t sequence = next_sequence_++;
+                RecordIdentity identity{
+                    .tenant_id = requests[index].tenant_id,
+                    .object_key = requests[index].object_key,
+                    .incarnation = {.high = directory_->identity().high,
+                                    .low = sequence}};
+                chunk.appends.push_back({.identity = std::move(identity),
+                                         .value = requests[index].value,
+                                         .kind = RecordKind::kValue,
+                                         .sequence = sequence});
+            }
+            auto reserved = chunk.writer->ReserveBatch(chunk.appends);
+            if (!reserved) {
+                for (auto& reserved_chunk : chunks) {
+                    reserved_chunk.writer->CancelReservedBatch();
+                    auto pending = pending_segment_writes_.find(
+                        reserved_chunk.writer->segment_id());
+                    if (pending != pending_segment_writes_.end() &&
+                        --pending->second == 0) {
+                        pending_segment_writes_.erase(pending);
+                    }
+                }
+                return tl::unexpected(StoreError::kIoError);
+            }
+            chunk.physical_records = std::move(*reserved);
+            auto& segment = segments_.at(chunk.writer->segment_id());
+            segment.valid_bytes = chunk.writer->tail();
+            ++segment.mutation_epoch;
+            ++pending_segment_writes_[chunk.writer->segment_id()];
+            chunks.push_back(std::move(chunk));
+            begin = end;
+        }
     }
 
+    bool write_failed = false;
+    for (auto& chunk : chunks) {
+        auto written = chunk.writer->WriteReservedBatch(
+            chunk.appends, chunk.physical_records, config_.sync_data,
+            config_.payload_write_parallelism);
+        if (!written) write_failed = true;
+    }
     std::vector<PreparedWrite> prepared;
     prepared.reserve(requests.size());
-    size_t begin = 0;
-    while (begin < requests.size()) {
-        auto rotated = RotateSegmentIfNeeded(record_sizes[begin]);
-        if (!rotated) return tl::unexpected(rotated.error());
-
-        const uint64_t segment_tail = active_segment_->tail();
-        uint64_t chunk_bytes = 0;
-        size_t end = begin;
-        while (end < requests.size()) {
-            const uint64_t next_bytes = record_sizes[end];
-            if (end != begin &&
-                (chunk_bytes > config_.max_segment_bytes - segment_tail ||
-                 next_bytes >
-                     config_.max_segment_bytes - segment_tail - chunk_bytes)) {
-                break;
+    std::lock_guard lock(mutex_);
+    auto finish_pending = [&] {
+        for (const auto& chunk : chunks) {
+            auto pending =
+                pending_segment_writes_.find(chunk.writer->segment_id());
+            if (pending == pending_segment_writes_.end()) continue;
+            if (--pending->second != 0) continue;
+            pending_segment_writes_.erase(pending);
+            auto segment = segments_.find(chunk.writer->segment_id());
+            if (segment != segments_.end() &&
+                segment->second.state == SegmentLifecycle::kSealing) {
+                segment->second.state = SegmentLifecycle::kSealed;
+                ++segment->second.mutation_epoch;
             }
-            chunk_bytes += next_bytes;
-            ++end;
-            if (segment_tail + chunk_bytes >= config_.max_segment_bytes) break;
         }
+    };
+    if (write_failed) {
+        finish_pending();
+        return tl::unexpected(StoreError::kIoError);
+    }
 
-        std::vector<SegmentAppendRequest> appends;
-        std::vector<WalRecord> wal_records;
-        appends.reserve(end - begin);
-        wal_records.reserve(end - begin);
-        for (size_t index = begin; index < end; ++index) {
-            const uint64_t sequence = next_sequence_++;
-            RecordIdentity identity{
-                .tenant_id = requests[index].tenant_id,
-                .object_key = requests[index].object_key,
-                .incarnation = {.high = directory_->identity().high,
-                                .low = sequence}};
-            appends.push_back({.identity = std::move(identity),
-                               .value = requests[index].value,
-                               .kind = RecordKind::kValue,
-                               .sequence = sequence});
-        }
-
-        auto physical_records = active_segment_->AppendBatch(
-            appends, config_.sync_data, config_.payload_write_parallelism);
-        if (!physical_records) {
-            return tl::unexpected(StoreError::kIoError);
-        }
-        auto& segment = segments_.at(active_segment_->segment_id());
-        segment.valid_bytes = active_segment_->tail();
-        segment.record_count += appends.size();
-        ++segment.mutation_epoch;
-
-        for (size_t index = 0; index < appends.size(); ++index) {
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    std::vector<WalRecord> wal_records;
+    wal_records.reserve(requests.size());
+    for (const auto& chunk : chunks) {
+        for (size_t index = 0; index < chunk.appends.size(); ++index) {
             wal_records.push_back({.type = WalRecordType::kPrepareValue,
-                                   .sequence = appends[index].sequence,
-                                   .identity = appends[index].identity,
-                                   .physical = (*physical_records)[index]});
+                                   .sequence = chunk.appends[index].sequence,
+                                   .identity = chunk.appends[index].identity,
+                                   .physical = chunk.physical_records[index]});
         }
-        if (!wal_->AppendBatch(wal_records, config_.sync_wal)) {
-            return tl::unexpected(StoreError::kIoError);
-        }
-
-        for (size_t index = 0; index < appends.size(); ++index) {
-            auto indexed = index_.Prepare(appends[index].identity,
-                                          (*physical_records)[index],
-                                          appends[index].sequence);
+    }
+    if (!wal_->AppendBatch(wal_records, config_.sync_wal)) {
+        finish_pending();
+        return tl::unexpected(StoreError::kIoError);
+    }
+    for (const auto& chunk : chunks) {
+        auto& segment = segments_.at(chunk.writer->segment_id());
+        segment.record_count += chunk.appends.size();
+        for (size_t index = 0; index < chunk.appends.size(); ++index) {
+            auto indexed = index_.Prepare(chunk.appends[index].identity,
+                                          chunk.physical_records[index],
+                                          chunk.appends[index].sequence);
             if (!indexed) {
                 recovery_required_ = true;
+                finish_pending();
                 return tl::unexpected(StoreError::kRecoveryRequired);
             }
-            auto live = AddLiveRecordLocked((*physical_records)[index]);
-            if (!live) return tl::unexpected(live.error());
-            prepared.push_back({.identity = appends[index].identity,
-                                .sequence = appends[index].sequence,
-                                .physical = (*physical_records)[index]});
+            auto live = AddLiveRecordLocked(chunk.physical_records[index]);
+            if (!live) {
+                finish_pending();
+                return tl::unexpected(live.error());
+            }
+            prepared.push_back({.identity = chunk.appends[index].identity,
+                                .sequence = chunk.appends[index].sequence,
+                                .physical = chunk.physical_records[index]});
         }
-        begin = end;
     }
+    finish_pending();
     return prepared;
 }
 
@@ -806,6 +853,7 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
 
 tl::expected<void, StoreError> LogStructuredStore::CommitPut(
     const RecordIdentity& identity, uint64_t sequence) {
+    std::shared_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
@@ -840,6 +888,7 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
 
 tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
     const std::vector<PreparedWrite>& writes) {
+    std::shared_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
@@ -882,6 +931,7 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
 
 tl::expected<void, StoreError> LogStructuredStore::AbortPut(
     const RecordIdentity& identity, uint64_t sequence) {
+    std::shared_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
@@ -911,6 +961,7 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
 
 tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
     const std::vector<PreparedWrite>& writes) {
+    std::shared_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
@@ -949,6 +1000,7 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
 
 tl::expected<void, StoreError> LogStructuredStore::Delete(
     const RecordIdentity& identity) {
+    std::shared_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
@@ -980,17 +1032,23 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
 }
 
 tl::expected<void, StoreError> LogStructuredStore::Sync() {
+    std::unique_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    for (const auto& writer : sealed_writers_) {
+        if (!writer->Sync()) return tl::unexpected(StoreError::kIoError);
+    }
     if (!active_segment_->Sync() || !wal_->Sync()) {
         return tl::unexpected(StoreError::kIoError);
     }
+    sealed_writers_.clear();
     return {};
 }
 
 tl::expected<void, StoreError> LogStructuredStore::SealActiveSegment() {
+    std::unique_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
@@ -1000,6 +1058,7 @@ tl::expected<void, StoreError> LogStructuredStore::SealActiveSegment() {
 }
 
 tl::expected<void, StoreError> LogStructuredStore::Checkpoint() {
+    std::unique_lock mutation_lock(mutation_mutex_);
     std::lock_guard lock(mutex_);
     return CheckpointLocked();
 }
@@ -1008,9 +1067,13 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    for (const auto& writer : sealed_writers_) {
+        if (!writer->Sync()) return tl::unexpected(StoreError::kIoError);
+    }
     if (!active_segment_->Sync() || !wal_->Sync()) {
         return tl::unexpected(StoreError::kIoError);
     }
+    sealed_writers_.clear();
     const uint64_t generation = manifest_generation_ + 1;
     const uint64_t checkpoint_sequence = next_sequence_ - 1;
     std::vector<SegmentMetadata> segment_snapshot;

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -270,9 +270,6 @@ tl::expected<void, StoreError> LogStructuredStore::Recover() {
             return tl::unexpected(StoreError::kCorruptData);
         }
         for (const auto& record : scan->records) {
-            if (record.sequence <= checkpoint_sequence_) {
-                return tl::unexpected(StoreError::kCorruptData);
-            }
             max_sequence = std::max(max_sequence, record.sequence);
         }
         auto replayed = ReplayWal(scan->records, index_);
@@ -444,7 +441,8 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
     if (active_segment_id == 0) {
         const uint64_t segment_id = next_segment_id_;
         const std::string path = SegmentPath(segment_id);
-        auto created = SegmentWriter::Create(path, segment_id);
+        auto created =
+            SegmentWriter::Create(path, segment_id, config_.use_uring);
         if (!created || !SyncDirectory(segments_path_)) {
             return tl::unexpected(StoreError::kIoError);
         }
@@ -469,9 +467,9 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
         return tl::unexpected(StoreError::kCorruptData);
     }
     active_metadata->second.state = SegmentLifecycle::kActive;
-    auto opened =
-        SegmentWriter::OpenForAppend(active_path->second, active_segment_id,
-                                     active_metadata->second.valid_bytes);
+    auto opened = SegmentWriter::OpenForAppend(
+        active_path->second, active_segment_id,
+        active_metadata->second.valid_bytes, config_.use_uring);
     if (!opened) return tl::unexpected(StoreError::kIoError);
     active_segment_ = std::move(opened.value());
     return {};
@@ -479,16 +477,20 @@ tl::expected<void, StoreError> LogStructuredStore::RecoverSegments(
 
 tl::expected<void, StoreError> LogStructuredStore::ValidateIndexRecords()
     const {
+    std::unordered_map<uint64_t, std::shared_ptr<SegmentReader>> readers;
     for (const auto& snapshot : index_.Snapshot()) {
         if (snapshot.version.state != VersionState::kCommitted) continue;
         if (snapshot.version.physical.total_length == 0) {
             return tl::unexpected(StoreError::kCorruptData);
         }
-        auto path = segment_paths_.find(snapshot.version.physical.segment_id);
-        if (path == segment_paths_.end()) {
-            return tl::unexpected(StoreError::kCorruptData);
+        const uint64_t segment_id = snapshot.version.physical.segment_id;
+        auto reader = readers.find(segment_id);
+        if (reader == readers.end()) {
+            auto opened = GetSegmentReaderLocked(segment_id);
+            if (!opened) return tl::unexpected(opened.error());
+            reader = readers.emplace(segment_id, std::move(*opened)).first;
         }
-        auto record = ReadRecord(path->second, snapshot.version.physical);
+        auto record = reader->second->Read(snapshot.version.physical);
         if (!record || record->identity != snapshot.identity ||
             record->sequence != snapshot.version.sequence) {
             return tl::unexpected(StoreError::kCorruptData);
@@ -508,6 +510,30 @@ uint64_t LogStructuredStore::PhysicalBytesLocked() const {
         physical_bytes += segment.valid_bytes;
     }
     return physical_bytes;
+}
+
+tl::expected<void, StoreError>
+LogStructuredStore::EnsureForegroundCapacityLocked(uint64_t requested_bytes) {
+    if (requested_bytes > config_.max_physical_bytes ||
+        requested_bytes > config_.max_total_physical_bytes) {
+        return tl::unexpected(StoreError::kNoSpace);
+    }
+    const uint64_t physical_bytes = PhysicalBytesLocked();
+    const bool exceeds_foreground =
+        physical_bytes > config_.max_physical_bytes - requested_bytes;
+    const bool exceeds_total =
+        physical_bytes > config_.max_total_physical_bytes ||
+        compaction_reserved_bytes_ >
+            config_.max_total_physical_bytes - physical_bytes ||
+        requested_bytes > config_.max_total_physical_bytes - physical_bytes -
+                              compaction_reserved_bytes_;
+    if (!exceeds_foreground && !exceeds_total) return {};
+
+    if (active_segment_ && active_segment_->tail() != 0) {
+        auto rotated = RotateActiveSegmentLocked();
+        if (!rotated) return tl::unexpected(rotated.error());
+    }
+    return tl::unexpected(StoreError::kNoSpace);
 }
 
 void LogStructuredStore::RefreshSegmentLiveBytes() {
@@ -569,7 +595,7 @@ tl::expected<void, StoreError> LogStructuredStore::RotateActiveSegmentLocked() {
     }
     const uint64_t segment_id = next_segment_id_;
     const std::string path = SegmentPath(segment_id);
-    auto created = SegmentWriter::Create(path, segment_id);
+    auto created = SegmentWriter::Create(path, segment_id, config_.use_uring);
     if (!created || !SyncDirectory(segments_path_)) {
         return tl::unexpected(StoreError::kIoError);
     }
@@ -651,17 +677,8 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
         if (recovery_required_) {
             return tl::unexpected(StoreError::kRecoveryRequired);
         }
-        const uint64_t physical_bytes = PhysicalBytesLocked();
-        if (physical_bytes > config_.max_physical_bytes ||
-            total_record_bytes > config_.max_physical_bytes - physical_bytes ||
-            physical_bytes > config_.max_total_physical_bytes ||
-            compaction_reserved_bytes_ >
-                config_.max_total_physical_bytes - physical_bytes ||
-            total_record_bytes > config_.max_total_physical_bytes -
-                                     physical_bytes -
-                                     compaction_reserved_bytes_) {
-            return tl::unexpected(StoreError::kNoSpace);
-        }
+        auto capacity = EnsureForegroundCapacityLocked(total_record_bytes);
+        if (!capacity) return tl::unexpected(capacity.error());
 
         size_t begin = 0;
         while (begin < requests.size()) {
@@ -755,6 +772,7 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
     }
 
     if (recovery_required_) {
+        finish_pending();
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
     std::vector<WalRecord> wal_records;
@@ -768,8 +786,9 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
         }
     }
     if (!wal_->AppendBatch(wal_records, config_.sync_wal)) {
+        recovery_required_ = true;
         finish_pending();
-        return tl::unexpected(StoreError::kIoError);
+        return tl::unexpected(StoreError::kRecoveryRequired);
     }
     for (const auto& chunk : chunks) {
         auto& segment = segments_.at(chunk.writer->segment_id());
@@ -815,16 +834,8 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
     if (record_bytes == 0) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
-    const uint64_t physical_bytes = PhysicalBytesLocked();
-    if (physical_bytes > config_.max_physical_bytes ||
-        record_bytes > config_.max_physical_bytes - physical_bytes ||
-        physical_bytes > config_.max_total_physical_bytes ||
-        compaction_reserved_bytes_ >
-            config_.max_total_physical_bytes - physical_bytes ||
-        record_bytes > config_.max_total_physical_bytes - physical_bytes -
-                           compaction_reserved_bytes_) {
-        return tl::unexpected(StoreError::kNoSpace);
-    }
+    auto capacity = EnsureForegroundCapacityLocked(record_bytes);
+    if (!capacity) return tl::unexpected(capacity.error());
     auto rotated = RotateSegmentIfNeeded(record_bytes);
     if (!rotated) return tl::unexpected(rotated.error());
 
@@ -841,7 +852,10 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
                          .identity = identity,
                          .physical = appended.value()};
     auto wal_result = wal_->Append(transition, config_.sync_wal);
-    if (!wal_result) return tl::unexpected(StoreError::kIoError);
+    if (!wal_result) {
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto prepared = index_.Prepare(identity, appended.value(), sequence);
     if (!prepared) return tl::unexpected(MapIndexError(prepared.error()));
     auto live = AddLiveRecordLocked(appended.value());
@@ -875,7 +889,10 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
                                             .identity = identity,
                                             .physical = {}},
                                   config_.sync_wal);
-    if (!persisted) return tl::unexpected(StoreError::kIoError);
+    if (!persisted) {
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto committed = index_.Commit(identity, sequence);
     if (!committed) return tl::unexpected(MapIndexError(committed.error()));
     if (previous_current && previous_current->identity != identity) {
@@ -910,7 +927,8 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
                            .physical = {}});
     }
     if (!wal_->AppendBatch(records, config_.sync_wal)) {
-        return tl::unexpected(StoreError::kIoError);
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
     }
     for (const auto& write : writes) {
         auto previous_current = index_.LookupCurrent(write.identity.tenant_id,
@@ -951,7 +969,10 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
                                             .identity = identity,
                                             .physical = {}},
                                   config_.sync_wal);
-    if (!persisted) return tl::unexpected(StoreError::kIoError);
+    if (!persisted) {
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto aborted = index_.Abort(identity, sequence);
     if (!aborted) return tl::unexpected(MapIndexError(aborted.error()));
     auto removed = RemoveLiveRecordLocked(current->physical);
@@ -983,7 +1004,8 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
                            .physical = {}});
     }
     if (!wal_->AppendBatch(records, config_.sync_wal)) {
-        return tl::unexpected(StoreError::kIoError);
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
     }
     for (const auto& write : writes) {
         auto current = index_.Lookup(write.identity);
@@ -1017,7 +1039,10 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
                                .identity = identity,
                                .physical = {}},
                      config_.sync_wal);
-    if (!persisted) return tl::unexpected(StoreError::kIoError);
+    if (!persisted) {
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
     auto tombstoned = index_.ApplyTombstone(identity, sequence);
     if (!tombstoned) {
         return tl::unexpected(MapIndexError(tombstoned.error()));
@@ -1038,10 +1063,14 @@ tl::expected<void, StoreError> LogStructuredStore::Sync() {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
     for (const auto& writer : sealed_writers_) {
-        if (!writer->Sync()) return tl::unexpected(StoreError::kIoError);
+        if (!writer->Sync()) {
+            recovery_required_ = true;
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
     }
     if (!active_segment_->Sync() || !wal_->Sync()) {
-        return tl::unexpected(StoreError::kIoError);
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
     }
     sealed_writers_.clear();
     return {};
@@ -1068,10 +1097,14 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
     for (const auto& writer : sealed_writers_) {
-        if (!writer->Sync()) return tl::unexpected(StoreError::kIoError);
+        if (!writer->Sync()) {
+            recovery_required_ = true;
+            return tl::unexpected(StoreError::kRecoveryRequired);
+        }
     }
     if (!active_segment_->Sync() || !wal_->Sync()) {
-        return tl::unexpected(StoreError::kIoError);
+        recovery_required_ = true;
+        return tl::unexpected(StoreError::kRecoveryRequired);
     }
     sealed_writers_.clear();
     const uint64_t generation = manifest_generation_ + 1;
@@ -1096,7 +1129,7 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
         .next_sequence = next_sequence_,
         .next_segment_id = next_segment_id_,
         .applied_delete_watermark = applied_delete_watermark_,
-        .index = index_.Snapshot(),
+        .index = index_.CheckpointSnapshot(),
         .segments = segment_snapshot};
     auto checkpoint_file =
         WriteCheckpoint(config_.root_path, generation, checkpoint);
@@ -1149,6 +1182,7 @@ tl::expected<void, StoreError> LogStructuredStore::CheckpointLocked() {
     wal_generation_ = next_wal_generation;
     manifest_generation_ = generation;
     checkpoint_sequence_ = checkpoint_sequence;
+    index_.PruneCheckpointedHistory();
     if (old_wal_file != next_wal_file) {
         static_cast<void>(RemoveFileDurably(config_.root_path, old_wal_file));
     }
@@ -1243,6 +1277,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 }
                 return left.segment_id < right.segment_id;
             });
+        bool tiering_selected = false;
         if (sources.empty() && options.enable_tiering) {
             for (uint32_t level = 0; level + 1 < options.max_levels; ++level) {
                 std::vector<SegmentMetadata> level_segments;
@@ -1258,6 +1293,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                           });
                 level_segments.resize(options.fanout);
                 sources = std::move(level_segments);
+                tiering_selected = true;
                 break;
             }
         }
@@ -1291,6 +1327,9 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             if (selected_bytes >= options.max_input_bytes) break;
         }
         sources = std::move(bounded_sources);
+        if (tiering_selected && sources.size() < options.fanout) {
+            return CompactionResult{};
+        }
         if (sources.empty()) return CompactionResult{};
 
         std::unordered_set<uint64_t> source_ids;
@@ -1318,6 +1357,17 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
                 live_entries.push_back(entry);
             }
         }
+        std::sort(live_entries.begin(), live_entries.end(),
+                  [](const IndexSnapshotEntry& left,
+                     const IndexSnapshotEntry& right) {
+                      if (left.version.physical.segment_id !=
+                          right.version.physical.segment_id) {
+                          return left.version.physical.segment_id <
+                                 right.version.physical.segment_id;
+                      }
+                      return left.version.physical.record_offset <
+                             right.version.physical.record_offset;
+                  });
         reserved_target_ids.reserve(std::max<size_t>(1, live_entries.size()));
         for (size_t i = 0; i < std::max<size_t>(1, live_entries.size()); ++i) {
             reserved_target_ids.push_back(next_segment_id_++);
@@ -1349,6 +1399,7 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
     };
     std::vector<TargetOutput> targets;
     std::vector<CompactionIndexUpdate> updates;
+    std::unordered_map<uint64_t, std::shared_ptr<SegmentReader>> source_readers;
     std::unique_ptr<SegmentWriter> writer;
 
     const auto cleanup_targets = [&]() {
@@ -1387,7 +1438,21 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             reset_sources();
             return tl::unexpected(StoreError::kCorruptData);
         }
-        auto record = ReadRecord(path->second, entry.version.physical);
+        auto reader = source_readers.find(entry.version.physical.segment_id);
+        if (reader == source_readers.end()) {
+            auto opened = SegmentReader::Open(
+                path->second, entry.version.physical.segment_id);
+            if (!opened) {
+                cleanup_targets();
+                reset_sources();
+                return tl::unexpected(StoreError::kIoError);
+            }
+            reader = source_readers
+                         .emplace(entry.version.physical.segment_id,
+                                  std::move(*opened))
+                         .first;
+        }
+        auto record = reader->second->Read(entry.version.physical);
         if (!record || record->identity != entry.identity ||
             record->kind == RecordKind::kTombstone) {
             cleanup_targets();
@@ -1407,7 +1472,8 @@ tl::expected<CompactionResult, StoreError> LogStructuredStore::CompactOnce(
             const std::string temporary_path =
                 config_.root_path + "/tmp/" + FormatSegmentName(segment_id);
             const std::string final_path = SegmentPath(segment_id);
-            auto created = SegmentWriter::Create(temporary_path, segment_id);
+            auto created = SegmentWriter::Create(temporary_path, segment_id,
+                                                 config_.use_uring);
             if (!created) {
                 cleanup_targets();
                 reset_sources();

--- a/mooncake-store/src/storage/local/log_structured/store.cpp
+++ b/mooncake-store/src/storage/local/log_structured/store.cpp
@@ -170,6 +170,34 @@ bool ValidatePersistentMetadata(const CheckpointState& checkpoint,
 
 }  // namespace
 
+size_t LogStructuredStore::TransitionKeyHash::operator()(
+    const TransitionKey& key) const {
+    const size_t tenant_hash = std::hash<std::string>{}(key.tenant_id);
+    const size_t object_hash = std::hash<std::string>{}(key.object_key);
+    return tenant_hash ^ (object_hash + 0x9e3779b97f4a7c15ULL +
+                          (tenant_hash << 6) + (tenant_hash >> 2));
+}
+
+bool LogStructuredStore::AcquireTransitionKeysLocked(
+    std::unique_lock<std::mutex>& lock,
+    const std::vector<TransitionKey>& keys) {
+    transition_cv_.wait(lock, [&] {
+        if (recovery_required_) return true;
+        return std::none_of(keys.begin(), keys.end(), [&](const auto& key) {
+            return transitions_in_flight_.contains(key);
+        });
+    });
+    if (recovery_required_) return false;
+    for (const auto& key : keys) transitions_in_flight_.insert(key);
+    return true;
+}
+
+void LogStructuredStore::ReleaseTransitionKeysLocked(
+    const std::vector<TransitionKey>& keys) {
+    for (const auto& key : keys) transitions_in_flight_.erase(key);
+    transition_cv_.notify_all();
+}
+
 LogStructuredStore::LogStructuredStore(LogStructuredStoreConfig config)
     : config_(std::move(config)),
       segments_path_(config_.root_path + "/segments"),
@@ -750,7 +778,14 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
     }
     std::vector<PreparedWrite> prepared;
     prepared.reserve(requests.size());
-    std::lock_guard lock(mutex_);
+    std::vector<TransitionKey> transition_keys;
+    transition_keys.reserve(requests.size());
+    for (const auto& request : requests) {
+        transition_keys.push_back(
+            {.tenant_id = request.tenant_id, .object_key = request.object_key});
+    }
+
+    std::unique_lock lock(mutex_);
     auto finish_pending = [&] {
         for (const auto& chunk : chunks) {
             auto pending =
@@ -775,6 +810,15 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
         finish_pending();
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    if (!AcquireTransitionKeysLocked(lock, transition_keys)) {
+        finish_pending();
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    ScopeExit transition_guard([&] {
+        if (!lock.owns_lock()) lock.lock();
+        ReleaseTransitionKeysLocked(transition_keys);
+    });
+
     std::vector<WalRecord> wal_records;
     wal_records.reserve(requests.size());
     for (const auto& chunk : chunks) {
@@ -785,8 +829,16 @@ LogStructuredStore::PreparePutBatch(const std::vector<PutRequest>& requests) {
                                    .physical = chunk.physical_records[index]});
         }
     }
-    if (!wal_->AppendBatch(wal_records, config_.sync_wal)) {
+    lock.unlock();
+    auto wal_result = wal_->AppendBatch(wal_records, config_.sync_wal);
+    lock.lock();
+    if (!wal_result) {
         recovery_required_ = true;
+        finish_pending();
+        transition_cv_.notify_all();
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    if (recovery_required_) {
         finish_pending();
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
@@ -868,10 +920,20 @@ tl::expected<PreparedWrite, StoreError> LogStructuredStore::PreparePutLocked(
 tl::expected<void, StoreError> LogStructuredStore::CommitPut(
     const RecordIdentity& identity, uint64_t sequence) {
     std::shared_lock mutation_lock(mutation_mutex_);
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    const std::vector<TransitionKey> transition_keys = {
+        {.tenant_id = identity.tenant_id, .object_key = identity.object_key}};
+    if (!AcquireTransitionKeysLocked(lock, transition_keys)) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    ScopeExit transition_guard([&] {
+        if (!lock.owns_lock()) lock.lock();
+        ReleaseTransitionKeysLocked(transition_keys);
+    });
+
     auto current = index_.Lookup(identity);
     if (!current) return tl::unexpected(StoreError::kNotFound);
     if (current->state == VersionState::kCommitted &&
@@ -882,17 +944,24 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
         current->sequence != sequence) {
         return tl::unexpected(StoreError::kInvalidTransition);
     }
-    auto previous_current =
-        index_.LookupCurrent(identity.tenant_id, identity.object_key);
+
+    lock.unlock();
     auto persisted = wal_->Append(WalRecord{.type = WalRecordType::kCommitValue,
                                             .sequence = sequence,
                                             .identity = identity,
                                             .physical = {}},
                                   config_.sync_wal);
+    lock.lock();
     if (!persisted) {
         recovery_required_ = true;
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+
+    auto previous_current =
+        index_.LookupCurrent(identity.tenant_id, identity.object_key);
     auto committed = index_.Commit(identity, sequence);
     if (!committed) return tl::unexpected(MapIndexError(committed.error()));
     if (previous_current && previous_current->identity != identity) {
@@ -906,11 +975,25 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPut(
 tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
     const std::vector<PreparedWrite>& writes) {
     std::shared_lock mutation_lock(mutation_mutex_);
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
     if (writes.empty()) return {};
+
+    std::vector<TransitionKey> transition_keys;
+    transition_keys.reserve(writes.size());
+    for (const auto& write : writes) {
+        transition_keys.push_back({.tenant_id = write.identity.tenant_id,
+                                   .object_key = write.identity.object_key});
+    }
+    if (!AcquireTransitionKeysLocked(lock, transition_keys)) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    ScopeExit transition_guard([&] {
+        if (!lock.owns_lock()) lock.lock();
+        ReleaseTransitionKeysLocked(transition_keys);
+    });
 
     std::vector<WalRecord> records;
     records.reserve(writes.size());
@@ -926,10 +1009,18 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
                            .identity = write.identity,
                            .physical = {}});
     }
-    if (!wal_->AppendBatch(records, config_.sync_wal)) {
+
+    lock.unlock();
+    auto persisted = wal_->AppendBatch(records, config_.sync_wal);
+    lock.lock();
+    if (!persisted) {
         recovery_required_ = true;
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+
     for (const auto& write : writes) {
         auto previous_current = index_.LookupCurrent(write.identity.tenant_id,
                                                      write.identity.object_key);
@@ -950,10 +1041,20 @@ tl::expected<void, StoreError> LogStructuredStore::CommitPuts(
 tl::expected<void, StoreError> LogStructuredStore::AbortPut(
     const RecordIdentity& identity, uint64_t sequence) {
     std::shared_lock mutation_lock(mutation_mutex_);
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    const std::vector<TransitionKey> transition_keys = {
+        {.tenant_id = identity.tenant_id, .object_key = identity.object_key}};
+    if (!AcquireTransitionKeysLocked(lock, transition_keys)) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    ScopeExit transition_guard([&] {
+        if (!lock.owns_lock()) lock.lock();
+        ReleaseTransitionKeysLocked(transition_keys);
+    });
+
     auto current = index_.Lookup(identity);
     if (!current) return tl::unexpected(StoreError::kNotFound);
     if (current->state == VersionState::kAborted &&
@@ -964,15 +1065,23 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
         current->sequence != sequence) {
         return tl::unexpected(StoreError::kInvalidTransition);
     }
+
+    lock.unlock();
     auto persisted = wal_->Append(WalRecord{.type = WalRecordType::kAbortValue,
                                             .sequence = sequence,
                                             .identity = identity,
                                             .physical = {}},
                                   config_.sync_wal);
+    lock.lock();
     if (!persisted) {
         recovery_required_ = true;
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+
+    current = index_.Lookup(identity);
     auto aborted = index_.Abort(identity, sequence);
     if (!aborted) return tl::unexpected(MapIndexError(aborted.error()));
     auto removed = RemoveLiveRecordLocked(current->physical);
@@ -983,11 +1092,25 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPut(
 tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
     const std::vector<PreparedWrite>& writes) {
     std::shared_lock mutation_lock(mutation_mutex_);
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
     if (writes.empty()) return {};
+
+    std::vector<TransitionKey> transition_keys;
+    transition_keys.reserve(writes.size());
+    for (const auto& write : writes) {
+        transition_keys.push_back({.tenant_id = write.identity.tenant_id,
+                                   .object_key = write.identity.object_key});
+    }
+    if (!AcquireTransitionKeysLocked(lock, transition_keys)) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    ScopeExit transition_guard([&] {
+        if (!lock.owns_lock()) lock.lock();
+        ReleaseTransitionKeysLocked(transition_keys);
+    });
 
     std::vector<WalRecord> records;
     records.reserve(writes.size());
@@ -1003,10 +1126,18 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
                            .identity = write.identity,
                            .physical = {}});
     }
-    if (!wal_->AppendBatch(records, config_.sync_wal)) {
+
+    lock.unlock();
+    auto persisted = wal_->AppendBatch(records, config_.sync_wal);
+    lock.lock();
+    if (!persisted) {
         recovery_required_ = true;
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+
     for (const auto& write : writes) {
         auto current = index_.Lookup(write.identity);
         auto aborted = index_.Abort(write.identity, write.sequence);
@@ -1023,7 +1154,7 @@ tl::expected<void, StoreError> LogStructuredStore::AbortPuts(
 tl::expected<void, StoreError> LogStructuredStore::Delete(
     const RecordIdentity& identity) {
     std::shared_lock mutation_lock(mutation_mutex_);
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
     if (recovery_required_) {
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
@@ -1031,18 +1162,35 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
         identity.object_key.size() > kMaxKeyLength) {
         return tl::unexpected(StoreError::kInvalidArgument);
     }
-    const auto existing = index_.Lookup(identity);
+
+    const std::vector<TransitionKey> transition_keys = {
+        {.tenant_id = identity.tenant_id, .object_key = identity.object_key}};
+    if (!AcquireTransitionKeysLocked(lock, transition_keys)) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+    ScopeExit transition_guard([&] {
+        if (!lock.owns_lock()) lock.lock();
+        ReleaseTransitionKeysLocked(transition_keys);
+    });
+
     const uint64_t sequence = next_sequence_++;
+    lock.unlock();
     auto persisted =
         wal_->Append(WalRecord{.type = WalRecordType::kApplyTombstone,
                                .sequence = sequence,
                                .identity = identity,
                                .physical = {}},
                      config_.sync_wal);
+    lock.lock();
     if (!persisted) {
         recovery_required_ = true;
         return tl::unexpected(StoreError::kRecoveryRequired);
     }
+    if (recovery_required_) {
+        return tl::unexpected(StoreError::kRecoveryRequired);
+    }
+
+    const auto existing = index_.Lookup(identity);
     auto tombstoned = index_.ApplyTombstone(identity, sequence);
     if (!tombstoned) {
         return tl::unexpected(MapIndexError(tombstoned.error()));
@@ -1052,7 +1200,7 @@ tl::expected<void, StoreError> LogStructuredStore::Delete(
         auto removed = RemoveLiveRecordLocked(existing->physical);
         if (!removed) return tl::unexpected(removed.error());
     }
-    applied_delete_watermark_ = sequence;
+    applied_delete_watermark_ = std::max(applied_delete_watermark_, sequence);
     return {};
 }
 
@@ -1779,6 +1927,11 @@ StoreStats LogStructuredStore::SnapshotStats() const {
     }
     stats.reclaimable_bytes = stats.physical_bytes - stats.live_record_bytes;
     stats.wal_sequence = next_sequence_ - 1;
+    const auto wal_stats = wal_->SnapshotStats();
+    stats.wal_append_requests = wal_stats.append_requests;
+    stats.wal_write_groups = wal_stats.write_groups;
+    stats.wal_sync_groups = wal_stats.sync_groups;
+    stats.wal_max_group_requests = wal_stats.max_group_requests;
     stats.checkpoint_sequence = checkpoint_sequence_;
     return stats;
 }

--- a/mooncake-store/src/storage/local/log_structured/uring_batch_io.cpp
+++ b/mooncake-store/src/storage/local/log_structured/uring_batch_io.cpp
@@ -1,0 +1,188 @@
+#include "storage/local/log_structured/uring_batch_io.h"
+
+#ifdef USE_URING
+#include <liburing.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <climits>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "uring_submit.h"
+#endif
+
+namespace mooncake::logstructured {
+
+#ifdef USE_URING
+namespace {
+
+class ThreadLocalUringBatchWriter {
+   public:
+    static constexpr unsigned kQueueDepth = 32;
+
+    static ThreadLocalUringBatchWriter& Instance() {
+        thread_local ThreadLocalUringBatchWriter writer;
+        return writer;
+    }
+
+    UringBatchWriteResult Write(int fd,
+                                std::span<const UringWriteRequest> requests,
+                                size_t max_in_flight) {
+        if (!initialized_) return UringBatchWriteResult::kUnavailable;
+        if (fd < 0 || requests.empty() || max_in_flight == 0) {
+            return UringBatchWriteResult::kIoError;
+        }
+
+        std::vector<size_t> bytes_written(requests.size(), 0);
+        size_t next_request = 0;
+        while (next_request < requests.size()) {
+            const size_t batch_size =
+                std::min({requests.size() - next_request, max_in_flight,
+                          static_cast<size_t>(kQueueDepth)});
+            if (!WriteBatch(fd, requests.subspan(next_request, batch_size),
+                            std::span<size_t>(bytes_written)
+                                .subspan(next_request, batch_size))) {
+                return UringBatchWriteResult::kIoError;
+            }
+            next_request += batch_size;
+        }
+        return UringBatchWriteResult::kSuccess;
+    }
+
+   private:
+    static constexpr unsigned kBatchIndexBits = 8;
+    static constexpr uint64_t kBatchIndexMask =
+        (uint64_t{1} << kBatchIndexBits) - 1;
+    static_assert(kQueueDepth <= kBatchIndexMask);
+
+    ThreadLocalUringBatchWriter() {
+        initialized_ = io_uring_queue_init(kQueueDepth, &ring_, 0) == 0;
+    }
+
+    ~ThreadLocalUringBatchWriter() {
+        if (initialized_) io_uring_queue_exit(&ring_);
+    }
+
+    bool WriteBatch(int fd, std::span<const UringWriteRequest> requests,
+                    std::span<size_t> bytes_written) {
+        size_t remaining = requests.size();
+        while (remaining > 0) {
+            const uint64_t operation = (++operation_id_) << kBatchIndexBits;
+            unsigned submitted_requests = 0;
+            for (size_t index = 0; index < requests.size(); ++index) {
+                if (bytes_written[index] == requests[index].length) continue;
+
+                io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+                if (sqe == nullptr) return false;
+                const size_t pending =
+                    requests[index].length - bytes_written[index];
+                const unsigned write_size = static_cast<unsigned>(
+                    std::min(pending, static_cast<size_t>(INT_MAX)));
+                io_uring_prep_write(sqe, fd,
+                                    requests[index].data + bytes_written[index],
+                                    write_size,
+                                    static_cast<off_t>(requests[index].offset +
+                                                       bytes_written[index]));
+                sqe->user_data = operation | (index + 1);
+                ++submitted_requests;
+            }
+
+            const auto submit = detail::submit_all_pending(
+                [this] { return io_uring_sq_ready(&ring_); },
+                [this](unsigned pending) {
+                    return io_uring_submit_and_wait(&ring_, pending);
+                },
+                [] { std::this_thread::yield(); });
+            if (submit.error != 0 || submit.pending != 0 ||
+                submit.submitted != submitted_requests) {
+                DrainSubmitted(submit.submitted, operation);
+                Reset();
+                return false;
+            }
+
+            unsigned completed = 0;
+            bool failed = false;
+            while (completed < submitted_requests) {
+                io_uring_cqe* cqe = nullptr;
+                int result;
+                do {
+                    result = io_uring_wait_cqe(&ring_, &cqe);
+                } while (result == -EINTR);
+                if (result < 0) {
+                    Reset();
+                    return false;
+                }
+
+                const uint64_t cqe_operation =
+                    cqe->user_data & ~kBatchIndexMask;
+                if (cqe_operation == operation) {
+                    const size_t encoded_index =
+                        cqe->user_data & kBatchIndexMask;
+                    if (encoded_index == 0 || encoded_index > requests.size() ||
+                        cqe->res <= 0) {
+                        failed = true;
+                    } else {
+                        const size_t index = encoded_index - 1;
+                        const size_t result_size =
+                            static_cast<size_t>(cqe->res);
+                        if (result_size >
+                            requests[index].length - bytes_written[index]) {
+                            failed = true;
+                        } else {
+                            bytes_written[index] += result_size;
+                        }
+                    }
+                    ++completed;
+                }
+                io_uring_cqe_seen(&ring_, cqe);
+            }
+            if (failed) return false;
+
+            remaining = 0;
+            for (size_t index = 0; index < requests.size(); ++index) {
+                if (bytes_written[index] != requests[index].length) ++remaining;
+            }
+        }
+        return true;
+    }
+
+    void DrainSubmitted(unsigned submitted, uint64_t operation) {
+        unsigned completed = 0;
+        while (completed < submitted) {
+            io_uring_cqe* cqe = nullptr;
+            if (io_uring_wait_cqe(&ring_, &cqe) < 0) return;
+            if ((cqe->user_data & ~kBatchIndexMask) == operation) ++completed;
+            io_uring_cqe_seen(&ring_, cqe);
+        }
+    }
+
+    void Reset() {
+        if (initialized_) io_uring_queue_exit(&ring_);
+        ring_ = {};
+        initialized_ = io_uring_queue_init(kQueueDepth, &ring_, 0) == 0;
+    }
+
+    io_uring ring_{};
+    bool initialized_ = false;
+    uint64_t operation_id_ = 0;
+};
+
+}  // namespace
+#endif
+
+UringBatchWriteResult UringBatchWrite(
+    int fd, std::span<const UringWriteRequest> requests, size_t max_in_flight) {
+#ifdef USE_URING
+    return ThreadLocalUringBatchWriter::Instance().Write(fd, requests,
+                                                         max_in_flight);
+#else
+    static_cast<void>(fd);
+    static_cast<void>(requests);
+    static_cast<void>(max_in_flight);
+    return UringBatchWriteResult::kUnavailable;
+#endif
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/wal.cpp
+++ b/mooncake-store/src/storage/local/log_structured/wal.cpp
@@ -1,0 +1,426 @@
+#include "storage/local/log_structured/wal.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <span>
+#include <type_traits>
+
+#include "crc32c.h"
+
+namespace mooncake::logstructured {
+namespace {
+
+constexpr uint32_t kWalMagic = 0x4C57434D;
+constexpr uint16_t kWalVersion = 1;
+constexpr uint64_t kWalCommitMagic = 0x54494D4D4F43574DULL;
+constexpr size_t kWalHeaderSize = 96;
+constexpr size_t kWalFooterSize = 16;
+constexpr size_t kWalAlignment = 8;
+constexpr size_t kMagicOffset = 0;
+constexpr size_t kVersionOffset = 4;
+constexpr size_t kTypeOffset = 6;
+constexpr size_t kTotalLengthOffset = 8;
+constexpr size_t kSequenceOffset = 16;
+constexpr size_t kIncarnationHighOffset = 24;
+constexpr size_t kIncarnationLowOffset = 32;
+constexpr size_t kSegmentIdOffset = 40;
+constexpr size_t kRecordOffset = 48;
+constexpr size_t kValueOffset = 56;
+constexpr size_t kValueLengthOffset = 64;
+constexpr size_t kPhysicalLengthOffset = 72;
+constexpr size_t kTenantLengthOffset = 80;
+constexpr size_t kKeyLengthOffset = 84;
+constexpr size_t kHeaderChecksumOffset = 88;
+constexpr size_t kHeaderChecksumInputSize = kHeaderChecksumOffset;
+constexpr size_t kFooterPayloadChecksumOffset = 0;
+constexpr size_t kFooterChecksumOffset = 4;
+constexpr size_t kFooterMagicOffset = 8;
+constexpr size_t kFooterChecksumInputSize = kFooterChecksumOffset;
+
+template <typename T>
+void WriteLittleEndian(char* output, T value) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned unsigned_value = static_cast<Unsigned>(value);
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        output[i] = static_cast<char>((unsigned_value >> (i * 8)) & 0xff);
+    }
+}
+
+template <typename T>
+T ReadLittleEndian(const char* input) {
+    using Unsigned = std::make_unsigned_t<T>;
+    Unsigned value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        value |= static_cast<Unsigned>(static_cast<unsigned char>(input[i]))
+                 << (i * 8);
+    }
+    return static_cast<T>(value);
+}
+
+bool IsKnownType(WalRecordType type) {
+    return type == WalRecordType::kPrepareValue ||
+           type == WalRecordType::kCommitValue ||
+           type == WalRecordType::kAbortValue ||
+           type == WalRecordType::kApplyTombstone ||
+           type == WalRecordType::kCheckpoint;
+}
+
+bool HasPhysicalRecord(const PhysicalRecord& physical) {
+    return physical.total_length != 0;
+}
+
+bool IsValidRecord(const WalRecord& record) {
+    if (!IsKnownType(record.type) ||
+        record.identity.tenant_id.size() > kMaxTenantLength ||
+        record.identity.object_key.size() > kMaxKeyLength) {
+        return false;
+    }
+    if (record.type == WalRecordType::kPrepareValue) {
+        return HasPhysicalRecord(record.physical);
+    }
+    if (record.type == WalRecordType::kCheckpoint) {
+        return record.identity.tenant_id.empty() &&
+               record.identity.object_key.empty() &&
+               record.identity.incarnation == ObjectIncarnation{} &&
+               !HasPhysicalRecord(record.physical);
+    }
+    return !HasPhysicalRecord(record.physical);
+}
+
+uint64_t EncodedLength(const WalRecord& record) {
+    const uint64_t payload_length =
+        record.identity.tenant_id.size() + record.identity.object_key.size();
+    const uint64_t unaligned = kWalHeaderSize + payload_length;
+    return ((unaligned + kWalAlignment - 1) & ~(kWalAlignment - 1)) +
+           kWalFooterSize;
+}
+
+bool PwriteAll(int fd, const char* data, size_t length, uint64_t offset) {
+    size_t written = 0;
+    while (written < length) {
+        const ssize_t result =
+            pwrite(fd, data + written, length - written, offset + written);
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (result == 0) return false;
+        written += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+bool PreadAll(int fd, char* data, size_t length, uint64_t offset) {
+    size_t read_bytes = 0;
+    while (read_bytes < length) {
+        const ssize_t result = pread(fd, data + read_bytes, length - read_bytes,
+                                     offset + read_bytes);
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (result == 0) return false;
+        read_bytes += static_cast<size_t>(result);
+    }
+    return true;
+}
+
+tl::expected<std::string, WalError> EncodeWalRecord(const WalRecord& record) {
+    if (!IsValidRecord(record)) {
+        return tl::unexpected(WalError::kInvalidArgument);
+    }
+    const uint64_t total_length = EncodedLength(record);
+    if (total_length >
+        static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        return tl::unexpected(WalError::kInvalidArgument);
+    }
+
+    std::string encoded(static_cast<size_t>(total_length), '\0');
+    char* header = encoded.data();
+    WriteLittleEndian<uint32_t>(header + kMagicOffset, kWalMagic);
+    WriteLittleEndian<uint16_t>(header + kVersionOffset, kWalVersion);
+    WriteLittleEndian<uint16_t>(header + kTypeOffset,
+                                static_cast<uint16_t>(record.type));
+    WriteLittleEndian<uint64_t>(header + kTotalLengthOffset, total_length);
+    WriteLittleEndian<uint64_t>(header + kSequenceOffset, record.sequence);
+    WriteLittleEndian<uint64_t>(header + kIncarnationHighOffset,
+                                record.identity.incarnation.high);
+    WriteLittleEndian<uint64_t>(header + kIncarnationLowOffset,
+                                record.identity.incarnation.low);
+    WriteLittleEndian<uint64_t>(header + kSegmentIdOffset,
+                                record.physical.segment_id);
+    WriteLittleEndian<uint64_t>(header + kRecordOffset,
+                                record.physical.record_offset);
+    WriteLittleEndian<uint64_t>(header + kValueOffset,
+                                record.physical.value_offset);
+    WriteLittleEndian<uint64_t>(header + kValueLengthOffset,
+                                record.physical.value_length);
+    WriteLittleEndian<uint64_t>(header + kPhysicalLengthOffset,
+                                record.physical.total_length);
+    WriteLittleEndian<uint32_t>(header + kTenantLengthOffset,
+                                record.identity.tenant_id.size());
+    WriteLittleEndian<uint32_t>(header + kKeyLengthOffset,
+                                record.identity.object_key.size());
+    WriteLittleEndian<uint32_t>(header + kHeaderChecksumOffset,
+                                Crc32cValue(header, kHeaderChecksumInputSize));
+
+    size_t cursor = kWalHeaderSize;
+    std::memcpy(encoded.data() + cursor, record.identity.tenant_id.data(),
+                record.identity.tenant_id.size());
+    cursor += record.identity.tenant_id.size();
+    std::memcpy(encoded.data() + cursor, record.identity.object_key.data(),
+                record.identity.object_key.size());
+
+    Crc32c payload_crc;
+    payload_crc.Extend(record.identity.tenant_id.data(),
+                       record.identity.tenant_id.size());
+    payload_crc.Extend(record.identity.object_key.data(),
+                       record.identity.object_key.size());
+    char* footer = encoded.data() + total_length - kWalFooterSize;
+    WriteLittleEndian<uint32_t>(footer + kFooterPayloadChecksumOffset,
+                                payload_crc.Final());
+    WriteLittleEndian<uint32_t>(footer + kFooterChecksumOffset,
+                                Crc32cValue(footer, kFooterChecksumInputSize));
+    WriteLittleEndian<uint64_t>(footer + kFooterMagicOffset, kWalCommitMagic);
+    return encoded;
+}
+
+tl::expected<WalRecord, WalError> DecodeWalRecord(std::span<const char> bytes) {
+    if (bytes.size() < kWalHeaderSize ||
+        ReadLittleEndian<uint32_t>(bytes.data() + kMagicOffset) != kWalMagic ||
+        ReadLittleEndian<uint16_t>(bytes.data() + kVersionOffset) !=
+            kWalVersion ||
+        Crc32cValue(bytes.data(), kHeaderChecksumInputSize) !=
+            ReadLittleEndian<uint32_t>(bytes.data() + kHeaderChecksumOffset)) {
+        return tl::unexpected(WalError::kCorruptRecord);
+    }
+
+    const auto type = static_cast<WalRecordType>(
+        ReadLittleEndian<uint16_t>(bytes.data() + kTypeOffset));
+    const uint64_t total_length =
+        ReadLittleEndian<uint64_t>(bytes.data() + kTotalLengthOffset);
+    const uint32_t tenant_length =
+        ReadLittleEndian<uint32_t>(bytes.data() + kTenantLengthOffset);
+    const uint32_t key_length =
+        ReadLittleEndian<uint32_t>(bytes.data() + kKeyLengthOffset);
+    const uint64_t expected_length =
+        ((kWalHeaderSize + static_cast<uint64_t>(tenant_length) + key_length +
+          kWalAlignment - 1) &
+         ~(kWalAlignment - 1)) +
+        kWalFooterSize;
+    if (!IsKnownType(type) || tenant_length > kMaxTenantLength ||
+        key_length > kMaxKeyLength || total_length != expected_length ||
+        total_length > bytes.size()) {
+        return tl::unexpected(WalError::kCorruptRecord);
+    }
+
+    const char* footer = bytes.data() + total_length - kWalFooterSize;
+    if (ReadLittleEndian<uint64_t>(footer + kFooterMagicOffset) !=
+            kWalCommitMagic ||
+        Crc32cValue(footer, kFooterChecksumInputSize) !=
+            ReadLittleEndian<uint32_t>(footer + kFooterChecksumOffset)) {
+        return tl::unexpected(WalError::kCorruptRecord);
+    }
+
+    WalRecord record;
+    record.type = type;
+    record.sequence =
+        ReadLittleEndian<uint64_t>(bytes.data() + kSequenceOffset);
+    record.identity.incarnation.high =
+        ReadLittleEndian<uint64_t>(bytes.data() + kIncarnationHighOffset);
+    record.identity.incarnation.low =
+        ReadLittleEndian<uint64_t>(bytes.data() + kIncarnationLowOffset);
+    record.physical.segment_id =
+        ReadLittleEndian<uint64_t>(bytes.data() + kSegmentIdOffset);
+    record.physical.record_offset =
+        ReadLittleEndian<uint64_t>(bytes.data() + kRecordOffset);
+    record.physical.value_offset =
+        ReadLittleEndian<uint64_t>(bytes.data() + kValueOffset);
+    record.physical.value_length =
+        ReadLittleEndian<uint64_t>(bytes.data() + kValueLengthOffset);
+    record.physical.total_length =
+        ReadLittleEndian<uint64_t>(bytes.data() + kPhysicalLengthOffset);
+    size_t cursor = kWalHeaderSize;
+    record.identity.tenant_id.assign(bytes.data() + cursor, tenant_length);
+    cursor += tenant_length;
+    record.identity.object_key.assign(bytes.data() + cursor, key_length);
+
+    Crc32c payload_crc;
+    payload_crc.Extend(record.identity.tenant_id.data(),
+                       record.identity.tenant_id.size());
+    payload_crc.Extend(record.identity.object_key.data(),
+                       record.identity.object_key.size());
+    if (payload_crc.Final() !=
+            ReadLittleEndian<uint32_t>(footer + kFooterPayloadChecksumOffset) ||
+        !IsValidRecord(record)) {
+        return tl::unexpected(WalError::kCorruptRecord);
+    }
+    return record;
+}
+
+}  // namespace
+
+WalWriter::WalWriter(std::string path, int fd, uint64_t tail)
+    : path_(std::move(path)), fd_(fd), tail_(tail) {}
+
+WalWriter::~WalWriter() {
+    if (fd_ >= 0) close(fd_);
+}
+
+tl::expected<std::unique_ptr<WalWriter>, WalError> WalWriter::Create(
+    std::string path) {
+    const int fd =
+        open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0644);
+    if (fd < 0) return tl::unexpected(WalError::kOpenFailed);
+    return std::unique_ptr<WalWriter>(new WalWriter(std::move(path), fd, 0));
+}
+
+tl::expected<std::unique_ptr<WalWriter>, WalError> WalWriter::OpenForAppend(
+    std::string path, uint64_t valid_bytes) {
+    const int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0) return tl::unexpected(WalError::kOpenFailed);
+    struct stat file_stat{};
+    if (fstat(fd, &file_stat) != 0 || file_stat.st_size < 0 ||
+        valid_bytes > static_cast<uint64_t>(file_stat.st_size) ||
+        valid_bytes >
+            static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+        close(fd);
+        return tl::unexpected(WalError::kInvalidArgument);
+    }
+    if (ftruncate(fd, static_cast<off_t>(valid_bytes)) != 0) {
+        close(fd);
+        return tl::unexpected(WalError::kTruncateFailed);
+    }
+    return std::unique_ptr<WalWriter>(
+        new WalWriter(std::move(path), fd, valid_bytes));
+}
+
+tl::expected<void, WalError> WalWriter::Append(const WalRecord& record,
+                                               bool sync) {
+    auto encoded = EncodeWalRecord(record);
+    if (!encoded ||
+        tail_ > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+                    encoded->size()) {
+        return tl::unexpected(WalError::kInvalidArgument);
+    }
+    if (!PwriteAll(fd_, encoded->data(), encoded->size(), tail_)) {
+        return tl::unexpected(WalError::kIoError);
+    }
+    if (sync && fdatasync(fd_) != 0) {
+        return tl::unexpected(WalError::kSyncFailed);
+    }
+    tail_ += encoded->size();
+    return {};
+}
+
+tl::expected<void, WalError> WalWriter::Sync() {
+    if (fdatasync(fd_) != 0) return tl::unexpected(WalError::kSyncFailed);
+    return {};
+}
+
+tl::expected<WalScanResult, WalError> ScanWal(const std::string& path) {
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return tl::unexpected(WalError::kOpenFailed);
+    struct FdGuard {
+        int fd;
+        ~FdGuard() { close(fd); }
+    } guard{fd};
+
+    struct stat file_stat{};
+    if (fstat(fd, &file_stat) != 0 || file_stat.st_size < 0) {
+        return tl::unexpected(WalError::kIoError);
+    }
+    const uint64_t file_size = static_cast<uint64_t>(file_stat.st_size);
+    WalScanResult result;
+    std::array<char, kWalHeaderSize> header{};
+    uint64_t offset = 0;
+    while (offset < file_size) {
+        const uint64_t remaining = file_size - offset;
+        if (remaining < kWalHeaderSize) {
+            result.valid_bytes = offset;
+            result.termination = WalScanTermination::kIncompleteTail;
+            return result;
+        }
+        if (!PreadAll(fd, header.data(), header.size(), offset)) {
+            return tl::unexpected(WalError::kIoError);
+        }
+        if (ReadLittleEndian<uint32_t>(header.data() + kMagicOffset) !=
+                kWalMagic ||
+            ReadLittleEndian<uint16_t>(header.data() + kVersionOffset) !=
+                kWalVersion ||
+            Crc32cValue(header.data(), kHeaderChecksumInputSize) !=
+                ReadLittleEndian<uint32_t>(header.data() +
+                                           kHeaderChecksumOffset)) {
+            result.valid_bytes = offset;
+            result.termination = WalScanTermination::kCorruptRecord;
+            return result;
+        }
+        const uint64_t total_length =
+            ReadLittleEndian<uint64_t>(header.data() + kTotalLengthOffset);
+        if (total_length < kWalHeaderSize + kWalFooterSize ||
+            total_length > remaining ||
+            total_length >
+                static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+            result.valid_bytes = offset;
+            result.termination = total_length > remaining
+                                     ? WalScanTermination::kIncompleteTail
+                                     : WalScanTermination::kCorruptRecord;
+            return result;
+        }
+        std::string encoded(static_cast<size_t>(total_length), '\0');
+        if (!PreadAll(fd, encoded.data(), encoded.size(), offset)) {
+            return tl::unexpected(WalError::kIoError);
+        }
+        auto decoded = DecodeWalRecord(encoded);
+        if (!decoded) {
+            result.valid_bytes = offset;
+            result.termination = WalScanTermination::kCorruptRecord;
+            return result;
+        }
+        result.records.push_back(std::move(decoded.value()));
+        offset += total_length;
+    }
+    result.valid_bytes = offset;
+    result.termination = WalScanTermination::kCleanEof;
+    return result;
+}
+
+tl::expected<void, WalError> ReplayWal(const std::vector<WalRecord>& records,
+                                       VersionIndex& index) {
+    for (const auto& record : records) {
+        bool success = false;
+        switch (record.type) {
+            case WalRecordType::kPrepareValue:
+                success = index
+                              .Prepare(record.identity, record.physical,
+                                       record.sequence)
+                              .has_value();
+                break;
+            case WalRecordType::kCommitValue:
+                success =
+                    index.Commit(record.identity, record.sequence).has_value();
+                break;
+            case WalRecordType::kAbortValue:
+                success =
+                    index.Abort(record.identity, record.sequence).has_value();
+                break;
+            case WalRecordType::kApplyTombstone:
+                success = index.ApplyTombstone(record.identity, record.sequence)
+                              .has_value();
+                break;
+            case WalRecordType::kCheckpoint:
+                success = true;
+                break;
+        }
+        if (!success) return tl::unexpected(WalError::kReplayFailed);
+    }
+    return {};
+}
+
+}  // namespace mooncake::logstructured

--- a/mooncake-store/src/storage/local/log_structured/wal.cpp
+++ b/mooncake-store/src/storage/local/log_structured/wal.cpp
@@ -37,6 +37,7 @@ constexpr size_t kPhysicalLengthOffset = 72;
 constexpr size_t kTenantLengthOffset = 80;
 constexpr size_t kKeyLengthOffset = 84;
 constexpr size_t kHeaderChecksumOffset = 88;
+constexpr size_t kHeaderReservedOffset = 92;
 constexpr size_t kHeaderChecksumInputSize = kHeaderChecksumOffset;
 constexpr size_t kFooterPayloadChecksumOffset = 0;
 constexpr size_t kFooterChecksumOffset = 4;
@@ -67,8 +68,7 @@ bool IsKnownType(WalRecordType type) {
     return type == WalRecordType::kPrepareValue ||
            type == WalRecordType::kCommitValue ||
            type == WalRecordType::kAbortValue ||
-           type == WalRecordType::kApplyTombstone ||
-           type == WalRecordType::kCheckpoint;
+           type == WalRecordType::kApplyTombstone;
 }
 
 bool HasPhysicalRecord(const PhysicalRecord& physical) {
@@ -83,12 +83,6 @@ bool IsValidRecord(const WalRecord& record) {
     }
     if (record.type == WalRecordType::kPrepareValue) {
         return HasPhysicalRecord(record.physical);
-    }
-    if (record.type == WalRecordType::kCheckpoint) {
-        return record.identity.tenant_id.empty() &&
-               record.identity.object_key.empty() &&
-               record.identity.incarnation == ObjectIncarnation{} &&
-               !HasPhysicalRecord(record.physical);
     }
     return !HasPhysicalRecord(record.physical);
 }
@@ -197,7 +191,8 @@ tl::expected<WalRecord, WalError> DecodeWalRecord(std::span<const char> bytes) {
         ReadLittleEndian<uint16_t>(bytes.data() + kVersionOffset) !=
             kWalVersion ||
         Crc32cValue(bytes.data(), kHeaderChecksumInputSize) !=
-            ReadLittleEndian<uint32_t>(bytes.data() + kHeaderChecksumOffset)) {
+            ReadLittleEndian<uint32_t>(bytes.data() + kHeaderChecksumOffset) ||
+        ReadLittleEndian<uint32_t>(bytes.data() + kHeaderReservedOffset) != 0) {
         return tl::unexpected(WalError::kCorruptRecord);
     }
 
@@ -413,9 +408,6 @@ tl::expected<void, WalError> ReplayWal(const std::vector<WalRecord>& records,
             case WalRecordType::kApplyTombstone:
                 success = index.ApplyTombstone(record.identity, record.sequence)
                               .has_value();
-                break;
-            case WalRecordType::kCheckpoint:
-                success = true;
                 break;
         }
         if (!success) return tl::unexpected(WalError::kReplayFailed);

--- a/mooncake-store/src/storage/local/log_structured/wal.cpp
+++ b/mooncake-store/src/storage/local/log_structured/wal.cpp
@@ -314,6 +314,35 @@ tl::expected<void, WalError> WalWriter::Append(const WalRecord& record,
     return {};
 }
 
+tl::expected<void, WalError> WalWriter::AppendBatch(
+    const std::vector<WalRecord>& records, bool sync) {
+    if (records.empty()) return {};
+    const uint64_t original_tail = tail_;
+    uint64_t next_tail = tail_;
+    for (const auto& record : records) {
+        auto encoded = EncodeWalRecord(record);
+        if (!encoded ||
+            next_tail >
+                static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+                    encoded->size() ||
+            !PwriteAll(fd_, encoded->data(), encoded->size(), next_tail)) {
+            if (ftruncate(fd_, static_cast<off_t>(original_tail)) != 0) {
+                return tl::unexpected(WalError::kTruncateFailed);
+            }
+            return tl::unexpected(WalError::kIoError);
+        }
+        next_tail += encoded->size();
+    }
+    if (sync && fdatasync(fd_) != 0) {
+        if (ftruncate(fd_, static_cast<off_t>(original_tail)) != 0) {
+            return tl::unexpected(WalError::kTruncateFailed);
+        }
+        return tl::unexpected(WalError::kSyncFailed);
+    }
+    tail_ = next_tail;
+    return {};
+}
+
 tl::expected<void, WalError> WalWriter::Sync() {
     if (fdatasync(fd_) != 0) return tl::unexpected(WalError::kSyncFailed);
     return {};

--- a/mooncake-store/src/storage/local/log_structured/wal.cpp
+++ b/mooncake-store/src/storage/local/log_structured/wal.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <limits>
@@ -43,6 +44,21 @@ constexpr size_t kFooterPayloadChecksumOffset = 0;
 constexpr size_t kFooterChecksumOffset = 4;
 constexpr size_t kFooterMagicOffset = 8;
 constexpr size_t kFooterChecksumInputSize = kFooterChecksumOffset;
+constexpr size_t kMaxGroupBytes = 1024 * 1024;
+constexpr size_t kMaxGroupRequests = 128;
+constexpr size_t kMaxGroupRecords = 4096;
+
+std::mutex wal_test_hook_mutex;
+std::function<void()> before_write_hook;
+
+void RunBeforeWriteHook() {
+    std::function<void()> hook;
+    {
+        std::lock_guard lock(wal_test_hook_mutex);
+        hook = before_write_hook;
+    }
+    if (hook) hook();
+}
 
 template <typename T>
 void WriteLittleEndian(char* output, T value) {
@@ -298,54 +314,162 @@ tl::expected<std::unique_ptr<WalWriter>, WalError> WalWriter::OpenForAppend(
 
 tl::expected<void, WalError> WalWriter::Append(const WalRecord& record,
                                                bool sync) {
-    auto encoded = EncodeWalRecord(record);
-    if (!encoded ||
-        tail_ > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
-                    encoded->size()) {
-        return tl::unexpected(WalError::kInvalidArgument);
-    }
-    if (!PwriteAll(fd_, encoded->data(), encoded->size(), tail_)) {
-        return tl::unexpected(WalError::kIoError);
-    }
-    if (sync && fdatasync(fd_) != 0) {
-        return tl::unexpected(WalError::kSyncFailed);
-    }
-    tail_ += encoded->size();
-    return {};
+    return AppendBatch(std::vector<WalRecord>{record}, sync);
 }
 
 tl::expected<void, WalError> WalWriter::AppendBatch(
     const std::vector<WalRecord>& records, bool sync) {
     if (records.empty()) return {};
-    const uint64_t original_tail = tail_;
-    uint64_t next_tail = tail_;
+
+    PendingAppend request;
+    request.record_count = records.size();
+    request.sync = sync;
     for (const auto& record : records) {
         auto encoded = EncodeWalRecord(record);
         if (!encoded ||
-            next_tail >
-                static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
-                    encoded->size() ||
-            !PwriteAll(fd_, encoded->data(), encoded->size(), next_tail)) {
-            if (ftruncate(fd_, static_cast<off_t>(original_tail)) != 0) {
-                return tl::unexpected(WalError::kTruncateFailed);
-            }
-            return tl::unexpected(WalError::kIoError);
+            request.encoded.size() >
+                std::numeric_limits<size_t>::max() - encoded->size()) {
+            return tl::unexpected(WalError::kInvalidArgument);
         }
-        next_tail += encoded->size();
+        request.encoded.append(*encoded);
     }
-    if (sync && fdatasync(fd_) != 0) {
-        if (ftruncate(fd_, static_cast<off_t>(original_tail)) != 0) {
-            return tl::unexpected(WalError::kTruncateFailed);
-        }
-        return tl::unexpected(WalError::kSyncFailed);
-    }
-    tail_ = next_tail;
-    return {};
+    return Submit(request);
 }
 
 tl::expected<void, WalError> WalWriter::Sync() {
-    if (fdatasync(fd_) != 0) return tl::unexpected(WalError::kSyncFailed);
+    PendingAppend request;
+    request.sync = true;
+    return Submit(request);
+}
+
+tl::expected<void, WalError> WalWriter::Submit(PendingAppend& request) {
+    std::unique_lock lock(mutex_);
+    if (terminal_error_) return tl::unexpected(*terminal_error_);
+    pending_.push_back(&request);
+    ++stats_.append_requests;
+    stats_.appended_records += request.record_count;
+    if (!writer_active_) {
+        writer_active_ = true;
+        request.leader = true;
+    }
+
+    completion_cv_.wait(lock, [&] { return request.done || request.leader; });
+    if (request.leader) {
+        lock.unlock();
+        RunWriter();
+        lock.lock();
+        if (!terminal_error_ && !pending_.empty()) {
+            pending_.front()->leader = true;
+        } else {
+            writer_active_ = false;
+        }
+        completion_cv_.notify_all();
+    }
+    if (request.error) return tl::unexpected(*request.error);
     return {};
+}
+
+void WalWriter::RunWriter() {
+    std::vector<PendingAppend*> group;
+    uint64_t original_tail = 0;
+    size_t group_bytes = 0;
+    size_t group_records = 0;
+    bool sync = false;
+    {
+        std::lock_guard lock(mutex_);
+        original_tail = tail_;
+        while (!pending_.empty()) {
+            PendingAppend* next = pending_.front();
+            const bool exceeds_limit =
+                !group.empty() &&
+                (group.size() >= kMaxGroupRequests ||
+                 group_bytes >= kMaxGroupBytes ||
+                 next->encoded.size() > kMaxGroupBytes - group_bytes ||
+                 group_records >= kMaxGroupRecords ||
+                 next->record_count > kMaxGroupRecords - group_records);
+            if (exceeds_limit) break;
+            pending_.pop_front();
+            group.push_back(next);
+            group_bytes += next->encoded.size();
+            group_records += next->record_count;
+            sync = sync || next->sync;
+        }
+    }
+
+    std::string encoded_group;
+    encoded_group.reserve(group_bytes);
+    for (const auto* request : group) {
+        encoded_group.append(request->encoded);
+    }
+
+    RunBeforeWriteHook();
+
+    std::optional<WalError> error;
+    if (encoded_group.size() >
+        static_cast<uint64_t>(std::numeric_limits<off_t>::max()) -
+            original_tail) {
+        error = WalError::kInvalidArgument;
+    } else if (!encoded_group.empty() &&
+               !PwriteAll(fd_, encoded_group.data(), encoded_group.size(),
+                          original_tail)) {
+        error = WalError::kIoError;
+    } else if (sync && fdatasync(fd_) != 0) {
+        error = WalError::kSyncFailed;
+    }
+
+    if (error && ftruncate(fd_, static_cast<off_t>(original_tail)) != 0) {
+        error = WalError::kTruncateFailed;
+    }
+
+    {
+        std::lock_guard lock(mutex_);
+        ++stats_.write_groups;
+        if (sync) ++stats_.sync_groups;
+        stats_.grouped_requests += group.size();
+        stats_.max_group_requests =
+            std::max<uint64_t>(stats_.max_group_requests, group.size());
+        if (!error) {
+            tail_ = original_tail + encoded_group.size();
+            stats_.appended_bytes += encoded_group.size();
+        }
+    }
+    CompleteGroup(group, error);
+}
+
+void WalWriter::CompleteGroup(const std::vector<PendingAppend*>& group,
+                              std::optional<WalError> error) {
+    {
+        std::lock_guard lock(mutex_);
+        for (auto* request : group) {
+            request->error = error;
+            request->done = true;
+        }
+        if (error) {
+            terminal_error_ = error;
+            while (!pending_.empty()) {
+                PendingAppend* request = pending_.front();
+                pending_.pop_front();
+                request->error = error;
+                request->done = true;
+            }
+        }
+    }
+    completion_cv_.notify_all();
+}
+
+uint64_t WalWriter::tail() const {
+    std::lock_guard lock(mutex_);
+    return tail_;
+}
+
+WalWriterStats WalWriter::SnapshotStats() const {
+    std::lock_guard lock(mutex_);
+    return stats_;
+}
+
+void WalWriter::SetBeforeWriteHookForTest(std::function<void()> hook) {
+    std::lock_guard lock(wal_test_hook_mutex);
+    before_write_hook = std::move(hook);
 }
 
 tl::expected<WalScanResult, WalError> ScanWal(const std::string& path) {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -51,6 +51,7 @@ struct FdGuard {
 
 #include "storage/distributed/distributed_storage_backend.h"
 #include "storage/distributed/posix_fs_adapter.h"
+#include "storage/local/log_structured/log_structured_backend.h"
 #ifdef USE_3FS
 #include "storage/distributed/hf3fs_adapter.h"
 #endif
@@ -5545,6 +5546,9 @@ CreateStorageBackend(const FileStorageConfig& config) {
         }
         case StorageBackendType::kNvmeKv:
             return std::make_shared<NvmeKvStorageBackend>(config);
+
+        case StorageBackendType::kLogStructured:
+            return std::make_shared<LogStructuredStorageBackend>(config);
 
         case StorageBackendType::kDistributed: {
             auto distributed_config =

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -200,24 +200,11 @@ target_link_libraries(log_structured_store_test
                       PRIVATE mooncake_log_structured_storage gtest gtest_main)
 add_test(NAME log_structured_store_test COMMAND log_structured_store_test)
 
-add_executable(log_structured_wal_test
-               storage/local/log_structured/wal_test.cpp)
-target_link_libraries(log_structured_wal_test
-                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
-add_test(NAME log_structured_wal_test COMMAND log_structured_wal_test)
-
-add_executable(log_structured_metadata_test
-               storage/local/log_structured/metadata_test.cpp)
-target_link_libraries(log_structured_metadata_test
-                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
-add_test(NAME log_structured_metadata_test COMMAND log_structured_metadata_test)
-
-add_executable(log_structured_storage_directory_test
-               storage/local/log_structured/storage_directory_test.cpp)
-target_link_libraries(log_structured_storage_directory_test
-                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
-add_test(NAME log_structured_storage_directory_test
-         COMMAND log_structured_storage_directory_test)
+add_executable(log_structured_backend_test
+               storage/local/log_structured/backend_test.cpp)
+target_link_libraries(log_structured_backend_test
+                      PRIVATE mooncake_store gtest gtest_main)
+add_test(NAME log_structured_backend_test COMMAND log_structured_backend_test)
 add_store_test(local_ssd_codec_test ha/snapshot/local_ssd_codec_test.cpp)
 add_store_test(offset_allocator_test offset_allocator_test.cpp)
 add_store_test(utils_test utils_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -181,6 +181,19 @@ target_link_libraries(log_structured_wal_test
                       PRIVATE mooncake_log_structured_storage gtest gtest_main)
 add_test(NAME log_structured_wal_test COMMAND log_structured_wal_test)
 
+add_executable(log_structured_metadata_test
+               storage/local/log_structured/metadata_test.cpp)
+target_link_libraries(log_structured_metadata_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_metadata_test COMMAND log_structured_metadata_test)
+
+add_executable(log_structured_storage_directory_test
+               storage/local/log_structured/storage_directory_test.cpp)
+target_link_libraries(log_structured_storage_directory_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_storage_directory_test
+         COMMAND log_structured_storage_directory_test)
+
 add_executable(log_structured_store_test
                storage/local/log_structured/store_test.cpp)
 target_link_libraries(log_structured_store_test
@@ -192,6 +205,19 @@ add_executable(log_structured_wal_test
 target_link_libraries(log_structured_wal_test
                       PRIVATE mooncake_log_structured_storage gtest gtest_main)
 add_test(NAME log_structured_wal_test COMMAND log_structured_wal_test)
+
+add_executable(log_structured_metadata_test
+               storage/local/log_structured/metadata_test.cpp)
+target_link_libraries(log_structured_metadata_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_metadata_test COMMAND log_structured_metadata_test)
+
+add_executable(log_structured_storage_directory_test
+               storage/local/log_structured/storage_directory_test.cpp)
+target_link_libraries(log_structured_storage_directory_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_storage_directory_test
+         COMMAND log_structured_storage_directory_test)
 add_store_test(local_ssd_codec_test ha/snapshot/local_ssd_codec_test.cpp)
 add_store_test(offset_allocator_test offset_allocator_test.cpp)
 add_store_test(utils_test utils_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -162,6 +162,36 @@ target_include_directories(local_ssd_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(local_ssd_test PRIVATE mooncake_local_ssd gtest
                                              gtest_main)
 add_test(NAME local_ssd_test COMMAND local_ssd_test)
+add_executable(
+  log_structured_segment_test
+  storage/local/log_structured/segment_test.cpp)
+target_link_libraries(log_structured_segment_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_segment_test COMMAND log_structured_segment_test)
+
+add_executable(log_structured_index_test
+               storage/local/log_structured/index_test.cpp)
+target_link_libraries(log_structured_index_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_index_test COMMAND log_structured_index_test)
+
+add_executable(log_structured_wal_test
+               storage/local/log_structured/wal_test.cpp)
+target_link_libraries(log_structured_wal_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_wal_test COMMAND log_structured_wal_test)
+
+add_executable(log_structured_store_test
+               storage/local/log_structured/store_test.cpp)
+target_link_libraries(log_structured_store_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_store_test COMMAND log_structured_store_test)
+
+add_executable(log_structured_wal_test
+               storage/local/log_structured/wal_test.cpp)
+target_link_libraries(log_structured_wal_test
+                      PRIVATE mooncake_log_structured_storage gtest gtest_main)
+add_test(NAME log_structured_wal_test COMMAND log_structured_wal_test)
 add_store_test(local_ssd_codec_test ha/snapshot/local_ssd_codec_test.cpp)
 add_store_test(offset_allocator_test offset_allocator_test.cpp)
 add_store_test(utils_test utils_test.cpp)

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -73,6 +73,19 @@ class FileStorageTest : public ::testing::Test {
                                 batch_data, buckets);
     }
 
+    tl::expected<void, ErrorCode> FileStorageInitBackend(
+        FileStorage& fileStorage) {
+        return fileStorage.storage_backend_->Init();
+    }
+
+    tl::expected<void, ErrorCode> FileStorageScanMeta(
+        FileStorage& fileStorage,
+        const std::function<ErrorCode(const std::vector<std::string>&,
+                                      std::vector<StorageObjectMetadata>&)>&
+            handler) {
+        return fileStorage.storage_backend_->ScanMeta(handler);
+    }
+
     tl::expected<std::shared_ptr<FileStorage::AllocatedBatch>, ErrorCode>
     FileStorageAllocateBatch(FileStorage& fileStorage,
                              const std::vector<std::string>& keys,
@@ -1003,6 +1016,53 @@ TEST_F(FileStorageTest, BatchLoad_WithStorageBackendAdaptor) {
         ASSERT_TRUE(found != batch_data.end())
             << "key not found in batch_data: " << key;
         EXPECT_EQ(data, found->second);
+    }
+}
+
+TEST_F(FileStorageTest, LogStructuredBackendSurvivesFileStorageRestart) {
+    auto config = FileStorageConfig::FromEnvironment();
+    config.storage_backend_type = StorageBackendType::kLogStructured;
+    config.storage_filepath = data_path;
+    config.local_buffer_size = 128 * 1024 * 1024;
+    config.total_keys_limit = 1000;
+    config.total_size_limit = 64 * 1024 * 1024;
+
+    std::vector<std::string> keys;
+    std::vector<int64_t> sizes;
+    std::unordered_map<std::string, std::string> batch_data;
+    {
+        FileStorage file_storage(config, nullptr, "localhost:9003");
+        ASSERT_TRUE(
+            FileStorageBatchOffload(file_storage, keys, sizes, batch_data));
+        auto allocated = FileStorageAllocateBatch(file_storage, keys, sizes);
+        ASSERT_TRUE(allocated.has_value());
+        ASSERT_TRUE(
+            FileStorageBatchLoad(file_storage, allocated.value()->slices));
+        for (const auto& [key, slice] : allocated.value()->slices) {
+            EXPECT_EQ(std::string(static_cast<char*>(slice.ptr), slice.size),
+                      batch_data.at(key));
+        }
+    }
+
+    FileStorage recovered(config, nullptr, "localhost:9003");
+    ASSERT_TRUE(FileStorageInitBackend(recovered));
+    std::vector<std::string> scanned_keys;
+    ASSERT_TRUE(FileStorageScanMeta(
+        recovered, [&](const std::vector<std::string>& batch_keys,
+                       std::vector<StorageObjectMetadata>& metadatas) {
+            EXPECT_EQ(batch_keys.size(), metadatas.size());
+            scanned_keys.insert(scanned_keys.end(), batch_keys.begin(),
+                                batch_keys.end());
+            return ErrorCode::OK;
+        }));
+    EXPECT_EQ(scanned_keys.size(), keys.size());
+
+    auto allocated = FileStorageAllocateBatch(recovered, keys, sizes);
+    ASSERT_TRUE(allocated.has_value());
+    ASSERT_TRUE(FileStorageBatchLoad(recovered, allocated.value()->slices));
+    for (const auto& [key, slice] : allocated.value()->slices) {
+        EXPECT_EQ(std::string(static_cast<char*>(slice.ptr), slice.size),
+                  batch_data.at(key));
     }
 }
 

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -86,6 +86,11 @@ class FileStorageTest : public ::testing::Test {
         return fileStorage.storage_backend_->ScanMeta(handler);
     }
 
+    std::optional<StorageBackendStats> FileStorageSnapshotBackendStats(
+        FileStorage& fileStorage) {
+        return fileStorage.storage_backend_->SnapshotStats();
+    }
+
     tl::expected<std::shared_ptr<FileStorage::AllocatedBatch>, ErrorCode>
     FileStorageAllocateBatch(FileStorage& fileStorage,
                              const std::vector<std::string>& keys,
@@ -1064,6 +1069,65 @@ TEST_F(FileStorageTest, LogStructuredBackendSurvivesFileStorageRestart) {
         EXPECT_EQ(std::string(static_cast<char*>(slice.ptr), slice.size),
                   batch_data.at(key));
     }
+}
+
+TEST_F(FileStorageTest, HeartbeatProjectsLogStructuredBackendStats) {
+    std::filesystem::path master_root =
+        std::filesystem::path(data_path) / "log_stats_master";
+    std::filesystem::create_directories(master_root);
+
+    testing::InProcMaster master;
+    auto master_config = InProcMasterConfigBuilder()
+                             .set_enable_offload(true)
+                             .set_root_fs_dir(master_root.string())
+                             .build();
+    ASSERT_TRUE(master.Start(master_config));
+
+    std::string local_rpc_addr =
+        "127.0.0.1:" + std::to_string(getFreeTcpPort());
+    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                                 std::nullopt, master.master_address());
+    ASSERT_TRUE(client.has_value());
+    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+    auto config = FileStorageConfig::FromEnvironment();
+    config.storage_backend_type = StorageBackendType::kLogStructured;
+    config.storage_filepath = data_path + "/log_stats";
+    config.local_buffer_size = 128 * 1024 * 1024;
+    config.total_keys_limit = 1000;
+    config.total_size_limit = 64 * 1024 * 1024;
+    config.enable_disk_watermark_eviction = false;
+    fs::create_directories(config.storage_filepath);
+
+    SsdMetric ssd_metric;
+    FileStorage file_storage(config, client.value(), local_rpc_addr,
+                             &ssd_metric);
+    ASSERT_TRUE(FileStorageInitBackend(file_storage).has_value());
+
+    std::vector<std::string> keys;
+    std::vector<int64_t> sizes;
+    std::unordered_map<std::string, std::string> batch_data;
+    ASSERT_TRUE(FileStorageBatchOffload(file_storage, keys, sizes, batch_data));
+
+    const auto backend_stats = FileStorageSnapshotBackendStats(file_storage);
+    ASSERT_TRUE(backend_stats.has_value());
+    ASSERT_GT(backend_stats->physical_bytes, 0);
+    ASSERT_GT(backend_stats->logical_value_bytes, 0);
+    ASSERT_GT(backend_stats->wal_sequence, 0);
+
+    ASSERT_TRUE(FileStorageHeartbeat(file_storage).has_value());
+    EXPECT_EQ(ssd_metric.backend_physical_bytes.value(),
+              static_cast<int64_t>(backend_stats->physical_bytes));
+    EXPECT_EQ(ssd_metric.backend_live_record_bytes.value(),
+              static_cast<int64_t>(backend_stats->live_record_bytes));
+    EXPECT_EQ(ssd_metric.backend_logical_value_bytes.value(),
+              static_cast<int64_t>(backend_stats->logical_value_bytes));
+    EXPECT_EQ(ssd_metric.backend_active_segments.value(),
+              static_cast<int64_t>(backend_stats->active_segments));
+    EXPECT_EQ(ssd_metric.backend_wal_sequence.value(),
+              static_cast<int64_t>(backend_stats->wal_sequence));
+    EXPECT_EQ(ssd_metric.backend_checkpoint_sequence.value(),
+              static_cast<int64_t>(backend_stats->checkpoint_sequence));
 }
 
 TEST_F(FileStorageTest, BatchLoadRecordsSsdMetrics) {

--- a/mooncake-store/tests/ssd_metrics_test.cpp
+++ b/mooncake-store/tests/ssd_metrics_test.cpp
@@ -37,6 +37,13 @@ TEST_F(SsdMetricsTest, SerializeTest) {
     metrics.ssd_write_latency_summary.observe(1000);
     metrics.ssd_total_latency_summary.observe(200);
     metrics.ssd_total_latency_summary.observe(1000);
+    metrics.backend_physical_bytes.update(8192);
+    metrics.backend_live_record_bytes.update(4096);
+    metrics.backend_logical_value_bytes.update(3072);
+    metrics.backend_reclaimable_bytes.update(4096);
+    metrics.backend_active_segments.update(1);
+    metrics.backend_sealed_segments.update(2);
+    metrics.backend_retired_segments.update(3);
 
     std::string serialized;
     metrics.serialize(serialized);
@@ -61,6 +68,23 @@ TEST_F(SsdMetricsTest, SerializeTest) {
     EXPECT_TRUE(serialized.find("mooncake_ssd_total_latency_us") !=
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_ssd_read_latency_summary_us") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_ssd_backend_physical_bytes 8192") !=
+                std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_ssd_backend_live_record_bytes 4096") !=
+        std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_ssd_backend_logical_value_bytes 3072") !=
+        std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_ssd_backend_reclaimable_bytes 4096") !=
+        std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_ssd_backend_active_segments 1") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_ssd_backend_sealed_segments 2") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_ssd_backend_retired_segments 3") !=
                 std::string::npos);
 
     std::cout << "Serialized SSD Metrics:\n" << serialized << std::endl;

--- a/mooncake-store/tests/ssd_metrics_test.cpp
+++ b/mooncake-store/tests/ssd_metrics_test.cpp
@@ -44,6 +44,16 @@ TEST_F(SsdMetricsTest, SerializeTest) {
     metrics.backend_active_segments.update(1);
     metrics.backend_sealed_segments.update(2);
     metrics.backend_retired_segments.update(3);
+    metrics.backend_compaction_runs.update(4);
+    metrics.backend_compaction_input_bytes.update(16384);
+    metrics.backend_compaction_output_bytes.update(8192);
+    metrics.backend_compaction_reclaimed_bytes.update(8192);
+    metrics.backend_compaction_conflicts.update(1);
+    metrics.backend_compaction_cancellations.update(2);
+    metrics.backend_compaction_errors.update(3);
+    metrics.backend_compaction_last_duration_us.update(250);
+    metrics.backend_wal_sequence.update(17);
+    metrics.backend_checkpoint_sequence.update(12);
 
     std::string serialized;
     metrics.serialize(serialized);
@@ -86,6 +96,21 @@ TEST_F(SsdMetricsTest, SerializeTest) {
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_ssd_backend_retired_segments 3") !=
                 std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_ssd_backend_compaction_runs_total 4") !=
+        std::string::npos);
+    EXPECT_TRUE(
+        serialized.find(
+            "mooncake_ssd_backend_compaction_reclaimed_bytes_total 8192") !=
+        std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_ssd_backend_compaction_conflicts_total 1") !=
+        std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_ssd_backend_wal_sequence 17") !=
+                std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_ssd_backend_checkpoint_sequence 12") !=
+        std::string::npos);
 
     std::cout << "Serialized SSD Metrics:\n" << serialized << std::endl;
 }

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -173,6 +173,7 @@ TEST(LogStructuredStorageBackendTest, PartialFailureReportsOnlyStoredKeys) {
 
 TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     setenv("MOONCAKE_LOG_SEGMENT_SIZE_BYTES", "4096", 1);
+    setenv("MOONCAKE_LOG_WRITE_PARALLELISM", "7", 1);
     setenv("MOONCAKE_LOG_SYNC_POLICY", "batch", 1);
     setenv("MOONCAKE_LOG_CHECKPOINT_INTERVAL", "17", 1);
     setenv("MOONCAKE_LOG_COMPACTION_POLICY", "tiered", 1);
@@ -189,6 +190,7 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     const auto config = LogStructuredBackendConfig::FromEnvironment();
 
     unsetenv("MOONCAKE_LOG_SEGMENT_SIZE_BYTES");
+    unsetenv("MOONCAKE_LOG_WRITE_PARALLELISM");
     unsetenv("MOONCAKE_LOG_SYNC_POLICY");
     unsetenv("MOONCAKE_LOG_CHECKPOINT_INTERVAL");
     unsetenv("MOONCAKE_LOG_COMPACTION_POLICY");
@@ -204,6 +206,7 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
 
     EXPECT_TRUE(config.Validate());
     EXPECT_EQ(config.segment_size_bytes, uint64_t{4096});
+    EXPECT_EQ(config.payload_write_parallelism, size_t{7});
     EXPECT_EQ(config.sync_policy, LogStructuredSyncPolicy::kBatch);
     EXPECT_EQ(config.checkpoint_interval_records, uint64_t{17});
     EXPECT_EQ(config.compaction_policy, LogStructuredCompactionPolicy::kTiered);

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -1,0 +1,172 @@
+#include "storage/local/log_structured/log_structured_backend.h"
+
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "tenant_id.h"
+
+namespace mooncake {
+namespace {
+
+class BackendTempDirectory {
+   public:
+    BackendTempDirectory() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        const char* tmpdir = std::getenv("TMPDIR");
+        const std::filesystem::path base =
+            tmpdir == nullptr ? std::filesystem::temp_directory_path()
+                              : std::filesystem::path(tmpdir);
+        path_ = base / ("mooncake-log-structured-backend-test-" +
+                        std::to_string(getpid()) + "-" + std::to_string(id));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~BackendTempDirectory() {
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    const std::filesystem::path& path() const { return path_; }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+FileStorageConfig BackendConfig(const BackendTempDirectory& temp) {
+    FileStorageConfig config;
+    config.storage_backend_type = StorageBackendType::kLogStructured;
+    config.storage_filepath = temp.path().string();
+    config.total_keys_limit = 100;
+    config.total_size_limit = 1024 * 1024;
+    config.scanmeta_iterator_keys_limit = 1;
+    return config;
+}
+
+std::unordered_map<std::string, std::vector<Slice>> SingleValueBatch(
+    const std::string& key, std::string& value) {
+    return {{key, {Slice{value.data(), value.size()}}}};
+}
+
+TEST(LogStructuredStorageBackendTest, OffloadLoadAndScanPreserveTenantKey) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string storage_key = TenantId("tenant-a").MakeScopedKey("key");
+    std::string value = "payload";
+
+    {
+        LogStructuredStorageBackend backend(config);
+        ASSERT_TRUE(backend.Init().has_value());
+        auto result = backend.BatchOffload(
+            SingleValueBatch(storage_key, value),
+            [&](const std::vector<std::string>& keys,
+                std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+                EXPECT_EQ(keys, std::vector<std::string>{storage_key});
+                EXPECT_EQ(metadatas.size(), size_t{1});
+                if (metadatas.size() == 1) {
+                    EXPECT_EQ(metadatas[0].bucket_id, -1);
+                    EXPECT_EQ(metadatas[0].offset, 0);
+                    EXPECT_EQ(metadatas[0].data_size,
+                              static_cast<int64_t>(value.size()));
+                }
+                return ErrorCode::OK;
+            });
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(*result, 1);
+
+        std::string loaded(value.size(), '\0');
+        std::unordered_map<std::string, Slice> slices{
+            {storage_key, Slice{loaded.data(), loaded.size()}}};
+        ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+        EXPECT_EQ(loaded, value);
+    }
+
+    LogStructuredStorageBackend recovered(config);
+    ASSERT_TRUE(recovered.Init().has_value());
+    std::vector<std::string> scanned_keys;
+    ASSERT_TRUE(
+        recovered
+            .ScanMeta([&](const std::vector<std::string>& keys,
+                          std::vector<StorageObjectMetadata>& metadatas) {
+                scanned_keys.insert(scanned_keys.end(), keys.begin(),
+                                    keys.end());
+                EXPECT_EQ(keys.size(), metadatas.size());
+                return ErrorCode::OK;
+            })
+            .has_value());
+    EXPECT_EQ(scanned_keys, std::vector<std::string>{storage_key});
+}
+
+TEST(LogStructuredStorageBackendTest,
+     CallbackFailureAbortsNewVersionAndPreservesCommittedValue) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string storage_key = TenantId("tenant-b").MakeScopedKey("key");
+    std::string old_value = "old";
+    std::string rejected_value = "new-value";
+
+    LogStructuredStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+    ASSERT_TRUE(backend
+                    .BatchOffload(SingleValueBatch(storage_key, old_value),
+                                  [](const std::vector<std::string>&,
+                                     std::vector<StorageObjectMetadata>&) {
+                                      return ErrorCode::OK;
+                                  })
+                    .has_value());
+
+    auto rejected =
+        backend.BatchOffload(SingleValueBatch(storage_key, rejected_value),
+                             [](const std::vector<std::string>&,
+                                std::vector<StorageObjectMetadata>&) {
+                                 return ErrorCode::INTERNAL_ERROR;
+                             });
+    ASSERT_FALSE(rejected.has_value());
+    EXPECT_TRUE(rejected.error() == ErrorCode::INTERNAL_ERROR);
+
+    std::string loaded(old_value.size(), '\0');
+    std::unordered_map<std::string, Slice> slices{
+        {storage_key, Slice{loaded.data(), loaded.size()}}};
+    ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+    EXPECT_EQ(loaded, old_value);
+}
+
+TEST(LogStructuredStorageBackendTest, PartialFailureReportsOnlyStoredKeys) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    std::string first = "first";
+    std::string second = "second";
+    std::unordered_map<std::string, std::vector<Slice>> batch{
+        {"key-1", {Slice{first.data(), first.size()}}},
+        {"key-2", {Slice{second.data(), second.size()}}}};
+
+    LogStructuredStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+    backend.SetTestFailurePredicate(
+        [](const std::string& key) { return key == "key-2"; });
+
+    std::vector<std::string> completed;
+    auto result =
+        backend.BatchOffload(batch, [&](const std::vector<std::string>& keys,
+                                        std::vector<StorageObjectMetadata>&) {
+            completed = keys;
+            return ErrorCode::OK;
+        });
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 1);
+    EXPECT_EQ(completed, std::vector<std::string>{"key-1"});
+    EXPECT_EQ(backend.IsExist("key-1").value(), true);
+    EXPECT_EQ(backend.IsExist("key-2").value(), false);
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -187,6 +187,49 @@ TEST(LogStructuredStorageBackendTest, SupportsConcurrentBatchLoads) {
 }
 
 TEST(LogStructuredStorageBackendTest,
+     BatchLoadWaitsUntilMasterAcknowledgedWriteIsCommitted) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string storage_key = TenantId("tenant-a").MakeScopedKey("key");
+    std::string value = "payload";
+
+    LogStructuredStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+
+    std::promise<void> callback_entered;
+    std::promise<void> allow_callback_return;
+    auto callback_gate = allow_callback_return.get_future().share();
+    auto offload = std::async(std::launch::async, [&]() {
+        return backend.BatchOffload(
+            SingleValueBatch(storage_key, value),
+            [&](const std::vector<std::string>&,
+                std::vector<StorageObjectMetadata>&) {
+                callback_entered.set_value();
+                callback_gate.wait();
+                return ErrorCode::OK;
+            });
+    });
+
+    ASSERT_EQ(callback_entered.get_future().wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+
+    std::string loaded(value.size(), '\0');
+    std::unordered_map<std::string, Slice> slices{
+        {storage_key, Slice{loaded.data(), loaded.size()}}};
+    auto read = std::async(std::launch::async,
+                           [&]() { return backend.BatchLoad(slices); });
+    EXPECT_EQ(read.wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+
+    allow_callback_return.set_value();
+    ASSERT_TRUE(offload.get().has_value());
+    ASSERT_EQ(read.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    EXPECT_TRUE(read.get().has_value());
+    EXPECT_EQ(loaded, value);
+}
+
+TEST(LogStructuredStorageBackendTest,
      CallbackFailureAbortsNewVersionAndPreservesCommittedValue) {
     BackendTempDirectory temp;
     const auto config = BackendConfig(temp);

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -315,6 +315,12 @@ TEST(LogStructuredStorageBackendTest,
     EXPECT_TRUE(evicted->empty());
     EXPECT_LT(disk_bytes(), before);
     EXPECT_TRUE(backend.IsEnableOffloading().value());
+    const auto stats = backend.SnapshotStats();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_GE(stats->compaction_runs, uint64_t{1});
+    EXPECT_GT(stats->compaction_input_bytes, uint64_t{0});
+    EXPECT_GT(stats->compaction_reclaimed_bytes, uint64_t{0});
+    EXPECT_EQ(stats->compaction_errors, uint64_t{0});
 
     std::string loaded(96, '\0');
     std::unordered_map<std::string, Slice> slices{
@@ -400,6 +406,8 @@ TEST(LogStructuredStorageBackendTest, ExposesPhysicalStorageStats) {
     EXPECT_EQ(stats->active_segments, 1);
     EXPECT_EQ(stats->sealed_segments, 0);
     EXPECT_EQ(stats->retired_segments, 0);
+    EXPECT_GT(stats->wal_sequence, uint64_t{0});
+    EXPECT_LE(stats->checkpoint_sequence, stats->wal_sequence);
 }
 
 }  // namespace

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -109,6 +109,83 @@ TEST(LogStructuredStorageBackendTest, OffloadLoadAndScanPreserveTenantKey) {
     EXPECT_EQ(scanned_keys, std::vector<std::string>{storage_key});
 }
 
+TEST(LogStructuredStorageBackendTest, BatchLoadsRecordsAcrossSegments) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    LogStructuredBackendConfig backend_config;
+    backend_config.segment_size_bytes = 256;
+    backend_config.sync_policy = LogStructuredSyncPolicy::kNone;
+    backend_config.compaction_policy = LogStructuredCompactionPolicy::kNone;
+
+    LogStructuredStorageBackend backend(config, backend_config);
+    ASSERT_TRUE(backend.Init().has_value());
+    const auto commit = [](const std::vector<std::string>&,
+                           std::vector<StorageObjectMetadata>&) {
+        return ErrorCode::OK;
+    };
+
+    std::unordered_map<std::string, std::string> values;
+    for (size_t index = 0; index < 4; ++index) {
+        const std::string key =
+            TenantId("tenant-batch")
+                .MakeScopedKey("key-" + std::to_string(index));
+        auto [it, inserted] = values.emplace(
+            key, std::string(96, static_cast<char>('a' + index)));
+        ASSERT_TRUE(inserted);
+        ASSERT_TRUE(
+            backend
+                .BatchOffload(SingleValueBatch(it->first, it->second), commit)
+                .has_value());
+    }
+
+    std::unordered_map<std::string, std::string> loaded;
+    std::unordered_map<std::string, Slice> slices;
+    for (const auto& [key, value] : values) {
+        auto [it, inserted] =
+            loaded.emplace(key, std::string(value.size(), '\0'));
+        ASSERT_TRUE(inserted);
+        slices.emplace(key, Slice{it->second.data(), it->second.size()});
+    }
+    ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+    EXPECT_EQ(loaded, values);
+}
+
+TEST(LogStructuredStorageBackendTest, SupportsConcurrentBatchLoads) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string storage_key = TenantId("tenant-a").MakeScopedKey("key");
+    std::string value(128 * 1024, 'v');
+
+    LogStructuredStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+    ASSERT_TRUE(backend
+                    .BatchOffload(SingleValueBatch(storage_key, value),
+                                  [](const std::vector<std::string>&,
+                                     std::vector<StorageObjectMetadata>&) {
+                                      return ErrorCode::OK;
+                                  })
+                    .has_value());
+
+    std::atomic<uint64_t> errors{0};
+    std::vector<std::thread> readers;
+    for (size_t index = 0; index < 8; ++index) {
+        readers.emplace_back([&]() {
+            for (size_t iteration = 0; iteration < 64; ++iteration) {
+                std::string loaded(value.size(), '\0');
+                std::unordered_map<std::string, Slice> slices{
+                    {storage_key, Slice{loaded.data(), loaded.size()}}};
+                auto result = backend.BatchLoad(slices);
+                if (!result || loaded != value) {
+                    errors.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& reader : readers) reader.join();
+
+    EXPECT_EQ(errors.load(std::memory_order_relaxed), uint64_t{0});
+}
+
 TEST(LogStructuredStorageBackendTest,
      CallbackFailureAbortsNewVersionAndPreservesCommittedValue) {
     BackendTempDirectory temp;

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -3,10 +3,12 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -166,6 +168,141 @@ TEST(LogStructuredStorageBackendTest, PartialFailureReportsOnlyStoredKeys) {
     EXPECT_EQ(completed, std::vector<std::string>{"key-1"});
     EXPECT_EQ(backend.IsExist("key-1").value(), true);
     EXPECT_EQ(backend.IsExist("key-2").value(), false);
+}
+
+TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
+    setenv("MOONCAKE_LOG_SEGMENT_SIZE_BYTES", "4096", 1);
+    setenv("MOONCAKE_LOG_SYNC_POLICY", "batch", 1);
+    setenv("MOONCAKE_LOG_CHECKPOINT_INTERVAL", "17", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_POLICY", "tiered", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_INTERVAL_MS", "25", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_FANOUT", "3", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MAX_LEVELS", "5", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MAX_SOURCES", "6", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND", "8192", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES", "16384", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MIN_RECLAIM_RATIO", "0.35", 1);
+
+    const auto config = LogStructuredBackendConfig::FromEnvironment();
+
+    unsetenv("MOONCAKE_LOG_SEGMENT_SIZE_BYTES");
+    unsetenv("MOONCAKE_LOG_SYNC_POLICY");
+    unsetenv("MOONCAKE_LOG_CHECKPOINT_INTERVAL");
+    unsetenv("MOONCAKE_LOG_COMPACTION_POLICY");
+    unsetenv("MOONCAKE_LOG_COMPACTION_INTERVAL_MS");
+    unsetenv("MOONCAKE_LOG_COMPACTION_FANOUT");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_LEVELS");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_SOURCES");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MIN_RECLAIM_RATIO");
+
+    EXPECT_TRUE(config.Validate());
+    EXPECT_EQ(config.segment_size_bytes, uint64_t{4096});
+    EXPECT_EQ(config.sync_policy, LogStructuredSyncPolicy::kBatch);
+    EXPECT_EQ(config.checkpoint_interval_records, uint64_t{17});
+    EXPECT_EQ(config.compaction_policy, LogStructuredCompactionPolicy::kTiered);
+    EXPECT_EQ(config.compaction_interval_ms, uint64_t{25});
+    EXPECT_EQ(config.compaction_fanout, size_t{3});
+    EXPECT_EQ(config.compaction_max_levels, uint32_t{5});
+    EXPECT_EQ(config.compaction_max_sources, size_t{6});
+    EXPECT_EQ(config.compaction_max_bytes_per_round, uint64_t{8192});
+    EXPECT_EQ(config.compaction_max_target_bytes, uint64_t{16384});
+    EXPECT_DOUBLE_EQ(config.compaction_min_reclaim_ratio, 0.35);
+}
+
+TEST(LogStructuredStorageBackendTest, BackgroundTieringKeepsObjectsReadable) {
+    BackendTempDirectory temp;
+    auto config = BackendConfig(temp);
+    LogStructuredBackendConfig backend_config;
+    backend_config.segment_size_bytes = 256;
+    backend_config.sync_policy = LogStructuredSyncPolicy::kBatch;
+    backend_config.checkpoint_interval_records = 2;
+    backend_config.compaction_policy = LogStructuredCompactionPolicy::kTiered;
+    backend_config.compaction_interval_ms = 5;
+    backend_config.compaction_fanout = 4;
+    backend_config.compaction_max_sources = 4;
+    backend_config.compaction_max_target_bytes = 1024;
+    backend_config.compaction_min_reclaim_ratio = 1.0;
+
+    LogStructuredStorageBackend backend(config, backend_config);
+    ASSERT_TRUE(backend.Init().has_value());
+    std::vector<std::string> values;
+    for (size_t i = 0; i < 5; ++i) {
+        values.push_back(std::string(96, static_cast<char>('a' + i)));
+        const std::string key = "key-" + std::to_string(i);
+        ASSERT_TRUE(backend
+                        .BatchOffload(SingleValueBatch(key, values.back()),
+                                      [](const std::vector<std::string>&,
+                                         std::vector<StorageObjectMetadata>&) {
+                                          return ErrorCode::OK;
+                                      })
+                        .has_value());
+    }
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    size_t segment_count = 0;
+    do {
+        segment_count = 0;
+        for (const auto& entry : std::filesystem::directory_iterator(
+                 temp.path() / "log_structured" / "segments")) {
+            if (entry.is_regular_file()) ++segment_count;
+        }
+        if (segment_count <= 2) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+    EXPECT_LE(segment_count, size_t{2});
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        const std::string key = "key-" + std::to_string(i);
+        std::string loaded(values[i].size(), '\0');
+        std::unordered_map<std::string, Slice> slices{
+            {key, Slice{loaded.data(), loaded.size()}}};
+        ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+        EXPECT_EQ(loaded, values[i]);
+    }
+}
+
+TEST(LogStructuredStorageBackendTest, RemoveAllSurvivesRestart) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    std::string first = "first-value";
+    std::string second = "second-value";
+    {
+        LogStructuredBackendConfig backend_config;
+        backend_config.segment_size_bytes = 256;
+        backend_config.compaction_policy = LogStructuredCompactionPolicy::kNone;
+        LogStructuredStorageBackend backend(config, backend_config);
+        ASSERT_TRUE(backend.Init().has_value());
+        std::unordered_map<std::string, std::vector<Slice>> batch{
+            {"first", {Slice{first.data(), first.size()}}},
+            {"second", {Slice{second.data(), second.size()}}}};
+        ASSERT_TRUE(backend
+                        .BatchOffload(batch,
+                                      [](const std::vector<std::string>&,
+                                         std::vector<StorageObjectMetadata>&) {
+                                          return ErrorCode::OK;
+                                      })
+                        .has_value());
+        backend.RemoveAll();
+        EXPECT_FALSE(backend.IsExist("first").value());
+        EXPECT_FALSE(backend.IsExist("second").value());
+    }
+
+    LogStructuredStorageBackend recovered(config);
+    ASSERT_TRUE(recovered.Init().has_value());
+    EXPECT_FALSE(recovered.IsExist("first").value());
+    EXPECT_FALSE(recovered.IsExist("second").value());
+    size_t scanned = 0;
+    ASSERT_TRUE(recovered
+                    .ScanMeta([&](const std::vector<std::string>& keys,
+                                  std::vector<StorageObjectMetadata>&) {
+                        scanned += keys.size();
+                        return ErrorCode::OK;
+                    })
+                    .has_value());
+    EXPECT_EQ(scanned, size_t{0});
 }
 
 }  // namespace

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <future>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -179,7 +180,7 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     setenv("MOONCAKE_LOG_COMPACTION_FANOUT", "3", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MAX_LEVELS", "5", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MAX_SOURCES", "6", 1);
-    setenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND", "8192", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MAX_INPUT_BYTES", "8192", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES", "16384", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_SEC", "32768", 1);
     setenv("MOONCAKE_LOG_COMPACTION_RESERVE_BYTES", "2048", 1);
@@ -195,7 +196,7 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     unsetenv("MOONCAKE_LOG_COMPACTION_FANOUT");
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_LEVELS");
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_SOURCES");
-    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_INPUT_BYTES");
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES");
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_SEC");
     unsetenv("MOONCAKE_LOG_COMPACTION_RESERVE_BYTES");
@@ -210,7 +211,7 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     EXPECT_EQ(config.compaction_fanout, size_t{3});
     EXPECT_EQ(config.compaction_max_levels, uint32_t{5});
     EXPECT_EQ(config.compaction_max_sources, size_t{6});
-    EXPECT_EQ(config.compaction_max_bytes_per_round, uint64_t{8192});
+    EXPECT_EQ(config.compaction_max_input_bytes, uint64_t{8192});
     EXPECT_EQ(config.compaction_max_target_bytes, uint64_t{16384});
     EXPECT_EQ(config.compaction_max_bytes_per_second, uint64_t{32768});
     EXPECT_EQ(config.compaction_reserve_bytes, uint64_t{2048});
@@ -271,6 +272,74 @@ TEST(LogStructuredStorageBackendTest, BackgroundTieringKeepsObjectsReadable) {
 }
 
 TEST(LogStructuredStorageBackendTest,
+     BatchLoadCompletesWhileBackgroundCompactionCopies) {
+    BackendTempDirectory temp;
+    auto config = BackendConfig(temp);
+    LogStructuredBackendConfig backend_config;
+    backend_config.segment_size_bytes = 512;
+    backend_config.sync_policy = LogStructuredSyncPolicy::kBatch;
+    backend_config.checkpoint_interval_records = 1000;
+    backend_config.compaction_policy =
+        LogStructuredCompactionPolicy::kReclaimOnly;
+    backend_config.compaction_interval_ms = 5;
+    backend_config.compaction_min_reclaim_ratio = 0.0;
+
+    std::promise<void> target_ready;
+    std::promise<void> allow_publication;
+    auto allow_publication_future = allow_publication.get_future().share();
+    std::atomic<bool> blocked{false};
+    logstructured::LogStructuredStore::SetCompactionCrashPredicateForTest(
+        [&](logstructured::CompactionCrashPoint point) {
+            if (point !=
+                    logstructured::CompactionCrashPoint::kAfterTargetRename ||
+                blocked.exchange(true)) {
+                return false;
+            }
+            target_ready.set_value();
+            allow_publication_future.wait();
+            return false;
+        });
+
+    LogStructuredStorageBackend backend(config, backend_config);
+    ASSERT_TRUE(backend.Init().has_value());
+    const std::string stale_key =
+        TenantId("tenant-peer").MakeScopedKey("stale");
+    const std::string live_key = TenantId("tenant-peer").MakeScopedKey("live");
+    std::string stale_value(96, 'a');
+    std::string live_value(96, 'b');
+    std::string replacement_value(96, 'c');
+    const auto commit = [](const std::vector<std::string>&,
+                           std::vector<StorageObjectMetadata>&) {
+        return ErrorCode::OK;
+    };
+    ASSERT_TRUE(
+        backend.BatchOffload(SingleValueBatch(stale_key, stale_value), commit)
+            .has_value());
+    ASSERT_TRUE(
+        backend.BatchOffload(SingleValueBatch(live_key, live_value), commit)
+            .has_value());
+    ASSERT_TRUE(backend
+                    .BatchOffload(
+                        SingleValueBatch(stale_key, replacement_value), commit)
+                    .has_value());
+
+    ASSERT_EQ(target_ready.get_future().wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    std::string loaded(live_value.size(), '\0');
+    std::unordered_map<std::string, Slice> slices{
+        {live_key, Slice{loaded.data(), loaded.size()}}};
+    auto read = std::async(std::launch::async,
+                           [&]() { return backend.BatchLoad(slices); });
+    ASSERT_EQ(read.wait_for(std::chrono::seconds(1)),
+              std::future_status::ready);
+    ASSERT_TRUE(read.get().has_value());
+    EXPECT_EQ(loaded, live_value);
+
+    allow_publication.set_value();
+    logstructured::LogStructuredStore::SetCompactionCrashPredicateForTest({});
+}
+
+TEST(LogStructuredStorageBackendTest,
      CapacityLimitRejectsAppendAndPreservesCommittedValue) {
     BackendTempDirectory temp;
     auto config = BackendConfig(temp);
@@ -317,7 +386,7 @@ TEST(LogStructuredStorageBackendTest,
     backend_config.compaction_policy = LogStructuredCompactionPolicy::kNone;
     backend_config.compaction_reserve_bytes = 256;
     backend_config.compaction_max_sources = 8;
-    backend_config.compaction_max_bytes_per_round = 4096;
+    backend_config.compaction_max_input_bytes = 4096;
     backend_config.compaction_max_target_bytes = 4096;
 
     LogStructuredStorageBackend backend(config, backend_config);

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -181,6 +181,8 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     setenv("MOONCAKE_LOG_COMPACTION_MAX_SOURCES", "6", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND", "8192", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES", "16384", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_SEC", "32768", 1);
+    setenv("MOONCAKE_LOG_COMPACTION_RESERVE_BYTES", "2048", 1);
     setenv("MOONCAKE_LOG_COMPACTION_MIN_RECLAIM_RATIO", "0.35", 1);
 
     const auto config = LogStructuredBackendConfig::FromEnvironment();
@@ -195,6 +197,8 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_SOURCES");
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_ROUND");
     unsetenv("MOONCAKE_LOG_COMPACTION_MAX_TARGET_BYTES");
+    unsetenv("MOONCAKE_LOG_COMPACTION_MAX_BYTES_PER_SEC");
+    unsetenv("MOONCAKE_LOG_COMPACTION_RESERVE_BYTES");
     unsetenv("MOONCAKE_LOG_COMPACTION_MIN_RECLAIM_RATIO");
 
     EXPECT_TRUE(config.Validate());
@@ -208,6 +212,8 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     EXPECT_EQ(config.compaction_max_sources, size_t{6});
     EXPECT_EQ(config.compaction_max_bytes_per_round, uint64_t{8192});
     EXPECT_EQ(config.compaction_max_target_bytes, uint64_t{16384});
+    EXPECT_EQ(config.compaction_max_bytes_per_second, uint64_t{32768});
+    EXPECT_EQ(config.compaction_reserve_bytes, uint64_t{2048});
     EXPECT_DOUBLE_EQ(config.compaction_min_reclaim_ratio, 0.35);
 }
 
@@ -262,6 +268,59 @@ TEST(LogStructuredStorageBackendTest, BackgroundTieringKeepsObjectsReadable) {
         ASSERT_TRUE(backend.BatchLoad(slices).has_value());
         EXPECT_EQ(loaded, values[i]);
     }
+}
+
+TEST(LogStructuredStorageBackendTest,
+     DiskWatermarkCompactsGarbageWithoutEvictingLiveKeys) {
+    BackendTempDirectory temp;
+    auto config = BackendConfig(temp);
+    config.total_size_limit = 512;
+    LogStructuredBackendConfig backend_config;
+    backend_config.segment_size_bytes = 128;
+    backend_config.compaction_policy = LogStructuredCompactionPolicy::kNone;
+    backend_config.compaction_reserve_bytes = 128;
+    backend_config.compaction_max_sources = 8;
+    backend_config.compaction_max_bytes_per_round = 4096;
+    backend_config.compaction_max_target_bytes = 4096;
+
+    LogStructuredStorageBackend backend(config, backend_config);
+    ASSERT_TRUE(backend.Init().has_value());
+    const std::string storage_key =
+        TenantId("tenant-a").MakeScopedKey("replaced-key");
+    for (char fill : {'a', 'b', 'c'}) {
+        std::string value(96, fill);
+        ASSERT_TRUE(backend
+                        .BatchOffload(SingleValueBatch(storage_key, value),
+                                      [](const std::vector<std::string>&,
+                                         std::vector<StorageObjectMetadata>&) {
+                                          return ErrorCode::OK;
+                                      })
+                        .has_value());
+    }
+    EXPECT_FALSE(backend.IsEnableOffloading().value());
+
+    const auto segments_path = temp.path() / "log_structured" / "segments";
+    const auto disk_bytes = [&]() {
+        uint64_t bytes = 0;
+        for (const auto& entry :
+             std::filesystem::directory_iterator(segments_path)) {
+            if (entry.is_regular_file()) bytes += entry.file_size();
+        }
+        return bytes;
+    };
+    const uint64_t before = disk_bytes();
+
+    auto evicted = backend.EvictAboveDiskWatermark(0.90, 0.75);
+    ASSERT_TRUE(evicted.has_value());
+    EXPECT_TRUE(evicted->empty());
+    EXPECT_LT(disk_bytes(), before);
+    EXPECT_TRUE(backend.IsEnableOffloading().value());
+
+    std::string loaded(96, '\0');
+    std::unordered_map<std::string, Slice> slices{
+        {storage_key, Slice{loaded.data(), loaded.size()}}};
+    ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+    EXPECT_EQ(loaded, std::string(96, 'c'));
 }
 
 TEST(LogStructuredStorageBackendTest, RemoveAllSurvivesRestart) {

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -364,5 +364,43 @@ TEST(LogStructuredStorageBackendTest, RemoveAllSurvivesRestart) {
     EXPECT_EQ(scanned, size_t{0});
 }
 
+TEST(LogStructuredStorageBackendTest, ExposesPhysicalStorageStats) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string storage_key =
+        TenantId("tenant-stats").MakeScopedKey("key");
+    std::string old_value = "old-value";
+    std::string new_value = "new-value-with-more-bytes";
+
+    LogStructuredStorageBackend backend(config);
+    EXPECT_FALSE(backend.SnapshotStats().has_value());
+    ASSERT_TRUE(backend.Init().has_value());
+    ASSERT_TRUE(backend
+                    .BatchOffload(SingleValueBatch(storage_key, old_value),
+                                  [](const std::vector<std::string>&,
+                                     std::vector<StorageObjectMetadata>&) {
+                                      return ErrorCode::OK;
+                                  })
+                    .has_value());
+    ASSERT_TRUE(backend
+                    .BatchOffload(SingleValueBatch(storage_key, new_value),
+                                  [](const std::vector<std::string>&,
+                                     std::vector<StorageObjectMetadata>&) {
+                                      return ErrorCode::OK;
+                                  })
+                    .has_value());
+
+    const auto stats = backend.SnapshotStats();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->logical_value_bytes, new_value.size());
+    EXPECT_GT(stats->live_record_bytes, stats->logical_value_bytes);
+    EXPECT_GT(stats->physical_bytes, stats->live_record_bytes);
+    EXPECT_EQ(stats->reclaimable_bytes,
+              stats->physical_bytes - stats->live_record_bytes);
+    EXPECT_EQ(stats->active_segments, 1);
+    EXPECT_EQ(stats->sealed_segments, 0);
+    EXPECT_EQ(stats->retired_segments, 0);
+}
+
 }  // namespace
 }  // namespace mooncake

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -271,14 +271,51 @@ TEST(LogStructuredStorageBackendTest, BackgroundTieringKeepsObjectsReadable) {
 }
 
 TEST(LogStructuredStorageBackendTest,
+     CapacityLimitRejectsAppendAndPreservesCommittedValue) {
+    BackendTempDirectory temp;
+    auto config = BackendConfig(temp);
+    config.total_size_limit = 256;
+    LogStructuredBackendConfig backend_config;
+    backend_config.segment_size_bytes = 1024;
+    backend_config.compaction_policy = LogStructuredCompactionPolicy::kNone;
+
+    LogStructuredStorageBackend backend(config, backend_config);
+    ASSERT_TRUE(backend.Init().has_value());
+    const std::string storage_key =
+        TenantId("tenant-a").MakeScopedKey("capacity-key");
+    std::string old_value(96, 'a');
+    ASSERT_TRUE(backend
+                    .BatchOffload(SingleValueBatch(storage_key, old_value),
+                                  [](const std::vector<std::string>&,
+                                     std::vector<StorageObjectMetadata>&) {
+                                      return ErrorCode::OK;
+                                  })
+                    .has_value());
+
+    std::string new_value(96, 'b');
+    auto rejected = backend.BatchOffload(
+        SingleValueBatch(storage_key, new_value),
+        [](const std::vector<std::string>&,
+           std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    ASSERT_FALSE(rejected.has_value());
+    EXPECT_EQ(rejected.error(), ErrorCode::KEYS_ULTRA_LIMIT);
+
+    std::string loaded(old_value.size(), '\0');
+    std::unordered_map<std::string, Slice> slices{
+        {storage_key, Slice{loaded.data(), loaded.size()}}};
+    ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+    EXPECT_EQ(loaded, old_value);
+}
+
+TEST(LogStructuredStorageBackendTest,
      DiskWatermarkCompactsGarbageWithoutEvictingLiveKeys) {
     BackendTempDirectory temp;
     auto config = BackendConfig(temp);
-    config.total_size_limit = 512;
+    config.total_size_limit = 1024;
     LogStructuredBackendConfig backend_config;
     backend_config.segment_size_bytes = 128;
     backend_config.compaction_policy = LogStructuredCompactionPolicy::kNone;
-    backend_config.compaction_reserve_bytes = 128;
+    backend_config.compaction_reserve_bytes = 256;
     backend_config.compaction_max_sources = 8;
     backend_config.compaction_max_bytes_per_round = 4096;
     backend_config.compaction_max_target_bytes = 4096;
@@ -297,7 +334,7 @@ TEST(LogStructuredStorageBackendTest,
                                       })
                         .has_value());
     }
-    EXPECT_FALSE(backend.IsEnableOffloading().value());
+    EXPECT_TRUE(backend.IsEnableOffloading().value());
 
     const auto segments_path = temp.path() / "log_structured" / "segments";
     const auto disk_bytes = [&]() {
@@ -310,7 +347,7 @@ TEST(LogStructuredStorageBackendTest,
     };
     const uint64_t before = disk_bytes();
 
-    auto evicted = backend.EvictAboveDiskWatermark(0.90, 0.75);
+    auto evicted = backend.EvictAboveDiskWatermark(0.70, 0.30);
     ASSERT_TRUE(evicted.has_value());
     EXPECT_TRUE(evicted->empty());
     EXPECT_LT(disk_bytes(), before);

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -200,14 +200,13 @@ TEST(LogStructuredStorageBackendTest,
     std::promise<void> allow_callback_return;
     auto callback_gate = allow_callback_return.get_future().share();
     auto offload = std::async(std::launch::async, [&]() {
-        return backend.BatchOffload(
-            SingleValueBatch(storage_key, value),
-            [&](const std::vector<std::string>&,
-                std::vector<StorageObjectMetadata>&) {
-                callback_entered.set_value();
-                callback_gate.wait();
-                return ErrorCode::OK;
-            });
+        return backend.BatchOffload(SingleValueBatch(storage_key, value),
+                                    [&](const std::vector<std::string>&,
+                                        std::vector<StorageObjectMetadata>&) {
+                                        callback_entered.set_value();
+                                        callback_gate.wait();
+                                        return ErrorCode::OK;
+                                    });
     });
 
     ASSERT_EQ(callback_entered.get_future().wait_for(std::chrono::seconds(2)),

--- a/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/backend_test.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <filesystem>
 #include <future>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -262,6 +263,24 @@ TEST(LogStructuredStorageBackendTest,
     EXPECT_EQ(loaded, old_value);
 }
 
+TEST(LogStructuredStorageBackendTest, CallbackExceptionAbortsPreparedWrite) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string storage_key = TenantId("tenant-b").MakeScopedKey("key");
+    std::string value = "value";
+
+    LogStructuredStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+    EXPECT_THROW(backend.BatchOffload(
+                     SingleValueBatch(storage_key, value),
+                     [](const std::vector<std::string>&,
+                        std::vector<StorageObjectMetadata>&) -> ErrorCode {
+                         throw std::runtime_error("callback failure");
+                     }),
+                 std::runtime_error);
+    EXPECT_FALSE(backend.IsExist(storage_key).value());
+}
+
 TEST(LogStructuredStorageBackendTest, PartialFailureReportsOnlyStoredKeys) {
     BackendTempDirectory temp;
     const auto config = BackendConfig(temp);
@@ -338,6 +357,15 @@ TEST(LogStructuredStorageBackendTest, ReadsAndValidatesBackendConfiguration) {
     EXPECT_EQ(config.compaction_max_bytes_per_second, uint64_t{32768});
     EXPECT_EQ(config.compaction_reserve_bytes, uint64_t{2048});
     EXPECT_DOUBLE_EQ(config.compaction_min_reclaim_ratio, 0.35);
+}
+
+TEST(LogStructuredStorageBackendTest, RejectsTieringSourceLimitBelowFanout) {
+    LogStructuredBackendConfig config;
+    config.compaction_policy = LogStructuredCompactionPolicy::kTiered;
+    config.compaction_fanout = 4;
+    config.compaction_max_sources = 3;
+
+    EXPECT_FALSE(config.Validate());
 }
 
 TEST(LogStructuredStorageBackendTest, BackgroundTieringKeepsObjectsReadable) {

--- a/mooncake-store/tests/storage/local/log_structured/index_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/index_test.cpp
@@ -174,5 +174,36 @@ TEST(LogStructuredIndexTest, ReclaimClearsOnlyDeadPhysicalMappings) {
     EXPECT_TRUE(index.LookupCommitted(current_identity).has_value());
 }
 
+TEST(LogStructuredIndexTest, RestoreRejectsUnknownVersionState) {
+    VersionIndex index;
+    auto version = VersionEntry{.physical = Physical(1, 0),
+                                .state = static_cast<VersionState>(255),
+                                .sequence = 1,
+                                .mutation_epoch = 1};
+    auto restored =
+        index.Restore({{.identity = Identity("key", 1), .version = version}});
+    ASSERT_FALSE(restored.has_value());
+    EXPECT_EQ(restored.error(), IndexError::kInvalidTransition);
+}
+
+TEST(LogStructuredIndexTest, RestoreRejectsMultipleCommittedIncarnations) {
+    VersionIndex index;
+    const auto first = IndexSnapshotEntry{
+        .identity = Identity("key", 1),
+        .version = VersionEntry{.physical = Physical(1, 0),
+                                .state = VersionState::kCommitted,
+                                .sequence = 1,
+                                .mutation_epoch = 1}};
+    const auto second = IndexSnapshotEntry{
+        .identity = Identity("key", 2),
+        .version = VersionEntry{.physical = Physical(1, 128),
+                                .state = VersionState::kCommitted,
+                                .sequence = 2,
+                                .mutation_epoch = 1}};
+    auto restored = index.Restore({first, second});
+    ASSERT_FALSE(restored.has_value());
+    EXPECT_EQ(restored.error(), IndexError::kInvalidTransition);
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/index_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/index_test.cpp
@@ -129,5 +129,50 @@ TEST(LogStructuredIndexTest, ReplayOperationsAreIdempotent) {
     ASSERT_TRUE(index.ApplyTombstone(identity, 20).has_value());
 }
 
+TEST(LogStructuredIndexTest, CompactionBatchIsAllOrNothing) {
+    VersionIndex index;
+    const auto first = Identity("first", 1);
+    const auto second = Identity("second", 1);
+    const auto first_source = Physical(1, 0);
+    const auto second_source = Physical(1, 128);
+    ASSERT_TRUE(index.Prepare(first, first_source, 10).has_value());
+    ASSERT_TRUE(index.Commit(first, 10).has_value());
+    ASSERT_TRUE(index.Prepare(second, second_source, 20).has_value());
+    ASSERT_TRUE(index.Commit(second, 20).has_value());
+    const auto first_epoch = index.LookupCommitted(first)->mutation_epoch;
+    const auto second_epoch = index.LookupCommitted(second)->mutation_epoch;
+
+    auto result =
+        index.InstallCompactionCopies({{.identity = first,
+                                        .expected_source = first_source,
+                                        .expected_epoch = first_epoch,
+                                        .target = Physical(2, 0)},
+                                       {.identity = second,
+                                        .expected_source = Physical(9, 0),
+                                        .expected_epoch = second_epoch,
+                                        .target = Physical(2, 128)}});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(index.LookupCommitted(first)->physical, first_source);
+    EXPECT_EQ(index.LookupCommitted(second)->physical, second_source);
+}
+
+TEST(LogStructuredIndexTest, ReclaimClearsOnlyDeadPhysicalMappings) {
+    VersionIndex index;
+    const auto old_identity = Identity("key", 1);
+    const auto current_identity = Identity("key", 2);
+    ASSERT_TRUE(index.Prepare(old_identity, Physical(1, 0), 10).has_value());
+    ASSERT_TRUE(index.Commit(old_identity, 10).has_value());
+    ASSERT_TRUE(
+        index.Prepare(current_identity, Physical(2, 0), 20).has_value());
+    ASSERT_TRUE(index.Commit(current_identity, 20).has_value());
+
+    index.ReclaimNonCurrentVersionsInSegments({1});
+    auto old = index.Lookup(old_identity);
+    ASSERT_TRUE(old.has_value());
+    EXPECT_EQ(old->state, VersionState::kReclaimable);
+    EXPECT_EQ(old->physical, PhysicalRecord{});
+    EXPECT_TRUE(index.LookupCommitted(current_identity).has_value());
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/index_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/index_test.cpp
@@ -102,6 +102,21 @@ TEST(LogStructuredIndexTest, CompactionInstallUsesPhysicalAndEpochCas) {
               IndexError::kStaleSequence);
 }
 
+TEST(LogStructuredIndexTest, LatestLookupTracksNewestCommittedIncarnation) {
+    VersionIndex index;
+    const auto first = Identity("key", 1);
+    const auto second = Identity("key", 2);
+    ASSERT_TRUE(index.Prepare(first, Physical(1, 0), 1).has_value());
+    ASSERT_TRUE(index.Commit(first, 1).has_value());
+    ASSERT_TRUE(index.Prepare(second, Physical(1, 128), 2).has_value());
+    ASSERT_TRUE(index.Commit(second, 2).has_value());
+
+    auto current = index.LookupCurrent("tenant-a", "key");
+    ASSERT_TRUE(current.has_value());
+    EXPECT_EQ(current->identity, second);
+    ASSERT_EQ(index.CurrentSnapshot().size(), size_t{1});
+}
+
 TEST(LogStructuredIndexTest, ReplayOperationsAreIdempotent) {
     VersionIndex index;
     const auto identity = Identity("key", 1);

--- a/mooncake-store/tests/storage/local/log_structured/index_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/index_test.cpp
@@ -1,0 +1,118 @@
+#include "storage/local/log_structured/index.h"
+
+#include <gtest/gtest.h>
+
+namespace mooncake::logstructured {
+namespace {
+
+RecordIdentity Identity(std::string key, uint64_t incarnation) {
+    return RecordIdentity{
+        .tenant_id = "tenant-a",
+        .object_key = std::move(key),
+        .incarnation = ObjectIncarnation{.high = 9, .low = incarnation},
+    };
+}
+
+PhysicalRecord Physical(uint64_t segment, uint64_t offset) {
+    return PhysicalRecord{.segment_id = segment,
+                          .record_offset = offset,
+                          .value_offset = offset + 64,
+                          .value_length = 32,
+                          .total_length = 128};
+}
+
+TEST(LogStructuredIndexTest, PreparedValueIsInvisibleUntilCommit) {
+    VersionIndex index;
+    const auto identity = Identity("key", 1);
+    ASSERT_TRUE(index.Prepare(identity, Physical(1, 0), 10).has_value());
+    EXPECT_FALSE(index.LookupCommitted(identity).has_value());
+
+    ASSERT_TRUE(index.Commit(identity, 10).has_value());
+    auto committed = index.LookupCommitted(identity);
+    ASSERT_TRUE(committed.has_value());
+    EXPECT_EQ(committed->physical, Physical(1, 0));
+    EXPECT_EQ(committed->state, VersionState::kCommitted);
+}
+
+TEST(LogStructuredIndexTest, FailedReplacementPreservesOldCommit) {
+    VersionIndex index;
+    const auto old_identity = Identity("key", 1);
+    const auto new_identity = Identity("key", 2);
+    ASSERT_TRUE(index.Prepare(old_identity, Physical(1, 0), 10).has_value());
+    ASSERT_TRUE(index.Commit(old_identity, 10).has_value());
+    ASSERT_TRUE(index.Prepare(new_identity, Physical(1, 128), 20).has_value());
+    ASSERT_TRUE(index.Abort(new_identity, 20).has_value());
+
+    EXPECT_TRUE(index.LookupCommitted(old_identity).has_value());
+    EXPECT_FALSE(index.LookupCommitted(new_identity).has_value());
+}
+
+TEST(LogStructuredIndexTest, NewCommitMakesOldIncarnationObsolete) {
+    VersionIndex index;
+    const auto old_identity = Identity("key", 1);
+    const auto new_identity = Identity("key", 2);
+    ASSERT_TRUE(index.Prepare(old_identity, Physical(1, 0), 10).has_value());
+    ASSERT_TRUE(index.Commit(old_identity, 10).has_value());
+    ASSERT_TRUE(index.Prepare(new_identity, Physical(1, 128), 20).has_value());
+    ASSERT_TRUE(index.Commit(new_identity, 20).has_value());
+
+    EXPECT_FALSE(index.LookupCommitted(old_identity).has_value());
+    EXPECT_EQ(index.Lookup(old_identity)->state, VersionState::kObsolete);
+    EXPECT_TRUE(index.LookupCommitted(new_identity).has_value());
+}
+
+TEST(LogStructuredIndexTest, StaleDeleteCannotRemoveRecreatedObject) {
+    VersionIndex index;
+    const auto old_identity = Identity("key", 1);
+    const auto new_identity = Identity("key", 2);
+    ASSERT_TRUE(index.Prepare(old_identity, Physical(1, 0), 10).has_value());
+    ASSERT_TRUE(index.Commit(old_identity, 10).has_value());
+    ASSERT_TRUE(index.Prepare(new_identity, Physical(1, 128), 20).has_value());
+    ASSERT_TRUE(index.Commit(new_identity, 20).has_value());
+
+    ASSERT_TRUE(index.ApplyTombstone(old_identity, 30).has_value());
+    EXPECT_TRUE(index.LookupCommitted(new_identity).has_value());
+    EXPECT_EQ(index.Lookup(old_identity)->state, VersionState::kTombstoned);
+}
+
+TEST(LogStructuredIndexTest, CompactionInstallUsesPhysicalAndEpochCas) {
+    VersionIndex index;
+    const auto identity = Identity("key", 1);
+    const auto source = Physical(1, 0);
+    const auto target = Physical(2, 0);
+    ASSERT_TRUE(index.Prepare(identity, source, 10).has_value());
+    ASSERT_TRUE(index.Commit(identity, 10).has_value());
+    const auto committed = index.LookupCommitted(identity);
+    ASSERT_TRUE(committed.has_value());
+
+    EXPECT_EQ(index
+                  .InstallCompactionCopy(identity, Physical(9, 0),
+                                         committed->mutation_epoch, target)
+                  .error(),
+              IndexError::kPhysicalMismatch);
+    ASSERT_TRUE(index
+                    .InstallCompactionCopy(identity, source,
+                                           committed->mutation_epoch, target)
+                    .has_value());
+    EXPECT_EQ(index.LookupCommitted(identity)->physical, target);
+    EXPECT_EQ(index
+                  .InstallCompactionCopy(identity, source,
+                                         committed->mutation_epoch, target)
+                  .error(),
+              IndexError::kStaleSequence);
+}
+
+TEST(LogStructuredIndexTest, ReplayOperationsAreIdempotent) {
+    VersionIndex index;
+    const auto identity = Identity("key", 1);
+    const auto physical = Physical(1, 0);
+    ASSERT_TRUE(index.Prepare(identity, physical, 10).has_value());
+    ASSERT_TRUE(index.Prepare(identity, physical, 10).has_value());
+    ASSERT_TRUE(index.Commit(identity, 10).has_value());
+    ASSERT_TRUE(index.Commit(identity, 10).has_value());
+    ASSERT_TRUE(index.ApplyTombstone(identity, 20).has_value());
+    ASSERT_TRUE(index.ApplyTombstone(identity, 20).has_value());
+}
+
+}  // namespace
+}  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/metadata_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/metadata_test.cpp
@@ -60,6 +60,13 @@ CheckpointState Checkpoint() {
     return checkpoint;
 }
 
+TEST(LogStructuredMetadataTest, RejectsZeroCheckpointGeneration) {
+    MetadataTempDirectory temp;
+    auto checkpoint = WriteCheckpoint(temp.path().string(), 0, Checkpoint());
+    ASSERT_FALSE(checkpoint.has_value());
+    EXPECT_EQ(checkpoint.error(), MetadataError::kInvalidArgument);
+}
+
 TEST(LogStructuredMetadataTest, PublishesAndLoadsCheckpointManifest) {
     MetadataTempDirectory temp;
     auto checkpoint_file =
@@ -93,6 +100,32 @@ TEST(LogStructuredMetadataTest, PublishesAndLoadsCheckpointManifest) {
               VersionState::kCommitted);
 }
 
+TEST(LogStructuredMetadataTest, ReportsUncertainCurrentPublication) {
+    MetadataTempDirectory temp;
+    auto checkpoint_file =
+        WriteCheckpoint(temp.path().string(), 1, Checkpoint());
+    ASSERT_TRUE(checkpoint_file.has_value());
+    ManifestState manifest{
+        .format_version = 1,
+        .generation = 1,
+        .checkpoint_sequence = 7,
+        .next_sequence = 8,
+        .next_segment_id = 3,
+        .active_segment_id = 1,
+        .checkpoint_file = *checkpoint_file,
+        .wal_file = "WAL-000002",
+        .segments = Checkpoint().segments,
+    };
+
+    auto published = PublishManifest(temp.path().string(), manifest, {},
+                                     [] { return true; });
+    ASSERT_FALSE(published.has_value());
+    EXPECT_EQ(published.error(), MetadataError::kPublicationUncertain);
+    auto loaded = LoadCurrentManifest(temp.path().string());
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->generation, uint64_t{1});
+}
+
 TEST(LogStructuredMetadataTest, CurrentIgnoresUnpublishedManifest) {
     MetadataTempDirectory temp;
     auto checkpoint_file =
@@ -119,6 +152,53 @@ TEST(LogStructuredMetadataTest, CurrentIgnoresUnpublishedManifest) {
     auto loaded = LoadCurrentManifest(temp.path().string());
     ASSERT_TRUE(loaded.has_value());
     EXPECT_EQ(loaded->generation, uint64_t{1});
+}
+
+TEST(LogStructuredMetadataTest, RejectsMismatchedManifestGeneration) {
+    MetadataTempDirectory temp;
+    auto checkpoint_file =
+        WriteCheckpoint(temp.path().string(), 1, Checkpoint());
+    ASSERT_TRUE(checkpoint_file.has_value());
+    ManifestState manifest{
+        .format_version = 1,
+        .generation = 1,
+        .checkpoint_sequence = 7,
+        .next_sequence = 8,
+        .next_segment_id = 3,
+        .active_segment_id = 1,
+        .checkpoint_file = *checkpoint_file,
+        .wal_file = "WAL-00000000000000000001",
+        .segments = Checkpoint().segments,
+    };
+    ASSERT_TRUE(PublishManifest(temp.path().string(), manifest).has_value());
+
+    std::filesystem::copy_file(temp.path() / "MANIFEST-00000000000000000001",
+                               temp.path() / "MANIFEST-00000000000000000002");
+    std::ofstream(temp.path() / "CURRENT", std::ios::binary | std::ios::trunc)
+        << "MANIFEST-00000000000000000002\n";
+
+    auto loaded = LoadCurrentManifest(temp.path().string());
+    ASSERT_FALSE(loaded.has_value());
+    EXPECT_EQ(loaded.error(), MetadataError::kCorruptData);
+}
+
+TEST(LogStructuredMetadataTest, RejectsMismatchedManifestReferences) {
+    MetadataTempDirectory temp;
+    ManifestState manifest{
+        .format_version = 1,
+        .generation = 2,
+        .checkpoint_sequence = 7,
+        .next_sequence = 8,
+        .next_segment_id = 3,
+        .active_segment_id = 1,
+        .checkpoint_file = "CHECKPOINT-00000000000000000001",
+        .wal_file = "WAL-00000000000000000002",
+        .segments = Checkpoint().segments,
+    };
+
+    auto published = PublishManifest(temp.path().string(), manifest);
+    ASSERT_FALSE(published.has_value());
+    EXPECT_EQ(published.error(), MetadataError::kInvalidArgument);
 }
 
 TEST(LogStructuredMetadataTest, CleansUnreferencedMetadataArtifacts) {

--- a/mooncake-store/tests/storage/local/log_structured/metadata_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/metadata_test.cpp
@@ -121,6 +121,83 @@ TEST(LogStructuredMetadataTest, CurrentIgnoresUnpublishedManifest) {
     EXPECT_EQ(loaded->generation, uint64_t{1});
 }
 
+TEST(LogStructuredMetadataTest, CleansUnreferencedMetadataArtifacts) {
+    MetadataTempDirectory temp;
+    auto first_checkpoint =
+        WriteCheckpoint(temp.path().string(), 1, Checkpoint());
+    ASSERT_TRUE(first_checkpoint.has_value());
+    ManifestState first_manifest{
+        .format_version = 1,
+        .generation = 1,
+        .checkpoint_sequence = 7,
+        .next_sequence = 8,
+        .next_segment_id = 3,
+        .active_segment_id = 1,
+        .checkpoint_file = *first_checkpoint,
+        .wal_file = "WAL-00000000000000000001",
+        .segments = Checkpoint().segments,
+    };
+    ASSERT_TRUE(
+        PublishManifest(temp.path().string(), first_manifest).has_value());
+
+    auto second_checkpoint =
+        WriteCheckpoint(temp.path().string(), 2, Checkpoint());
+    ASSERT_TRUE(second_checkpoint.has_value());
+    ManifestState second_manifest = first_manifest;
+    second_manifest.generation = 2;
+    second_manifest.checkpoint_file = *second_checkpoint;
+    second_manifest.wal_file = "WAL-00000000000000000002";
+    ASSERT_TRUE(
+        PublishManifest(temp.path().string(), second_manifest).has_value());
+
+    std::ofstream(temp.path() / first_manifest.wal_file) << "old";
+    std::ofstream(temp.path() / second_manifest.wal_file) << "current";
+    std::ofstream(temp.path() / "MANIFEST-00000000000000000003.tmp")
+        << "partial";
+    std::ofstream(temp.path() / "user.tmp") << "unmanaged";
+
+    ASSERT_TRUE(CleanupMetadataArtifacts(temp.path().string(), 2,
+                                         second_manifest.wal_file)
+                    .has_value());
+    EXPECT_FALSE(std::filesystem::exists(temp.path() / *first_checkpoint));
+    EXPECT_FALSE(
+        std::filesystem::exists(temp.path() / "MANIFEST-00000000000000000001"));
+    EXPECT_FALSE(
+        std::filesystem::exists(temp.path() / first_manifest.wal_file));
+    EXPECT_FALSE(std::filesystem::exists(temp.path() /
+                                         "MANIFEST-00000000000000000003.tmp"));
+    EXPECT_TRUE(std::filesystem::exists(temp.path() / *second_checkpoint));
+    EXPECT_TRUE(
+        std::filesystem::exists(temp.path() / "MANIFEST-00000000000000000002"));
+    EXPECT_TRUE(
+        std::filesystem::exists(temp.path() / second_manifest.wal_file));
+    EXPECT_TRUE(std::filesystem::exists(temp.path() / "user.tmp"));
+
+    auto loaded = LoadCurrentManifest(temp.path().string());
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->generation, uint64_t{2});
+}
+
+TEST(LogStructuredMetadataTest, CleansArtifactsBeforeFirstPublication) {
+    MetadataTempDirectory temp;
+    std::ofstream(temp.path() / "WAL-00000000000000000000") << "current";
+    std::ofstream(temp.path() / "WAL-00000000000000000001") << "orphan";
+    std::ofstream(temp.path() / "CHECKPOINT-00000000000000000001") << "orphan";
+    std::ofstream(temp.path() / "MANIFEST-00000000000000000001") << "orphan";
+
+    ASSERT_TRUE(CleanupMetadataArtifacts(temp.path().string(), 0,
+                                         "WAL-00000000000000000000")
+                    .has_value());
+    EXPECT_TRUE(
+        std::filesystem::exists(temp.path() / "WAL-00000000000000000000"));
+    EXPECT_FALSE(
+        std::filesystem::exists(temp.path() / "WAL-00000000000000000001"));
+    EXPECT_FALSE(std::filesystem::exists(temp.path() /
+                                         "CHECKPOINT-00000000000000000001"));
+    EXPECT_FALSE(
+        std::filesystem::exists(temp.path() / "MANIFEST-00000000000000000001"));
+}
+
 TEST(LogStructuredMetadataTest, RejectsCorruptCheckpoint) {
     MetadataTempDirectory temp;
     auto checkpoint_file =

--- a/mooncake-store/tests/storage/local/log_structured/metadata_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/metadata_test.cpp
@@ -1,0 +1,139 @@
+#include "storage/local/log_structured/metadata.h"
+
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace mooncake::logstructured {
+namespace {
+
+class MetadataTempDirectory {
+   public:
+    MetadataTempDirectory() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        path_ = std::filesystem::temp_directory_path() /
+                ("mooncake-log-metadata-test-" + std::to_string(getpid()) +
+                 "-" + std::to_string(id));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~MetadataTempDirectory() { std::filesystem::remove_all(path_); }
+
+    const std::filesystem::path& path() const { return path_; }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+CheckpointState Checkpoint() {
+    CheckpointState checkpoint;
+    checkpoint.checkpoint_sequence = 7;
+    checkpoint.next_sequence = 8;
+    checkpoint.next_segment_id = 3;
+    checkpoint.applied_delete_watermark = 6;
+    checkpoint.index.push_back(IndexSnapshotEntry{
+        .identity = RecordIdentity{.tenant_id = "tenant",
+                                   .object_key = "key",
+                                   .incarnation = {.high = 1, .low = 2}},
+        .version = VersionEntry{.physical = {.segment_id = 1,
+                                             .record_offset = 0,
+                                             .value_offset = 80,
+                                             .value_length = 5,
+                                             .total_length = 112},
+                                .state = VersionState::kCommitted,
+                                .sequence = 7,
+                                .mutation_epoch = 2}});
+    checkpoint.segments.push_back(
+        SegmentMetadata{.segment_id = 1,
+                        .level = 0,
+                        .state = SegmentLifecycle::kActive,
+                        .valid_bytes = 112,
+                        .live_bytes = 112,
+                        .record_count = 1,
+                        .mutation_epoch = 1});
+    return checkpoint;
+}
+
+TEST(LogStructuredMetadataTest, PublishesAndLoadsCheckpointManifest) {
+    MetadataTempDirectory temp;
+    auto checkpoint_file =
+        WriteCheckpoint(temp.path().string(), 1, Checkpoint());
+    ASSERT_TRUE(checkpoint_file.has_value());
+
+    ManifestState manifest{
+        .format_version = 1,
+        .generation = 1,
+        .checkpoint_sequence = 7,
+        .next_sequence = 8,
+        .next_segment_id = 3,
+        .active_segment_id = 1,
+        .checkpoint_file = *checkpoint_file,
+        .wal_file = "WAL-000002",
+        .segments = Checkpoint().segments,
+    };
+    ASSERT_TRUE(PublishManifest(temp.path().string(), manifest).has_value());
+
+    auto loaded_manifest = LoadCurrentManifest(temp.path().string());
+    ASSERT_TRUE(loaded_manifest.has_value());
+    EXPECT_EQ(loaded_manifest->generation, uint64_t{1});
+    EXPECT_EQ(loaded_manifest->segments, manifest.segments);
+    auto loaded_checkpoint =
+        LoadCheckpoint(temp.path().string(), loaded_manifest->checkpoint_file);
+    ASSERT_TRUE(loaded_checkpoint.has_value());
+    EXPECT_EQ(loaded_checkpoint->checkpoint_sequence, uint64_t{7});
+    ASSERT_EQ(loaded_checkpoint->index.size(), size_t{1});
+    EXPECT_EQ(loaded_checkpoint->index[0].identity.object_key, "key");
+    EXPECT_EQ(loaded_checkpoint->index[0].version.state,
+              VersionState::kCommitted);
+}
+
+TEST(LogStructuredMetadataTest, CurrentIgnoresUnpublishedManifest) {
+    MetadataTempDirectory temp;
+    auto checkpoint_file =
+        WriteCheckpoint(temp.path().string(), 1, Checkpoint());
+    ASSERT_TRUE(checkpoint_file.has_value());
+    ManifestState manifest{
+        .format_version = 1,
+        .generation = 1,
+        .checkpoint_sequence = 7,
+        .next_sequence = 8,
+        .next_segment_id = 3,
+        .active_segment_id = 1,
+        .checkpoint_file = *checkpoint_file,
+        .wal_file = "WAL-000002",
+        .segments = Checkpoint().segments,
+    };
+    ASSERT_TRUE(PublishManifest(temp.path().string(), manifest).has_value());
+
+    std::ofstream uncommitted(temp.path() / "MANIFEST-00000000000000000002",
+                              std::ios::binary);
+    uncommitted << "not-published";
+    uncommitted.close();
+
+    auto loaded = LoadCurrentManifest(temp.path().string());
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->generation, uint64_t{1});
+}
+
+TEST(LogStructuredMetadataTest, RejectsCorruptCheckpoint) {
+    MetadataTempDirectory temp;
+    auto checkpoint_file =
+        WriteCheckpoint(temp.path().string(), 1, Checkpoint());
+    ASSERT_TRUE(checkpoint_file.has_value());
+    const auto path = temp.path() / *checkpoint_file;
+    const auto size = std::filesystem::file_size(path);
+    std::filesystem::resize_file(path, size - 1);
+
+    auto loaded = LoadCheckpoint(temp.path().string(), *checkpoint_file);
+    ASSERT_FALSE(loaded.has_value());
+    EXPECT_EQ(loaded.error(), MetadataError::kCorruptData);
+}
+
+}  // namespace
+}  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
@@ -281,5 +281,69 @@ TEST(LogStructuredSegmentTest, InjectedWriteFailureLeavesRecoverableTail) {
     EXPECT_EQ(final_scan->records[0].identity, Identity("recovered", 2));
 }
 
+TEST(LogStructuredSegmentTest, AppendsBatchWithParallelPayloadWrites) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-batch.log");
+    auto writer = SegmentWriter::Create(path.string(), 5);
+    ASSERT_TRUE(writer.has_value());
+
+    std::vector<std::string> values;
+    std::vector<SegmentAppendRequest> requests;
+    values.reserve(16);
+    requests.reserve(16);
+    for (uint64_t index = 0; index < 16; ++index) {
+        values.push_back(
+            std::string(32 * 1024, static_cast<char>('a' + index)));
+    }
+    for (uint64_t index = 0; index < values.size(); ++index) {
+        requests.push_back(
+            {.identity = Identity("batch-" + std::to_string(index), index + 1),
+             .value = values[index],
+             .kind = RecordKind::kValue,
+             .sequence = index + 1});
+    }
+
+    auto appended = (*writer)->AppendBatch(requests, true, 4);
+    ASSERT_TRUE(appended.has_value());
+    ASSERT_EQ(appended->size(), requests.size());
+    writer.value().reset();
+
+    auto scan = ScanSegment(path.string(), 5);
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, ScanTermination::kCleanEof);
+    ASSERT_EQ(scan->records.size(), requests.size());
+    for (size_t index = 0; index < requests.size(); ++index) {
+        EXPECT_EQ(scan->records[index].identity, requests[index].identity);
+        EXPECT_EQ(scan->records[index].physical, (*appended)[index]);
+    }
+}
+
+TEST(LogStructuredSegmentTest, FailedBatchTruncatesWholeReservation) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-batch-failure.log");
+    auto writer = SegmentWriter::Create(path.string(), 6);
+    ASSERT_TRUE(writer.has_value());
+
+    std::vector<std::string> values(8, std::string(16 * 1024, 'x'));
+    std::vector<SegmentAppendRequest> requests;
+    requests.reserve(values.size());
+    for (uint64_t index = 0; index < values.size(); ++index) {
+        requests.push_back(
+            {.identity = Identity("failed-" + std::to_string(index), index + 1),
+             .value = values[index],
+             .kind = RecordKind::kValue,
+             .sequence = index + 1});
+    }
+
+    SegmentWriter::SetWriteFailurePredicateForTest(
+        [](std::string_view, uint64_t offset, size_t) { return offset != 0; });
+    auto appended = (*writer)->AppendBatch(requests, true, 4);
+    SegmentWriter::SetWriteFailurePredicateForTest({});
+    ASSERT_FALSE(appended.has_value());
+    EXPECT_EQ(appended.error(), SegmentError::kIoError);
+    EXPECT_EQ((*writer)->tail(), uint64_t{0});
+    EXPECT_EQ(std::filesystem::file_size(path), uint64_t{0});
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
@@ -94,6 +94,17 @@ TEST(LogStructuredRecordTest, RejectsCorruptedHeaderAndFooter) {
     EXPECT_EQ(decoded_footer.error(), DecodeError::kFooterMismatch);
 }
 
+TEST(LogStructuredRecordTest, RejectsNonzeroReservedHeaderField) {
+    auto encoded =
+        EncodeRecord(Identity("key-d", 6), "payload", RecordKind::kValue, 8);
+    ASSERT_TRUE(encoded.has_value());
+    (*encoded)[60] = 1;
+
+    auto decoded = DecodeRecord(*encoded);
+    ASSERT_FALSE(decoded.has_value());
+    EXPECT_EQ(decoded.error(), DecodeError::kInvalidFlags);
+}
+
 TEST(LogStructuredRecordTest, RejectsTombstoneWithValue) {
     auto encoded = EncodeRecord(Identity("key-d", 6), "not-empty",
                                 RecordKind::kTombstone, 8);

--- a/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
@@ -139,6 +139,56 @@ TEST(LogStructuredSegmentTest, AppendsAndScansRecords) {
     EXPECT_EQ(scan->valid_bytes, first->total_length + second->total_length);
 }
 
+TEST(LogStructuredSegmentTest, ReadsValueDirectlyFromPhysicalLocation) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-direct-read.log");
+    auto writer = SegmentWriter::Create(path.string(), 9);
+    ASSERT_TRUE(writer.has_value());
+    const auto identity = Identity("direct", 3);
+    auto physical =
+        (*writer)->Append(identity, "payload", RecordKind::kValue, 17, true);
+    ASSERT_TRUE(physical.has_value());
+
+    auto reader = SegmentReader::Open(path.string(), 9);
+    ASSERT_TRUE(reader.has_value());
+    std::string value(physical->value_length, '\0');
+    ASSERT_TRUE((*reader)
+                    ->ReadValue(*physical, value.data(), value.size())
+                    .has_value());
+    EXPECT_EQ(value, "payload");
+
+    EXPECT_EQ(
+        (*reader)->ReadValue(*physical, value.data(), value.size() - 1).error(),
+        SegmentError::kInvalidArgument);
+
+    auto invalid_physical = *physical;
+    invalid_physical.value_offset = invalid_physical.record_offset;
+    EXPECT_EQ((*reader)
+                  ->ReadValue(invalid_physical, value.data(), value.size())
+                  .error(),
+              SegmentError::kInvalidArgument);
+}
+
+TEST(LogStructuredSegmentTest, ReaderKeepsUnlinkedSegmentReadable) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-7.log");
+    auto writer = SegmentWriter::Create(path.string(), 7);
+    ASSERT_TRUE(writer.has_value());
+    auto physical = (*writer)->Append(Identity("pinned", 1), "value",
+                                      RecordKind::kValue, 1, true);
+    ASSERT_TRUE(physical.has_value());
+    writer.value().reset();
+
+    auto reader = SegmentReader::Open(path.string(), 7);
+    ASSERT_TRUE(reader.has_value());
+    ASSERT_EQ(unlink(path.c_str()), 0);
+
+    auto record = (*reader)->Read(*physical);
+    ASSERT_TRUE(record.has_value());
+    EXPECT_EQ(record->identity, Identity("pinned", 1));
+    EXPECT_EQ(record->value, "value");
+}
+
 TEST(LogStructuredSegmentTest, DetectsAndRepairsIncompleteTail) {
     TempDirectory temp;
     const auto path = temp.File("segment-2.log");

--- a/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
@@ -1,0 +1,235 @@
+#include "storage/local/log_structured/record_format.h"
+#include "storage/local/log_structured/segment.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace mooncake::logstructured {
+namespace {
+
+class TempDirectory {
+   public:
+    TempDirectory() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        path_ = std::filesystem::temp_directory_path() /
+                ("mooncake-log-segment-test-" + std::to_string(getpid()) + "-" +
+                 std::to_string(id));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempDirectory() { std::filesystem::remove_all(path_); }
+
+    std::filesystem::path File(std::string_view name) const {
+        return path_ / name;
+    }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+RecordIdentity Identity(std::string key, uint64_t incarnation) {
+    return RecordIdentity{
+        .tenant_id = "tenant-a",
+        .object_key = std::move(key),
+        .incarnation = ObjectIncarnation{.high = 17, .low = incarnation},
+    };
+}
+
+TEST(LogStructuredRecordTest, RoundTripsValueAndTombstone) {
+    const auto identity = Identity("key-a", 3);
+    auto encoded = EncodeRecord(identity, "value-a", RecordKind::kValue, 11);
+    ASSERT_TRUE(encoded.has_value());
+
+    auto decoded = DecodeRecord(*encoded);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->identity, identity);
+    EXPECT_EQ(decoded->kind, RecordKind::kValue);
+    EXPECT_EQ(decoded->sequence, uint64_t{11});
+    EXPECT_EQ(decoded->value, "value-a");
+    EXPECT_EQ(decoded->total_length, encoded->size());
+
+    auto tombstone = EncodeRecord(identity, "", RecordKind::kTombstone, 12);
+    ASSERT_TRUE(tombstone.has_value());
+    auto decoded_tombstone = DecodeRecord(*tombstone);
+    ASSERT_TRUE(decoded_tombstone.has_value());
+    EXPECT_EQ(decoded_tombstone->kind, RecordKind::kTombstone);
+    EXPECT_TRUE(decoded_tombstone->value.empty());
+}
+
+TEST(LogStructuredRecordTest, RejectsCorruptedPayload) {
+    auto encoded =
+        EncodeRecord(Identity("key-b", 4), "payload", RecordKind::kValue, 1);
+    ASSERT_TRUE(encoded.has_value());
+    (*encoded)[kRecordHeaderSize + std::string("tenant-a").size() +
+               std::string("key-b").size()] ^= 0x01;
+
+    auto decoded = DecodeRecord(*encoded);
+    ASSERT_FALSE(decoded.has_value());
+    EXPECT_EQ(decoded.error(), DecodeError::kPayloadChecksumMismatch);
+}
+
+TEST(LogStructuredRecordTest, RejectsCorruptedHeaderAndFooter) {
+    auto encoded =
+        EncodeRecord(Identity("key-c", 5), "payload", RecordKind::kValue, 7);
+    ASSERT_TRUE(encoded.has_value());
+
+    auto header_corruption = *encoded;
+    header_corruption[16] ^= 0x01;
+    auto decoded_header = DecodeRecord(header_corruption);
+    ASSERT_FALSE(decoded_header.has_value());
+    EXPECT_EQ(decoded_header.error(), DecodeError::kHeaderChecksumMismatch);
+
+    auto footer_corruption = *encoded;
+    footer_corruption.back() ^= 0x01;
+    auto decoded_footer = DecodeRecord(footer_corruption);
+    ASSERT_FALSE(decoded_footer.has_value());
+    EXPECT_EQ(decoded_footer.error(), DecodeError::kFooterMismatch);
+}
+
+TEST(LogStructuredRecordTest, RejectsTombstoneWithValue) {
+    auto encoded = EncodeRecord(Identity("key-d", 6), "not-empty",
+                                RecordKind::kTombstone, 8);
+    ASSERT_FALSE(encoded.has_value());
+    EXPECT_EQ(encoded.error(), DecodeError::kInvalidLength);
+}
+
+TEST(LogStructuredSegmentTest, AppendsAndScansRecords) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-1.log");
+    auto writer = SegmentWriter::Create(path.string(), 1);
+    ASSERT_TRUE(writer.has_value());
+
+    auto first = (*writer)->Append(Identity("a", 1), "first",
+                                   RecordKind::kValue, 1, false);
+    auto second = (*writer)->Append(Identity("b", 2), "second",
+                                    RecordKind::kCompactionCopy, 2, true);
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(first->record_offset, uint64_t{0});
+    EXPECT_EQ(second->record_offset, first->total_length);
+    writer.value().reset();
+
+    auto scan = ScanSegment(path.string(), 1);
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, ScanTermination::kCleanEof);
+    ASSERT_EQ(scan->records.size(), size_t{2});
+    EXPECT_EQ(scan->records[0].identity, Identity("a", 1));
+    EXPECT_EQ(scan->records[0].physical, *first);
+    EXPECT_EQ(scan->records[1].identity, Identity("b", 2));
+    EXPECT_EQ(scan->records[1].kind, RecordKind::kCompactionCopy);
+    EXPECT_EQ(scan->valid_bytes, first->total_length + second->total_length);
+}
+
+TEST(LogStructuredSegmentTest, DetectsAndRepairsIncompleteTail) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-2.log");
+    auto writer = SegmentWriter::Create(path.string(), 2);
+    ASSERT_TRUE(writer.has_value());
+    auto record = (*writer)->Append(Identity("stable", 8), "complete",
+                                    RecordKind::kValue, 1, true);
+    ASSERT_TRUE(record.has_value());
+    writer.value().reset();
+
+    auto incomplete =
+        EncodeRecord(Identity("torn", 9), "unfinished", RecordKind::kValue, 2);
+    ASSERT_TRUE(incomplete.has_value());
+    const int fd = open(path.c_str(), O_WRONLY | O_APPEND | O_CLOEXEC);
+    ASSERT_GE(fd, 0);
+    const size_t partial_size = incomplete->size() / 2;
+    ASSERT_EQ(write(fd, incomplete->data(), partial_size),
+              static_cast<ssize_t>(partial_size));
+    ASSERT_EQ(close(fd), 0);
+
+    auto scan = ScanSegment(path.string(), 2);
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, ScanTermination::kIncompleteTail);
+    EXPECT_EQ(scan->valid_bytes, record->total_length);
+    ASSERT_EQ(scan->records.size(), size_t{1});
+
+    ASSERT_TRUE(TruncateSegment(path.string(), scan->valid_bytes).has_value());
+    auto repaired = ScanSegment(path.string(), 2);
+    ASSERT_TRUE(repaired.has_value());
+    EXPECT_EQ(repaired->termination, ScanTermination::kCleanEof);
+    EXPECT_EQ(repaired->records.size(), size_t{1});
+}
+
+TEST(LogStructuredSegmentTest, ReopensAtRecoveredTailAndOverwritesGarbage) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-reopen.log");
+    auto writer = SegmentWriter::Create(path.string(), 4);
+    ASSERT_TRUE(writer.has_value());
+    auto first = (*writer)->Append(Identity("first", 1), "stable",
+                                   RecordKind::kValue, 1, true);
+    ASSERT_TRUE(first.has_value());
+    writer.value().reset();
+
+    {
+        std::ofstream output(path, std::ios::binary | std::ios::app);
+        ASSERT_TRUE(output.good());
+        output << "partial-record-garbage";
+    }
+
+    auto scan = ScanSegment(path.string(), 4);
+    ASSERT_TRUE(scan.has_value());
+    ASSERT_EQ(scan->termination, ScanTermination::kIncompleteTail);
+    ASSERT_EQ(scan->valid_bytes, first->total_length);
+
+    auto reopened =
+        SegmentWriter::OpenForAppend(path.string(), 4, scan->valid_bytes);
+    ASSERT_TRUE(reopened.has_value());
+    auto second =
+        (*reopened)->Append(Identity("second", 2), std::string(128 * 1024, 'x'),
+                            RecordKind::kValue, 2, true);
+    ASSERT_TRUE(second.has_value());
+    reopened.value().reset();
+
+    auto recovered = ScanSegment(path.string(), 4);
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ(recovered->termination, ScanTermination::kCleanEof);
+    ASSERT_EQ(recovered->records.size(), size_t{2});
+    EXPECT_EQ(recovered->records[1].identity, Identity("second", 2));
+    EXPECT_EQ(recovered->records[1].physical.value_length,
+              uint64_t{128 * 1024});
+}
+
+TEST(LogStructuredSegmentTest, StopsAtCorruptedRecordWithoutTruncating) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-3.log");
+    auto writer = SegmentWriter::Create(path.string(), 3);
+    ASSERT_TRUE(writer.has_value());
+    auto first = (*writer)->Append(Identity("good", 1), "good-value",
+                                   RecordKind::kValue, 1, false);
+    auto second = (*writer)->Append(Identity("bad", 2), "bad-value",
+                                    RecordKind::kValue, 2, true);
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(second.has_value());
+    writer.value().reset();
+
+    const int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+    ASSERT_GE(fd, 0);
+    char byte = 0;
+    ASSERT_EQ(pread(fd, &byte, 1, second->value_offset), 1);
+    byte ^= 0x40;
+    ASSERT_EQ(pwrite(fd, &byte, 1, second->value_offset), 1);
+    ASSERT_EQ(close(fd), 0);
+
+    auto scan = ScanSegment(path.string(), 3);
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, ScanTermination::kCorruptRecord);
+    EXPECT_EQ(scan->decode_error, DecodeError::kPayloadChecksumMismatch);
+    EXPECT_EQ(scan->valid_bytes, first->total_length);
+    ASSERT_EQ(scan->records.size(), size_t{1});
+    EXPECT_EQ(std::filesystem::file_size(path),
+              first->total_length + second->total_length);
+}
+
+}  // namespace
+}  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/segment_test.cpp
@@ -231,5 +231,44 @@ TEST(LogStructuredSegmentTest, StopsAtCorruptedRecordWithoutTruncating) {
               first->total_length + second->total_length);
 }
 
+TEST(LogStructuredSegmentTest, InjectedWriteFailureLeavesRecoverableTail) {
+    TempDirectory temp;
+    const auto path = temp.File("segment-4.log");
+    auto writer = SegmentWriter::Create(path.string(), 4);
+    ASSERT_TRUE(writer.has_value());
+
+    std::atomic<size_t> writes{0};
+    SegmentWriter::SetWriteFailurePredicateForTest(
+        [&](std::string_view, uint64_t, size_t) {
+            return writes.fetch_add(1, std::memory_order_relaxed) == 1;
+        });
+    auto failed = (*writer)->Append(Identity("partial", 1), "value",
+                                    RecordKind::kValue, 1, true);
+    SegmentWriter::SetWriteFailurePredicateForTest({});
+    ASSERT_FALSE(failed.has_value());
+    EXPECT_EQ(failed.error(), SegmentError::kIoError);
+    writer.value().reset();
+
+    auto scan = ScanSegment(path.string(), 4);
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, ScanTermination::kIncompleteTail);
+    EXPECT_EQ(scan->valid_bytes, uint64_t{0});
+    EXPECT_TRUE(scan->records.empty());
+
+    auto recovered = SegmentWriter::OpenForAppend(path.string(), 4, 0);
+    ASSERT_TRUE(recovered.has_value());
+    ASSERT_TRUE((*recovered)
+                    ->Append(Identity("recovered", 2), "value",
+                             RecordKind::kValue, 2, true)
+                    .has_value());
+    recovered.value().reset();
+
+    auto final_scan = ScanSegment(path.string(), 4);
+    ASSERT_TRUE(final_scan.has_value());
+    EXPECT_EQ(final_scan->termination, ScanTermination::kCleanEof);
+    ASSERT_EQ(final_scan->records.size(), size_t{1});
+    EXPECT_EQ(final_scan->records[0].identity, Identity("recovered", 2));
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/storage_directory_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/storage_directory_test.cpp
@@ -45,6 +45,19 @@ TEST(LogStructuredDirectoryTest, CreatesAndReusesStableIdentity) {
     EXPECT_EQ((*reopened)->identity(), identity);
 }
 
+TEST(LogStructuredDirectoryTest, RecoversStaleIdentityTemporaryFile) {
+    DirectoryTempPath temp;
+    std::filesystem::create_directories(temp.path());
+    std::ofstream(temp.path() / "IDENTITY.tmp", std::ios::binary)
+        << "incomplete";
+
+    auto directory = StorageDirectory::Open(temp.path().string());
+    ASSERT_TRUE(directory.has_value());
+    EXPECT_NE((*directory)->identity(), StorageIdentity{});
+    EXPECT_TRUE(std::filesystem::exists(temp.path() / "IDENTITY"));
+    EXPECT_FALSE(std::filesystem::exists(temp.path() / "IDENTITY.tmp"));
+}
+
 TEST(LogStructuredDirectoryTest, RejectsConcurrentMount) {
     DirectoryTempPath temp;
     auto first = StorageDirectory::Open(temp.path().string());

--- a/mooncake-store/tests/storage/local/log_structured/storage_directory_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/storage_directory_test.cpp
@@ -1,0 +1,78 @@
+#include "storage/local/log_structured/storage_directory.h"
+
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace mooncake::logstructured {
+namespace {
+
+class DirectoryTempPath {
+   public:
+    DirectoryTempPath() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        path_ = std::filesystem::temp_directory_path() /
+                ("mooncake-log-directory-test-" + std::to_string(getpid()) +
+                 "-" + std::to_string(id));
+    }
+
+    ~DirectoryTempPath() { std::filesystem::remove_all(path_); }
+
+    const std::filesystem::path& path() const { return path_; }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+TEST(LogStructuredDirectoryTest, CreatesAndReusesStableIdentity) {
+    DirectoryTempPath temp;
+    StorageIdentity identity;
+    {
+        auto directory = StorageDirectory::Open(temp.path().string());
+        ASSERT_TRUE(directory.has_value());
+        identity = (*directory)->identity();
+        EXPECT_NE(identity, StorageIdentity{});
+        EXPECT_TRUE(std::filesystem::exists(temp.path() / "IDENTITY"));
+    }
+    auto reopened = StorageDirectory::Open(temp.path().string());
+    ASSERT_TRUE(reopened.has_value());
+    EXPECT_EQ((*reopened)->identity(), identity);
+}
+
+TEST(LogStructuredDirectoryTest, RejectsConcurrentMount) {
+    DirectoryTempPath temp;
+    auto first = StorageDirectory::Open(temp.path().string());
+    ASSERT_TRUE(first.has_value());
+    auto second = StorageDirectory::Open(temp.path().string());
+    ASSERT_FALSE(second.has_value());
+    EXPECT_EQ(second.error(), StorageDirectoryError::kAlreadyMounted);
+}
+
+TEST(LogStructuredDirectoryTest, RejectsUnknownNonEmptyDirectory) {
+    DirectoryTempPath temp;
+    std::filesystem::create_directories(temp.path());
+    std::ofstream(temp.path() / "foreign.data") << "foreign";
+
+    auto directory = StorageDirectory::Open(temp.path().string());
+    ASSERT_FALSE(directory.has_value());
+    EXPECT_EQ(directory.error(), StorageDirectoryError::kUnrecognizedFormat);
+}
+
+TEST(LogStructuredDirectoryTest, RejectsCorruptIdentity) {
+    DirectoryTempPath temp;
+    std::filesystem::create_directories(temp.path());
+    std::ofstream(temp.path() / "IDENTITY", std::ios::binary) << "bad";
+
+    auto directory = StorageDirectory::Open(temp.path().string());
+    ASSERT_FALSE(directory.has_value());
+    EXPECT_EQ(directory.error(), StorageDirectoryError::kCorruptIdentity);
+}
+
+}  // namespace
+}  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -78,6 +78,72 @@ TEST(LogStructuredStoreTest, PutIsInvisibleUntilMasterCommit) {
     EXPECT_EQ((*store)->Get(identity).value(), "value");
 }
 
+TEST(LogStructuredStoreTest, ReadsCommittedRecordWhileActiveSegmentGrows) {
+    StoreTempDirectory temp;
+    auto config = Config(temp, 16 * 1024 * 1024);
+    config.sync_data = false;
+    config.sync_wal = false;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    auto initial = (*store)->PreparePut("tenant-a", "stable", "stable-value");
+    ASSERT_TRUE(initial.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(initial->identity, initial->sequence).has_value());
+
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> errors{0};
+    std::vector<std::thread> readers;
+    for (size_t index = 0; index < 8; ++index) {
+        readers.emplace_back([&]() {
+            while (!stop.load(std::memory_order_acquire)) {
+                auto value = (*store)->GetLatest("tenant-a", "stable");
+                if (!value || *value != "stable-value") {
+                    errors.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    for (size_t index = 0; index < 256; ++index) {
+        auto prepared = (*store)->PreparePut(
+            "tenant-a", "growing-" + std::to_string(index),
+            std::string(8 * 1024, static_cast<char>('a' + index % 26)));
+        ASSERT_TRUE(prepared.has_value());
+        ASSERT_TRUE((*store)
+                        ->CommitPut(prepared->identity, prepared->sequence)
+                        .has_value());
+    }
+    stop.store(true, std::memory_order_release);
+    for (auto& reader : readers) reader.join();
+
+    EXPECT_EQ(errors.load(std::memory_order_relaxed), uint64_t{0});
+}
+
+TEST(LogStructuredStoreTest, ReadsLatestValueIntoCallerBuffer) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(store.has_value());
+
+    auto prepared = (*store)->PreparePut("tenant-a", "direct", "value");
+    ASSERT_TRUE(prepared.has_value());
+    ASSERT_TRUE((*store)
+                    ->CommitPut(prepared->identity, prepared->sequence)
+                    .has_value());
+
+    std::string value(prepared->physical.value_length, '\0');
+    ASSERT_TRUE(
+        (*store)
+            ->GetLatestInto("tenant-a", "direct", value.data(), value.size())
+            .has_value());
+    EXPECT_EQ(value, "value");
+    EXPECT_EQ((*store)
+                  ->GetLatestInto("tenant-a", "direct", value.data(),
+                                  value.size() - 1)
+                  .error(),
+              StoreError::kCorruptData);
+}
+
 TEST(LogStructuredStoreTest, MaintainsLiveBytesAcrossVersionTransitions) {
     StoreTempDirectory temp;
     auto store = LogStructuredStore::Open(Config(temp));

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iomanip>
 #include <sstream>
+#include <stop_token>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -262,7 +263,8 @@ TEST(LogStructuredStoreTest, ReclaimsFullyDeadSealedSegment) {
 
     auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
                                             .max_input_bytes = 1024 * 1024,
-                                            .min_reclaim_ratio = 0.0});
+                                            .min_reclaim_ratio = 0.0,
+                                            .stop_token = {}});
     ASSERT_TRUE(compacted.has_value());
     EXPECT_EQ(compacted->source_segments, size_t{1});
     EXPECT_EQ(compacted->target_segments, size_t{0});
@@ -305,7 +307,8 @@ TEST(LogStructuredStoreTest, CompactsLiveRecordsAndRecoversAfterRestart) {
 
         auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
                                                 .max_input_bytes = 1024 * 1024,
-                                                .min_reclaim_ratio = 0.0});
+                                                .min_reclaim_ratio = 0.0,
+                                                .stop_token = {}});
         ASSERT_TRUE(compacted.has_value());
         EXPECT_EQ(compacted->source_segments, size_t{1});
         EXPECT_EQ(compacted->target_segments, size_t{1});
@@ -354,6 +357,58 @@ TEST(LogStructuredStoreTest, RemovesUnpublishedCompactionTargetOnRecovery) {
     EXPECT_FALSE(std::filesystem::exists(orphan_path));
 }
 
+TEST(LogStructuredStoreTest, ReportsPhysicalAndReclaimableBytes) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 128));
+    ASSERT_TRUE(store.has_value());
+
+    auto first = (*store)->PreparePut("tenant-a", "key", std::string(96, 'a'));
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(first->identity, first->sequence).has_value());
+    auto second = (*store)->PreparePut("tenant-a", "key", std::string(96, 'b'));
+    ASSERT_TRUE(second.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(second->identity, second->sequence).has_value());
+
+    const auto stats = (*store)->SnapshotStats();
+    EXPECT_GT(stats.physical_bytes, stats.live_record_bytes);
+    EXPECT_EQ(stats.reclaimable_bytes,
+              stats.physical_bytes - stats.live_record_bytes);
+    EXPECT_EQ(stats.logical_value_bytes, uint64_t{96});
+    EXPECT_EQ(stats.active_segments, size_t{1});
+    EXPECT_GE(stats.sealed_segments, size_t{1});
+}
+
+TEST(LogStructuredStoreTest, CancelledCompactionLeavesSourcesReadable) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 128));
+    ASSERT_TRUE(store.has_value());
+
+    auto first = (*store)->PreparePut("tenant-a", "key", std::string(96, 'a'));
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(first->identity, first->sequence).has_value());
+    auto second = (*store)->PreparePut("tenant-a", "key", std::string(96, 'b'));
+    ASSERT_TRUE(second.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(second->identity, second->sequence).has_value());
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+    std::stop_source stop_source;
+    stop_source.request_stop();
+    auto compacted =
+        (*store)->CompactOnce({.max_source_segments = 8,
+                               .max_input_bytes = 4096,
+                               .max_target_bytes = 4096,
+                               .min_reclaim_ratio = 0.0,
+                               .stop_token = stop_source.get_token()});
+    ASSERT_FALSE(compacted.has_value());
+    EXPECT_EQ(compacted.error(), StoreError::kCancelled);
+    EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
+              std::string(96, 'b'));
+}
+
 TEST(LogStructuredStoreTest, TieredCompactionMergesCleanSegments) {
     StoreTempDirectory temp;
     auto store = LogStructuredStore::Open(Config(temp, 256));
@@ -375,7 +430,8 @@ TEST(LogStructuredStoreTest, TieredCompactionMergesCleanSegments) {
                                             .fanout = 4,
                                             .max_levels = 4,
                                             .min_reclaim_ratio = 1.0,
-                                            .enable_tiering = true});
+                                            .enable_tiering = true,
+                                            .stop_token = {}});
     ASSERT_TRUE(compacted.has_value());
     EXPECT_EQ(compacted->source_segments, size_t{4});
     EXPECT_EQ(compacted->target_segments, size_t{1});

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -631,6 +631,40 @@ TEST(LogStructuredStoreTest,
     EXPECT_TRUE(std::filesystem::is_empty(temporary_path));
 }
 
+TEST(LogStructuredStoreTest,
+     CompactionInputBudgetAllowsOnlyOneOversizedSource) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 128));
+    ASSERT_TRUE(store.has_value());
+
+    for (int i = 0; i < 3; ++i) {
+        const auto old_identity = StoreIdentity("key-" + std::to_string(i), 1);
+        auto old_write =
+            (*store)->PreparePut(old_identity, std::string(96, 'a' + i));
+        ASSERT_TRUE(old_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+
+        const auto new_identity = StoreIdentity("key-" + std::to_string(i), 2);
+        auto new_write =
+            (*store)->PreparePut(new_identity, std::string(96, 'd' + i));
+        ASSERT_TRUE(new_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(new_identity, new_write->sequence).has_value());
+    }
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 3,
+                                            .max_input_bytes = 1,
+                                            .max_target_bytes = 1024,
+                                            .fanout = 2,
+                                            .max_levels = 2,
+                                            .min_reclaim_ratio = 0.0,
+                                            .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+}
+
 TEST(LogStructuredStoreTest, TieredCompactionMergesCleanSegments) {
     StoreTempDirectory temp;
     auto store = LogStructuredStore::Open(Config(temp, 256));
@@ -679,8 +713,7 @@ TEST(LogStructuredStoreTest, AppendFailurePreservesCommittedValueAfterRestart) {
 
         std::atomic<size_t> writes{0};
         SegmentWriter::SetWriteFailurePredicateForTest(
-            [&](std::string_view path, uint64_t, size_t) {
-                if (path.find("/tmp/") != std::string_view::npos) return false;
+            [&](std::string_view, uint64_t, size_t) {
                 return writes.fetch_add(1, std::memory_order_relaxed) == 1;
             });
         auto failed = (*store)->PreparePut(new_identity, "new-value");
@@ -715,10 +748,10 @@ TEST(LogStructuredStoreTest,
         (*store)->CommitPut(new_identity, new_write->sequence).has_value());
     ASSERT_TRUE((*store)->SealActiveSegment().has_value());
 
-    SegmentWriter::SetWriteFailurePredicateForTest(
-        [](std::string_view path, uint64_t, size_t) {
-            return path.find("/tmp/") != std::string_view::npos;
-        });
+    SegmentWriter::SetWriteFailurePredicateForTest([](std::string_view path,
+                                                      uint64_t, size_t) {
+        return std::filesystem::path(path).parent_path().filename() == "tmp";
+    });
     auto failed = (*store)->CompactOnce({.max_source_segments = 1,
                                          .max_input_bytes = 4096,
                                          .max_target_bytes = 4096,
@@ -792,13 +825,18 @@ TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
             EXPECT_EQ(interrupted.error(), StoreError::kIoError);
         }
 
-        auto recovered = LogStructuredStore::Open(Config(temp, 1024));
-        ASSERT_TRUE(recovered.has_value());
-        EXPECT_EQ((*recovered)->GetLatest("tenant-a", "key").value(),
-                  std::string(96, 'b'));
-        EXPECT_EQ((*recovered)->Get(old_identity).error(),
-                  StoreError::kNotFound);
-        EXPECT_TRUE(std::filesystem::is_empty(temp.path() / "tmp"));
+        for (int restart = 0; restart < 3; ++restart) {
+            auto recovered = LogStructuredStore::Open(Config(temp, 1024));
+            ASSERT_TRUE(recovered.has_value()) << "restart=" << restart;
+            EXPECT_EQ((*recovered)->GetLatest("tenant-a", "key").value(),
+                      std::string(96, 'b'))
+                << "restart=" << restart;
+            EXPECT_EQ((*recovered)->Get(old_identity).error(),
+                      StoreError::kNotFound)
+                << "restart=" << restart;
+            EXPECT_TRUE(std::filesystem::is_empty(temp.path() / "tmp"))
+                << "restart=" << restart;
+        }
     }
 }
 

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -60,6 +60,26 @@ TEST(LogStructuredStoreTest, PutIsInvisibleUntilMasterCommit) {
     EXPECT_EQ((*store)->Get(identity).value(), "value");
 }
 
+TEST(LogStructuredStoreTest, GeneratesIncarnationsForLatestLookup) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(store.has_value());
+
+    auto first = (*store)->PreparePut("tenant-a", "key", "first");
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(first->identity, first->sequence).has_value());
+    auto second = (*store)->PreparePut("tenant-a", "key", "second");
+    ASSERT_TRUE(second.has_value());
+    ASSERT_NE(first->identity.incarnation, second->identity.incarnation);
+    ASSERT_TRUE(
+        (*store)->CommitPut(second->identity, second->sequence).has_value());
+
+    EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(), "second");
+    EXPECT_TRUE((*store)->ContainsLatest("tenant-a", "key"));
+    ASSERT_EQ((*store)->SnapshotCurrentIndex().size(), size_t{1});
+}
+
 TEST(LogStructuredStoreTest, AbortedUpdateDoesNotHideCommittedIncarnation) {
     StoreTempDirectory temp;
     auto store = LogStructuredStore::Open(Config(temp));

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -354,5 +354,37 @@ TEST(LogStructuredStoreTest, RemovesUnpublishedCompactionTargetOnRecovery) {
     EXPECT_FALSE(std::filesystem::exists(orphan_path));
 }
 
+TEST(LogStructuredStoreTest, TieredCompactionMergesCleanSegments) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 256));
+    ASSERT_TRUE(store.has_value());
+    std::vector<RecordIdentity> identities;
+    for (uint64_t i = 0; i < 5; ++i) {
+        identities.push_back(StoreIdentity("key-" + std::to_string(i), 1));
+        auto write =
+            (*store)->PreparePut(identities.back(), std::string(96, 'a' + i));
+        ASSERT_TRUE(write.has_value());
+        ASSERT_TRUE((*store)
+                        ->CommitPut(identities.back(), write->sequence)
+                        .has_value());
+    }
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 4,
+                                            .max_input_bytes = 1024 * 1024,
+                                            .max_target_bytes = 1024,
+                                            .fanout = 4,
+                                            .max_levels = 4,
+                                            .min_reclaim_ratio = 1.0,
+                                            .enable_tiering = true});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{4});
+    EXPECT_EQ(compacted->target_segments, size_t{1});
+    EXPECT_EQ(compacted->reclaimed_bytes, uint64_t{0});
+    for (size_t i = 0; i < identities.size(); ++i) {
+        EXPECT_EQ((*store)->Get(identities[i]).value(),
+                  std::string(96, 'a' + i));
+    }
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -564,6 +564,43 @@ TEST(LogStructuredStoreTest, CancelledCompactionLeavesSourcesReadable) {
               std::string(96, 'b'));
 }
 
+TEST(LogStructuredStoreTest, CompactionHonorsBandwidthLimit) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 64 * 1024));
+    ASSERT_TRUE(store.has_value());
+
+    const auto live = StoreIdentity("live", 1);
+    const auto stale = StoreIdentity("stale", 1);
+    const auto replacement = StoreIdentity("stale", 2);
+    for (const auto& identity : {live, stale}) {
+        auto write = (*store)->PreparePut(identity, std::string(8 * 1024, 'a'));
+        ASSERT_TRUE(write.has_value());
+        ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
+    }
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+    auto replacement_write =
+        (*store)->PreparePut(replacement, std::string(8 * 1024, 'b'));
+    ASSERT_TRUE(replacement_write.has_value());
+    ASSERT_TRUE((*store)
+                    ->CommitPut(replacement, replacement_write->sequence)
+                    .has_value());
+
+    const auto started = std::chrono::steady_clock::now();
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                            .max_input_bytes = 64 * 1024,
+                                            .max_target_bytes = 64 * 1024,
+                                            .fanout = 2,
+                                            .max_levels = 2,
+                                            .min_reclaim_ratio = 0.0,
+                                            .max_bytes_per_second = 32 * 1024,
+                                            .stop_token = {}});
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_GE(elapsed, std::chrono::milliseconds(200));
+    EXPECT_EQ((*store)->Get(live).value(), std::string(8 * 1024, 'a'));
+}
+
 TEST(LogStructuredStoreTest,
      ConcurrentMutationRejectsStaleCompactionPublication) {
     StoreTempDirectory temp;
@@ -785,7 +822,10 @@ TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
         CompactionCrashPoint::kBeforeTargetSync,
         CompactionCrashPoint::kAfterTargetSync,
         CompactionCrashPoint::kAfterTargetRename,
+        CompactionCrashPoint::kBeforeManifestWrite,
+        CompactionCrashPoint::kAfterManifestWrite,
         CompactionCrashPoint::kAfterManifestPublication,
+        CompactionCrashPoint::kAfterSourceUnlink,
     };
 
     for (const auto crash_point : crash_points) {

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -78,6 +78,43 @@ TEST(LogStructuredStoreTest, PutIsInvisibleUntilMasterCommit) {
     EXPECT_EQ((*store)->Get(identity).value(), "value");
 }
 
+TEST(LogStructuredStoreTest, MaintainsLiveBytesAcrossVersionTransitions) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(store.has_value());
+
+    const auto aborted_identity = StoreIdentity("aborted", 1);
+    auto aborted = (*store)->PreparePut(aborted_identity, "aborted-value");
+    ASSERT_TRUE(aborted.has_value());
+    EXPECT_EQ((*store)->SnapshotStats().live_record_bytes,
+              aborted->physical.total_length);
+    ASSERT_TRUE(
+        (*store)->AbortPut(aborted_identity, aborted->sequence).has_value());
+    EXPECT_EQ((*store)->SnapshotStats().live_record_bytes, uint64_t{0});
+
+    const auto old_identity = StoreIdentity("key", 1);
+    auto old_write = (*store)->PreparePut(old_identity, "old-value");
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+    EXPECT_EQ((*store)->SnapshotStats().live_record_bytes,
+              old_write->physical.total_length);
+
+    const auto new_identity = StoreIdentity("key", 2);
+    auto new_write = (*store)->PreparePut(new_identity, "new-value");
+    ASSERT_TRUE(new_write.has_value());
+    EXPECT_EQ(
+        (*store)->SnapshotStats().live_record_bytes,
+        old_write->physical.total_length + new_write->physical.total_length);
+    ASSERT_TRUE(
+        (*store)->CommitPut(new_identity, new_write->sequence).has_value());
+    EXPECT_EQ((*store)->SnapshotStats().live_record_bytes,
+              new_write->physical.total_length);
+
+    ASSERT_TRUE((*store)->Delete(new_identity).has_value());
+    EXPECT_EQ((*store)->SnapshotStats().live_record_bytes, uint64_t{0});
+}
+
 TEST(LogStructuredStoreTest, GeneratesIncarnationsForLatestLookup) {
     StoreTempDirectory temp;
     auto store = LogStructuredStore::Open(Config(temp));

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -381,6 +381,52 @@ TEST(LogStructuredStoreTest, ReportsPhysicalAndReclaimableBytes) {
     EXPECT_GE(stats.sealed_segments, size_t{1});
 }
 
+TEST(LogStructuredStoreTest, CompactionHonorsTemporarySpaceBudget) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 512));
+    ASSERT_TRUE(store.has_value());
+    const auto stale = StoreIdentity("first", 1);
+    const auto live = StoreIdentity("second", 1);
+    const auto replacement = StoreIdentity("first", 2);
+
+    auto stale_write = (*store)->PreparePut(stale, std::string(80, 'a'));
+    ASSERT_TRUE(stale_write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(stale, stale_write->sequence).has_value());
+    auto live_write = (*store)->PreparePut(live, std::string(80, 'b'));
+    ASSERT_TRUE(live_write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(live, live_write->sequence).has_value());
+    auto replacement_write =
+        (*store)->PreparePut(replacement, std::string(160, 'c'));
+    ASSERT_TRUE(replacement_write.has_value());
+    ASSERT_TRUE((*store)
+                    ->CommitPut(replacement, replacement_write->sequence)
+                    .has_value());
+
+    const auto before = (*store)->SnapshotStats();
+    auto deferred = (*store)->CompactOnce({.max_source_segments = 1,
+                                           .max_input_bytes = 4096,
+                                           .max_target_bytes = 4096,
+                                           .max_temporary_bytes = 0,
+                                           .min_reclaim_ratio = 0.0,
+                                           .stop_token = {}});
+    ASSERT_TRUE(deferred.has_value());
+    EXPECT_EQ(deferred->source_segments, size_t{0});
+    EXPECT_EQ((*store)->SnapshotStats().physical_bytes, before.physical_bytes);
+    EXPECT_EQ((*store)->Get(live).value(), std::string(80, 'b'));
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                            .max_input_bytes = 4096,
+                                            .max_target_bytes = 4096,
+                                            .max_temporary_bytes = 4096,
+                                            .min_reclaim_ratio = 0.0,
+                                            .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_GT(compacted->reclaimed_bytes, uint64_t{0});
+    EXPECT_EQ((*store)->Get(live).value(), std::string(80, 'b'));
+    EXPECT_EQ((*store)->Get(replacement).value(), std::string(160, 'c'));
+}
+
 TEST(LogStructuredStoreTest, CancelledCompactionLeavesSourcesReadable) {
     StoreTempDirectory temp;
     auto store = LogStructuredStore::Open(Config(temp, 128));

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -351,7 +351,66 @@ TEST(LogStructuredStoreTest, PreparedValueRemainsInvisibleAfterRestart) {
     const auto snapshot = (*recovered)->SnapshotIndex();
     ASSERT_EQ(snapshot.size(), size_t{1});
     EXPECT_EQ(snapshot[0].identity, identity);
-    EXPECT_EQ(snapshot[0].version.state, VersionState::kPrepared);
+    EXPECT_EQ(snapshot[0].version.state, VersionState::kReclaimable);
+    EXPECT_EQ(snapshot[0].version.physical, PhysicalRecord{});
+    ASSERT_TRUE((*recovered)->SealActiveSegment().has_value());
+    auto compacted = (*recovered)
+                         ->CompactOnce({.max_source_segments = 1,
+                                        .max_input_bytes = 4096,
+                                        .max_target_bytes = 4096,
+                                        .fanout = 2,
+                                        .max_levels = 2,
+                                        .min_reclaim_ratio = 0.0,
+                                        .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_GT(compacted->reclaimed_bytes, uint64_t{0});
+}
+
+TEST(LogStructuredStoreTest, TornPreparedValueIsDiscardedOnRecovery) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("prepared", 1);
+    PhysicalRecord physical;
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto prepared = (*store)->PreparePut(identity, std::string(96, 'a'));
+        ASSERT_TRUE(prepared.has_value());
+        physical = prepared->physical;
+    }
+    std::filesystem::resize_file(
+        SegmentFile(temp, physical.segment_id),
+        physical.record_offset + physical.total_length / 2);
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(identity).error(), StoreError::kNotFound);
+    const auto snapshot = (*recovered)->SnapshotIndex();
+    ASSERT_EQ(snapshot.size(), size_t{1});
+    EXPECT_EQ(snapshot[0].version.state, VersionState::kReclaimable);
+    EXPECT_EQ(snapshot[0].version.physical, PhysicalRecord{});
+}
+
+TEST(LogStructuredStoreTest, PreparedValuePinsSealedSegmentUntilResolved) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 4096));
+    ASSERT_TRUE(store.has_value());
+    const auto identity = StoreIdentity("prepared", 1);
+    auto prepared = (*store)->PreparePut(identity, std::string(96, 'a'));
+    ASSERT_TRUE(prepared.has_value());
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                            .max_input_bytes = 4096,
+                                            .max_target_bytes = 4096,
+                                            .fanout = 2,
+                                            .max_levels = 2,
+                                            .min_reclaim_ratio = 0.0,
+                                            .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{0});
+    ASSERT_TRUE((*store)->CommitPut(identity, prepared->sequence).has_value());
+    EXPECT_EQ((*store)->Get(identity).value(), std::string(96, 'a'));
 }
 
 TEST(LogStructuredStoreTest, MissingCommittedCompactionTargetFailsClosed) {
@@ -393,6 +452,83 @@ TEST(LogStructuredStoreTest, MissingCommittedCompactionTargetFailsClosed) {
     auto recovered = LogStructuredStore::Open(Config(temp, 512));
     ASSERT_FALSE(recovered.has_value());
     EXPECT_EQ(recovered.error(), StoreError::kCorruptData);
+}
+
+TEST(LogStructuredStoreTest, RejectsSemanticallyInvalidCheckpoint) {
+    StoreTempDirectory temp;
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        const auto identity = StoreIdentity("key", 1);
+        auto prepared = (*store)->PreparePut(identity, "value");
+        ASSERT_TRUE(prepared.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(identity, prepared->sequence).has_value());
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+    }
+
+    auto manifest = LoadCurrentManifest(temp.path().string());
+    ASSERT_TRUE(manifest.has_value());
+    auto checkpoint =
+        LoadCheckpoint(temp.path().string(), manifest->checkpoint_file);
+    ASSERT_TRUE(checkpoint.has_value());
+    checkpoint->next_sequence = checkpoint->checkpoint_sequence;
+    manifest->next_sequence = checkpoint->next_sequence;
+    ASSERT_TRUE(
+        WriteCheckpoint(temp.path().string(), manifest->generation, *checkpoint)
+            .has_value());
+    ASSERT_TRUE(PublishManifest(temp.path().string(), *manifest).has_value());
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_FALSE(recovered.has_value());
+    EXPECT_EQ(recovered.error(), StoreError::kCorruptData);
+}
+
+TEST(LogStructuredStoreTest, IgnoresCorruptRetiredSourceAfterPublication) {
+    StoreTempDirectory temp;
+    const auto old_identity = StoreIdentity("key", 1);
+    const auto new_identity = StoreIdentity("key", 2);
+    uint64_t source_segment_id = 0;
+    {
+        auto store = LogStructuredStore::Open(Config(temp, 1024));
+        ASSERT_TRUE(store.has_value());
+        auto old_write =
+            (*store)->PreparePut(old_identity, std::string(96, 'a'));
+        ASSERT_TRUE(old_write.has_value());
+        source_segment_id = old_write->physical.segment_id;
+        ASSERT_TRUE(
+            (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+        auto new_write =
+            (*store)->PreparePut(new_identity, std::string(96, 'b'));
+        ASSERT_TRUE(new_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(new_identity, new_write->sequence).has_value());
+        ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+        LogStructuredStore::SetCompactionCrashPredicateForTest(
+            [](CompactionCrashPoint point) {
+                return point == CompactionCrashPoint::kAfterManifestPublication;
+            });
+        auto interrupted = (*store)->CompactOnce({.max_source_segments = 1,
+                                                  .max_input_bytes = 4096,
+                                                  .max_target_bytes = 4096,
+                                                  .fanout = 2,
+                                                  .max_levels = 2,
+                                                  .min_reclaim_ratio = 0.0,
+                                                  .stop_token = {}});
+        LogStructuredStore::SetCompactionCrashPredicateForTest({});
+        ASSERT_FALSE(interrupted.has_value());
+        EXPECT_EQ(interrupted.error(), StoreError::kIoError);
+    }
+
+    const auto source_path = SegmentFile(temp, source_segment_id);
+    ASSERT_TRUE(std::filesystem::exists(source_path));
+    std::filesystem::resize_file(source_path, 1);
+
+    auto recovered = LogStructuredStore::Open(Config(temp, 1024));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(new_identity).value(), std::string(96, 'b'));
+    EXPECT_FALSE(std::filesystem::exists(source_path));
 }
 
 TEST(LogStructuredStoreTest, CorruptCommittedCompactionTargetFailsClosed) {
@@ -487,6 +623,28 @@ TEST(LogStructuredStoreTest, ReportsPhysicalAndReclaimableBytes) {
     EXPECT_EQ(stats.logical_value_bytes, uint64_t{96});
     EXPECT_EQ(stats.active_segments, size_t{1});
     EXPECT_GE(stats.sealed_segments, size_t{1});
+}
+
+TEST(LogStructuredStoreTest, DeleteHonorsTotalCapacity) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("key", 1);
+    const std::string value(96, 'a');
+    const uint64_t value_record_bytes = AlignedRecordSize(
+        identity.tenant_id.size(), identity.object_key.size(), value.size());
+
+    auto config = Config(temp, 4096);
+    config.max_physical_bytes = value_record_bytes;
+    config.max_total_physical_bytes = value_record_bytes;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+    auto write = (*store)->PreparePut(identity, value);
+    ASSERT_TRUE(write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
+
+    auto deleted = (*store)->Delete(identity);
+    ASSERT_FALSE(deleted.has_value());
+    EXPECT_EQ(deleted.error(), StoreError::kNoSpace);
+    EXPECT_EQ((*store)->Get(identity).value(), value);
 }
 
 TEST(LogStructuredStoreTest, CompactionHonorsTemporarySpaceBudget) {
@@ -817,6 +975,73 @@ TEST(LogStructuredStoreTest,
               std::string(96, 'b'));
 }
 
+TEST(LogStructuredStoreTest,
+     ConcurrentCheckpointDoesNotPersistCompactingSegmentState) {
+    StoreTempDirectory temp;
+    const auto old_identity = StoreIdentity("key", 1);
+    const auto new_identity = StoreIdentity("key", 2);
+    {
+        auto store = LogStructuredStore::Open(Config(temp, 1024));
+        ASSERT_TRUE(store.has_value());
+        auto old_write =
+            (*store)->PreparePut(old_identity, std::string(96, 'a'));
+        ASSERT_TRUE(old_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+        auto new_write =
+            (*store)->PreparePut(new_identity, std::string(96, 'b'));
+        ASSERT_TRUE(new_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(new_identity, new_write->sequence).has_value());
+        ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+        std::promise<void> target_ready;
+        std::promise<void> allow_crash;
+        auto allow_crash_future = allow_crash.get_future().share();
+        LogStructuredStore::SetCompactionCrashPredicateForTest(
+            [&](CompactionCrashPoint point) {
+                if (point != CompactionCrashPoint::kAfterTargetRename) {
+                    return false;
+                }
+                target_ready.set_value();
+                allow_crash_future.wait();
+                return true;
+            });
+        auto compaction = std::async(std::launch::async, [&]() {
+            return (*store)->CompactOnce({.max_source_segments = 1,
+                                          .max_input_bytes = 4096,
+                                          .max_target_bytes = 4096,
+                                          .fanout = 2,
+                                          .max_levels = 2,
+                                          .min_reclaim_ratio = 0.0,
+                                          .stop_token = {}});
+        });
+        ASSERT_EQ(target_ready.get_future().wait_for(std::chrono::seconds(2)),
+                  std::future_status::ready);
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        allow_crash.set_value();
+        auto interrupted = compaction.get();
+        LogStructuredStore::SetCompactionCrashPredicateForTest({});
+        ASSERT_FALSE(interrupted.has_value());
+        EXPECT_EQ(interrupted.error(), StoreError::kIoError);
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp, 1024));
+    ASSERT_TRUE(recovered.has_value());
+    auto compacted = (*recovered)
+                         ->CompactOnce({.max_source_segments = 1,
+                                        .max_input_bytes = 4096,
+                                        .max_target_bytes = 4096,
+                                        .fanout = 2,
+                                        .max_levels = 2,
+                                        .min_reclaim_ratio = 0.0,
+                                        .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_EQ((*recovered)->GetLatest("tenant-a", "key").value(),
+              std::string(96, 'b'));
+}
+
 TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
     constexpr std::array crash_points{
         CompactionCrashPoint::kBeforeTargetSync,
@@ -824,6 +1049,7 @@ TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
         CompactionCrashPoint::kAfterTargetRename,
         CompactionCrashPoint::kBeforeManifestWrite,
         CompactionCrashPoint::kAfterManifestWrite,
+        CompactionCrashPoint::kAfterCurrentRenameBeforeDirectorySync,
         CompactionCrashPoint::kAfterManifestPublication,
         CompactionCrashPoint::kAfterSourceUnlink,
     };
@@ -862,7 +1088,20 @@ TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
                                                       .stop_token = {}});
             LogStructuredStore::SetCompactionCrashPredicateForTest({});
             ASSERT_FALSE(interrupted.has_value());
-            EXPECT_EQ(interrupted.error(), StoreError::kIoError);
+            const auto expected_error =
+                crash_point == CompactionCrashPoint::
+                                   kAfterCurrentRenameBeforeDirectorySync
+                    ? StoreError::kRecoveryRequired
+                    : StoreError::kIoError;
+            EXPECT_EQ(interrupted.error(), expected_error);
+            if (expected_error == StoreError::kRecoveryRequired) {
+                EXPECT_EQ((*store)->GetLatest("tenant-a", "key").error(),
+                          StoreError::kRecoveryRequired);
+                EXPECT_EQ((*store)
+                              ->PreparePut(StoreIdentity("later", 1), "x")
+                              .error(),
+                          StoreError::kRecoveryRequired);
+            }
         }
 
         for (int restart = 0; restart < 3; ++restart) {
@@ -878,6 +1117,86 @@ TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
                 << "restart=" << restart;
         }
     }
+}
+
+TEST(LogStructuredStoreTest, ForegroundPutHonorsCompactionReservation) {
+    StoreTempDirectory temp;
+    const auto old_identity = StoreIdentity("stale", 1);
+    const auto live_identity = StoreIdentity("live", 1);
+    const auto replacement_identity = StoreIdentity("stale", 2);
+    const auto foreground_identity = StoreIdentity("foreground", 1);
+    const std::string source_value(128, 'a');
+    const std::string replacement_value(128, 'b');
+    const std::string foreground_value(200, 'c');
+    const uint64_t old_record_bytes =
+        AlignedRecordSize(old_identity.tenant_id.size(),
+                          old_identity.object_key.size(), source_value.size());
+    const uint64_t live_record_bytes =
+        AlignedRecordSize(live_identity.tenant_id.size(),
+                          live_identity.object_key.size(), source_value.size());
+    const uint64_t replacement_record_bytes = AlignedRecordSize(
+        replacement_identity.tenant_id.size(),
+        replacement_identity.object_key.size(), replacement_value.size());
+    const uint64_t foreground_record_bytes = AlignedRecordSize(
+        foreground_identity.tenant_id.size(),
+        foreground_identity.object_key.size(), foreground_value.size());
+    const uint64_t physical_before_compaction =
+        old_record_bytes + live_record_bytes + replacement_record_bytes;
+
+    auto config = Config(temp, 4096);
+    config.max_physical_bytes =
+        physical_before_compaction + foreground_record_bytes;
+    config.max_total_physical_bytes = physical_before_compaction +
+                                      live_record_bytes +
+                                      foreground_record_bytes - 1;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    for (const auto& identity : {old_identity, live_identity}) {
+        auto write = (*store)->PreparePut(identity, source_value);
+        ASSERT_TRUE(write.has_value());
+        ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
+    }
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+    auto replacement =
+        (*store)->PreparePut(replacement_identity, replacement_value);
+    ASSERT_TRUE(replacement.has_value());
+    ASSERT_TRUE((*store)
+                    ->CommitPut(replacement_identity, replacement->sequence)
+                    .has_value());
+
+    std::promise<void> target_ready;
+    std::promise<void> allow_publication;
+    auto allow_publication_future = allow_publication.get_future().share();
+    LogStructuredStore::SetCompactionCrashPredicateForTest(
+        [&](CompactionCrashPoint point) {
+            if (point != CompactionCrashPoint::kAfterTargetRename) return false;
+            target_ready.set_value();
+            allow_publication_future.wait();
+            return false;
+        });
+    auto compaction = std::async(std::launch::async, [&]() {
+        return (*store)->CompactOnce({.max_source_segments = 1,
+                                      .max_input_bytes = 4096,
+                                      .max_target_bytes = 4096,
+                                      .max_temporary_bytes = 4096,
+                                      .fanout = 2,
+                                      .max_levels = 2,
+                                      .min_reclaim_ratio = 0.0,
+                                      .stop_token = {}});
+    });
+    ASSERT_EQ(target_ready.get_future().wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+
+    auto rejected = (*store)->PreparePut(foreground_identity, foreground_value);
+    ASSERT_FALSE(rejected.has_value());
+    EXPECT_EQ(rejected.error(), StoreError::kNoSpace);
+
+    allow_publication.set_value();
+    auto compacted = compaction.get();
+    LogStructuredStore::SetCompactionCrashPredicateForTest({});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ((*store)->Get(live_identity).value(), source_value);
 }
 
 TEST(LogStructuredStoreTest, GetCompletesWhileCompactionWaitsToPublish) {

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -1,5 +1,6 @@
 #include "storage/local/log_structured/store.h"
 
+#include <fcntl.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -53,6 +54,14 @@ LogStructuredStoreConfig Config(const StoreTempDirectory& temp,
                                     .max_segment_bytes = max_segment_bytes,
                                     .sync_data = true,
                                     .sync_wal = true};
+}
+
+std::filesystem::path SegmentFile(const StoreTempDirectory& temp,
+                                  uint64_t segment_id) {
+    std::ostringstream name;
+    name << "segment-" << std::setw(20) << std::setfill('0') << segment_id
+         << ".log";
+    return temp.path() / "segments" / name.str();
 }
 
 TEST(LogStructuredStoreTest, PutIsInvisibleUntilMasterCommit) {
@@ -326,6 +335,107 @@ TEST(LogStructuredStoreTest, CompactsLiveRecordsAndRecoversAfterRestart) {
               std::string(160, 'c'));
 }
 
+TEST(LogStructuredStoreTest, PreparedValueRemainsInvisibleAfterRestart) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("prepared", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        ASSERT_TRUE((*store)->PreparePut(identity, "uncommitted").has_value());
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(identity).error(), StoreError::kNotFound);
+    const auto snapshot = (*recovered)->SnapshotIndex();
+    ASSERT_EQ(snapshot.size(), size_t{1});
+    EXPECT_EQ(snapshot[0].identity, identity);
+    EXPECT_EQ(snapshot[0].version.state, VersionState::kPrepared);
+}
+
+TEST(LogStructuredStoreTest, MissingCommittedCompactionTargetFailsClosed) {
+    StoreTempDirectory temp;
+    const auto first = StoreIdentity("first", 1);
+    const auto second = StoreIdentity("second", 1);
+    uint64_t target_segment = 0;
+    {
+        auto store = LogStructuredStore::Open(Config(temp, 512));
+        ASSERT_TRUE(store.has_value());
+        auto first_write = (*store)->PreparePut(first, std::string(80, 'a'));
+        auto second_write = (*store)->PreparePut(second, std::string(80, 'b'));
+        ASSERT_TRUE(first_write.has_value());
+        ASSERT_TRUE(second_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(first, first_write->sequence).has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(second, second_write->sequence).has_value());
+        ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+        auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                                .max_input_bytes = 4096,
+                                                .max_target_bytes = 4096,
+                                                .fanout = 1,
+                                                .max_levels = 2,
+                                                .min_reclaim_ratio = 1.0,
+                                                .enable_tiering = true,
+                                                .stop_token = {}});
+        ASSERT_TRUE(compacted.has_value());
+        ASSERT_EQ(compacted->target_segments, size_t{1});
+        for (const auto& entry : (*store)->SnapshotCurrentIndex()) {
+            if (entry.identity == first) {
+                target_segment = entry.version.physical.segment_id;
+            }
+        }
+        ASSERT_NE(target_segment, uint64_t{0});
+    }
+
+    ASSERT_TRUE(std::filesystem::remove(SegmentFile(temp, target_segment)));
+    auto recovered = LogStructuredStore::Open(Config(temp, 512));
+    ASSERT_FALSE(recovered.has_value());
+    EXPECT_EQ(recovered.error(), StoreError::kCorruptData);
+}
+
+TEST(LogStructuredStoreTest, CorruptCommittedCompactionTargetFailsClosed) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("key", 1);
+    uint64_t target_segment = 0;
+    PhysicalRecord target_record;
+    {
+        auto store = LogStructuredStore::Open(Config(temp, 128));
+        ASSERT_TRUE(store.has_value());
+        auto write = (*store)->PreparePut(identity, std::string(96, 'a'));
+        ASSERT_TRUE(write.has_value());
+        ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
+        ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+        auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                                .max_input_bytes = 4096,
+                                                .max_target_bytes = 4096,
+                                                .fanout = 1,
+                                                .max_levels = 2,
+                                                .min_reclaim_ratio = 1.0,
+                                                .enable_tiering = true,
+                                                .stop_token = {}});
+        ASSERT_TRUE(compacted.has_value());
+        ASSERT_EQ(compacted->target_segments, size_t{1});
+        const auto snapshot = (*store)->SnapshotCurrentIndex();
+        ASSERT_EQ(snapshot.size(), size_t{1});
+        target_record = snapshot[0].version.physical;
+        target_segment = target_record.segment_id;
+    }
+
+    const int fd =
+        open(SegmentFile(temp, target_segment).c_str(), O_RDWR | O_CLOEXEC);
+    ASSERT_GE(fd, 0);
+    char byte = 0;
+    ASSERT_EQ(pread(fd, &byte, 1, target_record.value_offset), 1);
+    byte ^= 0x40;
+    ASSERT_EQ(pwrite(fd, &byte, 1, target_record.value_offset), 1);
+    ASSERT_EQ(close(fd), 0);
+
+    auto recovered = LogStructuredStore::Open(Config(temp, 128));
+    ASSERT_FALSE(recovered.has_value());
+    EXPECT_EQ(recovered.error(), StoreError::kCorruptData);
+}
+
 TEST(LogStructuredStoreTest, RemovesUnpublishedCompactionTargetOnRecovery) {
     StoreTempDirectory temp;
     const auto identity = StoreIdentity("key", 1);
@@ -340,10 +450,7 @@ TEST(LogStructuredStoreTest, RemovesUnpublishedCompactionTargetOnRecovery) {
         orphan_segment = (*store)->active_segment_id() + 1;
     }
 
-    std::ostringstream name;
-    name << "segment-" << std::setw(20) << std::setfill('0') << orphan_segment
-         << ".log";
-    const auto orphan_path = temp.path() / "segments" / name.str();
+    const auto orphan_path = SegmentFile(temp, orphan_segment);
     auto writer = SegmentWriter::Create(orphan_path.string(), orphan_segment);
     ASSERT_TRUE(writer.has_value());
     ASSERT_TRUE(

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <filesystem>
+#include <future>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
@@ -407,6 +408,73 @@ TEST(LogStructuredStoreTest, CancelledCompactionLeavesSourcesReadable) {
     EXPECT_EQ(compacted.error(), StoreError::kCancelled);
     EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
               std::string(96, 'b'));
+}
+
+TEST(LogStructuredStoreTest,
+     ConcurrentMutationRejectsStaleCompactionPublication) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 256 * 1024));
+    ASSERT_TRUE(store.has_value());
+    const auto updated = StoreIdentity("updated", 1);
+    const auto replacement_identity = StoreIdentity("updated", 2);
+    const auto deleted = StoreIdentity("deleted", 1);
+    const std::string old_value(32 * 1024, 'a');
+    const std::string deleted_value(32 * 1024, 'b');
+
+    auto old_write = (*store)->PreparePut(updated, old_value);
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(updated, old_write->sequence).has_value());
+    auto deleted_write = (*store)->PreparePut(deleted, deleted_value);
+    ASSERT_TRUE(deleted_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(deleted, deleted_write->sequence).has_value());
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+    auto compaction = std::async(std::launch::async, [&]() {
+        return (*store)->CompactOnce({.max_source_segments = 1,
+                                      .max_input_bytes = 1024 * 1024,
+                                      .max_target_bytes = 1024 * 1024,
+                                      .fanout = 1,
+                                      .max_levels = 2,
+                                      .min_reclaim_ratio = 1.0,
+                                      .max_bytes_per_second = 256 * 1024,
+                                      .enable_tiering = true,
+                                      .stop_token = {}});
+    });
+
+    const auto temporary_path = temp.path() / "tmp";
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    bool copy_started = false;
+    do {
+        for (const auto& entry :
+             std::filesystem::directory_iterator(temporary_path)) {
+            if (entry.is_regular_file() && entry.file_size() != 0) {
+                copy_started = true;
+                break;
+            }
+        }
+        if (!copy_started) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    } while (!copy_started && std::chrono::steady_clock::now() < deadline);
+    ASSERT_TRUE(copy_started);
+
+    const std::string new_value(32 * 1024, 'c');
+    auto replacement = (*store)->PreparePut(replacement_identity, new_value);
+    ASSERT_TRUE(replacement.has_value());
+    ASSERT_TRUE((*store)
+                    ->CommitPut(replacement_identity, replacement->sequence)
+                    .has_value());
+    ASSERT_TRUE((*store)->Delete(deleted).has_value());
+
+    auto compacted = compaction.get();
+    ASSERT_FALSE(compacted.has_value());
+    EXPECT_EQ(compacted.error(), StoreError::kInvalidTransition);
+    EXPECT_EQ((*store)->Get(updated).error(), StoreError::kNotFound);
+    EXPECT_EQ((*store)->Get(replacement_identity).value(), new_value);
+    EXPECT_EQ((*store)->Get(deleted).error(), StoreError::kNotFound);
+    EXPECT_TRUE(std::filesystem::is_empty(temporary_path));
 }
 
 TEST(LogStructuredStoreTest, TieredCompactionMergesCleanSegments) {

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -126,6 +126,68 @@ TEST(LogStructuredStoreTest, RotatesSegmentsWithoutChangingLookup) {
     EXPECT_EQ((*store)->Get(second).value(), std::string(128, 'b'));
 }
 
+TEST(LogStructuredStoreTest, CheckpointPublishesManifestAndRotatesWal) {
+    StoreTempDirectory temp;
+    const auto before_checkpoint = StoreIdentity("before", 1);
+    const auto after_checkpoint = StoreIdentity("after", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto first = (*store)->PreparePut(before_checkpoint, "first");
+        ASSERT_TRUE(first.has_value());
+        ASSERT_TRUE((*store)
+                        ->CommitPut(before_checkpoint, first->sequence)
+                        .has_value());
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        EXPECT_TRUE(std::filesystem::exists(temp.path() / "CURRENT"));
+        EXPECT_FALSE(
+            std::filesystem::exists(temp.path() / "WAL-00000000000000000001"));
+        EXPECT_TRUE(
+            std::filesystem::exists(temp.path() / "WAL-00000000000000000002"));
+
+        auto second = (*store)->PreparePut(after_checkpoint, "second");
+        ASSERT_TRUE(second.has_value());
+        ASSERT_TRUE((*store)
+                        ->CommitPut(after_checkpoint, second->sequence)
+                        .has_value());
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(before_checkpoint).value(), "first");
+    EXPECT_EQ((*recovered)->Get(after_checkpoint).value(), "second");
+}
+
+TEST(LogStructuredStoreTest, RecoversSegmentCreatedAfterCheckpoint) {
+    StoreTempDirectory temp;
+    const auto first_identity = StoreIdentity("first", 1);
+    const auto second_identity = StoreIdentity("second", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp, 256));
+        ASSERT_TRUE(store.has_value());
+        auto first =
+            (*store)->PreparePut(first_identity, std::string(128, 'a'));
+        ASSERT_TRUE(first.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(first_identity, first->sequence).has_value());
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+
+        auto second =
+            (*store)->PreparePut(second_identity, std::string(128, 'b'));
+        ASSERT_TRUE(second.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(second_identity, second->sequence).has_value());
+        EXPECT_EQ((*store)->active_segment_id(), uint64_t{2});
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp, 256));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->active_segment_id(), uint64_t{2});
+    EXPECT_EQ((*recovered)->Get(first_identity).value(), std::string(128, 'a'));
+    EXPECT_EQ((*recovered)->Get(second_identity).value(),
+              std::string(128, 'b'));
+}
+
 TEST(LogStructuredStoreTest, RepairsTornWalAndSegmentTailsOnRestart) {
     StoreTempDirectory temp;
     const auto identity = StoreIdentity("key", 1);
@@ -145,7 +207,7 @@ TEST(LogStructuredStoreTest, RepairsTornWalAndSegmentTailsOnRestart) {
     {
         std::ofstream segment(segment_path, std::ios::binary | std::ios::app);
         segment << "torn-segment";
-        std::ofstream wal(temp.path() / "WAL-000001",
+        std::ofstream wal(temp.path() / "WAL-00000000000000000001",
                           std::ios::binary | std::ios::app);
         wal << "torn-wal";
     }

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -663,5 +663,88 @@ TEST(LogStructuredStoreTest, TieredCompactionMergesCleanSegments) {
     }
 }
 
+TEST(LogStructuredStoreTest, AppendFailurePreservesCommittedValueAfterRestart) {
+    StoreTempDirectory temp;
+    const auto old_identity = StoreIdentity("key", 1);
+    const auto new_identity = StoreIdentity("key", 2);
+
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto old_write = (*store)->PreparePut(old_identity, "old-value");
+        ASSERT_TRUE(old_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+
+        std::atomic<size_t> writes{0};
+        SegmentWriter::SetWriteFailurePredicateForTest(
+            [&](std::string_view path, uint64_t, size_t) {
+                if (path.find("/tmp/") != std::string_view::npos) return false;
+                return writes.fetch_add(1, std::memory_order_relaxed) == 1;
+            });
+        auto failed = (*store)->PreparePut(new_identity, "new-value");
+        SegmentWriter::SetWriteFailurePredicateForTest({});
+        ASSERT_FALSE(failed.has_value());
+        EXPECT_EQ(failed.error(), StoreError::kIoError);
+        EXPECT_EQ((*store)->Get(old_identity).value(), "old-value");
+        EXPECT_EQ((*store)->Get(new_identity).error(), StoreError::kNotFound);
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(old_identity).value(), "old-value");
+    EXPECT_EQ((*recovered)->Get(new_identity).error(), StoreError::kNotFound);
+}
+
+TEST(LogStructuredStoreTest,
+     CompactionTargetWriteFailurePreservesSourcesAndLatestValue) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 1024));
+    ASSERT_TRUE(store.has_value());
+    const auto old_identity = StoreIdentity("key", 1);
+    const auto new_identity = StoreIdentity("key", 2);
+
+    auto old_write = (*store)->PreparePut(old_identity, std::string(96, 'a'));
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+    auto new_write = (*store)->PreparePut(new_identity, std::string(96, 'b'));
+    ASSERT_TRUE(new_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(new_identity, new_write->sequence).has_value());
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+    SegmentWriter::SetWriteFailurePredicateForTest(
+        [](std::string_view path, uint64_t, size_t) {
+            return path.find("/tmp/") != std::string_view::npos;
+        });
+    auto failed = (*store)->CompactOnce({.max_source_segments = 1,
+                                         .max_input_bytes = 4096,
+                                         .max_target_bytes = 4096,
+                                         .fanout = 1,
+                                         .max_levels = 2,
+                                         .min_reclaim_ratio = 0.0,
+                                         .stop_token = {}});
+    SegmentWriter::SetWriteFailurePredicateForTest({});
+    ASSERT_FALSE(failed.has_value());
+    EXPECT_EQ(failed.error(), StoreError::kIoError);
+    EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
+              std::string(96, 'b'));
+    EXPECT_TRUE(std::filesystem::is_empty(temp.path() / "tmp"));
+    EXPECT_EQ((*store)->SnapshotStats().sealed_segments, size_t{1});
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                            .max_input_bytes = 4096,
+                                            .max_target_bytes = 4096,
+                                            .fanout = 1,
+                                            .max_levels = 2,
+                                            .min_reclaim_ratio = 0.0,
+                                            .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
+              std::string(96, 'b'));
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <array>
 #include <atomic>
 #include <cstdlib>
 #include <filesystem>
@@ -742,6 +743,114 @@ TEST(LogStructuredStoreTest,
                                             .stop_token = {}});
     ASSERT_TRUE(compacted.has_value());
     EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
+              std::string(96, 'b'));
+}
+
+TEST(LogStructuredStoreTest, RecoversAcrossCompactionPublicationCrashPoints) {
+    constexpr std::array crash_points{
+        CompactionCrashPoint::kBeforeTargetSync,
+        CompactionCrashPoint::kAfterTargetSync,
+        CompactionCrashPoint::kAfterTargetRename,
+        CompactionCrashPoint::kAfterManifestPublication,
+    };
+
+    for (const auto crash_point : crash_points) {
+        StoreTempDirectory temp;
+        const auto old_identity = StoreIdentity("key", 1);
+        const auto new_identity = StoreIdentity("key", 2);
+        {
+            auto store = LogStructuredStore::Open(Config(temp, 1024));
+            ASSERT_TRUE(store.has_value());
+            auto old_write =
+                (*store)->PreparePut(old_identity, std::string(96, 'a'));
+            ASSERT_TRUE(old_write.has_value());
+            ASSERT_TRUE((*store)
+                            ->CommitPut(old_identity, old_write->sequence)
+                            .has_value());
+            auto new_write =
+                (*store)->PreparePut(new_identity, std::string(96, 'b'));
+            ASSERT_TRUE(new_write.has_value());
+            ASSERT_TRUE((*store)
+                            ->CommitPut(new_identity, new_write->sequence)
+                            .has_value());
+            ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+            LogStructuredStore::SetCompactionCrashPredicateForTest(
+                [crash_point](CompactionCrashPoint point) {
+                    return point == crash_point;
+                });
+            auto interrupted = (*store)->CompactOnce({.max_source_segments = 1,
+                                                      .max_input_bytes = 4096,
+                                                      .max_target_bytes = 4096,
+                                                      .fanout = 1,
+                                                      .max_levels = 2,
+                                                      .min_reclaim_ratio = 0.0,
+                                                      .stop_token = {}});
+            LogStructuredStore::SetCompactionCrashPredicateForTest({});
+            ASSERT_FALSE(interrupted.has_value());
+            EXPECT_EQ(interrupted.error(), StoreError::kIoError);
+        }
+
+        auto recovered = LogStructuredStore::Open(Config(temp, 1024));
+        ASSERT_TRUE(recovered.has_value());
+        EXPECT_EQ((*recovered)->GetLatest("tenant-a", "key").value(),
+                  std::string(96, 'b'));
+        EXPECT_EQ((*recovered)->Get(old_identity).error(),
+                  StoreError::kNotFound);
+        EXPECT_TRUE(std::filesystem::is_empty(temp.path() / "tmp"));
+    }
+}
+
+TEST(LogStructuredStoreTest, GetCompletesWhileCompactionWaitsToPublish) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 1024));
+    ASSERT_TRUE(store.has_value());
+    const auto old_identity = StoreIdentity("key", 1);
+    const auto new_identity = StoreIdentity("key", 2);
+
+    auto old_write = (*store)->PreparePut(old_identity, std::string(96, 'a'));
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+    auto new_write = (*store)->PreparePut(new_identity, std::string(96, 'b'));
+    ASSERT_TRUE(new_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(new_identity, new_write->sequence).has_value());
+    ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+
+    std::promise<void> reached_publish;
+    std::promise<void> allow_publish;
+    auto allow_publish_future = allow_publish.get_future().share();
+    LogStructuredStore::SetCompactionCrashPredicateForTest(
+        [&](CompactionCrashPoint point) {
+            if (point != CompactionCrashPoint::kAfterTargetRename) return false;
+            reached_publish.set_value();
+            allow_publish_future.wait();
+            return false;
+        });
+    auto compaction = std::async(std::launch::async, [&]() {
+        return (*store)->CompactOnce({.max_source_segments = 1,
+                                      .max_input_bytes = 4096,
+                                      .max_target_bytes = 4096,
+                                      .fanout = 1,
+                                      .max_levels = 2,
+                                      .min_reclaim_ratio = 0.0,
+                                      .stop_token = {}});
+    });
+    ASSERT_EQ(reached_publish.get_future().wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+
+    auto read = std::async(std::launch::async,
+                           [&]() { return (*store)->Get(new_identity); });
+    ASSERT_EQ(read.wait_for(std::chrono::seconds(1)),
+              std::future_status::ready);
+    ASSERT_TRUE(read.get().has_value());
+
+    allow_publish.set_value();
+    auto compacted = compaction.get();
+    LogStructuredStore::SetCompactionCrashPredicateForTest({});
+    ASSERT_TRUE(compacted.has_value());
     EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
               std::string(96, 'b'));
 }

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -1,0 +1,159 @@
+#include "storage/local/log_structured/store.h"
+
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace mooncake::logstructured {
+namespace {
+
+class StoreTempDirectory {
+   public:
+    StoreTempDirectory() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        path_ = std::filesystem::temp_directory_path() /
+                ("mooncake-log-store-test-" + std::to_string(getpid()) + "-" +
+                 std::to_string(id));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~StoreTempDirectory() { std::filesystem::remove_all(path_); }
+
+    const std::filesystem::path& path() const { return path_; }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+RecordIdentity StoreIdentity(std::string key, uint64_t incarnation) {
+    return RecordIdentity{
+        .tenant_id = "tenant-a",
+        .object_key = std::move(key),
+        .incarnation = ObjectIncarnation{.high = 5, .low = incarnation},
+    };
+}
+
+LogStructuredStoreConfig Config(const StoreTempDirectory& temp,
+                                uint64_t max_segment_bytes = 1024 * 1024) {
+    return LogStructuredStoreConfig{.root_path = temp.path().string(),
+                                    .max_segment_bytes = max_segment_bytes,
+                                    .sync_data = true,
+                                    .sync_wal = true};
+}
+
+TEST(LogStructuredStoreTest, PutIsInvisibleUntilMasterCommit) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(store.has_value());
+    const auto identity = StoreIdentity("key", 1);
+
+    auto prepared = (*store)->PreparePut(identity, "value");
+    ASSERT_TRUE(prepared.has_value());
+    EXPECT_EQ((*store)->Get(identity).error(), StoreError::kNotFound);
+    ASSERT_TRUE((*store)->CommitPut(identity, prepared->sequence).has_value());
+    EXPECT_EQ((*store)->Get(identity).value(), "value");
+}
+
+TEST(LogStructuredStoreTest, AbortedUpdateDoesNotHideCommittedIncarnation) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(store.has_value());
+    const auto old_identity = StoreIdentity("key", 1);
+    const auto new_identity = StoreIdentity("key", 2);
+
+    auto old_write = (*store)->PreparePut(old_identity, "old-value");
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+    auto new_write = (*store)->PreparePut(new_identity, "new-value");
+    ASSERT_TRUE(new_write.has_value());
+    ASSERT_TRUE(
+        (*store)->AbortPut(new_identity, new_write->sequence).has_value());
+
+    EXPECT_EQ((*store)->Get(old_identity).value(), "old-value");
+    EXPECT_EQ((*store)->Get(new_identity).error(), StoreError::kNotFound);
+}
+
+TEST(LogStructuredStoreTest, RestartRecoversCommittedAndTombstonedState) {
+    StoreTempDirectory temp;
+    const auto live = StoreIdentity("live", 1);
+    const auto deleted = StoreIdentity("deleted", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto live_write = (*store)->PreparePut(live, "live-value");
+        auto deleted_write = (*store)->PreparePut(deleted, "dead-value");
+        ASSERT_TRUE(live_write.has_value());
+        ASSERT_TRUE(deleted_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(live, live_write->sequence).has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(deleted, deleted_write->sequence).has_value());
+        ASSERT_TRUE((*store)->Delete(deleted).has_value());
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(live).value(), "live-value");
+    EXPECT_EQ((*recovered)->Get(deleted).error(), StoreError::kNotFound);
+    EXPECT_GT((*recovered)->next_sequence(), uint64_t{3});
+}
+
+TEST(LogStructuredStoreTest, RotatesSegmentsWithoutChangingLookup) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 256));
+    ASSERT_TRUE(store.has_value());
+    const auto first = StoreIdentity("first", 1);
+    const auto second = StoreIdentity("second", 1);
+
+    auto first_write = (*store)->PreparePut(first, std::string(128, 'a'));
+    ASSERT_TRUE(first_write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(first, first_write->sequence).has_value());
+    const uint64_t first_segment = (*store)->active_segment_id();
+    auto second_write = (*store)->PreparePut(second, std::string(128, 'b'));
+    ASSERT_TRUE(second_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(second, second_write->sequence).has_value());
+
+    EXPECT_GT((*store)->active_segment_id(), first_segment);
+    EXPECT_EQ((*store)->Get(first).value(), std::string(128, 'a'));
+    EXPECT_EQ((*store)->Get(second).value(), std::string(128, 'b'));
+}
+
+TEST(LogStructuredStoreTest, RepairsTornWalAndSegmentTailsOnRestart) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("key", 1);
+    uint64_t segment_id = 0;
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto write = (*store)->PreparePut(identity, "value");
+        ASSERT_TRUE(write.has_value());
+        ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
+        segment_id = (*store)->active_segment_id();
+    }
+
+    const auto segment_path = temp.path() / "segments" /
+                              ("segment-" + std::string(19, '0') +
+                               std::to_string(segment_id) + ".log");
+    {
+        std::ofstream segment(segment_path, std::ios::binary | std::ios::app);
+        segment << "torn-segment";
+        std::ofstream wal(temp.path() / "WAL-000001",
+                          std::ios::binary | std::ios::app);
+        wal << "torn-wal";
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(identity).value(), "value");
+}
+
+}  // namespace
+}  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -662,7 +662,7 @@ TEST(LogStructuredStoreTest, ReportsPhysicalAndReclaimableBytes) {
     EXPECT_GE(stats.sealed_segments, size_t{1});
 }
 
-TEST(LogStructuredStoreTest, DeleteHonorsTotalCapacity) {
+TEST(LogStructuredStoreTest, DeleteNeedsNoAdditionalPayloadCapacity) {
     StoreTempDirectory temp;
     const auto identity = StoreIdentity("key", 1);
     const std::string value(96, 'a');
@@ -678,10 +678,12 @@ TEST(LogStructuredStoreTest, DeleteHonorsTotalCapacity) {
     ASSERT_TRUE(write.has_value());
     ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
 
-    auto deleted = (*store)->Delete(identity);
-    ASSERT_FALSE(deleted.has_value());
-    EXPECT_EQ(deleted.error(), StoreError::kNoSpace);
-    EXPECT_EQ((*store)->Get(identity).value(), value);
+    ASSERT_TRUE((*store)->Delete(identity).has_value());
+    EXPECT_EQ((*store)->Get(identity).error(), StoreError::kNotFound);
+    const auto stats = (*store)->SnapshotStats();
+    EXPECT_EQ(stats.physical_bytes, value_record_bytes);
+    EXPECT_EQ(stats.live_record_bytes, uint64_t{0});
+    EXPECT_EQ(stats.reclaimable_bytes, value_record_bytes);
 }
 
 TEST(LogStructuredStoreTest, CompactionHonorsTemporarySpaceBudget) {
@@ -1287,6 +1289,44 @@ TEST(LogStructuredStoreTest, GetCompletesWhileCompactionWaitsToPublish) {
     ASSERT_TRUE(compacted.has_value());
     EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
               std::string(96, 'b'));
+}
+
+TEST(LogStructuredStoreTest, PreparesBatchAcrossSegmentsAndRecovers) {
+    StoreTempDirectory temp;
+    auto config = Config(temp, 24 * 1024);
+    config.payload_write_parallelism = 4;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    std::vector<std::string> values;
+    std::vector<PutRequest> requests;
+    values.reserve(12);
+    requests.reserve(12);
+    for (size_t index = 0; index < 12; ++index) {
+        values.push_back(std::string(8 * 1024, static_cast<char>('a' + index)));
+    }
+    for (size_t index = 0; index < values.size(); ++index) {
+        requests.push_back({.tenant_id = "tenant-a",
+                            .object_key = "batch-" + std::to_string(index),
+                            .value = values[index]});
+    }
+
+    auto prepared = (*store)->PreparePutBatch(requests);
+    ASSERT_TRUE(prepared.has_value());
+    ASSERT_EQ(prepared->size(), requests.size());
+    ASSERT_TRUE((*store)->CommitPuts(*prepared).has_value());
+    ASSERT_TRUE((*store)->Checkpoint().has_value());
+    store.value().reset();
+
+    auto reopened = LogStructuredStore::Open(config);
+    ASSERT_TRUE(reopened.has_value());
+    for (size_t index = 0; index < values.size(); ++index) {
+        auto value =
+            (*reopened)->GetLatest("tenant-a", requests[index].object_key);
+        ASSERT_TRUE(value.has_value());
+        EXPECT_EQ(*value, values[index]);
+    }
+    EXPECT_GT((*reopened)->SnapshotStats().sealed_segments, size_t{0});
 }
 
 }  // namespace

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -3,8 +3,11 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
+#include <sstream>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -16,9 +19,12 @@ class StoreTempDirectory {
    public:
     StoreTempDirectory() {
         const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
-        path_ = std::filesystem::temp_directory_path() /
-                ("mooncake-log-store-test-" + std::to_string(getpid()) + "-" +
-                 std::to_string(id));
+        const char* tmpdir = std::getenv("TMPDIR");
+        const std::filesystem::path base =
+            tmpdir == nullptr ? std::filesystem::temp_directory_path()
+                              : std::filesystem::path(tmpdir);
+        path_ = base / ("mooncake-log-store-test-" + std::to_string(getpid()) +
+                        "-" + std::to_string(id));
         std::filesystem::create_directories(path_);
     }
 
@@ -235,6 +241,117 @@ TEST(LogStructuredStoreTest, RepairsTornWalAndSegmentTailsOnRestart) {
     auto recovered = LogStructuredStore::Open(Config(temp));
     ASSERT_TRUE(recovered.has_value());
     EXPECT_EQ((*recovered)->Get(identity).value(), "value");
+}
+
+TEST(LogStructuredStoreTest, ReclaimsFullyDeadSealedSegment) {
+    StoreTempDirectory temp;
+    const auto first = StoreIdentity("key", 1);
+    const auto second = StoreIdentity("key", 2);
+    auto store = LogStructuredStore::Open(Config(temp, 256));
+    ASSERT_TRUE(store.has_value());
+
+    auto old_write = (*store)->PreparePut(first, std::string(96, 'a'));
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(first, old_write->sequence).has_value());
+    const uint64_t dead_segment = old_write->physical.segment_id;
+
+    auto new_write = (*store)->PreparePut(second, std::string(96, 'b'));
+    ASSERT_TRUE(new_write.has_value());
+    ASSERT_TRUE((*store)->CommitPut(second, new_write->sequence).has_value());
+    ASSERT_NE(new_write->physical.segment_id, dead_segment);
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                            .max_input_bytes = 1024 * 1024,
+                                            .min_reclaim_ratio = 0.0});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_EQ(compacted->target_segments, size_t{0});
+    EXPECT_EQ(compacted->reclaimed_bytes, compacted->input_bytes);
+    EXPECT_FALSE(
+        std::filesystem::exists(temp.path() / "segments" /
+                                ("segment-" + std::string(19, '0') +
+                                 std::to_string(dead_segment) + ".log")));
+    EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
+              std::string(96, 'b'));
+}
+
+TEST(LogStructuredStoreTest, CompactsLiveRecordsAndRecoversAfterRestart) {
+    StoreTempDirectory temp;
+    const auto first = StoreIdentity("first", 1);
+    const auto second = StoreIdentity("second", 1);
+    const auto replacement = StoreIdentity("first", 2);
+    {
+        auto store = LogStructuredStore::Open(Config(temp, 512));
+        ASSERT_TRUE(store.has_value());
+        auto first_write = (*store)->PreparePut(first, std::string(80, 'a'));
+        ASSERT_TRUE(first_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(first, first_write->sequence).has_value());
+        auto second_write = (*store)->PreparePut(second, std::string(80, 'b'));
+        ASSERT_TRUE(second_write.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(second, second_write->sequence).has_value());
+        ASSERT_EQ(first_write->physical.segment_id,
+                  second_write->physical.segment_id);
+        const uint64_t source_segment = first_write->physical.segment_id;
+
+        auto replacement_write =
+            (*store)->PreparePut(replacement, std::string(160, 'c'));
+        ASSERT_TRUE(replacement_write.has_value());
+        ASSERT_TRUE((*store)
+                        ->CommitPut(replacement, replacement_write->sequence)
+                        .has_value());
+        ASSERT_NE(replacement_write->physical.segment_id, source_segment);
+
+        auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                                .max_input_bytes = 1024 * 1024,
+                                                .min_reclaim_ratio = 0.0});
+        ASSERT_TRUE(compacted.has_value());
+        EXPECT_EQ(compacted->source_segments, size_t{1});
+        EXPECT_EQ(compacted->target_segments, size_t{1});
+        EXPECT_GT(compacted->reclaimed_bytes, uint64_t{0});
+        EXPECT_EQ((*store)->Get(second).value(), std::string(80, 'b'));
+        EXPECT_EQ((*store)->GetLatest("tenant-a", "first").value(),
+                  std::string(160, 'c'));
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp, 512));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(second).value(), std::string(80, 'b'));
+    EXPECT_EQ((*recovered)->GetLatest("tenant-a", "first").value(),
+              std::string(160, 'c'));
+}
+
+TEST(LogStructuredStoreTest, RemovesUnpublishedCompactionTargetOnRecovery) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("key", 1);
+    uint64_t orphan_segment = 0;
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto write = (*store)->PreparePut(identity, "value");
+        ASSERT_TRUE(write.has_value());
+        ASSERT_TRUE((*store)->CommitPut(identity, write->sequence).has_value());
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        orphan_segment = (*store)->active_segment_id() + 1;
+    }
+
+    std::ostringstream name;
+    name << "segment-" << std::setw(20) << std::setfill('0') << orphan_segment
+         << ".log";
+    const auto orphan_path = temp.path() / "segments" / name.str();
+    auto writer = SegmentWriter::Create(orphan_path.string(), orphan_segment);
+    ASSERT_TRUE(writer.has_value());
+    ASSERT_TRUE(
+        (*writer)
+            ->Append(identity, "value", RecordKind::kCompactionCopy, 1, true)
+            .has_value());
+    writer.value().reset();
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(identity).value(), "value");
+    EXPECT_FALSE(std::filesystem::exists(orphan_path));
 }
 
 }  // namespace

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <cstdlib>
 #include <filesystem>
 #include <future>
@@ -1355,6 +1356,91 @@ TEST(LogStructuredStoreTest, GetCompletesWhileCompactionWaitsToPublish) {
     ASSERT_TRUE(compacted.has_value());
     EXPECT_EQ((*store)->GetLatest("tenant-a", "key").value(),
               std::string(96, 'b'));
+}
+
+TEST(LogStructuredStoreTest, RecoversCommittedBatchAfterAbandonedReservation) {
+    StoreTempDirectory temp;
+    auto config = Config(temp);
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    SegmentWriter::SetWriteFailurePredicateForTest(
+        [](std::string_view, uint64_t, size_t) { return true; });
+    std::vector<PutRequest> failed_requests{{.tenant_id = "tenant-a",
+                                             .object_key = "failed",
+                                             .value = "abandoned-payload"}};
+    auto failed = (*store)->PreparePutBatch(failed_requests);
+    SegmentWriter::SetWriteFailurePredicateForTest({});
+    ASSERT_FALSE(failed.has_value());
+    EXPECT_EQ(failed.error(), StoreError::kIoError);
+
+    std::vector<PutRequest> committed_requests{{.tenant_id = "tenant-a",
+                                                .object_key = "committed",
+                                                .value = "durable-value"}};
+    auto prepared = (*store)->PreparePutBatch(committed_requests);
+    ASSERT_TRUE(prepared.has_value());
+    ASSERT_TRUE((*store)->CommitPuts(*prepared).has_value());
+    store.value().reset();
+
+    auto reopened = LogStructuredStore::Open(config);
+    ASSERT_TRUE(reopened.has_value());
+    EXPECT_EQ((*reopened)->GetLatest("tenant-a", "committed").value(),
+              "durable-value");
+    EXPECT_EQ((*reopened)->GetLatest("tenant-a", "failed").error(),
+              StoreError::kNotFound);
+}
+
+TEST(LogStructuredStoreTest, ConcurrentBatchesWritePayloadsInParallel) {
+    StoreTempDirectory temp;
+    auto config = Config(temp);
+    config.payload_write_parallelism = 1;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    std::mutex overlap_mutex;
+    std::condition_variable overlap_cv;
+    size_t entered = 0;
+    std::atomic<bool> overlapped{false};
+    SegmentWriter::SetWriteFailurePredicateForTest(
+        [&](std::string_view, uint64_t, size_t) {
+            std::unique_lock lock(overlap_mutex);
+            ++entered;
+            overlap_cv.notify_all();
+            overlap_cv.wait_for(lock, std::chrono::seconds(2),
+                                [&] { return entered >= 2; });
+            if (entered >= 2) overlapped.store(true, std::memory_order_release);
+            return false;
+        });
+
+    auto prepare = [&](std::string key, char fill) {
+        std::string value(128 * 1024, fill);
+        std::vector<PutRequest> requests{{.tenant_id = "tenant-a",
+                                          .object_key = std::move(key),
+                                          .value = value}};
+        return (*store)->PreparePutBatch(requests);
+    };
+    auto first =
+        std::async(std::launch::async, [&] { return prepare("first", 'a'); });
+    auto second =
+        std::async(std::launch::async, [&] { return prepare("second", 'b'); });
+    auto first_result = first.get();
+    auto second_result = second.get();
+    SegmentWriter::SetWriteFailurePredicateForTest({});
+
+    ASSERT_TRUE(first_result.has_value());
+    ASSERT_TRUE(second_result.has_value());
+    EXPECT_TRUE(overlapped.load(std::memory_order_acquire));
+    ASSERT_TRUE((*store)->CommitPuts(*first_result).has_value());
+    ASSERT_TRUE((*store)->CommitPuts(*second_result).has_value());
+    ASSERT_TRUE((*store)->Checkpoint().has_value());
+    store.value().reset();
+
+    auto reopened = LogStructuredStore::Open(config);
+    ASSERT_TRUE(reopened.has_value());
+    EXPECT_EQ((*reopened)->GetLatest("tenant-a", "first").value(),
+              std::string(128 * 1024, 'a'));
+    EXPECT_EQ((*reopened)->GetLatest("tenant-a", "second").value(),
+              std::string(128 * 1024, 'b'));
 }
 
 TEST(LogStructuredStoreTest, PreparesBatchAcrossSegmentsAndRecovers) {

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -79,6 +79,87 @@ TEST(LogStructuredStoreTest, PutIsInvisibleUntilMasterCommit) {
     EXPECT_EQ((*store)->Get(identity).value(), "value");
 }
 
+TEST(LogStructuredStoreTest, ReplaysCommitWrittenAfterPreparedCheckpoint) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("key", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto prepared = (*store)->PreparePut(identity, "value");
+        ASSERT_TRUE(prepared.has_value());
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(identity, prepared->sequence).has_value());
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(identity).value(), "value");
+}
+
+TEST(LogStructuredStoreTest, ReplaysAbortWrittenAfterPreparedCheckpoint) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("key", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto prepared = (*store)->PreparePut(identity, "value");
+        ASSERT_TRUE(prepared.has_value());
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        ASSERT_TRUE(
+            (*store)->AbortPut(identity, prepared->sequence).has_value());
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->Get(identity).error(), StoreError::kNotFound);
+}
+
+TEST(LogStructuredStoreTest, CheckpointPrunesHistoricalVersions) {
+    StoreTempDirectory temp;
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        for (uint64_t incarnation = 1; incarnation <= 16; ++incarnation) {
+            const auto identity = StoreIdentity("key", incarnation);
+            auto prepared = (*store)->PreparePut(identity, "value");
+            ASSERT_TRUE(prepared.has_value());
+            ASSERT_TRUE(
+                (*store)->CommitPut(identity, prepared->sequence).has_value());
+        }
+        EXPECT_EQ((*store)->SnapshotIndex().size(), size_t{16});
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        EXPECT_EQ((*store)->SnapshotIndex().size(), size_t{1});
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_EQ((*recovered)->SnapshotIndex().size(), size_t{1});
+    EXPECT_EQ((*recovered)->GetLatest("tenant-a", "key").value(), "value");
+}
+
+TEST(LogStructuredStoreTest, CheckpointPrunesDeletedVersion) {
+    StoreTempDirectory temp;
+    const auto identity = StoreIdentity("deleted", 1);
+    {
+        auto store = LogStructuredStore::Open(Config(temp));
+        ASSERT_TRUE(store.has_value());
+        auto prepared = (*store)->PreparePut(identity, "value");
+        ASSERT_TRUE(prepared.has_value());
+        ASSERT_TRUE(
+            (*store)->CommitPut(identity, prepared->sequence).has_value());
+        ASSERT_TRUE((*store)->Delete(identity).has_value());
+        ASSERT_EQ((*store)->SnapshotIndex().size(), size_t{1});
+        ASSERT_TRUE((*store)->Checkpoint().has_value());
+        EXPECT_TRUE((*store)->SnapshotIndex().empty());
+    }
+
+    auto recovered = LogStructuredStore::Open(Config(temp));
+    ASSERT_TRUE(recovered.has_value());
+    EXPECT_TRUE((*recovered)->SnapshotIndex().empty());
+    EXPECT_EQ((*recovered)->Get(identity).error(), StoreError::kNotFound);
+}
+
 TEST(LogStructuredStoreTest, ReadsCommittedRecordWhileActiveSegmentGrows) {
     StoreTempDirectory temp;
     auto config = Config(temp, 16 * 1024 * 1024);
@@ -359,6 +440,50 @@ TEST(LogStructuredStoreTest, RepairsTornWalAndSegmentTailsOnRestart) {
     EXPECT_EQ((*recovered)->Get(identity).value(), "value");
 }
 
+TEST(LogStructuredStoreTest, CapacityFailureSealsActiveSegmentForReclaim) {
+    StoreTempDirectory temp;
+    const std::string value(96, 'a');
+    const uint64_t record_bytes = AlignedRecordSize(
+        static_cast<uint32_t>(std::string_view("tenant-a").size()),
+        static_cast<uint32_t>(std::string_view("old").size()), value.size());
+    auto config = Config(temp, 4096);
+    config.max_physical_bytes = record_bytes;
+    config.max_total_physical_bytes = record_bytes;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    const auto old_identity = StoreIdentity("old", 1);
+    auto old_write = (*store)->PreparePut(old_identity, value);
+    ASSERT_TRUE(old_write.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(old_identity, old_write->sequence).has_value());
+    ASSERT_TRUE((*store)->Delete(old_identity).has_value());
+
+    const auto new_identity = StoreIdentity("new", 2);
+    auto blocked = (*store)->PreparePut(new_identity, value);
+    ASSERT_FALSE(blocked.has_value());
+    EXPECT_EQ(blocked.error(), StoreError::kNoSpace);
+    EXPECT_EQ((*store)->SnapshotStats().sealed_segments, size_t{1});
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 1,
+                                            .max_input_bytes = 4096,
+                                            .max_target_bytes = 4096,
+                                            .max_temporary_bytes = 0,
+                                            .fanout = 2,
+                                            .max_levels = 2,
+                                            .min_reclaim_ratio = 0.0,
+                                            .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{1});
+    EXPECT_EQ(compacted->reclaimed_bytes, record_bytes);
+
+    auto retried = (*store)->PreparePut(new_identity, value);
+    ASSERT_TRUE(retried.has_value());
+    ASSERT_TRUE(
+        (*store)->CommitPut(new_identity, retried->sequence).has_value());
+    EXPECT_EQ((*store)->Get(new_identity).value(), value);
+}
+
 TEST(LogStructuredStoreTest, ReclaimsFullyDeadSealedSegment) {
     StoreTempDirectory temp;
     const auto first = StoreIdentity("key", 1);
@@ -515,6 +640,34 @@ TEST(LogStructuredStoreTest, PreparedValuePinsSealedSegmentUntilResolved) {
     EXPECT_EQ(compacted->source_segments, size_t{0});
     ASSERT_TRUE((*store)->CommitPut(identity, prepared->sequence).has_value());
     EXPECT_EQ((*store)->Get(identity).value(), std::string(96, 'a'));
+}
+
+TEST(LogStructuredStoreTest, TieringSkipsWhenBudgetDropsBelowFanout) {
+    StoreTempDirectory temp;
+    auto store = LogStructuredStore::Open(Config(temp, 256));
+    ASSERT_TRUE(store.has_value());
+
+    for (size_t index = 0; index < 4; ++index) {
+        auto prepared = (*store)->PreparePut(
+            "tenant-a", "key-" + std::to_string(index), std::string(96, 'a'));
+        ASSERT_TRUE(prepared.has_value());
+        ASSERT_TRUE((*store)
+                        ->CommitPut(prepared->identity, prepared->sequence)
+                        .has_value());
+        ASSERT_TRUE((*store)->SealActiveSegment().has_value());
+    }
+
+    auto compacted = (*store)->CompactOnce({.max_source_segments = 3,
+                                            .max_input_bytes = 1024 * 1024,
+                                            .max_target_bytes = 1024 * 1024,
+                                            .fanout = 4,
+                                            .max_levels = 2,
+                                            .min_reclaim_ratio = 1.0,
+                                            .enable_tiering = true,
+                                            .stop_token = {}});
+    ASSERT_TRUE(compacted.has_value());
+    EXPECT_EQ(compacted->source_segments, size_t{0});
+    EXPECT_EQ(compacted->target_segments, size_t{0});
 }
 
 TEST(LogStructuredStoreTest, MissingCommittedCompactionTargetFailsClosed) {

--- a/mooncake-store/tests/storage/local/log_structured/store_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/store_test.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <stop_token>
 #include <string>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -1632,6 +1633,129 @@ TEST(LogStructuredStoreTest, PreparesBatchAcrossSegmentsAndRecovers) {
         EXPECT_EQ(*value, values[index]);
     }
     EXPECT_GT((*reopened)->SnapshotStats().sealed_segments, size_t{0});
+}
+
+TEST(LogStructuredStoreTest, GroupsConcurrentPrepareWalSyncs) {
+    StoreTempDirectory temp;
+    auto config = Config(temp);
+    config.sync_data = false;
+    config.use_uring = false;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    const auto stats_before = (*store)->SnapshotStats();
+    std::mutex hook_mutex;
+    std::condition_variable hook_cv;
+    bool first_group_blocked = false;
+    bool release_first_group = false;
+    std::atomic<size_t> hook_calls{0};
+    WalWriter::SetBeforeWriteHookForTest([&] {
+        if (hook_calls.fetch_add(1, std::memory_order_relaxed) != 0) return;
+        std::unique_lock lock(hook_mutex);
+        first_group_blocked = true;
+        hook_cv.notify_all();
+        hook_cv.wait(lock, [&] { return release_first_group; });
+    });
+
+    constexpr size_t kRequests = 16;
+    std::vector<std::future<tl::expected<PreparedWrite, StoreError>>> futures;
+    futures.reserve(kRequests);
+    for (size_t index = 0; index < kRequests; ++index) {
+        futures.push_back(std::async(std::launch::async, [&, index] {
+            return (*store)->PreparePut(
+                "tenant-a", "group-" + std::to_string(index), "value");
+        }));
+    }
+
+    {
+        std::unique_lock lock(hook_mutex);
+        EXPECT_TRUE(hook_cv.wait_for(lock, std::chrono::seconds(2),
+                                     [&] { return first_group_blocked; }));
+    }
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while ((*store)->SnapshotStats().wal_append_requests < kRequests &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    const bool all_queued =
+        (*store)->SnapshotStats().wal_append_requests == kRequests;
+    {
+        std::lock_guard lock(hook_mutex);
+        release_first_group = true;
+    }
+    hook_cv.notify_all();
+
+    std::vector<PreparedWrite> prepared;
+    prepared.reserve(kRequests);
+    for (auto& future : futures) {
+        auto result = future.get();
+        EXPECT_TRUE(result.has_value());
+        if (result) prepared.push_back(std::move(*result));
+    }
+    WalWriter::SetBeforeWriteHookForTest({});
+
+    ASSERT_TRUE(all_queued);
+    ASSERT_EQ(prepared.size(), kRequests);
+    const auto stats = (*store)->SnapshotStats();
+    EXPECT_EQ(stats.wal_write_groups - stats_before.wal_write_groups,
+              uint64_t{2});
+    EXPECT_EQ(stats.wal_sync_groups - stats_before.wal_sync_groups,
+              uint64_t{2});
+    EXPECT_GT(stats.wal_max_group_requests, uint64_t{1});
+    EXPECT_TRUE((*store)->CommitPuts(prepared).has_value());
+}
+
+TEST(LogStructuredStoreTest, SerializesTransitionsForTheSameLogicalKey) {
+    StoreTempDirectory temp;
+    auto config = Config(temp);
+    config.sync_data = false;
+    auto store = LogStructuredStore::Open(config);
+    ASSERT_TRUE(store.has_value());
+
+    const auto identity = StoreIdentity("same-key", 1);
+    auto prepared = (*store)->PreparePut(identity, "value");
+    ASSERT_TRUE(prepared.has_value());
+    const uint64_t requests_before =
+        (*store)->SnapshotStats().wal_append_requests;
+
+    std::mutex hook_mutex;
+    std::condition_variable hook_cv;
+    bool commit_blocked = false;
+    bool release_commit = false;
+    WalWriter::SetBeforeWriteHookForTest([&] {
+        std::unique_lock lock(hook_mutex);
+        commit_blocked = true;
+        hook_cv.notify_all();
+        hook_cv.wait(lock, [&] { return release_commit; });
+    });
+
+    auto first = std::async(std::launch::async, [&] {
+        return (*store)->CommitPut(identity, prepared->sequence);
+    });
+    {
+        std::unique_lock lock(hook_mutex);
+        EXPECT_TRUE(hook_cv.wait_for(lock, std::chrono::seconds(2),
+                                     [&] { return commit_blocked; }));
+    }
+    auto second = std::async(std::launch::async, [&] {
+        return (*store)->CommitPut(identity, prepared->sequence);
+    });
+    EXPECT_EQ(second.wait_for(std::chrono::milliseconds(20)),
+              std::future_status::timeout);
+    EXPECT_EQ((*store)->SnapshotStats().wal_append_requests,
+              requests_before + 1);
+
+    {
+        std::lock_guard lock(hook_mutex);
+        release_commit = true;
+    }
+    hook_cv.notify_all();
+    EXPECT_TRUE(first.get().has_value());
+    EXPECT_TRUE(second.get().has_value());
+    WalWriter::SetBeforeWriteHookForTest({});
+    EXPECT_EQ((*store)->SnapshotStats().wal_append_requests,
+              requests_before + 1);
 }
 
 }  // namespace

--- a/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
@@ -89,6 +89,31 @@ TEST(LogStructuredWalTest, AppendsScansAndReplaysTransitions) {
     EXPECT_EQ(committed->physical, WalPhysical(1, 0));
 }
 
+TEST(LogStructuredWalTest, RejectsNonzeroReservedHeaderField) {
+    WalTempDirectory temp;
+    const auto path = temp.File("WAL-reserved");
+    auto writer = WalWriter::Create(path.string());
+    ASSERT_TRUE(writer.has_value());
+    ASSERT_TRUE(
+        (*writer)
+            ->Append(Transition(WalRecordType::kPrepareValue,
+                                WalIdentity("key", 1), 1, WalPhysical(1, 0)),
+                     true)
+            .has_value());
+    writer.value().reset();
+
+    const int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+    ASSERT_GE(fd, 0);
+    const char reserved = 1;
+    ASSERT_EQ(pwrite(fd, &reserved, 1, 92), 1);
+    ASSERT_EQ(close(fd), 0);
+
+    auto scan = ScanWal(path.string());
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, WalScanTermination::kCorruptRecord);
+    EXPECT_EQ(scan->valid_bytes, uint64_t{0});
+}
+
 TEST(LogStructuredWalTest, IncompleteTailIsTruncatedBeforeAppend) {
     WalTempDirectory temp;
     const auto path = temp.File("WAL-000002");

--- a/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
@@ -207,5 +207,27 @@ TEST(LogStructuredWalTest, ReplayedAbortPreservesPreviousIncarnation) {
     EXPECT_FALSE(index.LookupCommitted(new_identity).has_value());
 }
 
+TEST(LogStructuredWalTest, AppendsBatchWithSingleDurabilityBoundary) {
+    WalTempDirectory temp;
+    const auto path = temp.File("WAL-batch");
+    auto writer = WalWriter::Create(path.string());
+    ASSERT_TRUE(writer.has_value());
+
+    const auto first = WalIdentity("first", 1);
+    const auto second = WalIdentity("second", 2);
+    std::vector<WalRecord> records = {
+        Transition(WalRecordType::kPrepareValue, first, 1, WalPhysical(1, 0)),
+        Transition(WalRecordType::kPrepareValue, second, 2,
+                   WalPhysical(1, 160)),
+    };
+    ASSERT_TRUE((*writer)->AppendBatch(records, true).has_value());
+    writer.value().reset();
+
+    auto scan = ScanWal(path.string());
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, WalScanTermination::kCleanEof);
+    EXPECT_EQ(scan->records, records);
+}
+
 }  // namespace
 }  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
@@ -1,0 +1,186 @@
+#include "storage/local/log_structured/wal.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace mooncake::logstructured {
+namespace {
+
+class WalTempDirectory {
+   public:
+    WalTempDirectory() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        path_ = std::filesystem::temp_directory_path() /
+                ("mooncake-log-wal-test-" + std::to_string(getpid()) + "-" +
+                 std::to_string(id));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~WalTempDirectory() { std::filesystem::remove_all(path_); }
+
+    std::filesystem::path File(std::string_view name) const {
+        return path_ / name;
+    }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+RecordIdentity WalIdentity(std::string key, uint64_t incarnation) {
+    return RecordIdentity{
+        .tenant_id = "tenant-a",
+        .object_key = std::move(key),
+        .incarnation = ObjectIncarnation{.high = 4, .low = incarnation},
+    };
+}
+
+PhysicalRecord WalPhysical(uint64_t segment, uint64_t offset) {
+    return PhysicalRecord{.segment_id = segment,
+                          .record_offset = offset,
+                          .value_offset = offset + 80,
+                          .value_length = 64,
+                          .total_length = 160};
+}
+
+WalRecord Transition(WalRecordType type, const RecordIdentity& identity,
+                     uint64_t sequence, PhysicalRecord physical = {}) {
+    return WalRecord{.type = type,
+                     .sequence = sequence,
+                     .identity = identity,
+                     .physical = physical};
+}
+
+TEST(LogStructuredWalTest, AppendsScansAndReplaysTransitions) {
+    WalTempDirectory temp;
+    const auto path = temp.File("WAL-000001");
+    auto writer = WalWriter::Create(path.string());
+    ASSERT_TRUE(writer.has_value());
+
+    const auto identity = WalIdentity("key", 1);
+    ASSERT_TRUE((*writer)
+                    ->Append(Transition(WalRecordType::kPrepareValue, identity,
+                                        10, WalPhysical(1, 0)),
+                             false)
+                    .has_value());
+    ASSERT_TRUE(
+        (*writer)
+            ->Append(Transition(WalRecordType::kCommitValue, identity, 10),
+                     true)
+            .has_value());
+    writer.value().reset();
+
+    auto scan = ScanWal(path.string());
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, WalScanTermination::kCleanEof);
+    ASSERT_EQ(scan->records.size(), size_t{2});
+
+    VersionIndex index;
+    ASSERT_TRUE(ReplayWal(scan->records, index).has_value());
+    auto committed = index.LookupCommitted(identity);
+    ASSERT_TRUE(committed.has_value());
+    EXPECT_EQ(committed->physical, WalPhysical(1, 0));
+}
+
+TEST(LogStructuredWalTest, IncompleteTailIsTruncatedBeforeAppend) {
+    WalTempDirectory temp;
+    const auto path = temp.File("WAL-000002");
+    auto writer = WalWriter::Create(path.string());
+    ASSERT_TRUE(writer.has_value());
+    const auto first_identity = WalIdentity("first", 1);
+    ASSERT_TRUE((*writer)
+                    ->Append(Transition(WalRecordType::kPrepareValue,
+                                        first_identity, 1, WalPhysical(1, 0)),
+                             true)
+                    .has_value());
+    const uint64_t valid_bytes = (*writer)->tail();
+    writer.value().reset();
+
+    {
+        std::ofstream output(path, std::ios::binary | std::ios::app);
+        ASSERT_TRUE(output.good());
+        output << "torn-wal-record";
+    }
+    auto torn = ScanWal(path.string());
+    ASSERT_TRUE(torn.has_value());
+    EXPECT_EQ(torn->termination, WalScanTermination::kIncompleteTail);
+    EXPECT_EQ(torn->valid_bytes, valid_bytes);
+
+    auto reopened = WalWriter::OpenForAppend(path.string(), torn->valid_bytes);
+    ASSERT_TRUE(reopened.has_value());
+    ASSERT_TRUE(
+        (*reopened)
+            ->Append(Transition(WalRecordType::kAbortValue, first_identity, 1),
+                     true)
+            .has_value());
+    reopened.value().reset();
+
+    auto repaired = ScanWal(path.string());
+    ASSERT_TRUE(repaired.has_value());
+    EXPECT_EQ(repaired->termination, WalScanTermination::kCleanEof);
+    ASSERT_EQ(repaired->records.size(), size_t{2});
+    VersionIndex index;
+    ASSERT_TRUE(ReplayWal(repaired->records, index).has_value());
+    EXPECT_EQ(index.Lookup(first_identity)->state, VersionState::kAborted);
+}
+
+TEST(LogStructuredWalTest, CorruptionStopsAtLastValidTransition) {
+    WalTempDirectory temp;
+    const auto path = temp.File("WAL-000003");
+    auto writer = WalWriter::Create(path.string());
+    ASSERT_TRUE(writer.has_value());
+    const auto identity = WalIdentity("key", 1);
+    ASSERT_TRUE((*writer)
+                    ->Append(Transition(WalRecordType::kPrepareValue, identity,
+                                        1, WalPhysical(1, 0)),
+                             false)
+                    .has_value());
+    const uint64_t second_offset = (*writer)->tail();
+    ASSERT_TRUE(
+        (*writer)
+            ->Append(Transition(WalRecordType::kCommitValue, identity, 1), true)
+            .has_value());
+    writer.value().reset();
+
+    const int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+    ASSERT_GE(fd, 0);
+    char byte = 0;
+    ASSERT_EQ(pread(fd, &byte, 1, second_offset), 1);
+    byte ^= 0x01;
+    ASSERT_EQ(pwrite(fd, &byte, 1, second_offset), 1);
+    ASSERT_EQ(close(fd), 0);
+
+    auto scan = ScanWal(path.string());
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, WalScanTermination::kCorruptRecord);
+    EXPECT_EQ(scan->valid_bytes, second_offset);
+    ASSERT_EQ(scan->records.size(), size_t{1});
+}
+
+TEST(LogStructuredWalTest, ReplayedAbortPreservesPreviousIncarnation) {
+    const auto old_identity = WalIdentity("key", 1);
+    const auto new_identity = WalIdentity("key", 2);
+    std::vector<WalRecord> records = {
+        Transition(WalRecordType::kPrepareValue, old_identity, 1,
+                   WalPhysical(1, 0)),
+        Transition(WalRecordType::kCommitValue, old_identity, 1),
+        Transition(WalRecordType::kPrepareValue, new_identity, 2,
+                   WalPhysical(1, 160)),
+        Transition(WalRecordType::kAbortValue, new_identity, 2),
+    };
+
+    VersionIndex index;
+    ASSERT_TRUE(ReplayWal(records, index).has_value());
+    EXPECT_TRUE(index.LookupCommitted(old_identity).has_value());
+    EXPECT_FALSE(index.LookupCommitted(new_identity).has_value());
+}
+
+}  // namespace
+}  // namespace mooncake::logstructured

--- a/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
+++ b/mooncake-store/tests/storage/local/log_structured/wal_test.cpp
@@ -4,9 +4,15 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <fstream>
+#include <future>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -227,6 +233,87 @@ TEST(LogStructuredWalTest, AppendsBatchWithSingleDurabilityBoundary) {
     ASSERT_TRUE(scan.has_value());
     EXPECT_EQ(scan->termination, WalScanTermination::kCleanEof);
     EXPECT_EQ(scan->records, records);
+}
+
+TEST(LogStructuredWalTest, GroupsConcurrentDurableAppends) {
+    WalTempDirectory temp;
+    const auto path = temp.File("WAL-group-commit");
+    auto writer = WalWriter::Create(path.string());
+    ASSERT_TRUE(writer.has_value());
+
+    std::mutex hook_mutex;
+    std::condition_variable hook_cv;
+    bool first_group_blocked = false;
+    bool release_first_group = false;
+    std::atomic<size_t> hook_calls{0};
+    WalWriter::SetBeforeWriteHookForTest([&] {
+        if (hook_calls.fetch_add(1, std::memory_order_relaxed) != 0) return;
+        std::unique_lock lock(hook_mutex);
+        first_group_blocked = true;
+        hook_cv.notify_all();
+        hook_cv.wait(lock, [&] { return release_first_group; });
+    });
+
+    auto first = std::async(std::launch::async, [&] {
+        const auto identity = WalIdentity("first", 1);
+        return (*writer)->Append(Transition(WalRecordType::kPrepareValue,
+                                            identity, 1, WalPhysical(1, 0)),
+                                 true);
+    });
+    bool hook_entered = false;
+    {
+        std::unique_lock lock(hook_mutex);
+        hook_entered = hook_cv.wait_for(lock, std::chrono::seconds(2),
+                                        [&] { return first_group_blocked; });
+    }
+    EXPECT_TRUE(hook_entered);
+
+    constexpr size_t kFollowers = 16;
+    std::vector<std::future<tl::expected<void, WalError>>> followers;
+    followers.reserve(kFollowers);
+    for (size_t index = 0; index < kFollowers; ++index) {
+        followers.push_back(std::async(std::launch::async, [&, index] {
+            const auto identity =
+                WalIdentity("follower-" + std::to_string(index), index + 2);
+            return (*writer)->Append(
+                Transition(WalRecordType::kPrepareValue, identity, index + 2,
+                           WalPhysical(1, (index + 1) * 160)),
+                true);
+        }));
+    }
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while ((*writer)->SnapshotStats().append_requests < kFollowers + 1 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    const bool all_queued =
+        (*writer)->SnapshotStats().append_requests == kFollowers + 1;
+    {
+        std::lock_guard lock(hook_mutex);
+        release_first_group = true;
+    }
+    hook_cv.notify_all();
+
+    EXPECT_TRUE(first.get().has_value());
+    for (auto& follower : followers) {
+        EXPECT_TRUE(follower.get().has_value());
+    }
+    WalWriter::SetBeforeWriteHookForTest({});
+
+    ASSERT_TRUE(all_queued);
+    const auto stats = (*writer)->SnapshotStats();
+    EXPECT_EQ(stats.append_requests, kFollowers + 1);
+    EXPECT_EQ(stats.write_groups, uint64_t{2});
+    EXPECT_EQ(stats.sync_groups, uint64_t{2});
+    EXPECT_EQ(stats.max_group_requests, kFollowers);
+    writer.value().reset();
+
+    auto scan = ScanWal(path.string());
+    ASSERT_TRUE(scan.has_value());
+    EXPECT_EQ(scan->termination, WalScanTermination::kCleanEof);
+    EXPECT_EQ(scan->records.size(), kFollowers + 1);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Implements #3856 by adding an opt-in log-structured `LOCAL_DISK` backend with an independent on-disk format.

The backend provides:

- append-only foreground writes into versioned Segment files, with short-lock offset reservation and payload I/O outside the Store lock;
- a holder-local version index with prepare/commit/abort semantics;
- WAL, checkpoint, manifest, and post-checkpoint recovery;
- crash-safe reclaim-only and size-tiered compaction;
- capacity reservation, compaction throttling, and backend metrics;
- concurrent batched payload submission through io_uring, with same-key striped serialization and an ordered publication barrier;
- concurrent reads with pinned Segment file descriptors, allowing in-flight reads to survive compaction unlink;
- direct-to-destination value reads without an intermediate decoded-record buffer;
- a shared read barrier that preserves the `complete_handler -> local commit` visibility protocol while allowing concurrent readers.

The Master continues to store only the logical `LOCAL_DISK` replica location. Segment IDs and offsets remain private to the holder, so compaction does not require a Master protocol change.

This is a separate backend and disk format. Existing FilePerKey, Bucket, OffsetAllocator, DFS, NoF, and NVMe-KV backends are unchanged.

### Integrity model

Complete records are checksummed and fully validated during recovery, Segment scanning, and compaction. The normal read path trusts the already validated committed physical index, validates its bounds, and reads the value directly into the caller buffer. It does not recompute the payload CRC on every cache hit. This matches the existing OffsetAllocator policy of performing full CRC validation during recovery rather than on the hot value-read path.

### Production-readiness hardening

The latest update (`94d70194`) addresses the concrete correctness and bounded-state issues identified during review:

- checkpoints retain prepared entries, while the post-checkpoint WAL uses its file generation as the replay boundary rather than incorrectly rejecting commit/abort records whose object sequence is already represented by the checkpoint;
- successful checkpoints prune obsolete, aborted, tombstoned, and reclaimable version history while preserving current committed and prepared versions;
- WAL append or sync failures fence the store into recovery-required state;
- callback exceptions abort prepared batches through an RAII guard;
- capacity rejection seals a non-empty active Segment so reclaim-only compaction can make progress;
- tiered compaction revalidates fan-in after input-budget truncation;
- recovery and compaction reuse one reader per source Segment, and compaction reads live records in physical-offset order;
- the existing FileStorage `use_uring` switch now controls log-structured payload writes.

### Current limitation

Durable delayed per-object deletion remains dependent on the object-incarnation and delete ACK protocol described by #3221. This backend does not advertise stronger deletion guarantees before that dependency is available.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
ctest --test-dir /tmp/Mooncake-rfc3856-build --output-on-failure \
  -R 'log_structured_.*test'

ctest --test-dir /tmp/Mooncake-rfc3856-build --output-on-failure \
  -R '^(file_storage_test|file_storage_config_test|ssd_metrics_test)$'

cargo test --offline --manifest-path mooncake-store/rust/Cargo.toml --lib
```

**Test results:**
- [x] All available `log_structured_*` test binaries pass (WAL 7/7, Store 46/46, Segment 14/14, Index 11/11, Metadata 9/9, StorageDirectory 5/5); the concurrent durable-append test also passes 100/100 repetitions.
- [x] Rust static-link unit tests pass: 8 passed, 0 failed.
- [x] `file_storage_test`, `file_storage_config_test`, and `ssd_metrics_test` pass.
- [x] Concurrent active-Segment reads, concurrent `BatchLoad`, compaction publication, reader-after-unlink, callback visibility, crash recovery, and capacity boundaries are covered.
- [ ] Integration tests pass (not run against a dedicated physical SSD host).

### Durable write benchmark

`storage_backend_bench`, buffered filesystem setup with equivalent durability policies:

- OffsetAllocator: `MOONCAKE_OFFSET_PERSIST_MODE=strict`
- Log Structured: `MOONCAKE_LOG_SYNC_POLICY=record`
- Three interleaved runs per point; medians shown; all operations completed with zero errors.
- Both backends were run with the same requested `use_uring` setting. The `io_uring` rows are not a pure layout-only comparison because OffsetAllocator's uring path opens its data file with `O_DIRECT`, while the log backend uses its batched uring writer on normally opened Segment files.

Results for `94d70194`, measured on September 7, 2026:

| Value / batch | Requested I/O | OffsetAllocator strict | Log Structured record-sync | Ratio |
| --- | --- | ---: | ---: | ---: |
| 4 KiB / 32 | pwrite | 244.39 MiB/s | 90.19 MiB/s (QD 4) | 0.37x |
| 4 KiB / 32 | io_uring | 145.41 MiB/s | 77.53 MiB/s (QD 4) | 0.53x |
| 128 KiB / 32 | pwrite | 345.98 MiB/s | 887.91 MiB/s (QD 16) | 2.57x |
| 128 KiB / 32 | io_uring | 341.74 MiB/s | 817.11 MiB/s (QD 16) | 2.39x |
| 4 MiB / 8 | pwrite | 358.59 MiB/s | 829.45 MiB/s (QD 32) | 2.31x |
| 4 MiB / 8 | io_uring | 360.20 MiB/s | 897.50 MiB/s (QD 32) | 2.49x |

This replaces the earlier 3–4x table, which unintentionally mixed I/O engines: the log backend used io_uring unconditionally while the OffsetAllocator benchmark used its default non-uring path. The corrected results show a clear medium/large-value benefit and a real 4 KiB regression caused by the log/WAL durability fixed cost. No small-value speedup is claimed.

The concurrent-append optimization is included in commit `9fe82b31`. Commit `3eb29922` embeds the implementation objects directly in `libmooncake_store.a`, preserving the Rust/Python/C static-link contract. Commit `94d70194` adds the recovery, bounded-state, capacity-progress, and configuration hardening described above.
Commit `ce1bcbc5` adds cross-request WAL group commit, releases the Store state mutex while waiting for WAL durability, and serializes transitions only per logical key so independent keys can share a durability boundary without reordering same-key state changes.

### WAL group-commit benchmark

The group-commit benchmark runs the real `PreparePut` + `CommitPut` path with `sync_data=true`, `sync_wal=true`, one operation per key, and no artificial batching delay. It compares the previous per-request WAL durability path at `8ff17433` with `ce1bcbc5`. Three interleaved runs were collected per point; medians are shown.

The shared 384-CPU host was heavily loaded during the run (`load average 278-289`), so these results are directional rather than stable hardware claims.

| Value | Writers | Baseline ops/s | Group commit ops/s | Speedup | WAL requests/fsync |
| --- | ---: | ---: | ---: | ---: | ---: |
| 4 KiB | 1 | 2,054 | 2,051 | 1.00x | 1.00 |
| 4 KiB | 8 | 3,114 | 8,138 | 2.61x | 3.26 |
| 4 KiB | 16 | 4,120 | 15,842 | 3.85x | 6.14 |
| 4 KiB | 32 | 3,517 | 21,026 | 5.98x | 13.01 |
| 128 KiB | 1 | 1,343 | 1,298 | 0.97x | 1.00 |
| 128 KiB | 8 | 3,341 | 3,961 | 1.19x | 2.52 |
| 128 KiB | 16 | 2,409 | 8,736 | 3.63x | 4.63 |
| 128 KiB | 32 | 2,116 | 11,954 | 5.65x | 9.36 |

Single-writer performance remains effectively neutral because no group forms. Under concurrency, fewer `fdatasync` calls account for the improvement; the benchmark does not attribute this gain to payload layout or io_uring.

### Read benchmark

The final implementation was also exercised for three interleaved rounds against OffsetAllocator for 4 KiB, 128 KiB, and 4 MiB values, using single-key and batched reads with one and eight reader threads. All valid-capacity runs completed with zero errors.

The shared host remained heavily loaded during this run (`load average 254-319` on 384 CPUs), so absolute and highly concurrent throughput numbers are not presented as stable performance claims. Representative three-run medians were:

| Workload | OffsetAllocator | Log Structured |
| --- | ---: | ---: |
| Single 4 KiB, 1 reader | 1410 MB/s | 1550 MB/s |
| Batch 128 KiB, 8 readers | 3908 MB/s | 3755 MB/s |
| Batch 4 MiB, 8 readers | 4407 MB/s | 4466 MB/s |

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (`--check --changed-lines --base origin/main` passes)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass (`uvx pre-commit run --files ...`)
- [x] I have updated the documentation (RFC #3856 describes the design; the hot-read integrity clarification is included above)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3856)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (OpenAI Codex assisted with implementation, tests, review, and benchmark scripting; the submitter reviewed the resulting changes and test evidence.)


