### PR TITLE
[Store] Fix get_batch returning unwritten buffer for duplicate keys

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3291,8 +3291,8 @@ RealClient::batch_get_buffer_internal(
         std::vector<std::string> batch_keys;
         std::vector<QueryResult> batch_query_results;
         std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-        std::vector<size_t> round_ops;      // valid_ops indices in this round
-        std::vector<size_t> deferred_ops;   // duplicate keys for a later round
+        std::vector<size_t> round_ops;     // valid_ops indices in this round
+        std::vector<size_t> deferred_ops;  // duplicate keys for a later round
         batch_keys.reserve(pending_ops.size());
         batch_query_results.reserve(pending_ops.size());
         round_ops.reserve(pending_ops.size());

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3332,62 +3332,91 @@ RealClient::batch_get_buffer_internal(
 
     // 5. Execute batch get for LOCAL_DISK replicas via SSD RPC
     if (!disk_ops.empty()) {
-        // Group by transport endpoint
-        std::unordered_map<std::string,
-                           std::unordered_map<std::string, std::vector<Slice>>>
-            offload_objects;
-        // Build key -> disk_ops index for result lookup
-        std::unordered_map<std::string, size_t> disk_key_to_idx;
-
-        for (size_t idx = 0; idx < disk_ops.size(); ++idx) {
-            auto &op = disk_ops[idx];
-            // Find the LOCAL_DISK replica — replicas may be in any order.
-            const Replica::Descriptor *replica_ptr = nullptr;
-            for (const auto &r : op.query_result.replicas) {
-                if (r.is_local_disk_replica()) {
-                    replica_ptr = &r;
-                    break;
-                }
-            }
-            if (!replica_ptr) {
-                LOG(ERROR) << "No LOCAL_DISK replica found for key: " << op.key;
-                continue;
-            }
-            const auto &replica = *replica_ptr;
-            offload_objects[replica.get_local_disk_descriptor()
-                                .transport_endpoint]
-                .emplace(op.key, std::vector<Slice>{
-                                     {op.buffer_handle->ptr(), op.total_size}});
-            disk_key_to_idx[op.key] = idx;
+        // Same duplicate-key hazard as the memory path above: offload_objects
+        // (emplace keeps the first occurrence's buffer) and disk_key_to_idx
+        // (assignment keeps the last occurrence's index) are both keyed by
+        // object key, so a key repeated within one batch collapses — the SSD
+        // read fills the first occurrence's buffer while the result is resolved
+        // to the last occurrence, whose own buffer is returned unwritten.
+        // Process the ops in rounds where each round holds at most one
+        // occurrence of any key, so every occurrence's own buffer is filled.
+        // The common, duplicate-free case runs in a single round.
+        std::vector<size_t> pending_disk_ops;
+        pending_disk_ops.reserve(disk_ops.size());
+        for (size_t i = 0; i < disk_ops.size(); ++i) {
+            pending_disk_ops.push_back(i);
         }
 
-        for (auto &[endpoint, objects] : offload_objects) {
-            if (objects.empty()) continue;
-            auto read_result =
-                batch_get_into_offload_object_internal(endpoint, objects);
-            for (auto &[key, slices] : objects) {
-                auto idx_it = disk_key_to_idx.find(key);
-                if (idx_it == disk_key_to_idx.end()) continue;
-                auto &op = disk_ops[idx_it->second];
-                if (read_result) {
-                    auto checksum_result = client_->VerifyObjectChecksum(
-                        key, slices, op.total_size,
-                        op.query_result.object_checksum);
-                    if (!checksum_result) {
-                        LOG(ERROR)
-                            << "SSD checksum verification failed for key '"
-                            << key
-                            << "': " << toString(checksum_result.error());
-                        continue;
+        while (!pending_disk_ops.empty()) {
+            // Group by transport endpoint
+            std::unordered_map<
+                std::string,
+                std::unordered_map<std::string, std::vector<Slice>>>
+                offload_objects;
+            // key -> disk_ops index for this round's result lookup
+            std::unordered_map<std::string, size_t> disk_key_to_idx;
+            std::vector<size_t> deferred_disk_ops;
+
+            for (size_t idx : pending_disk_ops) {
+                auto &op = disk_ops[idx];
+                // A key already claimed this round waits for the next round so
+                // it gets its own destination buffer.
+                if (disk_key_to_idx.find(op.key) != disk_key_to_idx.end()) {
+                    deferred_disk_ops.push_back(idx);
+                    continue;
+                }
+                // Find the LOCAL_DISK replica — replicas may be in any order.
+                const Replica::Descriptor *replica_ptr = nullptr;
+                for (const auto &r : op.query_result.replicas) {
+                    if (r.is_local_disk_replica()) {
+                        replica_ptr = &r;
+                        break;
                     }
-                    final_results[op.original_index] =
-                        std::make_shared<BufferHandle>(
-                            std::move(*op.buffer_handle));
-                } else {
-                    LOG(ERROR) << "SSD read failed for key '" << key
-                               << "': " << toString(read_result.error());
+                }
+                if (!replica_ptr) {
+                    LOG(ERROR)
+                        << "No LOCAL_DISK replica found for key: " << op.key;
+                    continue;
+                }
+                const auto &replica = *replica_ptr;
+                offload_objects[replica.get_local_disk_descriptor()
+                                    .transport_endpoint]
+                    .emplace(op.key,
+                             std::vector<Slice>{
+                                 {op.buffer_handle->ptr(), op.total_size}});
+                disk_key_to_idx[op.key] = idx;
+            }
+
+            for (auto &[endpoint, objects] : offload_objects) {
+                if (objects.empty()) continue;
+                auto read_result =
+                    batch_get_into_offload_object_internal(endpoint, objects);
+                for (auto &[key, slices] : objects) {
+                    auto idx_it = disk_key_to_idx.find(key);
+                    if (idx_it == disk_key_to_idx.end()) continue;
+                    auto &op = disk_ops[idx_it->second];
+                    if (read_result) {
+                        auto checksum_result = client_->VerifyObjectChecksum(
+                            key, slices, op.total_size,
+                            op.query_result.object_checksum);
+                        if (!checksum_result) {
+                            LOG(ERROR)
+                                << "SSD checksum verification failed for key '"
+                                << key
+                                << "': " << toString(checksum_result.error());
+                            continue;
+                        }
+                        final_results[op.original_index] =
+                            std::make_shared<BufferHandle>(
+                                std::move(*op.buffer_handle));
+                    } else {
+                        LOG(ERROR) << "SSD read failed for key '" << key
+                                   << "': " << toString(read_result.error());
+                    }
                 }
             }
+
+            pending_disk_ops.swap(deferred_disk_ops);
         }
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3270,34 +3270,64 @@ RealClient::batch_get_buffer_internal(
     }
 
     // 3. Execute batch get for memory/disk replicas
-    if (!valid_ops.empty()) {
+    //
+    // Client::BatchGet routes each transfer's destination through a
+    // std::unordered_map keyed by object key (slices.find(key)). If the same
+    // key appears more than once in a single call, those entries collapse onto
+    // one destination: every occurrence transfers into the last op's buffer,
+    // while the other occurrences' separately-allocated buffers are never
+    // written yet still reported successful (their contents are uninitialized /
+    // recycled allocator memory). To keep each occurrence's own buffer filled,
+    // process the ops in rounds where each round contains at most one
+    // occurrence of any key. The common, duplicate-free case runs in a single
+    // round and behaves exactly as before.
+    std::vector<size_t> pending_ops;
+    pending_ops.reserve(valid_ops.size());
+    for (size_t i = 0; i < valid_ops.size(); ++i) {
+        pending_ops.push_back(i);
+    }
+
+    while (!pending_ops.empty()) {
         std::vector<std::string> batch_keys;
         std::vector<QueryResult> batch_query_results;
         std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-        batch_keys.reserve(valid_ops.size());
-        batch_query_results.reserve(valid_ops.size());
+        std::vector<size_t> round_ops;      // valid_ops indices in this round
+        std::vector<size_t> deferred_ops;   // duplicate keys for a later round
+        batch_keys.reserve(pending_ops.size());
+        batch_query_results.reserve(pending_ops.size());
+        round_ops.reserve(pending_ops.size());
 
-        for (auto &op : valid_ops) {
-            batch_keys.push_back(op.key);
-            batch_query_results.push_back(op.query_result);
-            batch_slices[op.key] = op.slices;
+        for (size_t idx : pending_ops) {
+            auto &op = valid_ops[idx];
+            // batch_slices is keyed by key, so a key already claimed this round
+            // must wait for the next round to get its own destination.
+            if (batch_slices.find(op.key) == batch_slices.end()) {
+                batch_keys.push_back(op.key);
+                batch_query_results.push_back(op.query_result);
+                batch_slices[op.key] = op.slices;
+                round_ops.push_back(idx);
+            } else {
+                deferred_ops.push_back(idx);
+            }
         }
 
         auto batch_get_results =
             client_->BatchGet(batch_keys, batch_query_results, batch_slices);
 
         // 4. Process results and create BufferHandles
-        for (size_t i = 0; i < valid_ops.size(); ++i) {
-            if (batch_get_results[i]) {
-                auto &op = valid_ops[i];
+        for (size_t j = 0; j < round_ops.size(); ++j) {
+            auto &op = valid_ops[round_ops[j]];
+            if (batch_get_results[j]) {
                 final_results[op.original_index] =
                     std::make_shared<BufferHandle>(
                         std::move(*op.buffer_handle));
             } else {
-                LOG(ERROR) << "BatchGet failed for key '" << valid_ops[i].key
-                           << "': " << toString(batch_get_results[i].error());
+                LOG(ERROR) << "BatchGet failed for key '" << op.key
+                           << "': " << toString(batch_get_results[j].error());
             }
         }
+
+        pending_ops.swap(deferred_ops);
     }
 
     // 5. Execute batch get for LOCAL_DISK replicas via SSD RPC

--- a/mooncake-store/tests/dummy_client_get_buffer_test.cpp
+++ b/mooncake-store/tests/dummy_client_get_buffer_test.cpp
@@ -618,6 +618,87 @@ TEST_F(DummyClientGetBufferTest, Perf_BatchHotVsCold) {
         << "Batch hot cache path should be faster than fallback";
 }
 
+// ---- Regression: duplicate keys in one batch must each be filled ----
+//
+// Bug (pre-fix): RealClient::batch_get_buffer_internal built Client::BatchGet's
+// destination slice map keyed by object key. When the same key appeared more
+// than once in a single batch, those entries collapsed onto one destination:
+// every occurrence transferred into the last op's buffer, while the other
+// occurrences' separately-allocated buffers were left unwritten yet still
+// reported successful, surfacing uninitialized/recycled allocator memory as
+// valid data. The fix processes the ops in rounds so each occurrence gets its
+// own destination and is actually filled.
+//
+// The key is deliberately NOT warmed into the hot cache, so every occurrence
+// misses hot cache and flows through the allocator-fallback batch path
+// (DummyClient::batch_get_buffer -> RealClient::batch_acquire_buffer_dummy ->
+// RealClient::batch_get_buffer_internal), which is exactly where duplicate keys
+// used to collapse.
+TEST_F(DummyClientGetBufferTest, BatchGetBufferDuplicateKeysAllFilled) {
+    ASSERT_TRUE(SetupStack()) << "Failed to bring up real+dummy stack";
+
+    const std::string key = "duplicate_key_regression";
+
+    // Distinctive, non-zero, position-dependent payload so an unwritten buffer
+    // (typically zero-filled or recycled allocator memory) is clearly
+    // detectable rather than coincidentally matching.
+    const size_t kSize = 256 * 1024;  // 256 KB
+    std::string data(kSize, '\0');
+    for (size_t i = 0; i < kSize; ++i) {
+        data[i] = static_cast<char>((i * 31 + 7) & 0xFF);
+    }
+    PutData(key, data);
+
+    // Request the SAME key several times in a single batch.
+    const size_t kOccurrences = 3;
+    std::vector<std::string> keys(kOccurrences, key);
+
+    auto results = dummy_client_->batch_get_buffer(keys);
+    ASSERT_EQ(results.size(), kOccurrences);
+
+    for (size_t i = 0; i < kOccurrences; ++i) {
+        // Every occurrence is reported successful (non-null handle)...
+        ASSERT_NE(results[i], nullptr)
+            << "batch_get_buffer returned nullptr for duplicate occurrence "
+            << i;
+        ASSERT_EQ(results[i]->size(), data.size())
+            << "size mismatch for duplicate occurrence " << i;
+
+        // ...and every occurrence's own buffer must actually hold the object's
+        // bytes. Pre-fix, all but the last occurrence's buffer was left
+        // unwritten (stale/recycled memory) despite the success status.
+        const char *got = static_cast<const char *>(results[i]->ptr());
+        if (std::memcmp(got, data.data(), data.size()) != 0) {
+            size_t first_bad = 0;
+            while (first_bad < data.size() &&
+                   got[first_bad] == data[first_bad]) {
+                ++first_bad;
+            }
+            ADD_FAILURE()
+                << "Duplicate occurrence " << i << " of key '" << key
+                << "' was reported successful but its buffer holds stale data "
+                << "(first mismatch at byte " << first_bad << ": got "
+                << (static_cast<unsigned>(got[first_bad]) & 0xFFu)
+                << ", expected "
+                << (static_cast<unsigned>(data[first_bad]) & 0xFFu)
+                << "). This is the batch-get duplicate-key bug: "
+                << "the destination slice map collapsed duplicate "
+                << "keys onto one buffer, leaving this occurrence's "
+                << "buffer unwritten.";
+        }
+    }
+
+    // Each occurrence must also receive its own distinct destination buffer,
+    // not a shared/aliased one.
+    for (size_t i = 0; i < kOccurrences; ++i) {
+        for (size_t j = i + 1; j < kOccurrences; ++j) {
+            EXPECT_NE(results[i]->ptr(), results[j]->ptr())
+                << "duplicate occurrences " << i << " and " << j
+                << " unexpectedly share the same buffer pointer";
+        }
+    }
+}
+
 }  // namespace testing
 }  // namespace mooncake
 

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -2708,6 +2708,123 @@ TEST_F(RealClientTest, SunriseLinkHostPutGetRemove) {
 }
 #endif
 
+// Regression for the duplicate-key collapse on the LOCAL_DISK (SSD offload)
+// batch-get path. Pre-fix, disk_ops in RealClient::batch_get_buffer_internal
+// keyed offload_objects (first occurrence wins the buffer) and disk_key_to_idx
+// (last occurrence wins the index) by object key, so a key repeated within one
+// batch returned the last occurrence's never-written buffer as success. Force a
+// LOCAL_DISK-only replica (offload, then drop the MEMORY replica), then request
+// the key several times in one batch so every occurrence routes through
+// disk_ops, and assert each occurrence's own buffer is actually filled.
+TEST_F(RealClientTest, BatchGetBufferDuplicateKeysLocalDiskAllFilled) {
+    ScopedEnvVar local_memcpy("MC_STORE_MEMCPY", "1");
+    ScopedEnvVar heartbeat("MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS", "1");
+    ScopedEnvVar storage_backend("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+                                 "bucket_storage_backend");
+    ScopedEnvVar bucket_keys("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT", "1");
+
+    char path[] = "/tmp/mooncake_ssd_dupkey_XXXXXX";
+    const char* created = mkdtemp(path);
+    ASSERT_NE(created, nullptr);
+    ssd_path_ = created;
+
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder()
+                                  .set_enable_offload(true)
+                                  .set_default_kv_lease_ttl(10)
+                                  .build()));
+    master_address_ = master_.master_address();
+    ASSERT_EQ(
+        py_client_->setup_real("localhost:17813", "P2PHANDSHAKE",
+                               16 * 1024 * 1024, 16 * 1024 * 1024, "tcp", "",
+                               master_address_, nullptr, "", true, ssd_path_),
+        0);
+
+    // Distinctive, position-dependent payload so an unwritten buffer (zero /
+    // recycled memory) is clearly detectable rather than coincidentally equal.
+    constexpr size_t kSize = 256 * 1024;  // 256 KB
+    std::vector<char> source(kSize);
+    for (size_t i = 0; i < source.size(); ++i) {
+        source[i] = static_cast<char>((i * 31 + 7) & 0xFF);
+    }
+    const std::string key = "duplicate_key_local_disk_regression";
+    ASSERT_EQ(py_client_->put(key, source), 0);
+
+    // Wait for proactive offload to create a LOCAL_DISK replica.
+    bool disk_ready = false;
+    const auto offload_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (std::chrono::steady_clock::now() < offload_deadline && !disk_ready) {
+        for (const auto& replica : py_client_->get_replica_desc(key)) {
+            if (replica.is_local_disk_replica()) {
+                disk_ready = true;
+                break;
+            }
+        }
+        if (!disk_ready) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+    ASSERT_TRUE(disk_ready) << "object never offloaded to a LOCAL_DISK replica";
+
+    // Drop the MEMORY replica so only LOCAL_DISK remains -> forces disk_ops.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    const auto clear_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    bool memory_cleared = false;
+    while (std::chrono::steady_clock::now() < clear_deadline) {
+        if (py_client_->batch_replica_clear({key}, "localhost:17813").size() ==
+            1) {
+            memory_cleared = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(memory_cleared) << "failed to clear the MEMORY replica";
+
+    auto replicas = py_client_->get_replica_desc(key);
+    ASSERT_EQ(replicas.size(), 1u);
+    ASSERT_TRUE(replicas.front().is_local_disk_replica());
+
+    // Request the SAME key several times in one batch -> all via disk_ops.
+    const size_t kOccurrences = 3;
+    std::vector<std::string> keys(kOccurrences, key);
+    auto results = py_client_->batch_get_buffer(keys);
+    ASSERT_EQ(results.size(), kOccurrences);
+
+    for (size_t i = 0; i < kOccurrences; ++i) {
+        ASSERT_NE(results[i], nullptr)
+            << "batch_get_buffer returned nullptr for LOCAL_DISK duplicate "
+               "occurrence "
+            << i;
+        ASSERT_EQ(results[i]->size(), source.size())
+            << "size mismatch for LOCAL_DISK duplicate occurrence " << i;
+        const char* got = static_cast<const char*>(results[i]->ptr());
+        if (std::memcmp(got, source.data(), source.size()) != 0) {
+            size_t first_bad = 0;
+            while (first_bad < source.size() &&
+                   got[first_bad] == source[first_bad]) {
+                ++first_bad;
+            }
+            ADD_FAILURE()
+                << "LOCAL_DISK duplicate occurrence " << i << " of key '" << key
+                << "' was reported successful but its buffer holds stale data "
+                << "(first mismatch at byte " << first_bad << "). The disk_ops "
+                << "path collapsed duplicate keys onto one buffer, leaving "
+                   "this "
+                << "occurrence's buffer unwritten.";
+        }
+    }
+
+    // Each occurrence must receive its own distinct destination buffer.
+    for (size_t i = 0; i < kOccurrences; ++i) {
+        for (size_t j = i + 1; j < kOccurrences; ++j) {
+            EXPECT_NE(results[i]->ptr(), results[j]->ptr())
+                << "LOCAL_DISK duplicate occurrences " << i << " and " << j
+                << " unexpectedly share the same buffer pointer";
+        }
+    }
+}
+
 }  // namespace testing
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description

Fixes #3876.

`RealClient::batch_get_buffer_internal` built `Client::BatchGet`'s destination
map keyed by object key (`batch_slices[op.key] = op.slices`). When the same key
appeared more than once in a single batch, those entries collapsed onto one
destination: in `Client::BatchGet` the destination is resolved via
`slices.find(key)`, so every occurrence transferred into the last op's buffer,
while the other occurrences' separately-allocated buffers were never written yet
still reported successful — surfacing uninitialized/recycled allocator memory as
valid data (the checksum is computed against the filled buffer, so it does not
catch it). Duplicate keys occur naturally in real workloads (e.g. repeated
prefix-cache block hashes within one batch).

This change processes the ops in rounds where each round holds at most one
occurrence of any key, so every occurrence's own buffer is filled. The common,
duplicate-free case runs in a single round and behaves exactly as before.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Integration (`mooncake-integration`)
- [ ] Other

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Added `DummyClientGetBufferTest.BatchGetBufferDuplicateKeysAllFilled`
(`mooncake-store/tests/dummy_client_get_buffer_test.cpp`): puts an object under
one key, requests that key three times in a single `batch_get_buffer` call, and
asserts every occurrence's own buffer holds the object's bytes (not stale/zero
memory) and that occurrences do not share a buffer. The key is deliberately not
warmed into the hot cache so all occurrences flow through the allocator-fallback
path (`batch_get_buffer_internal`) where duplicate keys used to collapse.

Built and run on a clean Ubuntu 22.04 machine (`sudo bash dependencies.sh -y`
then `cmake -B build -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=OFF -DUSE_UB=OFF
-DUSE_CUDA=OFF -DWITH_P2P_STORE=OFF -DBUILD_UNIT_TESTS=ON` then
`cmake --build build --target dummy_client_get_buffer_test`):

- **With the fix — PASS:**
  ```
  [ RUN      ] DummyClientGetBufferTest.BatchGetBufferDuplicateKeysAllFilled
  [       OK ] DummyClientGetBufferTest.BatchGetBufferDuplicateKeysAllFilled (5034 ms)
  [  PASSED  ] 1 test.
  ```
- **Reverting only the fix hunk in `real_client.cpp` (pre-fix) — FAIL**, confirming the test catches the bug:
  ```
  Duplicate occurrence 0 ... was reported successful but its buffer holds stale data
    (first mismatch at byte 0: got 0, expected 7). ...
  Duplicate occurrence 1 ... was reported successful but its buffer holds stale data
    (first mismatch at byte 0: got 0, expected 7). ...
  [  FAILED  ] DummyClientGetBufferTest.BatchGetBufferDuplicateKeysAllFilled
  ```
  (Occurrences 0 and 1 return zeroed/unwritten memory; only the last, surviving
  buffer is filled — exactly the reported bug.)

**Formatting:** verified with `clang-format` 20.1.7 (LLVM 20, per
`CONTRIBUTING.md`); `scripts/code_format.sh --staged` reports no changes.

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (fixed=PASS, pre-fix=FAIL on Ubuntu 22.04, output above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format LLVM 20)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) — *N/A*
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue — *N/A, small change*

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding assistant was used to analyze the affected code path, draft the fix,
write the regression test, and run the build/test verification described above.
The submitter has reviewed the change.
