### PR TITLE
[Conductor] conductor: prefix index types and hash strategy

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -18,4 +18,8 @@ extend-exclude = [
   # DeepEP-derived elastic kernel headers keep upstream identifiers such as
   # `ue8m0x4`; exclude the imported header block from spelling checks.
   "mooncake-ep/include/elastic/*",
+  # Conductor hash golden vectors are generated digests and pickle byte
+  # dumps; hex runs collide with dictionary words. The generator scripts
+  # stay checked.
+  "mooncake-conductor/tests/fixtures/*.json",
 ]

--- a/mooncake-conductor/CMakeLists.txt
+++ b/mooncake-conductor/CMakeLists.txt
@@ -13,8 +13,10 @@ if(NOT GLOBAL_CONFIG)
 endif()
 
 find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED COMPONENTS Crypto)
 
-add_library(conductor_cpp_core STATIC src/common/utils.cpp)
+add_library(conductor_cpp_core STATIC src/common/utils.cpp
+                                      src/prefixindex/hash_strategy.cpp)
 
 # mooncake-common headers are consumed directly instead of linking
 # mooncake_common: the helpers conductor needs (ascii_string.h,
@@ -26,8 +28,40 @@ target_include_directories(
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
          ${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-common/include)
 
-target_link_libraries(conductor_cpp_core PUBLIC glog::glog JsonCpp::JsonCpp
-                                                Threads::Threads)
+target_link_libraries(
+  conductor_cpp_core PUBLIC OpenSSL::Crypto glog::glog JsonCpp::JsonCpp
+                            Threads::Threads)
+
+# The /query hash chain prefers the low-level SHA256_* API, which hashes through
+# a stack context instead of allocating an EVP context per call. Those
+# declarations are hidden in OpenSSL no-deprecated builds, so probe for them and
+# fall back to the EVP backend when unavailable. FIPS deployments should force
+# the EVP path explicitly with -DCONDUCTOR_FORCE_EVP_SHA256=ON.
+option(CONDUCTOR_FORCE_EVP_SHA256 "Force the EVP SHA-256 backend (e.g. FIPS)"
+       OFF)
+if(NOT CONDUCTOR_FORCE_EVP_SHA256)
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+  set(CMAKE_REQUIRED_LIBRARIES OpenSSL::Crypto)
+  check_cxx_source_compiles(
+    "
+    #define OPENSSL_SUPPRESS_DEPRECATED
+    #include <openssl/sha.h>
+    int main() { SHA256_CTX c; return SHA256_Init(&c); }
+  "
+    CONDUCTOR_HAS_LOWLEVEL_SHA256)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+if(CONDUCTOR_HAS_LOWLEVEL_SHA256)
+  target_compile_definitions(conductor_cpp_core
+                             PRIVATE CONDUCTOR_HAS_LOWLEVEL_SHA256=1)
+  message(STATUS "conductor: SHA-256 backend = low-level SHA256_*")
+else()
+  message(
+    STATUS
+      "conductor: SHA-256 backend = EVP (low-level API unavailable or forced)")
+endif()
 
 if(BUILD_UNIT_TESTS)
   enable_testing()

--- a/mooncake-conductor/include/conductor/prefixindex/hash_strategy.h
+++ b/mooncake-conductor/include/conductor/prefixindex/hash_strategy.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "conductor/prefixindex/types.h"
+
+namespace mooncake::conductor::prefixindex {
+
+struct HashBlock {
+    std::array<uint8_t, 32> digest{};
+    ProjectedPrefix projected;
+
+    bool operator==(const HashBlock&) const = default;
+};
+
+// A lazily-evaluated block-hash chain. Blocks are hashed on demand: asking
+// for block i hashes (and caches) every block up to i, so a caller that
+// stops early — e.g. a prefix-index walk whose cursors have all stalled —
+// never pays for the untouched tail.
+class HashChain {
+   public:
+    virtual ~HashChain() = default;
+
+    // Number of logical blocks the chain can produce. The SGLang strategies
+    // include their final partial block; vLLM keeps its complete-block rule.
+    virtual size_t BlockCount() const = 0;
+
+    // Number of blocks hashed so far (observability/testing hook).
+    virtual size_t ComputedCount() const = 0;
+
+    // Returns block index, hashing any uncomputed prefix first. Returns
+    // nullptr and sets error on failure; the error is sticky across calls.
+    virtual const HashBlock* At(size_t index, std::string* error) = 0;
+};
+
+class HashStrategy {
+   public:
+    virtual ~HashStrategy() = default;
+
+    // Computes hashes for the blocks defined by the selected engine strategy.
+    // Returns an empty string on success and leaves out empty on failure.
+    virtual std::string Compute(const ContextKey& context,
+                                std::span<const int32_t> token_ids,
+                                std::optional<std::string> cache_salt,
+                                std::vector<HashBlock>* out) const = 0;
+
+    // Creates a lazy hash chain over the same inputs as Compute. The chain
+    // borrows token_ids; the caller must keep it alive for the chain's
+    // lifetime. Returns nullptr and sets error when the inputs are invalid.
+    virtual std::unique_ptr<HashChain> CreateChain(
+        const ContextKey& context, std::span<const int32_t> token_ids,
+        std::optional<std::string> cache_salt, std::string* error) const = 0;
+};
+
+// Resolves a supported source profile and derives its root digest. Returns an
+// empty string on success.
+std::string ResolveHashProfile(const common::HashProfileConfig& config,
+                               HashProfile* out);
+
+// Returns an empty string when the resolved profile is supported, well formed,
+// and its root digest matches a fresh derivation from python_hash_seed.
+std::string ValidateHashProfile(const HashProfile& profile);
+
+// Returns nullptr and sets error when the resolved profile shape is invalid or
+// unsupported. This consumes the derived root without hashing the seed again.
+std::unique_ptr<HashStrategy> CreateHashStrategy(const HashProfile& profile,
+                                                 std::string* error);
+
+std::string DigestToHex(const std::array<uint8_t, 32>& digest);
+
+}  // namespace mooncake::conductor::prefixindex

--- a/mooncake-conductor/include/conductor/prefixindex/types.h
+++ b/mooncake-conductor/include/conductor/prefixindex/types.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "conductor/common/types.h"
+
+namespace mooncake::conductor::prefixindex {
+
+struct ContextKey {
+    std::string tenant_id;
+    std::string model_name;
+    std::string lora_name;
+    int64_t block_size = 0;
+
+    bool operator==(const ContextKey&) const = default;
+};
+
+using HashProfile = common::ResolvedHashProfile;
+
+struct ProjectedPrefix {
+    uint64_t value = 0;
+
+    auto operator<=>(const ProjectedPrefix&) const = default;
+};
+
+enum class StorageTier { kGpu, kCpu, kDisk };
+
+struct EngineOwner {
+    std::string source_stream;
+    std::string instance_id;
+    int64_t dp_rank = 0;
+
+    auto operator<=>(const EngineOwner&) const = default;
+};
+
+struct SharedObjectOwner {
+    std::string source_stream;
+    std::string backend_id;
+    std::string object_id;
+
+    auto operator<=>(const SharedObjectOwner&) const = default;
+};
+
+struct EngineRegistration {
+    ContextKey context;
+    HashProfile profile;
+    std::string instance_id;
+    int64_t dp_rank = 0;
+    int64_t effective_block_size = 0;
+    std::optional<int64_t> cache_group;
+};
+
+struct GpuMutation {
+    ContextKey context;
+    std::vector<ProjectedPrefix> prefixes;
+    EngineOwner owner;
+    int64_t effective_block_size = 0;
+    std::optional<int64_t> cache_group;
+};
+
+struct SharedMutation {
+    ContextKey context;
+    std::vector<ProjectedPrefix> prefixes;
+    StorageTier tier = StorageTier::kCpu;
+    SharedObjectOwner owner;
+    int64_t effective_block_size = 0;
+    std::optional<int64_t> cache_group;
+};
+
+struct GpuClear {
+    ContextKey context;
+    EngineOwner owner;
+    int64_t effective_block_size = 0;
+    std::optional<int64_t> cache_group;
+};
+
+struct SharedClear {
+    ContextKey context;
+    SharedObjectOwner owner;
+    std::optional<StorageTier> tier;
+    int64_t effective_block_size = 0;
+    std::optional<int64_t> cache_group;
+};
+
+}  // namespace mooncake::conductor::prefixindex
+
+template <>
+struct std::hash<mooncake::conductor::prefixindex::ContextKey> {
+    size_t operator()(const mooncake::conductor::prefixindex::ContextKey&
+                          context) const noexcept {
+        size_t seed = 0;
+        auto combine = [&seed](size_t value) {
+            seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+        };
+        combine(std::hash<std::string>{}(context.tenant_id));
+        combine(std::hash<std::string>{}(context.model_name));
+        combine(std::hash<std::string>{}(context.lora_name));
+        combine(std::hash<int64_t>{}(context.block_size));
+        return seed;
+    }
+};
+
+template <>
+struct std::hash<mooncake::conductor::prefixindex::ProjectedPrefix> {
+    size_t operator()(mooncake::conductor::prefixindex::ProjectedPrefix prefix)
+        const noexcept {
+        return std::hash<uint64_t>{}(prefix.value);
+    }
+};

--- a/mooncake-conductor/src/prefixindex/hash_strategy.cpp
+++ b/mooncake-conductor/src/prefixindex/hash_strategy.cpp
@@ -1,0 +1,1151 @@
+#include "conductor/prefixindex/hash_strategy.h"
+
+// Two SHA-256 backends, selected by CONDUCTOR_HAS_LOWLEVEL_SHA256 (probed by
+// CMake).  The low-level SHA256_* API hashes through a stack context, so it
+// skips the per-call EVP context allocation and provider lookup; its
+// declarations are hidden in OpenSSL no-deprecated builds and it bypasses the
+// provider framework FIPS requires, hence the EVP fallback.  Both backends
+// dispatch to the same OpenSSL implementation and produce byte-identical
+// digests.
+#if CONDUCTOR_HAS_LOWLEVEL_SHA256
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
+#else
+#include <openssl/evp.h>
+#endif
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include "integer_parser.h"
+
+namespace mooncake::conductor::prefixindex {
+
+namespace {
+
+constexpr size_t kSha256DigestSize = 32;
+constexpr uint64_t kMaxPythonHashSeed = std::numeric_limits<uint32_t>::max();
+
+// ---------------------------------------------------------------------------
+// Recipe boundary
+//
+// The vLLM v1 chain (complete-block selection, full-32-byte parent
+// advancement, SHA-256 digesting, and the low64_be projection) is shared by
+// every supported algorithm.  Each algorithm name selects exactly one value
+// codec that owns serialization of the seed root and of each
+// (parent, token tuple, extra keys) block value.  The codec receives the
+// already-computed extra-key ordering (non-empty LoRA on every block,
+// non-empty cache salt after LoRA only on the first block) and never sees
+// value shapes outside the Conductor query contract.
+//
+// Multimodal and prompt-embedding vLLM extra keys are deliberately NOT
+// representable here: the Conductor query API cannot express them, so the
+// codecs reject that shape by construction instead of approximating it.
+// ---------------------------------------------------------------------------
+
+struct VllmBlockValues {
+    std::span<const uint8_t> parent_digest;  // full 32-byte parent digest
+    std::span<const int32_t> token_ids;      // exactly one complete block
+    const std::string* lora_name;            // nullptr when no LoRA extra key
+    const std::string* cache_salt;           // nullptr when no salt extra key
+};
+
+class VllmValueCodec {
+   public:
+    virtual ~VllmValueCodec() = default;
+
+    virtual void EncodeSeed(std::string_view seed,
+                            std::vector<uint8_t>* out) const = 0;
+    virtual void EncodeBlock(const VllmBlockValues& values,
+                             std::vector<uint8_t>* out) const = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Canonical-CBOR codec (sha256_cbor)
+// ---------------------------------------------------------------------------
+
+void AppendTypeAndLength(uint8_t major_type, uint64_t value,
+                         std::vector<uint8_t>* out) {
+    const uint8_t initial = static_cast<uint8_t>(major_type << 5);
+    if (value < 24) {
+        out->push_back(static_cast<uint8_t>(initial | value));
+        return;
+    }
+    if (value <= std::numeric_limits<uint8_t>::max()) {
+        out->push_back(static_cast<uint8_t>(initial | 24));
+        out->push_back(static_cast<uint8_t>(value));
+        return;
+    }
+    if (value <= std::numeric_limits<uint16_t>::max()) {
+        out->push_back(static_cast<uint8_t>(initial | 25));
+        for (int shift = 8; shift >= 0; shift -= 8) {
+            out->push_back(static_cast<uint8_t>(value >> shift));
+        }
+        return;
+    }
+    if (value <= std::numeric_limits<uint32_t>::max()) {
+        out->push_back(static_cast<uint8_t>(initial | 26));
+        for (int shift = 24; shift >= 0; shift -= 8) {
+            out->push_back(static_cast<uint8_t>(value >> shift));
+        }
+        return;
+    }
+
+    out->push_back(static_cast<uint8_t>(initial | 27));
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        out->push_back(static_cast<uint8_t>(value >> shift));
+    }
+}
+
+void AppendArrayHeader(size_t size, std::vector<uint8_t>* out) {
+    AppendTypeAndLength(4, static_cast<uint64_t>(size), out);
+}
+
+void AppendBytes(std::span<const uint8_t> value, std::vector<uint8_t>* out) {
+    AppendTypeAndLength(2, static_cast<uint64_t>(value.size()), out);
+    out->insert(out->end(), value.begin(), value.end());
+}
+
+void AppendText(std::string_view value, std::vector<uint8_t>* out) {
+    AppendTypeAndLength(3, static_cast<uint64_t>(value.size()), out);
+    out->insert(out->end(), value.begin(), value.end());
+}
+
+void AppendSignedInteger(int32_t value, std::vector<uint8_t>* out) {
+    if (value >= 0) {
+        AppendTypeAndLength(0, static_cast<uint64_t>(value), out);
+        return;
+    }
+    const int64_t signed_value = value;
+    AppendTypeAndLength(1, static_cast<uint64_t>(-1 - signed_value), out);
+}
+
+class CborVllmCodec final : public VllmValueCodec {
+   public:
+    void EncodeSeed(std::string_view seed,
+                    std::vector<uint8_t>* out) const override {
+        out->clear();
+        AppendText(seed, out);
+    }
+
+    void EncodeBlock(const VllmBlockValues& values,
+                     std::vector<uint8_t>* out) const override {
+        out->clear();
+        AppendArrayHeader(3, out);
+        AppendBytes(values.parent_digest, out);
+
+        AppendArrayHeader(values.token_ids.size(), out);
+        for (const int32_t token : values.token_ids) {
+            AppendSignedInteger(token, out);
+        }
+
+        const bool has_lora = values.lora_name != nullptr;
+        const bool has_salt = values.cache_salt != nullptr;
+        if (!has_lora && !has_salt) {
+            out->push_back(0xf6U);
+        } else {
+            AppendArrayHeader(
+                static_cast<size_t>(has_lora) + static_cast<size_t>(has_salt),
+                out);
+            if (has_lora) {
+                AppendText(*values.lora_name, out);
+            }
+            if (has_salt) {
+                AppendText(*values.cache_salt, out);
+            }
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// CPython Pickle protocol-5 codec (sha256)
+//
+// Restricted encoder for the value types the Conductor query contract can
+// express: UTF-8 seed strings, full parent bytes, signed int32 token IDs,
+// None, tuple containers, and LoRA/cache-salt strings.  It reproduces the
+// CPython pickler byte-for-byte for those shapes:
+//   * \x80\x05 protocol header and protocol-4+ framing (frames committed at
+//     the start of every object save once the pending frame reaches 64 KiB,
+//     and one final forced frame before/around STOP);
+//   * SHORT_BINUNICODE/BINUNICODE/BINUNICODE8 and SHORT_BINBYTES/BINBYTES/
+//     BINBYTES8 length thresholds;
+//   * BININT1/BININT2/BININT integer thresholds;
+//   * EMPTY_TUPLE/TUPLE1/TUPLE2/TUPLE3/MARK+TUPLE arity opcodes;
+//   * MEMOIZE markers after every non-empty bytes/str/tuple object;
+//   * the \x2e STOP terminator inside the final frame.
+//
+// Values are always emitted fresh (no BINGET back-references).  That matches
+// CPython whenever the memoized objects are distinct, which is the only case
+// the Conductor contract can produce; Python object-identity aliasing between
+// equal strings is an explicitly unsupported shape, as are multimodal and
+// prompt-embedding extra-key object graphs.
+// ---------------------------------------------------------------------------
+
+constexpr uint8_t kPickleMark = 0x28;             // MARK
+constexpr uint8_t kPickleStop = 0x2e;             // STOP
+constexpr uint8_t kPickleEmptyTuple = 0x29;       // EMPTY_TUPLE
+constexpr uint8_t kPickleBinbytes = 0x42;         // BINBYTES
+constexpr uint8_t kPickleShortBinbytes = 0x43;    // SHORT_BINBYTES
+constexpr uint8_t kPickleBinint = 0x4a;           // BININT
+constexpr uint8_t kPickleBinint1 = 0x4b;          // BININT1
+constexpr uint8_t kPickleBinint2 = 0x4d;          // BININT2
+constexpr uint8_t kPickleNone = 0x4e;             // NONE
+constexpr uint8_t kPickleBinunicode = 0x58;       // BINUNICODE
+constexpr uint8_t kPickleTuple = 0x74;            // TUPLE
+constexpr uint8_t kPickleProto = 0x80;            // PROTO
+constexpr uint8_t kPickleTuple1 = 0x85;           // TUPLE1
+constexpr uint8_t kPickleTuple2 = 0x86;           // TUPLE2
+constexpr uint8_t kPickleTuple3 = 0x87;           // TUPLE3
+constexpr uint8_t kPickleShortBinunicode = 0x8c;  // SHORT_BINUNICODE
+constexpr uint8_t kPickleBinunicode8 = 0x8d;      // BINUNICODE8
+constexpr uint8_t kPickleBinbytes8 = 0x8e;        // BINBYTES8
+constexpr uint8_t kPickleMemoize = 0x94;          // MEMOIZE
+constexpr uint8_t kPickleFrame = 0x95;            // FRAME
+constexpr uint8_t kPickleProtocol5 = 0x05;
+
+// CPython _Framer._FRAME_SIZE_TARGET: a pending frame is committed before the
+// next object save once it reaches this size.
+constexpr size_t kPickleFrameTarget = 64 * 1024;
+
+// Emulates CPython's protocol-4+ _Framer: object bytes accumulate in
+// frame_bytes_; Checkpoint() flushes a full frame at the start of each object
+// save, and Finish() emits the final forced frame.
+class PickleStream {
+   public:
+    // Bytes written before framing starts (the protocol header).
+    void WriteRaw(uint8_t value) { out_.push_back(value); }
+
+    void Write(uint8_t value) { frame_.push_back(value); }
+
+    void Write(std::span<const uint8_t> bytes) {
+        frame_.insert(frame_.end(), bytes.begin(), bytes.end());
+    }
+
+    // Mirrors _Framer.commit_frame() at the start of Pickler.save().
+    void Checkpoint() {
+        if (frame_.size() >= kPickleFrameTarget) {
+            FlushFrame();
+        }
+    }
+
+    // Mirrors _Framer.write_large_bytes: the current frame is force-committed
+    // and the large payload is written with its length header but without a
+    // frame opcode.  `header` is the already-packed little-endian length.
+    void WriteLargePayload(uint8_t opcode, std::span<const uint8_t> header,
+                           std::span<const uint8_t> payload) {
+        FlushFrame();
+        out_.push_back(opcode);
+        out_.insert(out_.end(), header.begin(), header.end());
+        out_.insert(out_.end(), payload.begin(), payload.end());
+    }
+
+    // Mirrors _Framer.end_framing(): force-commit whatever remains.
+    void Finish() { FlushFrame(); }
+
+    const std::vector<uint8_t>& bytes() const { return out_; }
+
+   private:
+    void FlushFrame() {
+        if (frame_.empty()) {
+            return;
+        }
+        out_.push_back(kPickleFrame);
+        AppendLittleEndian(static_cast<uint64_t>(frame_.size()), &out_);
+        out_.insert(out_.end(), frame_.begin(), frame_.end());
+        frame_.clear();
+    }
+
+    static void AppendLittleEndian(uint64_t value, std::vector<uint8_t>* out) {
+        for (int shift = 0; shift < 64; shift += 8) {
+            out->push_back(static_cast<uint8_t>(value >> shift));
+        }
+    }
+
+    std::vector<uint8_t> out_;
+    std::vector<uint8_t> frame_;
+};
+
+void PickleAppendLittleEndian(uint64_t value, size_t byte_count,
+                              std::vector<uint8_t>* out) {
+    for (size_t index = 0; index < byte_count; ++index) {
+        out->push_back(static_cast<uint8_t>(value >> (index * 8)));
+    }
+}
+
+void PickleEncodeBytes(std::span<const uint8_t> value, PickleStream* stream) {
+    const uint64_t length = value.size();
+    if (length <= 0xffU) {
+        stream->Write(kPickleShortBinbytes);
+        stream->Write(static_cast<uint8_t>(length));
+        stream->Write(value);
+    } else if (length > std::numeric_limits<uint32_t>::max()) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 8, &header);
+        stream->WriteLargePayload(kPickleBinbytes8, header, value);
+    } else if (length >= kPickleFrameTarget) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 4, &header);
+        stream->WriteLargePayload(kPickleBinbytes, header, value);
+    } else {
+        stream->Write(kPickleBinbytes);
+        for (int shift = 0; shift < 32; shift += 8) {
+            stream->Write(static_cast<uint8_t>(length >> shift));
+        }
+        stream->Write(value);
+    }
+    stream->Write(kPickleMemoize);
+}
+
+void PickleEncodeString(std::string_view value, PickleStream* stream) {
+    const auto* bytes = reinterpret_cast<const uint8_t*>(value.data());
+    const std::span<const uint8_t> encoded(bytes, value.size());
+    const uint64_t length = encoded.size();
+    if (length <= 0xffU) {
+        stream->Write(kPickleShortBinunicode);
+        stream->Write(static_cast<uint8_t>(length));
+        stream->Write(encoded);
+    } else if (length > std::numeric_limits<uint32_t>::max()) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 8, &header);
+        stream->WriteLargePayload(kPickleBinunicode8, header, encoded);
+    } else if (length >= kPickleFrameTarget) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 4, &header);
+        stream->WriteLargePayload(kPickleBinunicode, header, encoded);
+    } else {
+        stream->Write(kPickleBinunicode);
+        for (int shift = 0; shift < 32; shift += 8) {
+            stream->Write(static_cast<uint8_t>(length >> shift));
+        }
+        stream->Write(encoded);
+    }
+    stream->Write(kPickleMemoize);
+}
+
+void PickleEncodeInt(int32_t value, PickleStream* stream) {
+    if (value >= 0 && value <= 0xff) {
+        stream->Write(kPickleBinint1);
+        stream->Write(static_cast<uint8_t>(value));
+        return;
+    }
+    if (value >= 0 && value <= 0xffff) {
+        stream->Write(kPickleBinint2);
+        const uint16_t narrow = static_cast<uint16_t>(value);
+        stream->Write(static_cast<uint8_t>(narrow));
+        stream->Write(static_cast<uint8_t>(narrow >> 8));
+        return;
+    }
+    stream->Write(kPickleBinint);
+    const uint32_t bits = static_cast<uint32_t>(value);
+    for (int shift = 0; shift < 32; shift += 8) {
+        stream->Write(static_cast<uint8_t>(bits >> shift));
+    }
+}
+
+// Encodes the token tuple: per-element save checkpoints, the CPython tuple
+// arity opcodes, and the trailing MEMOIZE marker for non-empty tuples.
+void PickleEncodeTokenTuple(std::span<const int32_t> tokens,
+                            PickleStream* stream) {
+    if (tokens.empty()) {
+        stream->Write(kPickleEmptyTuple);
+        return;
+    }
+    if (tokens.size() > 3) {
+        stream->Write(kPickleMark);
+    }
+    for (const int32_t token : tokens) {
+        stream->Checkpoint();
+        PickleEncodeInt(token, stream);
+    }
+    switch (tokens.size()) {
+        case 1:
+            stream->Write(kPickleTuple1);
+            break;
+        case 2:
+            stream->Write(kPickleTuple2);
+            break;
+        case 3:
+            stream->Write(kPickleTuple3);
+            break;
+        default:
+            stream->Write(kPickleTuple);
+            break;
+    }
+    stream->Write(kPickleMemoize);
+}
+
+// Encodes the extras slot: Python None when there are no extra keys,
+// otherwise the (LoRA, salt) string tuple in vLLM's ordering.  The caller
+// must have executed the save-entry checkpoint for this value already.
+void PickleEncodeExtras(const VllmBlockValues& values, PickleStream* stream) {
+    const bool has_lora = values.lora_name != nullptr;
+    const bool has_salt = values.cache_salt != nullptr;
+    if (!has_lora && !has_salt) {
+        stream->Write(kPickleNone);
+        return;
+    }
+    if (has_lora) {
+        stream->Checkpoint();
+        PickleEncodeString(*values.lora_name, stream);
+    }
+    if (has_salt) {
+        stream->Checkpoint();
+        PickleEncodeString(*values.cache_salt, stream);
+    }
+    stream->Write(has_lora && has_salt ? kPickleTuple2 : kPickleTuple1);
+    stream->Write(kPickleMemoize);
+}
+
+class PickleVllmCodec final : public VllmValueCodec {
+   public:
+    void EncodeSeed(std::string_view seed,
+                    std::vector<uint8_t>* out) const override {
+        PickleStream stream;
+        stream.WriteRaw(kPickleProto);
+        stream.WriteRaw(kPickleProtocol5);
+        stream.Checkpoint();
+        PickleEncodeString(seed, &stream);
+        stream.Write(kPickleStop);
+        stream.Finish();
+        *out = stream.bytes();
+    }
+
+    void EncodeBlock(const VllmBlockValues& values,
+                     std::vector<uint8_t>* out) const override {
+        PickleStream stream;
+        stream.WriteRaw(kPickleProto);
+        stream.WriteRaw(kPickleProtocol5);
+
+        // Outer (parent, tokens, extras) tuple: TUPLE3.  Each Checkpoint()
+        // mirrors Pickler.save() entry for the corresponding value.
+        stream.Checkpoint();  // save((parent, tokens, extras))
+        stream.Checkpoint();  // save(parent bytes)
+        PickleEncodeBytes(values.parent_digest, &stream);
+        stream.Checkpoint();  // save(token tuple)
+        PickleEncodeTokenTuple(values.token_ids, &stream);
+        stream.Checkpoint();  // save(extras)
+        PickleEncodeExtras(values, &stream);
+        stream.Write(kPickleTuple3);
+        stream.Write(kPickleMemoize);
+
+        stream.Write(kPickleStop);
+        stream.Finish();
+        *out = stream.bytes();
+    }
+};
+
+const VllmValueCodec* CodecForAlgorithm(std::string_view algorithm) {
+    static const CborVllmCodec kCborCodec;
+    static const PickleVllmCodec kPickleCodec;
+    if (algorithm == "sha256_cbor") {
+        return &kCborCodec;
+    }
+    if (algorithm == "sha256") {
+        return &kPickleCodec;
+    }
+    return nullptr;
+}
+
+bool IsContinuationByte(uint8_t value) { return (value & 0xc0U) == 0x80U; }
+
+bool IsValidUtf8(std::string_view value) {
+    const auto* bytes = reinterpret_cast<const uint8_t*>(value.data());
+    size_t index = 0;
+    while (index < value.size()) {
+        const uint8_t first = bytes[index];
+        if (first <= 0x7fU) {
+            ++index;
+            continue;
+        }
+
+        if (first >= 0xc2U && first <= 0xdfU) {
+            if (index + 1 >= value.size() ||
+                !IsContinuationByte(bytes[index + 1])) {
+                return false;
+            }
+            index += 2;
+            continue;
+        }
+
+        if (first >= 0xe0U && first <= 0xefU) {
+            if (index + 2 >= value.size() ||
+                !IsContinuationByte(bytes[index + 1]) ||
+                !IsContinuationByte(bytes[index + 2])) {
+                return false;
+            }
+            if ((first == 0xe0U && bytes[index + 1] < 0xa0U) ||
+                (first == 0xedU && bytes[index + 1] > 0x9fU)) {
+                return false;
+            }
+            index += 3;
+            continue;
+        }
+
+        if (first >= 0xf0U && first <= 0xf4U) {
+            if (index + 3 >= value.size() ||
+                !IsContinuationByte(bytes[index + 1]) ||
+                !IsContinuationByte(bytes[index + 2]) ||
+                !IsContinuationByte(bytes[index + 3])) {
+                return false;
+            }
+            if ((first == 0xf0U && bytes[index + 1] < 0x90U) ||
+                (first == 0xf4U && bytes[index + 1] > 0x8fU)) {
+                return false;
+            }
+            index += 4;
+            continue;
+        }
+
+        return false;
+    }
+    return true;
+}
+
+#if CONDUCTOR_HAS_LOWLEVEL_SHA256
+
+std::string Sha256(std::span<const uint8_t> input,
+                   std::array<uint8_t, kSha256DigestSize>* digest) {
+    SHA256_CTX context;
+    if (SHA256_Init(&context) != 1 ||
+        SHA256_Update(&context, input.data(), input.size()) != 1 ||
+        SHA256_Final(digest->data(), &context) != 1) {
+        return "OpenSSL SHA-256 computation failed";
+    }
+    return "";
+}
+
+#else  // EVP backend: no-deprecated builds and FIPS-forced configurations.
+
+std::string Sha256(std::span<const uint8_t> input,
+                   std::array<uint8_t, kSha256DigestSize>* digest) {
+    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+    EvpContext context(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    if (!context ||
+        EVP_DigestInit_ex(context.get(), EVP_sha256(), nullptr) != 1 ||
+        EVP_DigestUpdate(context.get(), input.data(), input.size()) != 1) {
+        return "OpenSSL EVP SHA-256 initialization failed";
+    }
+
+    unsigned int digest_size = 0;
+    if (EVP_DigestFinal_ex(context.get(), digest->data(), &digest_size) != 1 ||
+        digest_size != digest->size()) {
+        return "OpenSSL EVP SHA-256 finalization failed";
+    }
+    return "";
+}
+
+// Same as Sha256 but reuses a caller-owned context across invocations,
+// avoiding an EVP_MD_CTX allocation per hashed block in long hash chains.
+std::string Sha256Reuse(EVP_MD_CTX* context, std::span<const uint8_t> input,
+                        std::array<uint8_t, kSha256DigestSize>* digest) {
+    if (EVP_MD_CTX_reset(context) != 1 ||
+        EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1 ||
+        EVP_DigestUpdate(context, input.data(), input.size()) != 1) {
+        return "OpenSSL EVP SHA-256 initialization failed";
+    }
+
+    unsigned int digest_size = 0;
+    if (EVP_DigestFinal_ex(context, digest->data(), &digest_size) != 1 ||
+        digest_size != digest->size()) {
+        return "OpenSSL EVP SHA-256 finalization failed";
+    }
+    return "";
+}
+
+#endif
+
+int LowerHexValue(char value) {
+    if (value >= '0' && value <= '9') {
+        return value - '0';
+    }
+    if (value >= 'a' && value <= 'f') {
+        return value - 'a' + 10;
+    }
+    return -1;
+}
+
+std::string ValidateProfileSelectors(std::string_view strategy,
+                                     std::string_view algorithm,
+                                     std::string_view index_projection) {
+    if (strategy != "vllm_v1" && strategy != "sglang" &&
+        strategy != "sglang_bigram") {
+        return "unsupported hash strategy: " + std::string(strategy);
+    }
+    if (strategy == "sglang" || strategy == "sglang_bigram") {
+        if (algorithm != "sha256_raw") {
+            return "unsupported SGLang hash algorithm: " +
+                   std::string(algorithm);
+        }
+        if (index_projection != "first64_be") {
+            return "unsupported SGLang index projection: " +
+                   std::string(index_projection);
+        }
+        return "";
+    }
+    if (algorithm != "sha256" && algorithm != "sha256_cbor") {
+        return "unsupported hash algorithm: " + std::string(algorithm);
+    }
+    if (index_projection != "low64_be") {
+        return "unsupported index projection: " + std::string(index_projection);
+    }
+    return "";
+}
+
+std::string ValidatePythonHashSeed(std::string_view seed) {
+    if (!IsValidUtf8(seed)) {
+        return "python_hash_seed must contain valid UTF-8";
+    }
+    if (seed == "random") {
+        return "";
+    }
+    if (seed.empty()) {
+        return "python_hash_seed must be \"random\" or ASCII decimal text in "
+               "0..4294967295";
+    }
+
+    // Accepts only bare ASCII decimal digits: the default options reject a
+    // leading sign, surrounding whitespace, and trailing characters.  Parsing
+    // into uint64 keeps the range check separate from the well-formedness
+    // check, so a numeric seed past the uint32 ceiling reports the range
+    // error.
+    const auto value = TryParseInteger<uint64_t>(seed);
+    if (!value.has_value()) {
+        return "python_hash_seed must be \"random\" or ASCII decimal text in "
+               "0..4294967295";
+    }
+    if (*value > kMaxPythonHashSeed) {
+        return "python_hash_seed must be in range 0..4294967295";
+    }
+    return "";
+}
+
+std::string ValidateRootDigest(std::string_view root_digest) {
+    if (root_digest.size() != kSha256DigestSize * 2) {
+        return "root_digest must contain exactly 64 lowercase hex characters";
+    }
+    for (const char value : root_digest) {
+        if (LowerHexValue(value) < 0) {
+            return "root_digest must contain exactly 64 lowercase hex "
+                   "characters";
+        }
+    }
+    return "";
+}
+
+std::string ValidateResolvedHashProfileShape(const HashProfile& profile) {
+    if (auto error = ValidateProfileSelectors(
+            profile.strategy, profile.algorithm, profile.index_projection);
+        !error.empty()) {
+        return error;
+    }
+    if (profile.strategy == "vllm_v1") {
+        if (auto error = ValidatePythonHashSeed(profile.python_hash_seed);
+            !error.empty()) {
+            return error;
+        }
+    }
+    return ValidateRootDigest(profile.root_digest);
+}
+
+std::array<uint8_t, kSha256DigestSize> DecodeRootDigest(
+    std::string_view root_digest) {
+    std::array<uint8_t, kSha256DigestSize> result{};
+    for (size_t index = 0; index < result.size(); ++index) {
+        const int high = LowerHexValue(root_digest[index * 2]);
+        const int low = LowerHexValue(root_digest[index * 2 + 1]);
+        result[index] = static_cast<uint8_t>((high << 4) | low);
+    }
+    return result;
+}
+
+ProjectedPrefix ProjectDigest(
+    const std::array<uint8_t, kSha256DigestSize>& digest) {
+    uint64_t value = 0;
+    for (size_t index = digest.size() - sizeof(value); index < digest.size();
+         ++index) {
+        value = (value << 8) | digest[index];
+    }
+    return ProjectedPrefix{value};
+}
+
+// Lazily-hashed vLLM v1 block chain. Hashing is incremental: block i is
+// computed only when first requested via At(), and every block up to i is
+// cached, so prefix-index walks that stall early never hash the tail.
+class VllmV1HashChain final : public HashChain {
+   public:
+    VllmV1HashChain(const VllmValueCodec* codec,
+                    std::array<uint8_t, kSha256DigestSize> root_digest,
+                    const ContextKey& context,
+                    std::span<const int32_t> token_ids,
+                    std::optional<std::string> cache_salt)
+        : codec_(codec),
+          parent_(std::move(root_digest)),
+          lora_name_(context.lora_name),
+          cache_salt_(std::move(cache_salt)),
+          token_ids_(token_ids),
+          block_size_(static_cast<size_t>(context.block_size)),
+          block_count_(token_ids.size() / block_size_) {
+        computed_.reserve(block_count_);
+        // Reused across blocks: every codec clears the buffer at the start of
+        // EncodeBlock, so reserving worst-case capacity once keeps the whole
+        // chain on a single allocation instead of one per block.
+        encoded_.reserve(64 + block_size_ * 9);
+    }
+
+    // Validates inputs eagerly (same contract as Compute). Returns an empty
+    // string on success.
+    static std::string ValidateInputs(const ContextKey& context,
+                                      std::optional<std::string> cache_salt) {
+        if (context.block_size <= 0 ||
+            static_cast<uint64_t>(context.block_size) >
+                std::numeric_limits<size_t>::max()) {
+            return "block_size must be a positive size_t value";
+        }
+        if (!IsValidUtf8(context.lora_name)) {
+            return "lora_name must contain valid UTF-8";
+        }
+        if (cache_salt.has_value() && !IsValidUtf8(*cache_salt)) {
+            return "cache_salt must contain valid UTF-8";
+        }
+        return "";
+    }
+
+    size_t BlockCount() const override { return block_count_; }
+
+    size_t ComputedCount() const override { return computed_.size(); }
+
+    const HashBlock* At(size_t index, std::string* error) override {
+        if (index >= block_count_) {
+            if (error != nullptr) {
+                *error = "hash chain index out of range";
+            }
+            return nullptr;
+        }
+        if (!sticky_error_.empty()) {
+            if (error != nullptr) {
+                *error = sticky_error_;
+            }
+            return nullptr;
+        }
+#if !CONDUCTOR_HAS_LOWLEVEL_SHA256
+        if (!EnsureEvp()) {
+            if (error != nullptr) {
+                *error = sticky_error_;
+            }
+            return nullptr;
+        }
+#endif
+        while (computed_.size() <= index) {
+            const size_t block_index = computed_.size();
+            const bool has_lora = !lora_name_.empty();
+            const bool has_salt = block_index == 0 && cache_salt_.has_value() &&
+                                  !cache_salt_->empty();
+            const VllmBlockValues values{
+                .parent_digest = parent_,
+                .token_ids =
+                    token_ids_.subspan(block_index * block_size_, block_size_),
+                .lora_name = has_lora ? &lora_name_ : nullptr,
+                .cache_salt = has_salt ? &*cache_salt_ : nullptr,
+            };
+
+            codec_->EncodeBlock(values, &encoded_);
+
+            HashBlock block;
+#if CONDUCTOR_HAS_LOWLEVEL_SHA256
+            std::string hash_error = Sha256(encoded_, &block.digest);
+#else
+            std::string hash_error =
+                Sha256Reuse(evp_.get(), encoded_, &block.digest);
+#endif
+            if (!hash_error.empty()) {
+                sticky_error_ = std::move(hash_error);
+                if (error != nullptr) {
+                    *error = sticky_error_;
+                }
+                return nullptr;
+            }
+            block.projected = ProjectDigest(block.digest);
+            parent_ = block.digest;
+            computed_.push_back(std::move(block));
+        }
+        return &computed_[index];
+    }
+
+   private:
+#if !CONDUCTOR_HAS_LOWLEVEL_SHA256
+    bool EnsureEvp() {
+        if (evp_) {
+            return true;
+        }
+        evp_ = EvpContext(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+        if (!evp_) {
+            sticky_error_ = "OpenSSL EVP MD context allocation failed";
+            return false;
+        }
+        return true;
+    }
+
+    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+#endif
+
+    const VllmValueCodec* codec_;
+    std::array<uint8_t, kSha256DigestSize> parent_;
+    std::string lora_name_;
+    std::optional<std::string> cache_salt_;
+    std::span<const int32_t> token_ids_;
+    size_t block_size_;
+    size_t block_count_;
+    std::vector<HashBlock> computed_;
+    std::vector<uint8_t> encoded_;
+#if !CONDUCTOR_HAS_LOWLEVEL_SHA256
+    EvpContext evp_{nullptr, EVP_MD_CTX_free};
+#endif
+    std::string sticky_error_;
+};
+
+class VllmV1HashStrategy final : public HashStrategy {
+   public:
+    VllmV1HashStrategy(const VllmValueCodec* codec,
+                       std::array<uint8_t, kSha256DigestSize> root_digest)
+        : codec_(codec), root_digest_(std::move(root_digest)) {}
+
+    std::string Compute(const ContextKey& context,
+                        std::span<const int32_t> token_ids,
+                        std::optional<std::string> cache_salt,
+                        std::vector<HashBlock>* out) const override {
+        if (out == nullptr) {
+            return "hash output must not be null";
+        }
+        out->clear();
+
+        std::string error;
+        auto chain =
+            CreateChain(context, token_ids, std::move(cache_salt), &error);
+        if (!chain) {
+            return error;
+        }
+        std::vector<HashBlock> computed;
+        computed.reserve(chain->BlockCount());
+        for (size_t index = 0; index < chain->BlockCount(); ++index) {
+            const HashBlock* block = chain->At(index, &error);
+            if (block == nullptr) {
+                return error;
+            }
+            computed.push_back(*block);
+        }
+
+        *out = std::move(computed);
+        return "";
+    }
+
+    std::unique_ptr<HashChain> CreateChain(
+        const ContextKey& context, std::span<const int32_t> token_ids,
+        std::optional<std::string> cache_salt,
+        std::string* error) const override {
+        if (std::string validation_error =
+                VllmV1HashChain::ValidateInputs(context, cache_salt);
+            !validation_error.empty()) {
+            if (error != nullptr) {
+                *error = std::move(validation_error);
+            }
+            return nullptr;
+        }
+        return std::make_unique<VllmV1HashChain>(
+            codec_, root_digest_, context, token_ids, std::move(cache_salt));
+    }
+
+   private:
+    const VllmValueCodec* codec_;
+    std::array<uint8_t, kSha256DigestSize> root_digest_;
+};
+
+ProjectedPrefix ProjectSglangDigest(
+    const std::array<uint8_t, kSha256DigestSize>& digest) {
+    uint64_t value = 0;
+    for (size_t index = 0; index < sizeof(value); ++index) {
+        value = (value << 8) | digest[index];
+    }
+    return ProjectedPrefix{value};
+}
+
+class SglangHashChain final : public HashChain {
+   public:
+    SglangHashChain(const ContextKey& context,
+                    std::span<const int32_t> token_ids,
+                    std::optional<std::string> cache_salt, bool bigram)
+        : token_ids_(token_ids),
+          block_size_(static_cast<size_t>(context.block_size)),
+          block_count_(
+              bigram ? (token_ids.size() < 2
+                            ? 0
+                            : (token_ids.size() - 1) / block_size_ +
+                                  ((token_ids.size() - 1) % block_size_ != 0))
+                     : token_ids.size() / block_size_ +
+                           (token_ids.size() % block_size_ != 0)),
+          bigram_(bigram),
+          cache_salt_(std::move(cache_salt)) {
+        computed_.reserve(block_count_);
+        encoded_.reserve(block_size_ * sizeof(uint32_t) * (bigram ? 2 : 1));
+        if (cache_salt_.has_value()) {
+            std::vector<uint8_t> root_input;
+            constexpr std::string_view kSaltPrefix("sglang-cache-salt-v1\0",
+                                                   21);
+            root_input.insert(root_input.end(), kSaltPrefix.begin(),
+                              kSaltPrefix.end());
+            root_input.insert(root_input.end(), cache_salt_->begin(),
+                              cache_salt_->end());
+            if (std::string error = Sha256(root_input, &parent_);
+                !error.empty()) {
+                sticky_error_ = std::move(error);
+            } else {
+                has_parent_ = true;
+            }
+        }
+    }
+
+    static std::string ValidateInputs(const ContextKey& context,
+                                      std::optional<std::string> cache_salt,
+                                      std::span<const int32_t> token_ids) {
+        if (context.block_size <= 0 ||
+            static_cast<uint64_t>(context.block_size) >
+                std::numeric_limits<size_t>::max()) {
+            return "block_size must be a positive size_t value";
+        }
+        if (cache_salt.has_value() && !IsValidUtf8(*cache_salt)) {
+            return "cache_salt must contain valid UTF-8";
+        }
+        for (int32_t token : token_ids) {
+            if (token < 0) {
+                return "SGLang token_ids must be non-negative";
+            }
+        }
+        return "";
+    }
+
+    size_t BlockCount() const override { return block_count_; }
+    size_t ComputedCount() const override { return computed_.size(); }
+
+    const HashBlock* At(size_t index, std::string* error) override {
+        if (index >= block_count_) {
+            if (error != nullptr) *error = "hash chain index out of range";
+            return nullptr;
+        }
+        if (!sticky_error_.empty()) {
+            if (error != nullptr) *error = sticky_error_;
+            return nullptr;
+        }
+        while (computed_.size() <= index) {
+            const size_t block_index = computed_.size();
+            encoded_.clear();
+            const size_t logical_length =
+                bigram_ ? token_ids_.size() - 1 : token_ids_.size();
+            const size_t block_begin = block_index * block_size_;
+            const size_t block_end =
+                std::min(block_begin + block_size_, logical_length);
+            for (size_t token_index = block_begin; token_index < block_end;
+                 ++token_index) {
+                const int32_t token = token_ids_[token_index];
+                const uint32_t value = static_cast<uint32_t>(token);
+                encoded_.push_back(static_cast<uint8_t>(value));
+                encoded_.push_back(static_cast<uint8_t>(value >> 8));
+                encoded_.push_back(static_cast<uint8_t>(value >> 16));
+                encoded_.push_back(static_cast<uint8_t>(value >> 24));
+                if (bigram_) {
+                    const uint32_t next_value =
+                        static_cast<uint32_t>(token_ids_[token_index + 1]);
+                    encoded_.push_back(static_cast<uint8_t>(next_value));
+                    encoded_.push_back(static_cast<uint8_t>(next_value >> 8));
+                    encoded_.push_back(static_cast<uint8_t>(next_value >> 16));
+                    encoded_.push_back(static_cast<uint8_t>(next_value >> 24));
+                }
+            }
+            std::vector<uint8_t> input;
+            input.reserve((has_parent_ ? parent_.size() : 0) + encoded_.size());
+            if (has_parent_) {
+                input.insert(input.end(), parent_.begin(), parent_.end());
+            }
+            input.insert(input.end(), encoded_.begin(), encoded_.end());
+
+            HashBlock hashed;
+            if (std::string hash_error = Sha256(input, &hashed.digest);
+                !hash_error.empty()) {
+                sticky_error_ = std::move(hash_error);
+                if (error != nullptr) *error = sticky_error_;
+                return nullptr;
+            }
+            hashed.projected = ProjectSglangDigest(hashed.digest);
+            parent_ = hashed.digest;
+            has_parent_ = true;
+            computed_.push_back(std::move(hashed));
+        }
+        return &computed_[index];
+    }
+
+   private:
+    std::span<const int32_t> token_ids_;
+    size_t block_size_;
+    size_t block_count_;
+    bool bigram_;
+    std::optional<std::string> cache_salt_;
+    std::array<uint8_t, kSha256DigestSize> parent_{};
+    bool has_parent_ = false;
+    std::vector<HashBlock> computed_;
+    std::vector<uint8_t> encoded_;
+    std::string sticky_error_;
+};
+
+class SglangHashStrategy final : public HashStrategy {
+   public:
+    explicit SglangHashStrategy(bool bigram) : bigram_(bigram) {}
+
+    std::string Compute(const ContextKey& context,
+                        std::span<const int32_t> token_ids,
+                        std::optional<std::string> cache_salt,
+                        std::vector<HashBlock>* out) const override {
+        if (out == nullptr) return "hash output must not be null";
+        out->clear();
+        std::string error;
+        auto chain =
+            CreateChain(context, token_ids, std::move(cache_salt), &error);
+        if (!chain) return error;
+        out->reserve(chain->BlockCount());
+        for (size_t index = 0; index < chain->BlockCount(); ++index) {
+            const auto* block = chain->At(index, &error);
+            if (block == nullptr) return error;
+            out->push_back(*block);
+        }
+        return "";
+    }
+
+    std::unique_ptr<HashChain> CreateChain(
+        const ContextKey& context, std::span<const int32_t> token_ids,
+        std::optional<std::string> cache_salt,
+        std::string* error) const override {
+        if (std::string validation =
+                SglangHashChain::ValidateInputs(context, cache_salt, token_ids);
+            !validation.empty()) {
+            if (error != nullptr) *error = std::move(validation);
+            return nullptr;
+        }
+        return std::make_unique<SglangHashChain>(
+            context, token_ids, std::move(cache_salt), bigram_);
+    }
+
+   private:
+    bool bigram_ = false;
+};
+
+}  // namespace
+
+std::string ResolveHashProfile(const common::HashProfileConfig& config,
+                               HashProfile* out) {
+    if (out == nullptr) {
+        return "resolved hash profile output must not be null";
+    }
+    *out = {};
+
+    if (auto error = ValidateProfileSelectors(config.strategy, config.algorithm,
+                                              config.index_projection);
+        !error.empty()) {
+        return error;
+    }
+    if (config.strategy == "sglang" || config.strategy == "sglang_bigram") {
+        // SGLang has no process-level Python seed/root in its token hash
+        // chain.  Keep a deterministic sentinel for the existing profile
+        // registration wire contract; cache_salt, when present, supplies the
+        // actual chain root at query time.
+        *out = {.strategy = config.strategy,
+                .algorithm = config.algorithm,
+                .python_hash_seed = config.python_hash_seed,
+                .root_digest = std::string(64, '0'),
+                .index_projection = config.index_projection};
+        return "";
+    }
+
+    if (auto error = ValidatePythonHashSeed(config.python_hash_seed);
+        !error.empty()) {
+        return error;
+    }
+
+    const VllmValueCodec* codec = CodecForAlgorithm(config.algorithm);
+    if (codec == nullptr) {
+        return "unsupported hash algorithm: " + config.algorithm;
+    }
+
+    std::vector<uint8_t> encoded_seed;
+    codec->EncodeSeed(config.python_hash_seed, &encoded_seed);
+    std::array<uint8_t, kSha256DigestSize> root_digest{};
+    if (auto error = Sha256(encoded_seed, &root_digest); !error.empty()) {
+        return error;
+    }
+
+    *out = {.strategy = config.strategy,
+            .algorithm = config.algorithm,
+            .python_hash_seed = config.python_hash_seed,
+            .root_digest = DigestToHex(root_digest),
+            .index_projection = config.index_projection};
+    return "";
+}
+
+std::string ValidateHashProfile(const HashProfile& profile) {
+    if (auto error = ValidateResolvedHashProfileShape(profile);
+        !error.empty()) {
+        return error;
+    }
+
+    HashProfile expected;
+    const common::HashProfileConfig source{
+        .strategy = profile.strategy,
+        .algorithm = profile.algorithm,
+        .python_hash_seed = profile.python_hash_seed,
+        .index_projection = profile.index_projection,
+    };
+    if (auto error = ResolveHashProfile(source, &expected); !error.empty()) {
+        return error;
+    }
+    if (profile.root_digest != expected.root_digest) {
+        return "root_digest does not match python_hash_seed and hash selectors";
+    }
+    return "";
+}
+
+std::unique_ptr<HashStrategy> CreateHashStrategy(const HashProfile& profile,
+                                                 std::string* error) {
+    const std::string validation_error =
+        ValidateResolvedHashProfileShape(profile);
+    if (error != nullptr) {
+        *error = validation_error;
+    }
+    if (!validation_error.empty()) {
+        return nullptr;
+    }
+    if (profile.strategy == "sglang" || profile.strategy == "sglang_bigram") {
+        return std::make_unique<SglangHashStrategy>(profile.strategy ==
+                                                    "sglang_bigram");
+    }
+    const VllmValueCodec* codec = CodecForAlgorithm(profile.algorithm);
+    if (codec == nullptr) {
+        if (error != nullptr) {
+            *error = "unsupported hash algorithm: " + profile.algorithm;
+        }
+        return nullptr;
+    }
+    return std::make_unique<VllmV1HashStrategy>(
+        codec, DecodeRootDigest(profile.root_digest));
+}
+
+std::string DigestToHex(const std::array<uint8_t, 32>& digest) {
+    static constexpr char kHexDigits[] = "0123456789abcdef";
+    std::string result;
+    result.resize(digest.size() * 2);
+    for (size_t index = 0; index < digest.size(); ++index) {
+        result[index * 2] = kHexDigits[digest[index] >> 4];
+        result[index * 2 + 1] = kHexDigits[digest[index] & 0x0fU];
+    }
+    return result;
+}
+
+}  // namespace mooncake::conductor::prefixindex

--- a/mooncake-conductor/tests/CMakeLists.txt
+++ b/mooncake-conductor/tests/CMakeLists.txt
@@ -7,9 +7,15 @@ else()
   set(CONDUCTOR_GTEST_LIBS GTest::gtest GTest::gtest_main)
 endif()
 
-add_executable(conductor_test common_utils_test.cpp json_uint64_test.cpp)
+add_executable(conductor_test common_utils_test.cpp json_uint64_test.cpp
+                              model_context_test.cpp compute_hash_test.cpp)
 
 target_link_libraries(conductor_test PRIVATE conductor_cpp_core
                                              ${CONDUCTOR_GTEST_LIBS})
+
+# Tests load golden vectors relative to this directory.
+target_compile_definitions(
+  conductor_test
+  PRIVATE CONDUCTOR_TEST_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
 
 add_test(NAME conductor_test COMMAND conductor_test)

--- a/mooncake-conductor/tests/compute_hash_test.cpp
+++ b/mooncake-conductor/tests/compute_hash_test.cpp
@@ -1,0 +1,869 @@
+#include <gtest/gtest.h>
+
+#include <openssl/evp.h>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "conductor/prefixindex/hash_strategy.h"
+#include "test_fixtures.h"
+
+namespace {
+
+using mooncake::conductor::common::HashProfileConfig;
+using mooncake::conductor::prefixindex::ContextKey;
+using mooncake::conductor::prefixindex::CreateHashStrategy;
+using mooncake::conductor::prefixindex::DigestToHex;
+using mooncake::conductor::prefixindex::HashBlock;
+using mooncake::conductor::prefixindex::HashProfile;
+using mooncake::conductor::prefixindex::ResolveHashProfile;
+using mooncake::conductor::prefixindex::ValidateHashProfile;
+using mooncake::conductor::test::LoadJsonFixture;
+using mooncake::conductor::test::ParseU64;
+
+constexpr char kSeedZeroRoot[] =
+    "4e1195df020de59e0d65a33a4279f1183e7ae4e5d980e309f8b55adff2e61c3e";
+constexpr char kPaddedSeedZeroRoot[] =
+    "8d912e4e62b3cc377b1d1c7a14ef61dffbdaa0990237035c05401c29414c4172";
+constexpr char kPickleSeedZeroRoot[] =
+    "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c";
+
+HashProfile ProfileFrom(const Json::Value& value) {
+    HashProfile profile;
+    profile.strategy = value["strategy"].asString();
+    profile.algorithm = value["algorithm"].asString();
+    profile.python_hash_seed = value["python_hash_seed"].asString();
+    profile.root_digest = value["root_digest"].asString();
+    profile.index_projection = value["index_projection"].asString();
+    return profile;
+}
+
+HashProfileConfig SourceProfile(std::string python_hash_seed = "0",
+                                std::string algorithm = "sha256_cbor") {
+    return {.strategy = "vllm_v1",
+            .algorithm = std::move(algorithm),
+            .python_hash_seed = std::move(python_hash_seed),
+            .index_projection = "low64_be"};
+}
+
+HashProfile ValidProfile() {
+    return HashProfile{
+        .strategy = "vllm_v1",
+        .algorithm = "sha256_cbor",
+        .python_hash_seed = "0",
+        .root_digest = kSeedZeroRoot,
+        .index_projection = "low64_be",
+    };
+}
+
+HashProfile ValidPickleProfile() {
+    return HashProfile{
+        .strategy = "vllm_v1",
+        .algorithm = "sha256",
+        .python_hash_seed = "0",
+        .root_digest = kPickleSeedZeroRoot,
+        .index_projection = "low64_be",
+    };
+}
+
+HashProfile ResolvedProfile(std::string python_hash_seed,
+                            std::string algorithm = "sha256_cbor") {
+    HashProfile profile;
+    const std::string error = ResolveHashProfile(
+        SourceProfile(std::move(python_hash_seed), std::move(algorithm)),
+        &profile);
+    EXPECT_TRUE(error.empty()) << error;
+    return profile;
+}
+
+std::vector<int32_t> TokensFrom(const Json::Value& values) {
+    std::vector<int32_t> tokens;
+    tokens.reserve(values.size());
+    for (const auto& value : values) {
+        tokens.push_back(static_cast<int32_t>(value.asInt64()));
+    }
+    return tokens;
+}
+
+// Expands the compact repeat encoding used by large fixture cases.
+std::vector<int32_t> CaseTokens(const Json::Value& test_case) {
+    if (test_case.isMember("token_ids_repeat")) {
+        const Json::Value& repeat = test_case["token_ids_repeat"];
+        return std::vector<int32_t>(
+            static_cast<size_t>(repeat["count"].asUInt64()),
+            static_cast<int32_t>(repeat["value"].asInt64()));
+    }
+    return TokensFrom(test_case["token_ids"]);
+}
+
+std::string CaseLora(const Json::Value& test_case) {
+    if (test_case.isMember("lora_name_repeat")) {
+        const Json::Value& repeat = test_case["lora_name_repeat"];
+        return std::string(static_cast<size_t>(repeat["count"].asUInt64()),
+                           repeat["value"].asString().front());
+    }
+    return test_case["lora_name"].asString();
+}
+
+std::optional<std::string> SaltFrom(const Json::Value& value) {
+    if (value.isNull()) {
+        return std::nullopt;
+    }
+    return value.asString();
+}
+
+std::vector<uint8_t> HexToBytes(const std::string& hex) {
+    std::vector<uint8_t> bytes;
+    bytes.reserve(hex.size() / 2);
+    auto nibble = [](char value) -> int {
+        if (value >= '0' && value <= '9') {
+            return value - '0';
+        }
+        if (value >= 'a' && value <= 'f') {
+            return value - 'a' + 10;
+        }
+        return -1;
+    };
+    for (size_t index = 0; index + 1 < hex.size(); index += 2) {
+        const int high = nibble(hex[index]);
+        const int low = nibble(hex[index + 1]);
+        EXPECT_GE(high, 0);
+        EXPECT_GE(low, 0);
+        bytes.push_back(static_cast<uint8_t>((high << 4) | low));
+    }
+    return bytes;
+}
+
+// Recomputes SHA-256 over the fixture's pinned serialized bytes so the test
+// compares serialized bytes as well as digests.
+std::string Sha256Hex(const std::vector<uint8_t>& input) {
+    std::array<uint8_t, 32> digest{};
+    unsigned int digest_size = 0;
+    EVP_MD_CTX* context = EVP_MD_CTX_new();
+    EXPECT_NE(context, nullptr);
+    EXPECT_EQ(EVP_DigestInit_ex(context, EVP_sha256(), nullptr), 1);
+    EXPECT_EQ(EVP_DigestUpdate(context, input.data(), input.size()), 1);
+    EXPECT_EQ(EVP_DigestFinal_ex(context, digest.data(), &digest_size), 1);
+    EVP_MD_CTX_free(context);
+    EXPECT_EQ(digest_size, digest.size());
+    return DigestToHex(digest);
+}
+
+TEST(HashProfileResolver, MatchesSeedRootGoldenVectors) {
+    const Json::Value fixture = LoadJsonFixture("hash_golden_vectors.json");
+    const Json::Value& vectors = fixture["seed_root_vectors"];
+    ASSERT_TRUE(vectors.isArray());
+    ASSERT_GE(vectors.size(), 2u);
+
+    for (const auto& vector : vectors) {
+        const std::string seed = vector["python_hash_seed"].asString();
+        SCOPED_TRACE(seed);
+        HashProfile resolved;
+        const std::string error =
+            ResolveHashProfile(SourceProfile(seed), &resolved);
+        ASSERT_TRUE(error.empty()) << error;
+        EXPECT_EQ(resolved.python_hash_seed, seed);
+        EXPECT_EQ(resolved.root_digest, vector["root_digest"].asString());
+    }
+}
+
+TEST(HashProfileResolver, MatchesPickleSeedRootGoldenVectors) {
+    const Json::Value fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+    const Json::Value& vectors = fixture["seed_root_vectors"];
+    ASSERT_TRUE(vectors.isArray());
+    ASSERT_GE(vectors.size(), 4u);
+
+    for (const auto& vector : vectors) {
+        const std::string seed = vector["python_hash_seed"].asString();
+        SCOPED_TRACE(seed);
+        HashProfile resolved;
+        const std::string error =
+            ResolveHashProfile(SourceProfile(seed, "sha256"), &resolved);
+        ASSERT_TRUE(error.empty()) << error;
+        EXPECT_EQ(resolved.algorithm, "sha256");
+        EXPECT_EQ(resolved.python_hash_seed, seed);
+        EXPECT_EQ(resolved.root_digest, vector["root_digest"].asString());
+        // The serialized seed bytes pinned by the fixture must be exactly
+        // what the digest was computed over.
+        EXPECT_EQ(Sha256Hex(HexToBytes(vector["pickle_hex"].asString())),
+                  vector["root_digest"].asString());
+    }
+}
+
+TEST(HashProfileResolver, AcceptsSupportedSeedsAndPreservesExactText) {
+    struct SeedCase {
+        const char* seed;
+        const char* root_digest;
+    };
+    const SeedCase cases[] = {
+        {"0", kSeedZeroRoot},
+        {"00", kPaddedSeedZeroRoot},
+        {"random",
+         "78d6ac7e28de859e492449dcea03e3807377d69998c5af819fed33a6df490cad"},
+        {"4294967295",
+         "177f280a5695322a18f16c96a26dc99d9c03f905940103dfe24a9c646fe446a8"},
+    };
+
+    for (const SeedCase& test_case : cases) {
+        SCOPED_TRACE(test_case.seed);
+        const HashProfile resolved = ResolvedProfile(test_case.seed);
+        EXPECT_EQ(resolved.strategy, "vllm_v1");
+        EXPECT_EQ(resolved.algorithm, "sha256_cbor");
+        EXPECT_EQ(resolved.python_hash_seed, test_case.seed);
+        EXPECT_EQ(resolved.root_digest, test_case.root_digest);
+        EXPECT_EQ(resolved.index_projection, "low64_be");
+        EXPECT_TRUE(ValidateHashProfile(resolved).empty());
+    }
+
+    EXPECT_NE(ResolvedProfile("0"), ResolvedProfile("00"));
+}
+
+TEST(HashProfileResolver, AcceptsPickleSeedsAndPreservesExactText) {
+    const HashProfile resolved = ResolvedProfile("0", "sha256");
+    EXPECT_EQ(resolved.strategy, "vllm_v1");
+    EXPECT_EQ(resolved.algorithm, "sha256");
+    EXPECT_EQ(resolved.python_hash_seed, "0");
+    EXPECT_EQ(resolved.root_digest, kPickleSeedZeroRoot);
+    EXPECT_EQ(resolved.index_projection, "low64_be");
+    EXPECT_TRUE(ValidateHashProfile(resolved).empty());
+
+    // Seed text is never normalized, under either supported algorithm.
+    EXPECT_NE(ResolvedProfile("0", "sha256"), ResolvedProfile("00", "sha256"));
+    // Identical seed text under different algorithms yields different roots.
+    EXPECT_NE(ResolvedProfile("0", "sha256").root_digest,
+              ResolvedProfile("0", "sha256_cbor").root_digest);
+}
+
+TEST(HashProfileResolver, RejectsMalformedSeedTextAndClearsOutput) {
+    const std::vector<std::string> invalid = {
+        "",    "+1",     "-1",      " 0",         "0 ",         "0\n",
+        "1.0", "Random", "random ", "4294967296", "not-a-seed", "\xe9\x9b\xb6",
+    };
+
+    for (const std::string& seed : invalid) {
+        SCOPED_TRACE(seed);
+        for (const std::string& algorithm : {"sha256_cbor", "sha256"}) {
+            HashProfile resolved = ValidProfile();
+            EXPECT_FALSE(
+                ResolveHashProfile(SourceProfile(seed, algorithm), &resolved)
+                    .empty());
+            EXPECT_EQ(resolved, HashProfile{});
+        }
+    }
+
+    EXPECT_FALSE(ResolveHashProfile(SourceProfile(), nullptr).empty());
+}
+
+TEST(HashProfileResolver, RejectsInvalidUtf8AndUnsupportedSelectors) {
+    for (const std::string seed :
+         {std::string("\xc0\xaf", 2), std::string("\xed\xa0\x80", 3)}) {
+        HashProfile resolved;
+        const std::string error =
+            ResolveHashProfile(SourceProfile(seed), &resolved);
+        EXPECT_NE(error.find("valid UTF-8"), std::string::npos);
+    }
+
+    std::vector<HashProfileConfig> unsupported;
+    auto source = SourceProfile();
+    source.strategy = "vllm_v2";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "md5";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "sha512";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "xxhash";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "SHA256";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.index_projection = "high64_be";
+    unsupported.push_back(source);
+
+    for (const HashProfileConfig& candidate : unsupported) {
+        HashProfile resolved;
+        EXPECT_FALSE(ResolveHashProfile(candidate, &resolved).empty());
+        EXPECT_EQ(resolved, HashProfile{});
+    }
+}
+
+TEST(HashProfile, AcceptsOnlyTheSupportedResolvedProfile) {
+    for (const HashProfile& profile : {ValidProfile(), ValidPickleProfile()}) {
+        SCOPED_TRACE(profile.algorithm);
+        EXPECT_TRUE(ValidateHashProfile(profile).empty());
+
+        std::string error = "stale error";
+        auto strategy = CreateHashStrategy(profile, &error);
+        EXPECT_NE(strategy, nullptr);
+        EXPECT_TRUE(error.empty());
+        EXPECT_NE(CreateHashStrategy(profile, nullptr), nullptr);
+    }
+}
+
+TEST(HashProfile, RejectsUnsupportedAndMalformedResolvedShapes) {
+    std::vector<std::pair<std::string, HashProfile>> cases;
+
+    HashProfile profile = ValidProfile();
+    profile.strategy = "vllm_v2";
+    cases.emplace_back("strategy", profile);
+
+    profile = ValidProfile();
+    profile.algorithm = "md5";
+    cases.emplace_back("algorithm", profile);
+
+    profile = ValidProfile();
+    profile.index_projection = "high64_be";
+    cases.emplace_back("projection", profile);
+
+    profile = ValidProfile();
+    profile.python_hash_seed.clear();
+    cases.emplace_back("empty seed", profile);
+
+    profile = ValidProfile();
+    profile.root_digest.pop_back();
+    cases.emplace_back("short root", profile);
+
+    profile = ValidProfile();
+    profile.root_digest.push_back('0');
+    cases.emplace_back("long root", profile);
+
+    profile = ValidProfile();
+    profile.root_digest[1] = 'E';
+    cases.emplace_back("uppercase root", profile);
+
+    profile = ValidProfile();
+    profile.root_digest[0] = 'g';
+    cases.emplace_back("non-hex root", profile);
+
+    for (const auto& [name, candidate] : cases) {
+        SCOPED_TRACE(name);
+        const std::string validation_error = ValidateHashProfile(candidate);
+        EXPECT_FALSE(validation_error.empty());
+
+        std::string factory_error;
+        EXPECT_EQ(CreateHashStrategy(candidate, &factory_error), nullptr);
+        EXPECT_EQ(factory_error, validation_error);
+    }
+}
+
+TEST(HashProfile, SemanticValidationRejectsForgedSeedRootPair) {
+    HashProfile forged = ValidProfile();
+    forged.root_digest = kPaddedSeedZeroRoot;
+
+    const std::string validation_error = ValidateHashProfile(forged);
+    EXPECT_NE(validation_error.find("does not match"), std::string::npos);
+
+    std::string factory_error = "stale error";
+    EXPECT_NE(CreateHashStrategy(forged, &factory_error), nullptr);
+    EXPECT_TRUE(factory_error.empty());
+}
+
+TEST(HashProfile, SemanticValidationUsesTheSelectedRecipe) {
+    // A root derived with one recipe must not validate under the other
+    // algorithm even when every other field is well formed.
+    HashProfile mismatched = ValidPickleProfile();
+    mismatched.algorithm = "sha256_cbor";
+    EXPECT_NE(ValidateHashProfile(mismatched).find("does not match"),
+              std::string::npos);
+
+    mismatched = ValidProfile();
+    mismatched.algorithm = "sha256";
+    EXPECT_NE(ValidateHashProfile(mismatched).find("does not match"),
+              std::string::npos);
+}
+
+TEST(HashStrategyGolden, MatchesVllmAndCbor2Vectors) {
+    const Json::Value fixture = LoadJsonFixture("hash_golden_vectors.json");
+    const HashProfile profile = ProfileFrom(fixture["profile"]);
+    ASSERT_TRUE(ValidateHashProfile(profile).empty());
+
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(profile, &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    const Json::Value& cases = fixture["cases"];
+    ASSERT_GT(cases.size(), 0u);
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case["name"].asString());
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "golden-model",
+            .lora_name = test_case["lora_name"].asString(),
+            .block_size = test_case["block_size"].asInt64(),
+        };
+        const std::vector<int32_t> tokens = TokensFrom(test_case["token_ids"]);
+
+        std::vector<HashBlock> blocks;
+        const std::string error = strategy->Compute(
+            context, tokens, SaltFrom(test_case["cache_salt"]), &blocks);
+        ASSERT_TRUE(error.empty()) << error;
+
+        const Json::Value& expected = test_case["expected"];
+        ASSERT_EQ(blocks.size(), expected.size());
+        for (Json::ArrayIndex index = 0; index < expected.size(); ++index) {
+            const std::string digest = DigestToHex(blocks[index].digest);
+            EXPECT_EQ(digest, expected[index]["digest"].asString())
+                << "block=" << index;
+            EXPECT_EQ(digest.substr(48),
+                      expected[index]["projected_hex"].asString())
+                << "block=" << index;
+            EXPECT_EQ(blocks[index].projected.value,
+                      ParseU64(expected[index]["projected_decimal"]))
+                << "block=" << index;
+        }
+    }
+}
+
+TEST(HashStrategyGolden, MatchesVllmPickleVectors) {
+    const Json::Value fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+    const HashProfile profile = ProfileFrom(fixture["profile"]);
+    ASSERT_EQ(profile.algorithm, "sha256");
+    ASSERT_TRUE(ValidateHashProfile(profile).empty());
+
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(profile, &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    const Json::Value& cases = fixture["cases"];
+    ASSERT_GT(cases.size(), 0u);
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case["name"].asString());
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "golden-model",
+            .lora_name = CaseLora(test_case),
+            .block_size = test_case["block_size"].asInt64(),
+        };
+        const std::vector<int32_t> tokens = CaseTokens(test_case);
+
+        std::vector<HashBlock> blocks;
+        const std::string error = strategy->Compute(
+            context, tokens, SaltFrom(test_case["cache_salt"]), &blocks);
+        ASSERT_TRUE(error.empty()) << error;
+
+        const Json::Value& expected = test_case["expected"];
+        ASSERT_EQ(blocks.size(), expected.size());
+        for (Json::ArrayIndex index = 0; index < expected.size(); ++index) {
+            const std::string digest = DigestToHex(blocks[index].digest);
+            EXPECT_EQ(digest, expected[index]["digest"].asString())
+                << "block=" << index;
+            EXPECT_EQ(digest.substr(48),
+                      expected[index]["projected_hex"].asString())
+                << "block=" << index;
+            EXPECT_EQ(blocks[index].projected.value,
+                      ParseU64(expected[index]["projected_decimal"]))
+                << "block=" << index;
+            if (expected[index].isMember("pickle_hex")) {
+                // The fixture pins the exact serialized Pickle bytes; their
+                // SHA-256 must reproduce the pinned digest.
+                EXPECT_EQ(Sha256Hex(HexToBytes(
+                              expected[index]["pickle_hex"].asString())),
+                          expected[index]["digest"].asString())
+                    << "block=" << index;
+            }
+        }
+    }
+}
+
+TEST(HashStrategyGolden, PickleMultiBlockChainDoesNotReuseLow64AsParent) {
+    const Json::Value fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+    const Json::Value& test_case = fixture["cases"][0];
+    ASSERT_EQ(test_case["name"].asString(), "spec_unsalted");
+
+    std::string factory_error;
+    auto strategy =
+        CreateHashStrategy(ProfileFrom(fixture["profile"]), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "golden-model",
+        .lora_name = "",
+        .block_size = test_case["block_size"].asInt64(),
+    };
+    const std::vector<int32_t> tokens = CaseTokens(test_case);
+    std::vector<HashBlock> blocks;
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    ASSERT_EQ(blocks.size(), 2u);
+
+    const std::string second_digest = DigestToHex(blocks[1].digest);
+    EXPECT_EQ(second_digest, test_case["expected"][1]["digest"].asString());
+    EXPECT_NE(second_digest,
+              test_case["incorrect_low64_parent_digest"].asString());
+}
+
+TEST(HashStrategyGolden, AlgorithmsProduceDistinctDigestsForIdenticalTokens) {
+    const Json::Value cbor_fixture =
+        LoadJsonFixture("hash_golden_vectors.json");
+    const Json::Value pickle_fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+
+    std::string factory_error;
+    auto cbor_strategy = CreateHashStrategy(
+        ProfileFrom(cbor_fixture["profile"]), &factory_error);
+    ASSERT_NE(cbor_strategy, nullptr) << factory_error;
+    auto pickle_strategy = CreateHashStrategy(
+        ProfileFrom(pickle_fixture["profile"]), &factory_error);
+    ASSERT_NE(pickle_strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "golden-model",
+        .lora_name = "",
+        .block_size = 4,
+    };
+    const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8};
+    std::vector<HashBlock> cbor_blocks;
+    std::vector<HashBlock> pickle_blocks;
+    ASSERT_TRUE(
+        cbor_strategy->Compute(context, tokens, std::nullopt, &cbor_blocks)
+            .empty());
+    ASSERT_TRUE(
+        pickle_strategy->Compute(context, tokens, std::nullopt, &pickle_blocks)
+            .empty());
+    ASSERT_EQ(cbor_blocks.size(), pickle_blocks.size());
+
+    // Identical tokens under the two recipes must produce distinct digests
+    // while each recipe matches its own vLLM reference vectors.
+    for (size_t index = 0; index < cbor_blocks.size(); ++index) {
+        EXPECT_NE(cbor_blocks[index], pickle_blocks[index])
+            << "block=" << index;
+        EXPECT_EQ(DigestToHex(cbor_blocks[index].digest),
+                  cbor_fixture["cases"][0]["expected"]
+                              [static_cast<Json::ArrayIndex>(index)]["digest"]
+                                  .asString());
+        EXPECT_EQ(DigestToHex(pickle_blocks[index].digest),
+                  pickle_fixture["cases"][0]["expected"]
+                                [static_cast<Json::ArrayIndex>(index)]["digest"]
+                                    .asString());
+    }
+}
+
+TEST(HashStrategyGolden, MultiBlockChainDoesNotReuseLow64AsParent) {
+    const Json::Value fixture = LoadJsonFixture("hash_golden_vectors.json");
+    const Json::Value& test_case = fixture["cases"][0];
+    ASSERT_EQ(test_case["name"].asString(), "spec_unsalted");
+
+    std::string factory_error;
+    auto strategy =
+        CreateHashStrategy(ProfileFrom(fixture["profile"]), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "golden-model",
+        .lora_name = "",
+        .block_size = test_case["block_size"].asInt64(),
+    };
+    const std::vector<int32_t> tokens = TokensFrom(test_case["token_ids"]);
+    std::vector<HashBlock> blocks;
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    ASSERT_EQ(blocks.size(), 2u);
+
+    const std::string second_digest = DigestToHex(blocks[1].digest);
+    EXPECT_EQ(second_digest, test_case["expected"][1]["digest"].asString());
+    EXPECT_NE(second_digest,
+              test_case["incorrect_low64_parent_digest"].asString());
+}
+
+TEST(HashStrategy, EmptySaltHasNoExtraKey) {
+    for (const HashProfile& profile : {ValidProfile(), ValidPickleProfile()}) {
+        SCOPED_TRACE(profile.algorithm);
+        std::string factory_error;
+        auto strategy = CreateHashStrategy(profile, &factory_error);
+        ASSERT_NE(strategy, nullptr) << factory_error;
+
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "model",
+            .lora_name = "",
+            .block_size = 4,
+        };
+        const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8};
+        std::vector<HashBlock> omitted_salt;
+        std::vector<HashBlock> empty_salt;
+        ASSERT_TRUE(
+            strategy->Compute(context, tokens, std::nullopt, &omitted_salt)
+                .empty());
+        ASSERT_TRUE(
+            strategy->Compute(context, tokens, std::string{}, &empty_salt)
+                .empty());
+        EXPECT_EQ(empty_salt, omitted_salt);
+    }
+}
+
+TEST(HashStrategy, RejectsInvalidComputeInputsWithoutPartialOutput) {
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(ValidProfile(), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "model",
+        .lora_name = "",
+        .block_size = 0,
+    };
+    const std::vector<int32_t> tokens{1, 2, 3, 4};
+    std::vector<HashBlock> blocks(1);
+    EXPECT_FALSE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    EXPECT_TRUE(blocks.empty());
+
+    context.block_size = -4;
+    blocks.resize(1);
+    EXPECT_FALSE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    EXPECT_TRUE(blocks.empty());
+
+    context.block_size = 4;
+    context.lora_name = std::string("\xc0\xaf", 2);
+    blocks.resize(1);
+    EXPECT_FALSE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    EXPECT_TRUE(blocks.empty());
+
+    context.lora_name.clear();
+    const std::string invalid_salt("\xed\xa0\x80", 3);
+    blocks.resize(1);
+    EXPECT_FALSE(
+        strategy->Compute(context, tokens, invalid_salt, &blocks).empty());
+    EXPECT_TRUE(blocks.empty());
+
+    EXPECT_FALSE(
+        strategy->Compute(context, tokens, std::nullopt, nullptr).empty());
+}
+
+TEST(HashStrategy, ResolvedSeedChangesTheChain) {
+    const HashProfile alternate_profile = ResolvedProfile("00");
+
+    std::string factory_error;
+    auto default_strategy = CreateHashStrategy(ValidProfile(), &factory_error);
+    ASSERT_NE(default_strategy, nullptr) << factory_error;
+    auto alternate_strategy =
+        CreateHashStrategy(alternate_profile, &factory_error);
+    ASSERT_NE(alternate_strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "model",
+        .lora_name = "",
+        .block_size = 4,
+    };
+    const std::vector<int32_t> tokens{1, 2, 3, 4};
+    std::vector<HashBlock> default_blocks;
+    std::vector<HashBlock> alternate_blocks;
+    ASSERT_TRUE(default_strategy
+                    ->Compute(context, tokens, std::nullopt, &default_blocks)
+                    .empty());
+    ASSERT_TRUE(alternate_strategy
+                    ->Compute(context, tokens, std::nullopt, &alternate_blocks)
+                    .empty());
+    ASSERT_EQ(default_blocks.size(), 1u);
+    ASSERT_EQ(alternate_blocks.size(), 1u);
+    EXPECT_NE(default_blocks, alternate_blocks);
+}
+
+TEST(HashStrategy, DigestToHexPreservesLeadingZerosAndUsesLowercase) {
+    std::array<uint8_t, 32> digest{};
+    digest[0] = 0x01;
+    digest[30] = 0xcd;
+    digest[31] = 0xef;
+
+    const std::string encoded = DigestToHex(digest);
+    ASSERT_EQ(encoded.size(), 64u);
+    EXPECT_EQ(encoded.substr(0, 4), "0100");
+    EXPECT_EQ(encoded.substr(60), "cdef");
+}
+
+TEST(HashChain, MatchesEagerCompute) {
+    for (const HashProfile& profile : {ValidProfile(), ValidPickleProfile()}) {
+        SCOPED_TRACE(profile.algorithm);
+        std::string factory_error;
+        auto strategy = CreateHashStrategy(profile, &factory_error);
+        ASSERT_NE(strategy, nullptr) << factory_error;
+
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "model",
+            .lora_name = "lora-a",
+            .block_size = 4,
+        };
+        const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        const std::string salt = "salty";
+
+        std::vector<HashBlock> eager;
+        ASSERT_TRUE(strategy->Compute(context, tokens, salt, &eager).empty());
+        ASSERT_EQ(eager.size(), 2u);
+
+        std::string chain_error;
+        auto chain = strategy->CreateChain(context, tokens, salt, &chain_error);
+        ASSERT_NE(chain, nullptr) << chain_error;
+        EXPECT_EQ(chain->BlockCount(), eager.size());
+        for (size_t index = 0; index < eager.size(); ++index) {
+            const HashBlock* block = chain->At(index, &chain_error);
+            ASSERT_NE(block, nullptr) << chain_error;
+            EXPECT_EQ(*block, eager[index]) << "block=" << index;
+        }
+    }
+}
+
+TEST(HashChain, ComputesOnlyRequestedPrefix) {
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(ValidProfile(), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "model",
+        .lora_name = "",
+        .block_size = 4,
+    };
+    const std::vector<int32_t> tokens(400, 7);  // 100 complete blocks
+
+    std::string chain_error;
+    auto chain =
+        strategy->CreateChain(context, tokens, std::nullopt, &chain_error);
+    ASSERT_NE(chain, nullptr) << chain_error;
+    EXPECT_EQ(chain->BlockCount(), 100u);
+    EXPECT_EQ(chain->ComputedCount(), 0u);
+
+    ASSERT_NE(chain->At(0, &chain_error), nullptr) << chain_error;
+    EXPECT_EQ(chain->ComputedCount(), 1u);
+
+    ASSERT_NE(chain->At(2, &chain_error), nullptr) << chain_error;
+    EXPECT_EQ(chain->ComputedCount(), 3u);
+
+    // Already-computed blocks must not be rehashed.
+    ASSERT_NE(chain->At(2, &chain_error), nullptr) << chain_error;
+    EXPECT_EQ(chain->ComputedCount(), 3u);
+
+    EXPECT_EQ(chain->At(100, &chain_error), nullptr);
+    EXPECT_FALSE(chain_error.empty());
+    EXPECT_EQ(chain->ComputedCount(), 3u);
+}
+
+TEST(HashChain, RejectsInvalidInputsAtSetup) {
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(ValidProfile(), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "model",
+        .lora_name = "",
+        .block_size = 0,
+    };
+    const std::vector<int32_t> tokens{1, 2, 3, 4};
+
+    std::string chain_error;
+    EXPECT_EQ(
+        strategy->CreateChain(context, tokens, std::nullopt, &chain_error),
+        nullptr);
+    EXPECT_FALSE(chain_error.empty());
+
+    context.block_size = 4;
+    const std::string invalid_salt("\xed\xa0\x80", 3);
+    EXPECT_EQ(
+        strategy->CreateChain(context, tokens, invalid_salt, &chain_error),
+        nullptr);
+}
+
+TEST(SglangHashChain, MatchesNativeSha256TokenChain) {
+    HashProfile profile;
+    const HashProfileConfig source{
+        .strategy = "sglang",
+        .algorithm = "sha256_raw",
+        .python_hash_seed = "0",
+        .index_projection = "first64_be",
+    };
+    ASSERT_TRUE(ResolveHashProfile(source, &profile).empty());
+    ASSERT_TRUE(ValidateHashProfile(profile).empty());
+
+    std::string error;
+    auto strategy = CreateHashStrategy(profile, &error);
+    ASSERT_NE(strategy, nullptr) << error;
+    const ContextKey context{.tenant_id = "default",
+                             .model_name = "model",
+                             .lora_name = "",
+                             .block_size = 4};
+    const std::vector<int32_t> tokens{1, 2, 3, 4};
+    std::vector<HashBlock> blocks;
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    ASSERT_EQ(blocks.size(), 1u);
+    EXPECT_EQ(blocks[0].projected.value, 0xcf97adeedb59e05bULL);
+
+    blocks.clear();
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::string("salty"), &blocks)
+            .empty());
+    ASSERT_EQ(blocks.size(), 1u);
+    EXPECT_EQ(blocks[0].projected.value, 0xd98f7292c18ec8ddULL);
+}
+
+TEST(SglangHashChain, IncludesPartialFinalBlock) {
+    HashProfile profile;
+    const HashProfileConfig source{
+        .strategy = "sglang",
+        .algorithm = "sha256_raw",
+        .python_hash_seed = "0",
+        .index_projection = "first64_be",
+    };
+    ASSERT_TRUE(ResolveHashProfile(source, &profile).empty());
+
+    std::string error;
+    auto strategy = CreateHashStrategy(profile, &error);
+    ASSERT_NE(strategy, nullptr) << error;
+    const ContextKey context{.tenant_id = "default",
+                             .model_name = "model",
+                             .lora_name = "",
+                             .block_size = 2};
+    const std::vector<int32_t> tokens{1, 2, 3};
+    std::vector<HashBlock> blocks;
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    EXPECT_EQ(blocks.size(), 2u);
+}
+
+TEST(SglangHashChain, MatchesBigramGolden) {
+    HashProfile profile;
+    const HashProfileConfig source{
+        .strategy = "sglang_bigram",
+        .algorithm = "sha256_raw",
+        .python_hash_seed = "0",
+        .index_projection = "first64_be",
+    };
+    ASSERT_TRUE(ResolveHashProfile(source, &profile).empty());
+    ASSERT_TRUE(ValidateHashProfile(profile).empty());
+
+    std::string error;
+    auto strategy = CreateHashStrategy(profile, &error);
+    ASSERT_NE(strategy, nullptr) << error;
+    const ContextKey context{.tenant_id = "default",
+                             .model_name = "model",
+                             .lora_name = "",
+                             .block_size = 4};
+    const std::vector<int32_t> tokens{10, 20, 30, 40};
+    std::vector<HashBlock> blocks;
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    ASSERT_EQ(blocks.size(), 1u);
+    EXPECT_EQ(blocks[0].projected.value, 15710792592378487421ULL);
+}
+
+}  // namespace

--- a/mooncake-conductor/tests/fixtures/generate_hash_golden_vectors.py
+++ b/mooncake-conductor/tests/fixtures/generate_hash_golden_vectors.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Generates hash_golden_vectors_sha256.json from the vLLM `sha256` recipe.
+
+The `sha256` vLLM prefix-cache hash is SHA-256 over
+``pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)``; for the supported
+Python range (3.10-3.14) HIGHEST_PROTOCOL is protocol 5.  This script uses the
+real CPython pickler as the normative oracle and replicates
+vLLM's ``hash_block_tokens`` value shapes:
+
+    root  = sha256(pickle(seed_string))
+    block = sha256(pickle((parent_digest_bytes, tuple(block_token_ids),
+                           extra_keys)))
+
+with ``extra_keys`` equal to None, or the tuple ``(lora_name,)`` /
+``(lora_name, cache_salt)`` (salt only on the first block), matching
+vLLM's ``lora + mm + cache_salt + prompt_embeds`` ordering for the subset the
+Conductor query contract can express.
+
+The checked-in fixture pins the generator environment below.  Regenerate with:
+
+    python3 generate_hash_golden_vectors.py
+
+from this directory and diff the result; only regenerate intentionally.
+"""
+
+import hashlib
+import json
+import pickle
+import platform
+import sys
+from pathlib import Path
+
+PROTOCOL = pickle.HIGHEST_PROTOCOL
+assert PROTOCOL == 5, f"expected Pickle protocol 5, got {PROTOCOL}"
+
+# Pinned reference: vLLM v1 kv_cache_utils.hash_block_tokens +
+# utils/hashing.py sha256, verified against checkout
+# v0.22.1rc0-459-g462ef83d5 (commit 462ef83d58e6fadeb6e216dc583554a6980a0af9).
+VLLM_REFERENCE = (
+    "vLLM v0.22.1rc0-459-g462ef83d5 hash_block_tokens value shapes with "
+    "utils/hashing.py sha256 = SHA256(pickle.dumps(value, protocol=5))"
+)
+
+# Serialized block bytes are recorded in full for every case small enough to
+# keep the fixture reviewable.  Cases that must cross CPython's 64 KiB frame
+# target (frame boundary and large-payload paths) record pickle_len instead;
+# their digest is still the SHA-256 of the exact serialized bytes, so a digest
+# match certifies byte equality.
+PICKLE_HEX_SIZE_LIMIT = 8192
+
+SEEDS = ["0", "00", "random", "4294967295"]
+
+
+def sha256_pickle(value) -> bytes:
+    return hashlib.sha256(pickle.dumps(value, protocol=PROTOCOL)).digest()
+
+
+def extras_for(lora_name: str, cache_salt, block_index: int):
+    keys = []
+    if lora_name:
+        keys.append(lora_name)
+    if block_index == 0 and cache_salt:
+        keys.append(cache_salt)
+    return tuple(keys) if keys else None
+
+
+def block_entry(pickle_bytes: bytes) -> dict:
+    digest = hashlib.sha256(pickle_bytes).digest()
+    entry = {
+        "digest": digest.hex(),
+        "projected_hex": digest[-8:].hex(),
+        "projected_decimal": str(int.from_bytes(digest[-8:], "big")),
+    }
+    if len(pickle_bytes) <= PICKLE_HEX_SIZE_LIMIT:
+        entry["pickle_hex"] = pickle_bytes.hex()
+    else:
+        entry["pickle_len"] = len(pickle_bytes)
+    return entry
+
+
+def expand_tokens(case: dict):
+    if "token_ids_repeat" in case:
+        spec = case["token_ids_repeat"]
+        return [spec["value"]] * spec["count"]
+    return list(case["token_ids"])
+
+
+CASES = [
+    {
+        "name": "spec_unsalted",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "single_token_tuple",
+        "block_size": 1,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [7],
+    },
+    {
+        "name": "two_token_tuple",
+        "block_size": 2,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [7, 8],
+    },
+    {
+        "name": "three_token_tuple",
+        "block_size": 3,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [7, 8, 9],
+    },
+    {
+        "name": "empty_extras_encode_as_none",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [10, 20, 30, 40],
+    },
+    {
+        "name": "signed_integer_boundaries",
+        "block_size": 8,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [-2147483648, -1, 0, 255, 256, 65535, 65536, 2147483647],
+    },
+    {
+        "name": "utf8_multibyte",
+        "block_size": 4,
+        "lora_name": "模型-适配器",
+        "cache_salt": "盐值-🚀",
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "lora_length_255",
+        "block_size": 4,
+        "lora_name": "a" * 255,
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "lora_length_256",
+        "block_size": 4,
+        "lora_name": "a" * 256,
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "salt_length_255",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": "s" * 255,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "salt_length_256",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": "s" * 256,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "lora_every_block",
+        "block_size": 4,
+        "lora_name": "adapter-A",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "salt_first_block_only",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": "tenant-salt",
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "lora_then_salt",
+        "block_size": 4,
+        "lora_name": "adapter-A",
+        "cache_salt": "tenant-salt",
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "multi_block_chain",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": list(range(1, 17)),
+    },
+    {
+        "name": "incomplete_tail",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4, 5, 6],
+    },
+    {
+        "name": "no_complete_block",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3],
+    },
+    {
+        # 22000 BININT2 tokens serialize to ~66 KiB inside the token tuple,
+        # forcing CPython's _Framer to commit a frame mid-value.
+        "name": "frame_boundary_token_stream",
+        "block_size": 22000,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids_repeat": {"value": 256, "count": 22000},
+    },
+    {
+        # A >= 64 KiB extra-key string takes CPython's write_large_bytes path:
+        # the pending frame is force-committed and the string is written
+        # without a frame opcode.
+        "name": "large_lora_large_payload",
+        "block_size": 4,
+        "lora_name": "a" * 70000,
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4],
+    },
+]
+
+
+def main() -> None:
+    seed_root_vectors = []
+    for seed in SEEDS:
+        serialized = pickle.dumps(seed, protocol=PROTOCOL)
+        seed_root_vectors.append(
+            {
+                "python_hash_seed": seed,
+                "pickle_hex": serialized.hex(),
+                "root_digest": hashlib.sha256(serialized).hexdigest(),
+            }
+        )
+
+    root_digest = sha256_pickle("0")
+    cases = []
+    for case in CASES:
+        tokens = expand_tokens(case)
+        block_size = case["block_size"]
+        lora_name = case["lora_name"]
+        cache_salt = case["cache_salt"]
+
+        expected = []
+        parent = root_digest
+        for block_index in range(len(tokens) // block_size):
+            block_tokens = tokens[
+                block_index * block_size : (block_index + 1) * block_size
+            ]
+            value = (
+                parent,
+                tuple(block_tokens),
+                extras_for(lora_name, cache_salt, block_index),
+            )
+            serialized = pickle.dumps(value, protocol=PROTOCOL)
+            expected.append(block_entry(serialized))
+            parent = hashlib.sha256(serialized).digest()
+
+        entry = {
+            "name": case["name"],
+            "block_size": block_size,
+            "lora_name": lora_name if len(lora_name) <= 512 else "",
+            "cache_salt": cache_salt,
+            "expected": expected,
+        }
+        if len(lora_name) > 512:
+            entry["lora_name_repeat"] = {"value": "a", "count": len(lora_name)}
+        if "token_ids_repeat" in case:
+            entry["token_ids_repeat"] = case["token_ids_repeat"]
+        else:
+            entry["token_ids"] = tokens
+
+        if case["name"] == "spec_unsalted":
+            # Digest of the second block when the low-64 projection is
+            # incorrectly reused as the parent instead of the full digest.
+            first_digest = bytes.fromhex(expected[0]["digest"])
+            wrong_value = (
+                first_digest[-8:],
+                tuple(tokens[4:8]),
+                None,
+            )
+            entry["incorrect_low64_parent_digest"] = hashlib.sha256(
+                pickle.dumps(wrong_value, protocol=PROTOCOL)
+            ).hexdigest()
+
+        cases.append(entry)
+
+    fixture = {
+        "description": (
+            "Golden vectors for the supported vLLM v1 sha256 (CPython Pickle "
+            "protocol 5) seed-derived root and block-hash profile.  pickle_hex "
+            "records the exact serialized bytes hashed for small values; large "
+            "frame-boundary values record pickle_len and are certified by "
+            "their digest."
+        ),
+        "generator": VLLM_REFERENCE,
+        "generator_metadata": {
+            "python_version": platform.python_version(),
+            "pickle_protocol": PROTOCOL,
+            "pickle_highest_protocol": pickle.HIGHEST_PROTOCOL,
+        },
+        "profile": {
+            "strategy": "vllm_v1",
+            "algorithm": "sha256",
+            "python_hash_seed": "0",
+            "root_digest": root_digest.hex(),
+            "index_projection": "low64_be",
+        },
+        "seed_root_vectors": seed_root_vectors,
+        "cases": cases,
+    }
+
+    out = Path(__file__).with_name("hash_golden_vectors_sha256.json")
+    # ensure_ascii=False keeps the non-ASCII cache-salt cases readable, so both
+    # the encoding and the line ending are explicit rather than
+    # platform-dependent: the default encoding is not guaranteed to represent
+    # those characters, and LF keeps regeneration byte-identical everywhere so
+    # the "regenerate and diff" check above reports only real changes.
+    out.write_text(
+        json.dumps(fixture, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mooncake-conductor/tests/fixtures/hash_golden_vectors.json
+++ b/mooncake-conductor/tests/fixtures/hash_golden_vectors.json
@@ -1,0 +1,232 @@
+{
+  "description": "Golden vectors for the supported vLLM v1 sha256_cbor seed-derived root and block-hash profile.",
+  "generator": "vLLM 0.22.0 hash_block_tokens semantics with cbor2 6.1.1 canonical=True",
+  "profile": {
+    "strategy": "vllm_v1",
+    "algorithm": "sha256_cbor",
+    "python_hash_seed": "0",
+    "root_digest": "4e1195df020de59e0d65a33a4279f1183e7ae4e5d980e309f8b55adff2e61c3e",
+    "index_projection": "low64_be"
+  },
+  "seed_root_vectors": [
+    {
+      "python_hash_seed": "0",
+      "canonical_cbor_hex": "6130",
+      "root_digest": "4e1195df020de59e0d65a33a4279f1183e7ae4e5d980e309f8b55adff2e61c3e"
+    },
+    {
+      "python_hash_seed": "00",
+      "canonical_cbor_hex": "623030",
+      "root_digest": "8d912e4e62b3cc377b1d1c7a14ef61dffbdaa0990237035c05401c29414c4172"
+    }
+  ],
+  "cases": [
+    {
+      "name": "spec_unsalted",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+      "expected": [
+        {
+          "digest": "c9d58ba695280d69b243e1e0df813136ca9196b286fb1a021e0b2e028ef071cb",
+          "projected_hex": "1e0b2e028ef071cb",
+          "projected_decimal": "2164874634404590027"
+        },
+        {
+          "digest": "24125b23e68883b5c2141db2959d48433fe6bde2f26bd914efad121d154ab2d6",
+          "projected_hex": "efad121d154ab2d6",
+          "projected_decimal": "17270480062156288726"
+        }
+      ],
+      "incorrect_low64_parent_digest": "067bc227e5aa13cb174be22cd7016b7b21b663eddba6241928d7a7d1ffc0aa1e"
+    },
+    {
+      "name": "lora_every_block",
+      "block_size": 4,
+      "lora_name": "adapter-A",
+      "cache_salt": null,
+      "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+      "expected": [
+        {
+          "digest": "1424c0ec536f82188b592f263601d4e48c0255081c5f1e9225163c6d611a5222",
+          "projected_hex": "25163c6d611a5222",
+          "projected_decimal": "2672389869369184802"
+        },
+        {
+          "digest": "4a2ec941640a8f2470869ec2b3cf6bdd90e2be83b21807b628ac9abe9341eea9",
+          "projected_hex": "28ac9abe9341eea9",
+          "projected_decimal": "2930887600816385705"
+        }
+      ]
+    },
+    {
+      "name": "salt_first_block",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "tenant-salt",
+      "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+      "expected": [
+        {
+          "digest": "3be45574566e2f3c51c9f254d9627cf113382b627aeaefe8b661d66cfa089359",
+          "projected_hex": "b661d66cfa089359",
+          "projected_decimal": "13142020951183496025"
+        },
+        {
+          "digest": "22dea68f80ff7f40243dfb906a33db02571905c78a3b42153a56de5ad08c661a",
+          "projected_hex": "3a56de5ad08c661a",
+          "projected_decimal": "4203791783824221722"
+        }
+      ]
+    },
+    {
+      "name": "lora_then_salt",
+      "block_size": 4,
+      "lora_name": "adapter-A",
+      "cache_salt": "tenant-salt",
+      "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+      "expected": [
+        {
+          "digest": "22977da6c71098507264dbf4161d451c2d98494c5c146717f36787e184b36040",
+          "projected_hex": "f36787e184b36040",
+          "projected_decimal": "17539136676481425472"
+        },
+        {
+          "digest": "6a3cd7de2626c2d2982eb5bc9d4878a49745c3784bde8a2334ffac47286bb866",
+          "projected_hex": "34ffac47286bb866",
+          "projected_decimal": "3818960430654273638"
+        }
+      ]
+    },
+    {
+      "name": "signed_integer_boundaries",
+      "block_size": 12,
+      "lora_name": "",
+      "cache_salt": null,
+      "token_ids": [
+        -2147483648,
+        -257,
+        -256,
+        -25,
+        -24,
+        -1,
+        0,
+        23,
+        24,
+        255,
+        256,
+        2147483647
+      ],
+      "expected": [
+        {
+          "digest": "d4e5cc975a84b5ae7299d36910284bf256ea1eade2689dba6391b08d86e006d7",
+          "projected_hex": "6391b08d86e006d7",
+          "projected_decimal": "7174709803277616855"
+        }
+      ]
+    },
+    {
+      "name": "utf8_length_23",
+      "block_size": 4,
+      "lora_name": "aaaaaaaaaaaaaaaaaaaaaaa",
+      "cache_salt": null,
+      "token_ids": [1, 2, 3, 4],
+      "expected": [
+        {
+          "digest": "3cc96f507898959352d1d123c849d0ab4b11846c8de3c67123d72e78957adb07",
+          "projected_hex": "23d72e78957adb07",
+          "projected_decimal": "2582584006759078663"
+        }
+      ]
+    },
+    {
+      "name": "utf8_length_24",
+      "block_size": 4,
+      "lora_name": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "cache_salt": null,
+      "token_ids": [1, 2, 3, 4],
+      "expected": [
+        {
+          "digest": "553263ebbf33660ecba67f9fcabea06d20cca3a71c79abf6e1894d39c7fa8ff8",
+          "projected_hex": "e1894d39c7fa8ff8",
+          "projected_decimal": "16251605640906706936"
+        }
+      ]
+    },
+    {
+      "name": "utf8_multibyte",
+      "block_size": 4,
+      "lora_name": "\u6a21\u578b-\u9002\u914d\u5668",
+      "cache_salt": "\u76d0\u503c-\ud83d\ude80",
+      "token_ids": [1, 2, 3, 4],
+      "expected": [
+        {
+          "digest": "69af00b1b180a366c69003a00527c2baf6bbc71880abc3b1d3b60fa2f553cdca",
+          "projected_hex": "d3b60fa2f553cdca",
+          "projected_decimal": "15255397980339162570"
+        }
+      ]
+    },
+    {
+      "name": "definite_array_length_24",
+      "block_size": 24,
+      "lora_name": "",
+      "cache_salt": null,
+      "token_ids": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
+      "expected": [
+        {
+          "digest": "792917e681c347b21bebfdd57cabcca6b79c865f83ccd2cfbd9cb56ffed2b088",
+          "projected_hex": "bd9cb56ffed2b088",
+          "projected_decimal": "13662994862156460168"
+        }
+      ]
+    },
+    {
+      "name": "incomplete_tail",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "token_ids": [1, 2, 3, 4, 5, 6],
+      "expected": [
+        {
+          "digest": "c9d58ba695280d69b243e1e0df813136ca9196b286fb1a021e0b2e028ef071cb",
+          "projected_hex": "1e0b2e028ef071cb",
+          "projected_decimal": "2164874634404590027"
+        }
+      ]
+    },
+    {
+      "name": "no_complete_block",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "token_ids": [1, 2, 3],
+      "expected": []
+    }
+  ]
+}

--- a/mooncake-conductor/tests/fixtures/hash_golden_vectors_sha256.json
+++ b/mooncake-conductor/tests/fixtures/hash_golden_vectors_sha256.json
@@ -1,0 +1,485 @@
+{
+  "description": "Golden vectors for the supported vLLM v1 sha256 (CPython Pickle protocol 5) seed-derived root and block-hash profile.  pickle_hex records the exact serialized bytes hashed for small values; large frame-boundary values record pickle_len and are certified by their digest.",
+  "generator": "vLLM v0.22.1rc0-459-g462ef83d5 hash_block_tokens value shapes with utils/hashing.py sha256 = SHA256(pickle.dumps(value, protocol=5))",
+  "generator_metadata": {
+    "python_version": "3.12.13",
+    "pickle_protocol": 5,
+    "pickle_highest_protocol": 5
+  },
+  "profile": {
+    "strategy": "vllm_v1",
+    "algorithm": "sha256",
+    "python_hash_seed": "0",
+    "root_digest": "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c",
+    "index_projection": "low64_be"
+  },
+  "seed_root_vectors": [
+    {
+      "python_hash_seed": "0",
+      "pickle_hex": "80059505000000000000008c0130942e",
+      "root_digest": "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c"
+    },
+    {
+      "python_hash_seed": "00",
+      "pickle_hex": "80059506000000000000008c023030942e",
+      "root_digest": "67c61e0f70ad5d3fc0eacb59744008ac6f2a8bd2edad43540a743eaf0fb4993c"
+    },
+    {
+      "python_hash_seed": "random",
+      "pickle_hex": "8005950a000000000000008c0672616e646f6d942e",
+      "root_digest": "fa1326fc0ad784c54e10f808051a77f999f7b675b12fba49cbef92b3e1a09cb7"
+    },
+    {
+      "python_hash_seed": "4294967295",
+      "pickle_hex": "8005950e000000000000008c0a34323934393637323935942e",
+      "root_digest": "670c2eca46f5f7e11b9dce5c3bd2ff0e9e19567fd45b50c2db5cc0c9aae470d9"
+    }
+  ],
+  "cases": [
+    {
+      "name": "spec_unsalted",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d",
+          "projected_hex": "8fce057e23bae91d",
+          "projected_decimal": "10362225831949560093",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474944e87942e"
+        },
+        {
+          "digest": "9e62b5a7ec298f33cb4c7d9e00b659874bb2432d23ad6879ad1746592a2b036b",
+          "projected_hex": "ad1746592a2b036b",
+          "projected_decimal": "12472515041799373675",
+          "pickle_hex": "80059532000000000000004320762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d94284b054b064b074b0874944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "incorrect_low64_parent_digest": "22f70d17411c10aa544ecdac1d2df0fc1d7c7ac2d21efe1aebe32028620638c6"
+    },
+    {
+      "name": "single_token_tuple",
+      "block_size": 1,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "4e7493abc7315520e17ce180ee400439b7dc83e7406fb239462766705eb058c8",
+          "projected_hex": "462766705eb058c8",
+          "projected_decimal": "5055121739557656776",
+          "pickle_hex": "8005952b0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c944b0785944e87942e"
+        }
+      ],
+      "token_ids": [
+        7
+      ]
+    },
+    {
+      "name": "two_token_tuple",
+      "block_size": 2,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "aa9e79304bb6921235ea2e187b25f9bb43d9044ec232e3d1c07d7e21e51e64ee",
+          "projected_hex": "c07d7e21e51e64ee",
+          "projected_decimal": "13870381111413990638",
+          "pickle_hex": "8005952d0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c944b074b0886944e87942e"
+        }
+      ],
+      "token_ids": [
+        7,
+        8
+      ]
+    },
+    {
+      "name": "three_token_tuple",
+      "block_size": 3,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "6368e68a46c970c8ec2ebab3eb9d2fe7ddc2730165bb64d698aaed2907396794",
+          "projected_hex": "98aaed2907396794",
+          "projected_decimal": "11000865800276502420",
+          "pickle_hex": "8005952f0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c944b074b084b0987944e87942e"
+        }
+      ],
+      "token_ids": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "name": "empty_extras_encode_as_none",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "569de0636f6064532b63312eab095a4577e72dc55286dbfb43821ec866309e47",
+          "projected_hex": "43821ec866309e47",
+          "projected_decimal": "4864484393570311751",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b0a4b144b1e4b2874944e87942e"
+        }
+      ],
+      "token_ids": [
+        10,
+        20,
+        30,
+        40
+      ]
+    },
+    {
+      "name": "signed_integer_boundaries",
+      "block_size": 8,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "6c9e5f944f0a93319b3ba9478115a9447de2f6d4ef1cd1c0b19a7ebd607353e8",
+          "projected_hex": "b19a7ebd607353e8",
+          "projected_decimal": "12797680642958775272",
+          "pickle_hex": "800595480000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284a000000804affffffff4b004bff4d00014dffff4a000001004affffff7f74944e87942e"
+        }
+      ],
+      "token_ids": [
+        -2147483648,
+        -1,
+        0,
+        255,
+        256,
+        65535,
+        65536,
+        2147483647
+      ]
+    },
+    {
+      "name": "utf8_multibyte",
+      "block_size": 4,
+      "lora_name": "模型-适配器",
+      "cache_salt": "盐值-🚀",
+      "expected": [
+        {
+          "digest": "cc1a2ab147f91a34070bb430e35dbc6ca6261a93b490a2307d0b4b31696a247a",
+          "projected_hex": "7d0b4b31696a247a",
+          "projected_decimal": "9010378155078853754",
+          "pickle_hex": "800595540000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c10e6a8a1e59e8b2de98082e9858de599a8948c0be79b90e580bc2df09f9a8094869487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "lora_length_255",
+      "block_size": 4,
+      "lora_name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "866b277c9d76457e35bd6a5dd3ec0d5b598faa9e36d108608f6e925149b1524b",
+          "projected_hex": "8f6e925149b1524b",
+          "projected_decimal": "10335359072688230987",
+          "pickle_hex": "800595350100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948cff61616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "lora_length_256",
+      "block_size": 4,
+      "lora_name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "0c934ab8aa543128da871a91a46387ed907ed3ca8b39e5c137da510f80a106df",
+          "projected_hex": "37da510f80a106df",
+          "projected_decimal": "4024618344033355487",
+          "pickle_hex": "800595390100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b04749458000100006161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "salt_length_255",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "expected": [
+        {
+          "digest": "167d69abb219f81883e1fc5e554564bab043051f849914feb058487c8bffc398",
+          "projected_hex": "b058487c8bffc398",
+          "projected_decimal": "12706986048387793816",
+          "pickle_hex": "800595350100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948cff73737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737394859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "salt_length_256",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "expected": [
+        {
+          "digest": "0875d6e8c04ec7bb02928dc8f4b9e336aecb8adfae9078a9b6b54fe557b6857d",
+          "projected_hex": "b6b54fe557b6857d",
+          "projected_decimal": "13165516932125197693",
+          "pickle_hex": "800595390100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b04749458000100007373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737394859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "lora_every_block",
+      "block_size": 4,
+      "lora_name": "adapter-A",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "5c5d9e04e03de9f2f4a9f38766c4d0fb0e207ccf5d2fb3b272c50117f336ae0c",
+          "projected_hex": "72c50117f336ae0c",
+          "projected_decimal": "8270017493112106508",
+          "pickle_hex": "8005953f0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c09616461707465722d4194859487942e"
+        },
+        {
+          "digest": "bde66cc24757972cc88e0fe62079d85934868c2733874ffa1c54ff679604f61a",
+          "projected_hex": "1c54ff679604f61a",
+          "projected_decimal": "2041537351469299226",
+          "pickle_hex": "8005953f0000000000000043205c5d9e04e03de9f2f4a9f38766c4d0fb0e207ccf5d2fb3b272c50117f336ae0c94284b054b064b074b0874948c09616461707465722d4194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "name": "salt_first_block_only",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "tenant-salt",
+      "expected": [
+        {
+          "digest": "373c09c29ab08b91b13bf1a67e0a461990572d476016c064b6ba6b75c163ceb1",
+          "projected_hex": "b6ba6b75c163ceb1",
+          "projected_decimal": "13166954614070955697",
+          "pickle_hex": "800595410000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c0b74656e616e742d73616c7494859487942e"
+        },
+        {
+          "digest": "141900dd6fe59d22764357a125ecf4d670923bb12ad705a520de0e98c7338d5d",
+          "projected_hex": "20de0e98c7338d5d",
+          "projected_decimal": "2368346503383321949",
+          "pickle_hex": "80059532000000000000004320373c09c29ab08b91b13bf1a67e0a461990572d476016c064b6ba6b75c163ceb194284b054b064b074b0874944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "name": "lora_then_salt",
+      "block_size": 4,
+      "lora_name": "adapter-A",
+      "cache_salt": "tenant-salt",
+      "expected": [
+        {
+          "digest": "dacd8a5addba8cf4b89589bedab04999b3676299a455ba3e085cc7777be6b328",
+          "projected_hex": "085cc7777be6b328",
+          "projected_decimal": "602575766154556200",
+          "pickle_hex": "8005954d0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c09616461707465722d41948c0b74656e616e742d73616c7494869487942e"
+        },
+        {
+          "digest": "55575bd9b63ced6a3dc36c355afbb5f551599533795c26d27d8b5fc836681618",
+          "projected_hex": "7d8b5fc836681618",
+          "projected_decimal": "9046429590014662168",
+          "pickle_hex": "8005953f000000000000004320dacd8a5addba8cf4b89589bedab04999b3676299a455ba3e085cc7777be6b32894284b054b064b074b0874948c09616461707465722d4194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "name": "multi_block_chain",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d",
+          "projected_hex": "8fce057e23bae91d",
+          "projected_decimal": "10362225831949560093",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474944e87942e"
+        },
+        {
+          "digest": "9e62b5a7ec298f33cb4c7d9e00b659874bb2432d23ad6879ad1746592a2b036b",
+          "projected_hex": "ad1746592a2b036b",
+          "projected_decimal": "12472515041799373675",
+          "pickle_hex": "80059532000000000000004320762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d94284b054b064b074b0874944e87942e"
+        },
+        {
+          "digest": "fd503875de30430b3c7e35f7ecca2fe995f2d55487bfef31707e09b175f917a0",
+          "projected_hex": "707e09b175f917a0",
+          "projected_decimal": "8105927037106591648",
+          "pickle_hex": "800595320000000000000043209e62b5a7ec298f33cb4c7d9e00b659874bb2432d23ad6879ad1746592a2b036b94284b094b0a4b0b4b0c74944e87942e"
+        },
+        {
+          "digest": "ac30858a66380467632841b758acc6cbe95ff9cfd7b9d226aa33de029248adff",
+          "projected_hex": "aa33de029248adff",
+          "projected_decimal": "12264390312885530111",
+          "pickle_hex": "80059532000000000000004320fd503875de30430b3c7e35f7ecca2fe995f2d55487bfef31707e09b175f917a094284b0d4b0e4b0f4b1074944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ]
+    },
+    {
+      "name": "incomplete_tail",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d",
+          "projected_hex": "8fce057e23bae91d",
+          "projected_decimal": "10362225831949560093",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "name": "no_complete_block",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [],
+      "token_ids": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "name": "frame_boundary_token_stream",
+      "block_size": 22000,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "7f245129165bb9ba11747856a9a908740bf7b29c0033da4958281d87b252f469",
+          "projected_hex": "58281d87b252f469",
+          "projected_decimal": "6352359743055656041",
+          "pickle_len": 66062
+        }
+      ],
+      "token_ids_repeat": {
+        "value": 256,
+        "count": 22000
+      }
+    },
+    {
+      "name": "large_lora_large_payload",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "f30f906062e861807059e2099b689baf2c9484128a0c2fd40a5fdd1e1032f47f",
+          "projected_hex": "0a5fdd1e1032f47f",
+          "projected_decimal": "747559184357323903",
+          "pickle_len": 70077
+        }
+      ],
+      "lora_name_repeat": {
+        "value": "a",
+        "count": 70000
+      },
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  ]
+}

--- a/mooncake-conductor/tests/fixtures/verify_fixture_against_vllm.py
+++ b/mooncake-conductor/tests/fixtures/verify_fixture_against_vllm.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Verifies hash_golden_vectors_sha256.json against the checked-out vLLM.
+
+Loads ``vllm/utils/hashing.py`` directly from a vLLM source checkout (without
+importing the heavy ``vllm`` package) and uses its ``sha256`` function as the
+normative oracle: SHA-256 over ``pickle.dumps(value, protocol=5)``.  The block
+value shapes mirror ``vllm/v1/core/kv_cache_utils.py::hash_block_tokens``.
+
+Usage:
+
+    python3 verify_fixture_against_vllm.py <path-to-vllm-checkout>
+
+Prints the Python/vLLM/protocol metadata it ran against and exits non-zero on
+any mismatch.
+"""
+
+import importlib.util
+import json
+import pickle
+import platform
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+FIXTURE = Path(__file__).with_name("hash_golden_vectors_sha256.json")
+
+
+def load_vllm_hashing(checkout: Path):
+    hashing_py = checkout / "vllm" / "utils" / "hashing.py"
+    if not hashing_py.is_file():
+        raise SystemExit(f"vLLM hashing.py not found at {hashing_py}")
+    # hashing.py imports cbor2 at module scope; the sha256 recipe under test
+    # never touches it, so a stub is sufficient when cbor2 is absent.
+    if "cbor2" not in sys.modules:
+        try:
+            import cbor2  # noqa: F401
+        except ImportError:
+            sys.modules["cbor2"] = types.ModuleType("cbor2")
+    spec = importlib.util.spec_from_file_location("vllm_hashing", hashing_py)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.sha256
+
+
+def vllm_revision(checkout: Path) -> str:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(checkout), "describe", "--tags", "--always"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def expand_tokens(case: dict):
+    if "token_ids_repeat" in case:
+        spec = case["token_ids_repeat"]
+        return [spec["value"]] * spec["count"]
+    return list(case["token_ids"])
+
+
+def expand_lora(case: dict) -> str:
+    if "lora_name_repeat" in case:
+        spec = case["lora_name_repeat"]
+        return spec["value"] * spec["count"]
+    return case["lora_name"]
+
+
+def extras_for(lora_name: str, cache_salt, block_index: int):
+    keys = []
+    if lora_name:
+        keys.append(lora_name)
+    if block_index == 0 and cache_salt:
+        keys.append(cache_salt)
+    return tuple(keys) if keys else None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {Path(__file__).name} <path-to-vllm-checkout>")
+    checkout = Path(sys.argv[1])
+    vllm_sha256 = load_vllm_hashing(checkout)
+    # The fixture carries non-ASCII cache salts, so the encoding is explicit
+    # rather than platform-dependent.
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    print(f"python: {platform.python_version()}")
+    print(f"pickle protocol: {pickle.HIGHEST_PROTOCOL}")
+    print(f"vLLM checkout: {checkout} ({vllm_revision(checkout)})")
+
+    failures = 0
+
+    def check(label: str, actual: str, expected: str) -> None:
+        nonlocal failures
+        if actual != expected:
+            failures += 1
+            print(f"MISMATCH {label}:\n  actual   {actual}\n  expected {expected}")
+
+    for vector in fixture["seed_root_vectors"]:
+        seed = vector["python_hash_seed"]
+        check(f"seed root {seed!r}", vllm_sha256(seed).hex(), vector["root_digest"])
+        check(
+            f"seed pickle bytes {seed!r}",
+            pickle.dumps(seed, protocol=5).hex(),
+            vector["pickle_hex"],
+        )
+
+    root = bytes.fromhex(fixture["profile"]["root_digest"])
+    for case in fixture["cases"]:
+        tokens = expand_tokens(case)
+        block_size = case["block_size"]
+        lora_name = expand_lora(case)
+        cache_salt = case["cache_salt"]
+        parent = root
+        for index, entry in enumerate(case["expected"]):
+            block_tokens = tuple(tokens[index * block_size : (index + 1) * block_size])
+            value = (
+                parent,
+                block_tokens,
+                extras_for(lora_name, cache_salt, index),
+            )
+            serialized = pickle.dumps(value, protocol=5)
+            digest = vllm_sha256(value).hex()
+            check(f"{case['name']} block {index}", digest, entry["digest"])
+            if "pickle_hex" in entry:
+                check(
+                    f"{case['name']} block {index} pickle bytes",
+                    serialized.hex(),
+                    entry["pickle_hex"],
+                )
+            else:
+                check(
+                    f"{case['name']} block {index} pickle length",
+                    str(len(serialized)),
+                    str(entry["pickle_len"]),
+                )
+            parent = bytes.fromhex(digest)
+
+    if failures:
+        print(f"{failures} mismatch(es)")
+        return 1
+    print("all seed roots, block digests, and serialized bytes match vLLM")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mooncake-conductor/tests/model_context_test.cpp
+++ b/mooncake-conductor/tests/model_context_test.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <concepts>
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "conductor/prefixindex/types.h"
+
+namespace {
+
+using mooncake::conductor::common::HashProfileConfig;
+using mooncake::conductor::common::ResolvedHashProfile;
+using mooncake::conductor::prefixindex::ContextKey;
+using mooncake::conductor::prefixindex::EngineRegistration;
+using mooncake::conductor::prefixindex::GpuMutation;
+
+template <typename T>
+concept HasInstanceId = requires(T value) { value.instance_id; };
+
+template <typename T>
+concept HasCacheSalt = requires(T value) { value.cache_salt; };
+
+template <typename T>
+concept HasAdditionalSalt = requires(T value) { value.additional_salt; };
+
+template <typename T>
+concept HasCacheGroups = requires(T value) { value.cache_groups; };
+
+template <typename T>
+concept HasPythonHashSeed = requires(T value) { value.python_hash_seed; };
+
+template <typename T>
+concept HasRootDigest = requires(T value) { value.root_digest; };
+
+static_assert(!HasInstanceId<ContextKey>);
+static_assert(!HasCacheSalt<ContextKey>);
+static_assert(!HasAdditionalSalt<ContextKey>);
+static_assert(!HasPythonHashSeed<ContextKey>);
+static_assert(!HasCacheGroups<EngineRegistration>);
+static_assert(!HasCacheGroups<GpuMutation>);
+static_assert(HasPythonHashSeed<HashProfileConfig>);
+static_assert(!HasRootDigest<HashProfileConfig>);
+static_assert(HasPythonHashSeed<ResolvedHashProfile>);
+static_assert(HasRootDigest<ResolvedHashProfile>);
+static_assert(std::same_as<decltype(EngineRegistration::cache_group),
+                           std::optional<int64_t>>);
+static_assert(
+    std::same_as<decltype(GpuMutation::cache_group), std::optional<int64_t>>);
+
+ContextKey BaseContext() {
+    return {.tenant_id = "tenant-a",
+            .model_name = "model-a",
+            .lora_name = "lora-a",
+            .block_size = 16};
+}
+
+TEST(ContextKey, IdenticalCopiesCompareAndHashEqual) {
+    const ContextKey first = BaseContext();
+    const ContextKey second = first;
+
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(std::hash<ContextKey>{}(first), std::hash<ContextKey>{}(second));
+}
+
+struct FieldCase {
+    const char* name;
+    void (*change)(ContextKey*);
+};
+
+const FieldCase kFields[] = {
+    {"tenant_id", [](ContextKey* context) { context->tenant_id = "tenant-b"; }},
+    {"model_name",
+     [](ContextKey* context) { context->model_name = "model-b"; }},
+    {"lora_name", [](ContextKey* context) { context->lora_name = "lora-b"; }},
+    {"block_size", [](ContextKey* context) { context->block_size = 32; }},
+};
+
+TEST(ContextKey, ExactlyFourFieldsParticipateInEqualityAndLookup) {
+    std::unordered_map<ContextKey, int> contexts;
+    contexts.emplace(BaseContext(), 1);
+
+    for (const FieldCase& field : kFields) {
+        SCOPED_TRACE(field.name);
+        ContextKey changed = BaseContext();
+        field.change(&changed);
+        EXPECT_NE(changed, BaseContext());
+        EXPECT_FALSE(contexts.contains(changed));
+    }
+}
+
+TEST(ContextKey, OwnerAndRequestSaltLiveOutsideTheKey) {
+    ContextKey shared = BaseContext();
+    const std::string first_instance = "instance-a";
+    const std::string second_instance = "instance-b";
+    const std::string first_salt = "salt-a";
+    const std::string second_salt = "salt-b";
+
+    EXPECT_NE(first_instance, second_instance);
+    EXPECT_NE(first_salt, second_salt);
+    EXPECT_EQ(shared, BaseContext());
+    EXPECT_EQ(std::hash<ContextKey>{}(shared),
+              std::hash<ContextKey>{}(BaseContext()));
+}
+
+}  // namespace

--- a/mooncake-conductor/tests/test_fixtures.h
+++ b/mooncake-conductor/tests/test_fixtures.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Shared helpers for loading JSON golden-vector fixtures. uint64 values are
+// stored as decimal strings so that values above 2^53 survive JSON
+// round-trips without precision loss.
+
+#include <json/json.h>
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+#include "integer_parser.h"
+
+namespace mooncake::conductor::test {
+
+inline Json::Value LoadJsonFixture(const std::string& filename) {
+    const std::string path =
+        std::string(CONDUCTOR_TEST_FIXTURE_DIR) + "/" + filename;
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error("cannot open fixture: " + path);
+    }
+    Json::Value root;
+    Json::CharReaderBuilder builder;
+    std::string errs;
+    if (!Json::parseFromStream(builder, in, &root, &errs)) {
+        throw std::runtime_error("cannot parse fixture " + path + ": " + errs);
+    }
+    return root;
+}
+
+inline uint64_t ParseU64(const Json::Value& v) {
+    const std::string text = v.asString();
+    const auto parsed = TryParseInteger<uint64_t>(text);
+    if (!parsed.has_value()) {
+        throw std::runtime_error("fixture value is not a uint64: " + text);
+    }
+    return *parsed;
+}
+
+}  // namespace mooncake::conductor::test


### PR DESCRIPTION
## Description

Second slice of the Mooncake Conductor upstreaming series, on top of the skeleton and common layer (#3825). Adds the hashing foundation the prefix index is built on; still a pure addition — nothing outside `mooncake-conductor` changes.

What lands here:

- `prefixindex/types.h`: `ContextKey` (the four fields that identify a cache context), `ProjectedPrefix`, `StorageTier`, the engine/shared owner types, and the registration/mutation/clear payload shapes, plus `std::hash` specializations for the two lookup keys.
- `prefixindex/hash_strategy.{h,cpp}`: the `HashChain` / `HashStrategy` interfaces and their vLLM and SGLang implementations, profile resolution and validation (`ResolveHashProfile` / `ValidateHashProfile` / `CreateHashStrategy`), and `DigestToHex`. The chain is lazily evaluated: asking for block *i* hashes and caches only up to *i*, so a prefix walk whose cursors have all stalled never pays for the untouched tail.
- SHA-256 backend selection in CMake: probe for the low-level `SHA256_*` API, which hashes through a stack context instead of allocating an EVP context per call, and fall back to EVP when those declarations are hidden by an OpenSSL
  no-deprecated build. FIPS deployments can force EVP with `-DCONDUCTOR_FORCE_EVP_SHA256=ON`.
- Golden-vector fixtures for both hash profiles, the generator script, and the vLLM cross-check script, wired into `conductor_test` through  `CONDUCTOR_TEST_FIXTURE_DIR`.
   * `hash_golden_vectors.json` -- generated vectors for the `sha256_cbor` profile (`hash_block_tokens` semantics with cbor2 6.1.1 `canonical=True`): 2 seed roots and 11 cases totalling 14 block digests. 
   * `hash_golden_vectors_sha256.json` -- generated vectors for the `sha256` profile (SHA-256 over `pickle.dumps(value, protocol=5)`): 4 seed roots and 19 cases totalling 25 block digests. Cases cover UTF-8 multibyte lora and salt
names, the 255/256-byte string-length boundaries, signed 32-bit token boundaries, CPython's 64 KiB Pickle frame boundary and its large-payload path, incomplete tail blocks, and inputs with no complete block.
    * `generate_hash_golden_vectors.py` -- regenerates `hash_golden_vectors_sha256.json` with the real CPython pickler as the normative oracle. It writes in place, so copy it to a scratch directory before running it to keep the checked-in fixture intact if it raises partway through. Regeneration is reproducible apart from the `generator_metadata.python_version` line.
    * `verify_fixture_against_vllm.py` -- re-checks `hash_golden_vectors_sha256.json`, loading
`vllm/utils/hashing.py` directly so that the upstream `sha256` function is the oracle. It needs an external checkout, so it is run by hand, not in CI.

The fixture scripts pin encoding and line ending explicitly rather than inheriting the platform default: the vectors carry non-ASCII cache salts, which the default encoding is not guaranteed to represent, and a fixed LF keeps regeneration byte-identical so the documented regenerate-and-diff check reports only real changes.

Remaining slices, in order: tiered prefix indexer, ZMQ subscriber + wire protocol, KV event manager + HTTP API, then e2e tests + cache-aware proxy example + docs.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [x] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Standalone component build
cmake -S mooncake-conductor -B build -G Ninja -DBUILD_UNIT_TESTS=ON
cmake --build build -j8
ctest --test-dir build --output-on-failure

# EVP SHA-256 backend (FIPS path)
cmake -S mooncake-conductor -B build-evp -G Ninja -DBUILD_UNIT_TESTS=ON \
  -DCONDUCTOR_FORCE_EVP_SHA256=ON
cmake --build build-evp -j8 && ctest --test-dir build-evp --output-on-failure

# Top-level build, the path CI takes
cmake -S . -B build-top -G Ninja -DBUILD_UNIT_TESTS=ON -DWITH_CONDUCTOR=ON
cmake --build build-top -j8 --target conductor_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`conductor_test` passes — 38 tests across 11 suites — under both the standalone and top-level configurations, and both SHA-256 backends (low-level and `-DCONDUCTOR_FORCE_EVP_SHA256=ON`) produce identical digests. Golden vectors
regenerate byte-identically, and the vLLM cross-check script agrees with the checked-in vectors.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI-assisted. The conductor sources are carried over from the existing conductor branch; AI was used to determine the dependency-ordered split, scope the CMake increment to this slice, replace the hand-rolled integer parsing with `mooncake-common`'s `TryParseInteger` and differentially test the substitution, and make the fixture scripts platform-independent. Every changed line has been reviewed by the submitter.