### PR TITLE
[TransferEngine] Negotiate RC path MTU with the peer

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -195,6 +195,24 @@ GlobalConfig& globalConfig();
 
 uint16_t getDefaultHandshakePort();
 
+// Byte length of a path MTU enum, or 0 when the value names no path MTU.
+uint32_t mtuLengthToBytes(ibv_mtu mtu);
+
+// Name of a path MTU enum, or "UNKNOWN" when the value names no path MTU.
+// Covers the same enumerants as mtuLengthToBytes().
+std::string mtuLengthToString(ibv_mtu mtu);
+
+// Path MTU this side is able to use on a port whose active MTU is
+// `active_mtu`, lowered by MC_MTU when the operator configured a smaller one.
+ibv_mtu localPathMtu(ibv_mtu active_mtu);
+
+// Path MTU to program into an RC QP. Both ends of an RC connection must agree
+// on it, so each side advertises its own localPathMtu() during the handshake
+// and both keep the smaller. `peer_mtu_bytes` of 0, or any value that names no
+// path MTU, means the peer does not advertise one (older build): keep the
+// local choice, as before.
+ibv_mtu negotiatePathMtu(ibv_mtu local_mtu, uint32_t peer_mtu_bytes);
+
 // Validates a port range. Returns {default_min, default_max} on invalid input.
 // Rejects: min > max, well-known ports (0-1023), ephemeral ports (32768-60999).
 std::pair<int, int> ValidatePortRange(int min_port, int max_port,

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -168,6 +168,10 @@ class TransferMetadata {
         std::string local_nic_path;
         uint16_t local_lid = 0;
         std::string local_gid;
+        // Path MTU the sender can use, in bytes. RC requires both ends to be
+        // programmed with the same path MTU, so each side advertises its own
+        // and both keep the smaller. 0 = not advertised (older peer).
+        uint32_t local_mtu_bytes = 0;
         std::string peer_nic_path;
 #ifdef USE_UB
         std::vector<uint32_t> jetty_num;  // for ub/urma

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -178,15 +178,23 @@ class RdmaEndPoint {
 
     std::vector<uint32_t> qpNum() const;
 
+    // `peer_mtu_bytes` is the path MTU advertised by the peer handshake; 0
+    // when the peer does not advertise one. See negotiatePathMtu(). It is last
+    // so that the positional convention of the existing parameters is
+    // unchanged: `Status` is an unscoped enum, so a caller written against the
+    // old signature would otherwise still compile with its status silently
+    // bound to the MTU.
     int doSetupConnection(const std::string &peer_gid, uint16_t peer_lid,
                           std::vector<uint32_t> peer_qp_num_list,
                           Status connected_status = CONNECTED,
                           std::string *reply_msg = nullptr,
-                          SetupConnectionFailureInfo *failure_info = nullptr);
+                          SetupConnectionFailureInfo *failure_info = nullptr,
+                          uint32_t peer_mtu_bytes = 0);
 
     int doSetupConnection(int qp_index, const ibv_gid &peer_gid,
                           uint16_t peer_lid, uint32_t peer_qp_num,
-                          int local_gid_index, std::string *reply_msg = nullptr,
+                          int local_gid_index, ibv_mtu path_mtu,
+                          std::string *reply_msg = nullptr,
                           SetupConnectionFailureInfo *failure_info = nullptr);
 
    private:

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
@@ -96,7 +96,7 @@ class CtrlChannel {
     int postRecv(size_t idx);
     int repostAllRecvs();
     int connectQp(const std::string &peer_gid, uint16_t peer_lid,
-                  uint32_t peer_qp_num);
+                  uint32_t peer_qp_num, uint32_t peer_mtu_bytes);
     void dispatchRecvPayload(const uint8_t *data, size_t byte_len);
     void handleSendComplete();
     void handleRecvComplete(const ibv_wc &wc);

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -820,7 +820,9 @@ void loadGlobalConfig(GlobalConfig& config) {
 }
 
 std::string mtuLengthToString(ibv_mtu mtu) {
-    if (mtu == IBV_MTU_512)
+    if (mtu == IBV_MTU_256)
+        return "IBV_MTU_256";
+    else if (mtu == IBV_MTU_512)
         return "IBV_MTU_512";
     else if (mtu == IBV_MTU_1024)
         return "IBV_MTU_1024";
@@ -830,6 +832,56 @@ std::string mtuLengthToString(ibv_mtu mtu) {
         return "IBV_MTU_4096";
     else
         return "UNKNOWN";
+}
+
+uint32_t mtuLengthToBytes(ibv_mtu mtu) {
+    switch (mtu) {
+        case IBV_MTU_256:
+            return 256;
+        case IBV_MTU_512:
+            return 512;
+        case IBV_MTU_1024:
+            return 1024;
+        case IBV_MTU_2048:
+            return 2048;
+        case IBV_MTU_4096:
+            return 4096;
+        default:
+            return 0;
+    }
+}
+
+static bool mtuLengthFromBytes(uint32_t bytes, ibv_mtu& mtu) {
+    switch (bytes) {
+        case 256:
+            mtu = IBV_MTU_256;
+            return true;
+        case 512:
+            mtu = IBV_MTU_512;
+            return true;
+        case 1024:
+            mtu = IBV_MTU_1024;
+            return true;
+        case 2048:
+            mtu = IBV_MTU_2048;
+            return true;
+        case 4096:
+            mtu = IBV_MTU_4096;
+            return true;
+        default:
+            return false;
+    }
+}
+
+ibv_mtu localPathMtu(ibv_mtu active_mtu) {
+    return globalConfig().mtu_length < active_mtu ? globalConfig().mtu_length
+                                                  : active_mtu;
+}
+
+ibv_mtu negotiatePathMtu(ibv_mtu local_mtu, uint32_t peer_mtu_bytes) {
+    ibv_mtu peer_mtu;
+    if (!mtuLengthFromBytes(peer_mtu_bytes, peer_mtu)) return local_mtu;
+    return peer_mtu < local_mtu ? peer_mtu : local_mtu;
 }
 
 void updateGlobalConfig(ibv_device_attr& device_attr) {

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -165,6 +165,10 @@ struct TransferHandshakeUtil {
         root["local_nic_path"] = desc.local_nic_path;
         root["local_lid"] = desc.local_lid;
         root["local_gid"] = desc.local_gid;
+        // Emitted only by transports that negotiate it; absence tells the peer
+        // to keep its own path MTU.
+        if (desc.local_mtu_bytes != 0)
+            root["local_mtu_bytes"] = Json::UInt(desc.local_mtu_bytes);
         root["peer_nic_path"] = desc.peer_nic_path;
 #ifdef USE_BAREX
         root["barex_port"] = desc.barex_port;
@@ -210,6 +214,12 @@ struct TransferHandshakeUtil {
             desc.local_gid = root["local_gid"].asString();
         } else {
             desc.local_gid.clear();
+        }
+        if (root.isMember("local_mtu_bytes") &&
+            root["local_mtu_bytes"].isUInt()) {
+            desc.local_mtu_bytes = root["local_mtu_bytes"].asUInt();
+        } else {
+            desc.local_mtu_bytes = 0;
         }
         desc.peer_nic_path = root["peer_nic_path"].asString();
 #ifdef USE_BAREX

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -44,6 +44,8 @@ static GidSelectionSnapshot fillLocalHandshakeDesc(
     local_desc.local_nic_path = context.nicPath();
     local_desc.local_lid = context.lid();
     local_desc.local_gid = gid_selection.gid;
+    local_desc.local_mtu_bytes =
+        mtuLengthToBytes(localPathMtu(context.activeMTU()));
     local_desc.peer_nic_path = peer_nic;
     local_desc.qp_num = qp_num;
     local_desc.ready_ack = false;
@@ -601,10 +603,10 @@ int RdmaEndPoint::setupConnectionsByActive() {
                                             ? CONNECTED_WAIT_READY_ACK
                                             : CONNECTED;
                 if (!peer_desc.local_gid.empty()) {
-                    ret = doSetupConnection(peer_desc.local_gid,
-                                            peer_desc.local_lid,
-                                            peer_desc.qp_num, connected_status,
-                                            &failure_message, &failure_info);
+                    ret = doSetupConnection(
+                        peer_desc.local_gid, peer_desc.local_lid,
+                        peer_desc.qp_num, connected_status, &failure_message,
+                        &failure_info, peer_desc.local_mtu_bytes);
                 } else {
                     auto segment_desc =
                         context_.engine().meta()->getSegmentDescByName(
@@ -615,7 +617,7 @@ int RdmaEndPoint::setupConnectionsByActive() {
                                 ret = doSetupConnection(
                                     nic.gid, nic.lid, peer_desc.qp_num,
                                     connected_status, &failure_message,
-                                    &failure_info);
+                                    &failure_info, peer_desc.local_mtu_bytes);
                                 break;
                             }
                         }
@@ -803,9 +805,10 @@ int RdmaEndPoint::setupConnectionsByPassive(const HandShakeDesc &peer_desc,
             auto connected_status = peer_desc.ready_ack_supported
                                         ? CONNECTED_WAIT_READY_ACK
                                         : CONNECTED;
-            int ret = doSetupConnection(peer_gid, peer_lid, peer_desc.qp_num,
-                                        connected_status, &local_desc.reply_msg,
-                                        &failure_info);
+            int ret =
+                doSetupConnection(peer_gid, peer_lid, peer_desc.qp_num,
+                                  connected_status, &local_desc.reply_msg,
+                                  &failure_info, peer_desc.local_mtu_bytes);
             if (ret == 0) {
                 if (peer_desc.ready_ack_supported) {
                     ready_wait_start_ts_.store(getCurrentTimeInNano(),
@@ -1132,7 +1135,8 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
                                     std::vector<uint32_t> peer_qp_num_list,
                                     Status connected_status,
                                     std::string *reply_msg,
-                                    SetupConnectionFailureInfo *failure_info) {
+                                    SetupConnectionFailureInfo *failure_info,
+                                    uint32_t peer_mtu_bytes) {
     if (qp_list_.size() != peer_qp_num_list.size()) {
         std::string message =
             "QP count mismatch in peer and local endpoints, check "
@@ -1161,10 +1165,15 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
     }
 
     int local_gid_index = context_.gidIndex();
+    // RC rejects packets larger than the receiver's path MTU, so both ends
+    // must be programmed with the same value even when their ports run
+    // different active MTUs.
+    ibv_mtu path_mtu =
+        negotiatePathMtu(localPathMtu(context_.activeMTU()), peer_mtu_bytes);
     for (int qp_index = 0; qp_index < (int)qp_list_.size(); ++qp_index) {
         int ret = doSetupConnection(qp_index, peer_gid_raw, peer_lid,
                                     peer_qp_num_list[qp_index], local_gid_index,
-                                    reply_msg, failure_info);
+                                    path_mtu, reply_msg, failure_info);
         if (ret) return ret;
     }
 
@@ -1176,7 +1185,8 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
 
 int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
                                     uint16_t peer_lid, uint32_t peer_qp_num,
-                                    int local_gid_index, std::string *reply_msg,
+                                    int local_gid_index, ibv_mtu path_mtu,
+                                    std::string *reply_msg,
                                     SetupConnectionFailureInfo *failure_info) {
     if (qp_index < 0 || qp_index >= (int)qp_list_.size())
         return ERR_INVALID_ARGUMENT;
@@ -1223,9 +1233,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     // INIT -> RTR
     memset(&attr, 0, sizeof(attr));
     attr.qp_state = IBV_QPS_RTR;
-    attr.path_mtu = context_.activeMTU();
-    if (globalConfig().mtu_length < attr.path_mtu)
-        attr.path_mtu = globalConfig().mtu_length;
+    attr.path_mtu = path_mtu;
     attr.ah_attr.grh.dgid = peer_gid;
     // TODO gidIndex and portNum must fetch from REMOTE
     attr.ah_attr.grh.sgid_index = local_gid_index;

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
@@ -228,6 +228,8 @@ void CtrlChannel::fillLocalDesc(HandShakeDesc &local_desc) const {
     local_desc.local_nic_path = context_.nicPath();
     local_desc.local_lid = context_.lid();
     local_desc.local_gid = context_.gid();
+    local_desc.local_mtu_bytes =
+        mtuLengthToBytes(localPathMtu(context_.activeMTU()));
     local_desc.peer_nic_path = "__ctrl__";
     local_desc.ctrl_channel = true;
     local_desc.notify_qp_num = notifyQpNum();
@@ -235,7 +237,7 @@ void CtrlChannel::fillLocalDesc(HandShakeDesc &local_desc) const {
 }
 
 int CtrlChannel::connectQp(const std::string &peer_gid, uint16_t peer_lid,
-                           uint32_t peer_qp_num) {
+                           uint32_t peer_qp_num, uint32_t peer_mtu_bytes) {
     if (!qp_ || peer_qp_num == 0) return ERR_INVALID_ARGUMENT;
 
     ibv_gid peer_gid_raw{};
@@ -280,9 +282,10 @@ int CtrlChannel::connectQp(const std::string &peer_gid, uint16_t peer_lid,
 
     memset(&attr, 0, sizeof(attr));
     attr.qp_state = IBV_QPS_RTR;
-    attr.path_mtu = context_.activeMTU();
-    if (globalConfig().mtu_length < attr.path_mtu)
-        attr.path_mtu = globalConfig().mtu_length;
+    // Both ends of this RC QP must agree on the path MTU, so take the smaller
+    // of ours and the one the peer advertised.
+    attr.path_mtu =
+        negotiatePathMtu(localPathMtu(context_.activeMTU()), peer_mtu_bytes);
     attr.ah_attr.is_global = 1;
     attr.ah_attr.grh.dgid = peer_gid_raw;
     attr.ah_attr.grh.sgid_index = context_.gidIndex();
@@ -355,7 +358,7 @@ int CtrlChannel::connectActive() {
     {
         std::lock_guard<std::mutex> lock(resource_mutex_);
         ret = connectQp(peer_desc.local_gid, peer_desc.local_lid,
-                        peer_desc.notify_qp_num);
+                        peer_desc.notify_qp_num, peer_desc.local_mtu_bytes);
     }
     if (ret == 0) {
         LOG(INFO) << "CtrlChannel: connected to " << peer_server_name_
@@ -389,7 +392,7 @@ int CtrlChannel::acceptPassive(const HandShakeDesc &peer_desc,
         std::lock_guard<std::mutex> lock(resource_mutex_);
         fillLocalDesc(local_desc);
         ret = connectQp(peer_desc.local_gid, peer_desc.local_lid,
-                        peer_desc.notify_qp_num);
+                        peer_desc.notify_qp_num, peer_desc.local_mtu_bytes);
     }
     if (ret) {
         local_desc.reply_msg = "CtrlChannel connectQp failed";

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -993,5 +993,62 @@ TEST_F(ContextPauseTtlEnvTest, EmptyStringKeepsDefault) {
     EXPECT_EQ(config.context_pause_ttl_ms, 17);
 }
 
+// --- Path MTU negotiation (issue #3868) ---
+
+class MtuLengthScope {
+   public:
+    explicit MtuLengthScope(ibv_mtu value)
+        : previous_(globalConfig().mtu_length) {
+        globalConfig().mtu_length = value;
+    }
+
+    ~MtuLengthScope() { globalConfig().mtu_length = previous_; }
+
+   private:
+    ibv_mtu previous_;
+};
+
+TEST(PathMtuTest, MtuLengthToBytesCoversEveryEnumerant) {
+    EXPECT_EQ(mtuLengthToBytes(IBV_MTU_256), 256u);
+    EXPECT_EQ(mtuLengthToBytes(IBV_MTU_512), 512u);
+    EXPECT_EQ(mtuLengthToBytes(IBV_MTU_1024), 1024u);
+    EXPECT_EQ(mtuLengthToBytes(IBV_MTU_2048), 2048u);
+    EXPECT_EQ(mtuLengthToBytes(IBV_MTU_4096), 4096u);
+    EXPECT_EQ(mtuLengthToBytes(static_cast<ibv_mtu>(0)), 0u);
+}
+
+// mtuLengthToString() names what mtuLengthToBytes() can convert, so the two
+// must cover the same enumerants or MTU logs report a real value as UNKNOWN.
+TEST(PathMtuTest, MtuLengthToStringCoversEveryEnumerant) {
+    EXPECT_EQ(mtuLengthToString(IBV_MTU_256), "IBV_MTU_256");
+    EXPECT_EQ(mtuLengthToString(IBV_MTU_512), "IBV_MTU_512");
+    EXPECT_EQ(mtuLengthToString(IBV_MTU_1024), "IBV_MTU_1024");
+    EXPECT_EQ(mtuLengthToString(IBV_MTU_2048), "IBV_MTU_2048");
+    EXPECT_EQ(mtuLengthToString(IBV_MTU_4096), "IBV_MTU_4096");
+    EXPECT_EQ(mtuLengthToString(static_cast<ibv_mtu>(0)), "UNKNOWN");
+}
+
+TEST(PathMtuTest, LocalPathMtuIsCappedByConfiguredMtu) {
+    MtuLengthScope scope(IBV_MTU_1024);
+    EXPECT_EQ(localPathMtu(IBV_MTU_4096), IBV_MTU_1024);
+    // A port slower than MC_MTU still wins: the hardware cannot do more.
+    EXPECT_EQ(localPathMtu(IBV_MTU_512), IBV_MTU_512);
+}
+
+// The regression: a 4096-MTU port talking to a 1024-MTU peer must program the
+// RC QP with the peer's smaller MTU, otherwise its READ/WRITE packets exceed
+// what the peer accepts.
+TEST(PathMtuTest, NegotiateTakesTheSmallerOfBothPeers) {
+    EXPECT_EQ(negotiatePathMtu(IBV_MTU_4096, 1024), IBV_MTU_1024);
+    EXPECT_EQ(negotiatePathMtu(IBV_MTU_1024, 4096), IBV_MTU_1024);
+    EXPECT_EQ(negotiatePathMtu(IBV_MTU_2048, 2048), IBV_MTU_2048);
+}
+
+TEST(PathMtuTest, NegotiateKeepsLocalMtuWhenPeerDoesNotAdvertise) {
+    // Older peers omit the field; unknown lengths are treated the same way.
+    EXPECT_EQ(negotiatePathMtu(IBV_MTU_2048, 0), IBV_MTU_2048);
+    EXPECT_EQ(negotiatePathMtu(IBV_MTU_2048, 1500), IBV_MTU_2048);
+}
+
 }  // namespace
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -845,9 +845,9 @@ class RdmaEndPointTestPeer {
                                  std::string *reply_msg,
                                  int &out_stage, int &out_sys_errno) {
         RdmaEndPoint::SetupConnectionFailureInfo failure_info = {};
-        int rc = endpoint.doSetupConnection(qp_index, peer_gid, peer_lid,
-                                            peer_qp_num, local_gid_index,
-                                            reply_msg, &failure_info);
+        int rc = endpoint.doSetupConnection(
+            qp_index, peer_gid, peer_lid, peer_qp_num, local_gid_index,
+            IBV_MTU_4096, reply_msg, &failure_info);
         out_stage = static_cast<int>(failure_info.stage);
         out_sys_errno = failure_info.sys_errno;
         return rc;

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -157,6 +157,9 @@ TEST_F(TransferMetadataTest, NcclMetadataAndHandshakePayloadRoundTrip) {
                   [](const TransferMetadata::HandShakeDesc& peer,
                      TransferMetadata::HandShakeDesc& local) {
                       local.payload = "reply:" + peer.payload;
+                      // Echo the advertised path MTU so the test can check it
+                      // survives both directions of the wire encoding.
+                      local.local_mtu_bytes = peer.local_mtu_bytes;
                       return 0;
                   },
                   port, sockfd),
@@ -185,9 +188,20 @@ TEST_F(TransferMetadataTest, NcclMetadataAndHandshakePayloadRoundTrip) {
 
     TransferMetadata::HandShakeDesc request;
     request.payload = "bootstrap";
+    request.local_mtu_bytes = 1024;
     TransferMetadata::HandShakeDesc response;
     ASSERT_EQ(client.sendHandshake(server_name, request, response), 0);
     EXPECT_EQ(response.payload, "reply:bootstrap");
+    EXPECT_EQ(response.local_mtu_bytes, 1024u);
+
+    // A peer that does not advertise a path MTU leaves the field at 0, which
+    // tells the receiver to keep its own.
+    TransferMetadata::HandShakeDesc legacy_request;
+    legacy_request.payload = "legacy";
+    TransferMetadata::HandShakeDesc legacy_response;
+    ASSERT_EQ(
+        client.sendHandshake(server_name, legacy_request, legacy_response), 0);
+    EXPECT_EQ(legacy_response.local_mtu_bytes, 0u);
 }
 
 // add, get and remove RPCMetaEntryMeta


### PR DESCRIPTION
# Issue #3868 — Mixed peer active MTUs are not negotiated

## 1. Root cause

An RC queue pair is only legal when both ends are programmed with the *same*
`path_mtu`. The sender segments each READ/WRITE into packets of its own
`path_mtu`; if the responder's QP was programmed with a smaller one, it rejects
the oversized packet, which surfaces as a remote invalid request / retry
exhaustion error on the first sizeable transfer rather than at connect time.

Both RC connect paths in the transfer engine chose that value from purely local
information:

- `mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp`,
  `doSetupConnection()` (INIT -> RTR):
  ```cpp
  attr.path_mtu = context_.activeMTU();
  if (globalConfig().mtu_length < attr.path_mtu)
      attr.path_mtu = globalConfig().mtu_length;
  ```
- `mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp`,
  `connectQp()`: the identical two lines for the notify QP.

The handshake (`TransferMetadata::HandShakeDesc`) carried `local_lid`,
`local_gid` and `qp_num`, but nothing about the MTU, so neither side could see
the other's value. On a homogeneous fabric both sides independently arrive at
the same number and the defect is invisible. As soon as the peers' ports run
different active MTUs (mixed NIC generations, one port at 1024 and another at
4096, or `MC_MTU` set on only one node) the two QPs are programmed
inconsistently and RC READ/WRITE fail.

## 2. The fix and why

Negotiate the value instead of assuming it matches.

- `HandShakeDesc` gains `local_mtu_bytes`: the path MTU this side can use, in
  bytes. Both handshake fill sites (`fillLocalHandshakeDesc()` for the data QPs
  and `CtrlChannel::fillLocalDesc()` for the notify QP) populate it.
- At RTR time each side programs
  `negotiatePathMtu(localPathMtu(activeMTU()), peer_mtu_bytes)`, i.e. the
  smaller of the two resolved MTUs. The computation is symmetric, so both ends
  independently land on `min(local, peer)` and agree.
- Three small helpers live next to the existing `mtu_length` config and
  `mtuLengthToString()` in `config.{h,cpp}`, which keeps them shared by the two
  transports and unit-testable without an RDMA device:
  - `mtuLengthToBytes(ibv_mtu)` — enum to bytes for the wire.
  - `localPathMtu(ibv_mtu active_mtu)` — the pre-existing "port active MTU,
    capped by `MC_MTU`" rule, extracted verbatim.
  - `negotiatePathMtu(ibv_mtu local, uint32_t peer_bytes)` — the new `min`.

Bytes (not the `ibv_mtu` enumerator) go on the wire so the field is
self-describing and matches how `MC_MTU` is already expressed.

Wire compatibility is additive in both directions: the field is emitted only
when non-zero, and a `0`/unrecognised value means "peer does not advertise one"
and keeps the local choice — exactly the previous behavior. Loopback endpoints
keep using the 3-argument `doSetupConnection()` overload, where the parameter
defaults to 0 and both ends are the same port anyway.

## 3. Files changed

| File | Change |
|------|--------|
| `mooncake-transfer-engine/include/config.h` | Declare `mtuLengthToBytes()`, `localPathMtu()`, `negotiatePathMtu()`. |
| `mooncake-transfer-engine/src/config.cpp` | Define them (plus a file-local `mtuLengthFromBytes()`). |
| `mooncake-transfer-engine/include/transfer_metadata.h` | Add `HandShakeDesc::local_mtu_bytes`. |
| `mooncake-transfer-engine/src/transfer_metadata.cpp` | Encode/decode `local_mtu_bytes`. |
| `mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h` | Thread `peer_mtu_bytes` / `path_mtu` through the two `doSetupConnection()` overloads. |
| `mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp` | Advertise the local MTU; negotiate once per connection and program every QP with it. |
| `mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h` | `connectQp()` takes `peer_mtu_bytes`. |
| `mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp` | Same negotiation for the notify QP (identical defect, shared handshake field). |
| `mooncake-transfer-engine/tests/config_test.cpp` | New `PathMtuTest` suite (4 tests). |
| `mooncake-transfer-engine/tests/transfer_metadata_test.cpp` | Assert `local_mtu_bytes` round-trips over the handshake wire, and that an unset field decodes as 0. |
| `mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp` | Test peer updated for the new inner `doSetupConnection()` signature. |

## 4. Risk / uncertainty

- **Rolling upgrade is not fully fixed until both ends are upgraded.** A new
  node talking to an old one gets no advertisement back and keeps its own MTU,
  i.e. the mismatch persists exactly as it does today. This is a deliberate
  no-regression fallback, not a fix for the mixed-version case.
- **Behavior change on a heterogeneous fabric.** A node that previously ran at
  4096 will now drop to the peer's smaller MTU on that connection. That is the
  point of the fix (the large-MTU setting was not actually working), but it can
  look like a throughput regression to anyone who was reading `path_mtu` from
  the connect logs. It is strictly per-connection: links to same-MTU peers are
  unaffected.
- **`ibv_mtu` ordering.** The negotiation compares the enum directly, relying
  on `IBV_MTU_256 < ... < IBV_MTU_4096`. That ordering is fixed by the verbs
  ABI and the existing `MC_MTU` capping code already depended on it.
- **`CtrlChannel` was in scope by judgement, not by the issue text.** Its
  notify QP is also RC and had the identical two lines; its frames are small
  enough that a mismatch rarely bites in practice. Fixing it costs three lines
  and reuses the same handshake field, so leaving it inconsistent seemed worse
  than the slight scope increase.
- Not covered by any test: the actual `ibv_modify_qp` call with a negotiated
  MTU, which needs two RDMA NICs with different active MTUs.

## 5. How I verified it

No RDMA hardware and no project dependency tree (yalantinglibs et al.) are
available in this environment, so a full CMake build and the hardware tests
could not be run. What was run:

1. **Isolated logic check.** Extracted the three new `config.cpp` functions into
   a standalone TU against a minimal `ibv_mtu` stub, compiled with
   `-std=c++17 -Wall -Wextra` (clean) and ran assertions for every case,
   including `min` in both directions and the unknown-peer fallback: passed.
2. **`config_test` built and run for real.** Linked
   `tests/config_test.cpp` + `src/config.cpp` against system
   gtest/glog/gflags/libibverbs:
   `103 tests from 16 test suites ran ... [ PASSED ] 103 tests`, which is the
   4 new `PathMtuTest` cases plus every pre-existing case (the `MtuEnvTest`
   `MC_MTU` tests still pass unchanged).
3. **Compile check of every modified translation unit** —
   `config.cpp`, `transfer_metadata.cpp`, `rdma_endpoint.cpp`,
   `ctrl_channel.cpp`, `config_test.cpp`, `transfer_metadata_test.cpp`,
   `rdma_endpoint_reestablish_test.cpp` — with
   `g++ -fsyntax-only -std=c++20`: 0 errors each.
4. **Formatting.** `clang-format --style=file:.clang-format` reports no
   remaining diff on the lines this change touches.
   (`tests/rdma_endpoint_reestablish_test.cpp` has pre-existing deviations
   elsewhere in the file; per `CONTRIBUTING.md` the hook only formats changed
   lines, so those were left alone.)

`tests/transfer_metadata_test.cpp` could not be executed here — it pulls in the
full metadata/RPC stack. The assertions added there only exercise the JSON
encode/decode path, which is the same code the compile check covers.