### PR TITLE
[CI/Build] Retry transient PUT failures in SSD eviction test

### DIFF
--- a/mooncake-wheel/tests/test_ssd_offload_in_evict.py
+++ b/mooncake-wheel/tests/test_ssd_offload_in_evict.py
@@ -16,6 +16,9 @@ ADD_OPERATION_COUNT_ONE = 1
 ADD_OPERATION_COUNT_ZERO = 0
 NO_ADD_LATENCY = 0
 NO_ADD_DATA_SIZE = 0
+PUT_RETRY_TIMEOUT_SECONDS = 120
+CLEANUP_RETRY_TIMEOUT_SECONDS = 30
+RETRYABLE_REMOVE_RESULTS = {-703, -706, -708}
 
 
 # This test need to set the environment valid client storage root path.
@@ -380,6 +383,8 @@ class TestDistributedObjectStore(unittest.TestCase):
                 # PUT operation phase
                 put_start = time.perf_counter()
                 index = 0
+                retry_start = None
+                retry_count = 0
                 while index < OPERATIONS_PER_THREAD:
                     key = KEY_PREFIX + str(index)
                     test_data = references[key]
@@ -388,16 +393,38 @@ class TestDistributedObjectStore(unittest.TestCase):
                     result = self.store.put(key, test_data)
                     op_end = time.perf_counter()
                     latency = op_end - op_start
-                    success = result == 0
-                    if success:
-                        with successful_puts_lock:
-                            successful_puts.add(key)
+                    if result == -200:
+                        # Memory pressure can temporarily prevent a new
+                        # replica from starting while eviction is in flight.
+                        # Retry this logical PUT before reading the key.
+                        if retry_start is None:
+                            retry_start = time.monotonic()
+                        retry_count += 1
+                        if time.monotonic() - retry_start >= PUT_RETRY_TIMEOUT_SECONDS:
+                            raise RuntimeError(
+                                f"Put operation did not make progress for key "
+                                f"{key} after {retry_count} retries and "
+                                f"{PUT_RETRY_TIMEOUT_SECONDS}s"
+                            )
+                        put_stats.record_operation(
+                            False,
+                            ADD_OPERATION_COUNT_ONE,
+                            latency,
+                            VALUE_SIZE,
+                            result,
+                        )
+                        time.sleep(0.01)
+                        continue
+                    if result != 0:
+                        raise RuntimeError(
+                            f"Put operation failed for key {key}: {result}"
+                        )
+                    retry_start = None
+                    retry_count = 0
+                    with successful_puts_lock:
+                        successful_puts.add(key)
                     put_stats.record_operation(
-                        success,
-                        ADD_OPERATION_COUNT_ONE,
-                        latency,
-                        VALUE_SIZE,
-                        result if not success else None,
+                        True, ADD_OPERATION_COUNT_ONE, latency, VALUE_SIZE
                     )
                     index = index + 1
                 put_end = time.perf_counter()
@@ -472,8 +499,39 @@ class TestDistributedObjectStore(unittest.TestCase):
         # Record overall end time
         overall_end = time.perf_counter()
 
+        # Cleanup before checking worker errors so partial writes do not
+        # contaminate subsequent test cases. Replication may still be
+        # completing after the lease expires, so retry transient remove
+        # failures and report any key that cannot be removed.
+        time.sleep(default_kv_lease_ttl / 1000)
+        cleanup_failures = []
+        cleanup_deadline = time.monotonic() + CLEANUP_RETRY_TIMEOUT_SECONDS
+        index = 0
+        while index < OPERATIONS_PER_THREAD:
+            key = KEY_PREFIX + str(index)
+            while True:
+                result = self.store.remove(key)
+                if result in (0, -704):
+                    break
+                if result not in RETRYABLE_REMOVE_RESULTS:
+                    cleanup_failures.append(f"{key}: remove failed with {result}")
+                    break
+                if time.monotonic() >= cleanup_deadline:
+                    cleanup_failures.append(
+                        f"{key}: remove did not make progress for "
+                        f"{CLEANUP_RETRY_TIMEOUT_SECONDS}s; last result "
+                        f"{result}"
+                    )
+                    break
+                time.sleep(0.01)
+            index += 1
+        print("Cleanup completed")
+
         # Check for exceptions
-        self.assertEqual(len(thread_exceptions), 0, "\n".join(thread_exceptions))
+        failures = thread_exceptions + [
+            f"Cleanup failed: {failure}" for failure in cleanup_failures
+        ]
+        self.assertEqual(len(failures), 0, "\n".join(failures))
 
         # Merge thread statistics into main statistics objects
         for i in range(NUM_THREADS):
@@ -496,14 +554,6 @@ class TestDistributedObjectStore(unittest.TestCase):
         get_stats.print_stats()
         throughput_stats.print_throughput(thread_put_stats, thread_get_stats)
 
-        # Cleanup
-        time.sleep(default_kv_lease_ttl / 1000)
-        index = 0
-        while index < OPERATIONS_PER_THREAD:
-            key = KEY_PREFIX + str(index)
-            self.store.remove(key)
-            index += 1
-        print("Cleanup completed")
         self.assertEqual(
             get_stats.failure_count,
             0,


### PR DESCRIPTION
## Description

Fix the intermittent `-200` (`NO_AVAILABLE_HANDLE`) failures in the SSD
eviction concurrent stress test.

When eviction is in flight, `put()` can temporarily fail because no memory
handle is available. The test previously advanced to the next key, then
attempted to read a key that had never been stored. This change:

- retries the same logical PUT for `-200` with a bounded 120-second
  no-progress timeout;
- fails immediately for other non-zero PUT results;
- performs cleanup before reporting worker failures;
- retries transient cleanup results (`-703`, `-706`, and `-708`) within one
  30-second cleanup budget, treats `-704` as an idempotent success, and
  reports cleanup failures.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build-gate -j8
cmake --install build-gate
source /tmp/mooncake-cr-test-env/bin/activate
CI=false FREE_BUILD_DIR=0 NPU_BUILD=0 BUILD_DIR=build-gate \
  PYTHON_VERSION=3.12 OUTPUT_DIR=dist-py312 \
  ./scripts/build_wheel.sh 3.12 dist-py312
bash /tmp/run_alt_ssd_tests.sh
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (see below)

The non-CUDA build, installation, and Python wheel build passed. The wheel
was installed into the test virtual environment before running the owner
flow. With equivalent isolated ports (the standard ports were occupied by
an unrelated existing process), the final-commit validation passed:

- SSD eviction suite: `Ran 3 tests in 37.633s — OK`
- Promotion suite: `Ran 3 tests in 41.001s — OK (skipped=1)`
- The concurrent SSD test observed transient `-200` results and recovered;
  all 4,000 GET operations succeeded.
- `git diff --check` and Python compilation passed.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

This PR adds 72 lines and removes 9 lines in one existing test file; no
production code or API/ABI is changed, so no RFC is required.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (assisted with code review, test execution, and
  diagnostics; the final change was manually reviewed)