### PR TITLE
[Store] Restore caller thread affinity after SPDK env init

### DIFF
--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -6,6 +6,11 @@
 #include <cstring>
 #include <cstdlib>
 #include <thread>
+
+#if defined(__linux__)
+#include <pthread.h>
+#endif
+
 #include "spdk/spdk_wrapper.h"
 
 namespace mooncake {
@@ -122,7 +127,26 @@ bool SpdkWrapper::InitializeEnv() {
     spdk_env_opts_init(&opts);
     opts.name = "mooncake";
 
+    // spdk_env_init pins the calling thread to the first core in core_mask
+    // (CPU0 by default) as the DPDK main lcore. Mooncake runs in-process, so
+    // that silently overrides the host application's own affinity; hand the
+    // caller's mask back once DPDK is done with the thread.
+#if defined(__linux__)
+    cpu_set_t caller_mask;
+    const bool have_caller_mask =
+        pthread_getaffinity_np(pthread_self(), sizeof(caller_mask),
+                               &caller_mask) == 0;
+#endif
+
     int rc = spdk_env_init(&opts);
+
+#if defined(__linux__)
+    if (have_caller_mask) {
+        pthread_setaffinity_np(pthread_self(), sizeof(caller_mask),
+                               &caller_mask);
+    }
+#endif
+
     if (rc != 0) {
         fprintf(stderr, "SPDK init failed: %d\n", rc);
         return false;


### PR DESCRIPTION
## Description

Fixes #3865. `SpdkWrapper::InitializeEnv()` runs `spdk_env_init()` on the caller's thread, and under DPDK's default core mask that thread is pinned to CPU0 as the main lcore. Mooncake is linked in-process, so the host application (an inference scheduler, for example) silently keeps running with that restricted mask, and threads it spawns afterwards inherit it. This saves the caller's affinity before the init and restores it right after, on both the success and failure paths. Linux only; other platforms are untouched.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

No CI lane builds `USE_NOF` and there is no SPDK/DPDK setup available to me here, so a full-file compile against real SPDK headers and a live `spdk_env_init` were not possible. Verified what is verifiable without the hardware:

- Extracted the patched `InitializeEnv()` body verbatim and compiled it with `g++ 11.4 -std=c++17 -Wall -Wextra -Werror` (Ubuntu 22.04 container) against an SPDK stub whose `spdk_env_init` pins the calling thread to CPU0, mirroring DPDK's default core mask behavior.
- Stub sanity probe: without the restore, the thread really ends pinned to CPU0.
- Success path: returns true, caller's original mask restored.
- Failure path (`spdk_env_init` returns nonzero): returns false, affinity still restored.
- `clang-format-14 --dry-run --Werror` clean on the touched file.

A behavior check on a real NoF host is welcome; the change region is self-contained around the init call.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

See above; no in-repo harness exists for the NoF path.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format 14 dry-run clean)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass (format hook equivalent; see testing notes)
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Prepared with AI assistance (Kimi K3), including the container verification harness. The submitter reviewed every changed line and can defend the change end-to-end.