### PR TITLE
[Store] Expose explicit soft pin action and TTL in C ABI and Go/Rust bindings

### DIFF
--- a/docs/source/api-reference/rust/mooncake-store.md
+++ b/docs/source/api-reference/rust/mooncake-store.md
@@ -182,19 +182,21 @@ Replication settings for write operations (`put`, `put_from`, `batch_put_from`).
 Fields:
 
 - `replica_num`: number of replicas (0 means “use server default”).
-- `with_soft_pin`: prefer retaining the object in memory (soft pin).
+- `soft_pin_action`: soft-pin intent for the write, one of `SoftPinAction::Preserve` (default; keeps an existing unexpired deadline), `SoftPinAction::Enable` (commits a new soft pin when the write becomes readable), or `SoftPinAction::Disable` (removes an existing soft pin). A soft pin guards an object from eviction until a deadline fixed at write time; reads never extend it.
+- `soft_pin_ttl_ms`: optional soft-pin TTL override in milliseconds. Only valid with `SoftPinAction::Enable`; `None` uses the master’s default TTL.
 - `with_hard_pin`: never evict (hard pin).
 - `preferred_segments`: whitelist of segment names that should host a replica.
 
 Example:
 
 ```rust
-use mooncake_store::{MooncakeStore, ReplicateConfig};
+use mooncake_store::{MooncakeStore, ReplicateConfig, SoftPinAction};
 
 fn write_with_replication(store: &MooncakeStore) -> Result<(), mooncake_store::StoreError> {
     let cfg = ReplicateConfig {
         replica_num: 2,
-        with_soft_pin: true,
+        soft_pin_action: SoftPinAction::Enable,
+        soft_pin_ttl_ms: None,
         with_hard_pin: false,
         preferred_segments: vec!["seg-a".to_string(), "seg-b".to_string()],
     };

--- a/mooncake-store/go/mooncakestore/config.go
+++ b/mooncake-store/go/mooncakestore/config.go
@@ -35,9 +35,9 @@ const (
 type ReplicateConfig struct {
 	ReplicaNum    int
 	SoftPinAction SoftPinAction
-	// SoftPinTTLMS overrides the master's default soft-pin TTL in
+	// SoftPinTTLMs overrides the master's default soft-pin TTL in
 	// milliseconds. Only valid with SoftPinEnable.
-	SoftPinTTLMS      *uint64
+	SoftPinTTLMs      *uint64
 	WithHardPin       bool
 	PreferredSegments []string
 }

--- a/mooncake-store/go/mooncakestore/config.go
+++ b/mooncake-store/go/mooncakestore/config.go
@@ -14,10 +14,30 @@
 
 package mooncakestore
 
+// SoftPinAction selects the soft-pin intent of a put operation. A soft pin
+// guards an object from eviction until a deadline fixed at write time;
+// reads never extend it.
+type SoftPinAction int
+
+const (
+	// SoftPinPreserve keeps an existing unexpired soft-pin deadline. It is
+	// the zero value, so plain puts commit ordinary cache.
+	SoftPinPreserve SoftPinAction = iota
+	// SoftPinEnable commits a new soft-pin lifetime when the write
+	// becomes readable.
+	SoftPinEnable
+	// SoftPinDisable removes an existing soft pin when the write
+	// becomes readable.
+	SoftPinDisable
+)
+
 // ReplicateConfig controls replica placement for put operations.
 type ReplicateConfig struct {
-	ReplicaNum        int
-	WithSoftPin       bool
+	ReplicaNum    int
+	SoftPinAction SoftPinAction
+	// SoftPinTTLMS overrides the master's default soft-pin TTL in
+	// milliseconds. Only valid with SoftPinEnable.
+	SoftPinTTLMS      *uint64
 	WithHardPin       bool
 	PreferredSegments []string
 }
@@ -26,7 +46,6 @@ type ReplicateConfig struct {
 func DefaultReplicateConfig() ReplicateConfig {
 	return ReplicateConfig{
 		ReplicaNum:  1,
-		WithSoftPin: false,
 		WithHardPin: false,
 	}
 }

--- a/mooncake-store/go/mooncakestore/store.go
+++ b/mooncake-store/go/mooncakestore/store.go
@@ -136,9 +136,18 @@ func (s *Store) toCConfig(cfg *ReplicateConfig) (C.mooncake_replicate_config_t, 
 		return cc, nil, ErrInvalidArgument
 	}
 
+	if cfg.SoftPinAction < SoftPinPreserve || cfg.SoftPinAction > SoftPinDisable {
+		return cc, nil, ErrInvalidArgument
+	}
+	if cfg.SoftPinTTLMS != nil && cfg.SoftPinAction != SoftPinEnable {
+		return cc, nil, ErrInvalidArgument
+	}
+
 	cc.replica_num = C.size_t(cfg.ReplicaNum)
-	if cfg.WithSoftPin {
-		cc.with_soft_pin = 1
+	cc.soft_pin_action = C.int(cfg.SoftPinAction)
+	if cfg.SoftPinTTLMS != nil {
+		cc.has_soft_pin_ttl = 1
+		cc.soft_pin_ttl_ms = C.uint64_t(*cfg.SoftPinTTLMS)
 	}
 	if cfg.WithHardPin {
 		cc.with_hard_pin = 1

--- a/mooncake-store/go/mooncakestore/store.go
+++ b/mooncake-store/go/mooncakestore/store.go
@@ -139,15 +139,15 @@ func (s *Store) toCConfig(cfg *ReplicateConfig) (C.mooncake_replicate_config_t, 
 	if cfg.SoftPinAction < SoftPinPreserve || cfg.SoftPinAction > SoftPinDisable {
 		return cc, nil, ErrInvalidArgument
 	}
-	if cfg.SoftPinTTLMS != nil && cfg.SoftPinAction != SoftPinEnable {
+	if cfg.SoftPinTTLMs != nil && cfg.SoftPinAction != SoftPinEnable {
 		return cc, nil, ErrInvalidArgument
 	}
 
 	cc.replica_num = C.size_t(cfg.ReplicaNum)
 	cc.soft_pin_action = C.int(cfg.SoftPinAction)
-	if cfg.SoftPinTTLMS != nil {
+	if cfg.SoftPinTTLMs != nil {
 		cc.has_soft_pin_ttl = 1
-		cc.soft_pin_ttl_ms = C.uint64_t(*cfg.SoftPinTTLMS)
+		cc.soft_pin_ttl_ms = C.uint64_t(*cfg.SoftPinTTLMs)
 	}
 	if cfg.WithHardPin {
 		cc.with_hard_pin = 1

--- a/mooncake-store/go/tests/integration_test.go
+++ b/mooncake-store/go/tests/integration_test.go
@@ -167,8 +167,8 @@ func TestReplicateConfig(t *testing.T) {
 	defer s.Close()
 
 	cfg := &store.ReplicateConfig{
-		ReplicaNum:  2,
-		WithSoftPin: true,
+		ReplicaNum:    2,
+		SoftPinAction: store.SoftPinEnable,
 	}
 
 	key := "test_go_replicated"
@@ -185,4 +185,47 @@ func TestReplicateConfig(t *testing.T) {
 	}
 
 	_ = s.Remove(key, true)
+}
+
+func TestReplicateConfigSoftPinTTL(t *testing.T) {
+	s := setupStore(t)
+	defer s.Close()
+
+	ttl := uint64(60000)
+	cfg := &store.ReplicateConfig{
+		ReplicaNum:    1,
+		SoftPinAction: store.SoftPinEnable,
+		SoftPinTTLMS:  &ttl,
+	}
+
+	key := "test_go_softpin_ttl"
+	if err := s.Put(key, []byte("pinned data"), cfg); err != nil {
+		t.Fatalf("Put with soft pin TTL failed: %v", err)
+	}
+
+	exists, err := s.Exists(key)
+	if err != nil {
+		t.Fatalf("Exists() failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected soft-pinned key to exist")
+	}
+
+	_ = s.Remove(key, true)
+}
+
+func TestReplicateConfigSoftPinValidation(t *testing.T) {
+	s := setupStore(t)
+	defer s.Close()
+
+	ttl := uint64(60000)
+	invalidConfigs := []store.ReplicateConfig{
+		{ReplicaNum: 1, SoftPinAction: store.SoftPinDisable, SoftPinTTLMS: &ttl},
+		{ReplicaNum: 1, SoftPinAction: store.SoftPinAction(7)},
+	}
+	for i, cfg := range invalidConfigs {
+		if err := s.Put("test_go_softpin_invalid", []byte("v"), &cfg); err != store.ErrInvalidArgument {
+			t.Fatalf("config %d: expected ErrInvalidArgument, got %v", i, err)
+		}
+	}
 }

--- a/mooncake-store/go/tests/integration_test.go
+++ b/mooncake-store/go/tests/integration_test.go
@@ -208,7 +208,7 @@ func TestReplicateConfigSoftPinTTL(t *testing.T) {
 	cfg := &store.ReplicateConfig{
 		ReplicaNum:    1,
 		SoftPinAction: store.SoftPinEnable,
-		SoftPinTTLMS:  &ttl,
+		SoftPinTTLMs:  &ttl,
 	}
 
 	key := "test_go_softpin_ttl"
@@ -233,7 +233,7 @@ func TestReplicateConfigSoftPinValidation(t *testing.T) {
 
 	ttl := uint64(60000)
 	invalidConfigs := []store.ReplicateConfig{
-		{ReplicaNum: 1, SoftPinAction: store.SoftPinDisable, SoftPinTTLMS: &ttl},
+		{ReplicaNum: 1, SoftPinAction: store.SoftPinDisable, SoftPinTTLMs: &ttl},
 		{ReplicaNum: 1, SoftPinAction: store.SoftPinAction(7)},
 	}
 	for i, cfg := range invalidConfigs {

--- a/mooncake-store/go/tests/integration_test.go
+++ b/mooncake-store/go/tests/integration_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"os"
 	"testing"
 
 	store "github.com/kvcache-ai/Mooncake/mooncake-store/go/mooncakestore"
@@ -25,6 +26,18 @@ import (
 // To run:
 //   mooncake_master --enable_http_metadata_server=true
 //   go test -v ./tests/...
+//
+// The endpoints default to a master with its embedded HTTP metadata server
+// on the standard ports and can be overridden for other environments:
+//   MC_METADATA_SERVER (default "http://localhost:8080/metadata")
+//   MOONCAKE_MASTER    (default "localhost:50051")
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
 
 func setupStore(t *testing.T) *store.Store {
 	t.Helper()
@@ -34,12 +47,12 @@ func setupStore(t *testing.T) *store.Store {
 	}
 	err = s.Setup(
 		"localhost",
-		"http://localhost:8080/metadata",
+		envOrDefault("MC_METADATA_SERVER", "http://localhost:8080/metadata"),
 		512*1024*1024, // 512 MB global segment
 		128*1024*1024, // 128 MB local buffer
 		"tcp",
 		"",
-		"localhost:50051",
+		envOrDefault("MOONCAKE_MASTER", "localhost:50051"),
 	)
 	if err != nil {
 		s.Close()

--- a/mooncake-store/include/store_c.h
+++ b/mooncake-store/include/store_c.h
@@ -24,12 +24,31 @@ extern "C" {
 
 typedef void *mooncake_store_t;
 
+/*
+ * Soft-pin intent for mooncake_replicate_config_t::soft_pin_action.
+ * A soft pin guards an object from eviction until a deadline fixed at
+ * write time; reads never extend it. Zero-initialized configs default
+ * to MOONCAKE_SOFT_PIN_PRESERVE without a TTL.
+ */
+enum mooncake_soft_pin_action {
+    MOONCAKE_SOFT_PIN_PRESERVE = 0, /* keep an existing unexpired deadline */
+    MOONCAKE_SOFT_PIN_ENABLE = 1,   /* commit a new soft pin on publish */
+    MOONCAKE_SOFT_PIN_DISABLE = 2   /* remove an existing soft pin */
+};
+
 struct mooncake_replicate_config {
     size_t replica_num;
-    int with_soft_pin;
     int with_hard_pin;
     const char **preferred_segments;
     size_t preferred_segments_count;
+    /* One of enum mooncake_soft_pin_action. */
+    int soft_pin_action;
+    /* TTL override in milliseconds; meaningful only with
+     * MOONCAKE_SOFT_PIN_ENABLE. When unset, the master default TTL
+     * applies. The master rejects TTLs on other actions and values
+     * above its configured maximum. */
+    int has_soft_pin_ttl;
+    uint64_t soft_pin_ttl_ms;
 };
 typedef struct mooncake_replicate_config mooncake_replicate_config_t;
 

--- a/mooncake-store/include/store_c.h
+++ b/mooncake-store/include/store_c.h
@@ -41,7 +41,8 @@ struct mooncake_replicate_config {
     int with_hard_pin;
     const char **preferred_segments;
     size_t preferred_segments_count;
-    /* One of enum mooncake_soft_pin_action. */
+    /* One of enum mooncake_soft_pin_action; put functions return -1
+     * for any other value. */
     int soft_pin_action;
     /* TTL override in milliseconds; meaningful only with
      * MOONCAKE_SOFT_PIN_ENABLE. When unset, the master default TTL

--- a/mooncake-store/rust/examples/basic_usage.rs
+++ b/mooncake-store/rust/examples/basic_usage.rs
@@ -45,7 +45,7 @@
 //! cargo run --example basic_usage
 //! ```
 
-use mooncake_store::{MooncakeStore, ReplicateConfig, StoreError};
+use mooncake_store::{MooncakeStore, ReplicateConfig, SoftPinAction, StoreError};
 
 fn main() {
     println!("=== Mooncake Store Rust Bindings — Basic Usage ===\n");
@@ -128,7 +128,8 @@ fn main() {
     // Step 7: Put with explicit replication config.
     let config = ReplicateConfig {
         replica_num: 2,
-        with_soft_pin: true,
+        soft_pin_action: SoftPinAction::Enable,
+        soft_pin_ttl_ms: None,
         with_hard_pin: false,
         preferred_segments: vec!["seg-0".to_string()],
     };
@@ -136,7 +137,9 @@ fn main() {
     if let Err(e) = store.put("replicated-key", b"replicated value", Some(&config)) {
         eprintln!("[FAIL] put() with ReplicateConfig failed: {e}");
     } else {
-        println!("[OK] put(\"replicated-key\") with replica_num=2, soft_pin=true, hard_pin=false");
+        println!(
+            "[OK] put(\"replicated-key\") with replica_num=2, soft_pin=enable, hard_pin=false"
+        );
     }
 
     // Step 8: Remove the keys.

--- a/mooncake-store/rust/src/generated/ffi_dlopen_bindings.rs
+++ b/mooncake-store/rust/src/generated/ffi_dlopen_bindings.rs
@@ -4,31 +4,41 @@
 // Do not edit by hand; see mooncake-store/rust/README.md to regenerate.
 
 pub type mooncake_store_t = *mut ::std::os::raw::c_void;
+pub const mooncake_soft_pin_action_MOONCAKE_SOFT_PIN_PRESERVE: mooncake_soft_pin_action = 0;
+pub const mooncake_soft_pin_action_MOONCAKE_SOFT_PIN_ENABLE: mooncake_soft_pin_action = 1;
+pub const mooncake_soft_pin_action_MOONCAKE_SOFT_PIN_DISABLE: mooncake_soft_pin_action = 2;
+pub type mooncake_soft_pin_action = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct mooncake_replicate_config {
     pub replica_num: usize,
-    pub with_soft_pin: ::std::os::raw::c_int,
     pub with_hard_pin: ::std::os::raw::c_int,
     pub preferred_segments: *mut *const ::std::os::raw::c_char,
     pub preferred_segments_count: usize,
+    pub soft_pin_action: ::std::os::raw::c_int,
+    pub has_soft_pin_ttl: ::std::os::raw::c_int,
+    pub soft_pin_ttl_ms: u64,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of mooncake_replicate_config"]
-        [::std::mem::size_of::<mooncake_replicate_config>() - 32usize];
+        [::std::mem::size_of::<mooncake_replicate_config>() - 48usize];
     ["Alignment of mooncake_replicate_config"]
         [::std::mem::align_of::<mooncake_replicate_config>() - 8usize];
     ["Offset of field: mooncake_replicate_config::replica_num"]
         [::std::mem::offset_of!(mooncake_replicate_config, replica_num) - 0usize];
-    ["Offset of field: mooncake_replicate_config::with_soft_pin"]
-        [::std::mem::offset_of!(mooncake_replicate_config, with_soft_pin) - 8usize];
     ["Offset of field: mooncake_replicate_config::with_hard_pin"]
-        [::std::mem::offset_of!(mooncake_replicate_config, with_hard_pin) - 12usize];
+        [::std::mem::offset_of!(mooncake_replicate_config, with_hard_pin) - 8usize];
     ["Offset of field: mooncake_replicate_config::preferred_segments"]
         [::std::mem::offset_of!(mooncake_replicate_config, preferred_segments) - 16usize];
     ["Offset of field: mooncake_replicate_config::preferred_segments_count"]
         [::std::mem::offset_of!(mooncake_replicate_config, preferred_segments_count) - 24usize];
+    ["Offset of field: mooncake_replicate_config::soft_pin_action"]
+        [::std::mem::offset_of!(mooncake_replicate_config, soft_pin_action) - 32usize];
+    ["Offset of field: mooncake_replicate_config::has_soft_pin_ttl"]
+        [::std::mem::offset_of!(mooncake_replicate_config, has_soft_pin_ttl) - 36usize];
+    ["Offset of field: mooncake_replicate_config::soft_pin_ttl_ms"]
+        [::std::mem::offset_of!(mooncake_replicate_config, soft_pin_ttl_ms) - 40usize];
 };
 pub type mooncake_replicate_config_t = mooncake_replicate_config;
 pub struct MooncakeStoreLib {

--- a/mooncake-store/rust/src/lib.rs
+++ b/mooncake-store/rust/src/lib.rs
@@ -63,7 +63,7 @@ pub mod store;
 mod ffi_dlopen;
 
 pub use error::StoreError;
-pub use store::{MooncakeStore, ReplicateConfig};
+pub use store::{MooncakeStore, ReplicateConfig, SoftPinAction};
 
 #[cfg(all(feature = "dlopen", not(feature = "link")))]
 pub use ffi_dlopen::load_library;

--- a/mooncake-store/rust/src/store.rs
+++ b/mooncake-store/rust/src/store.rs
@@ -41,6 +41,22 @@ use crate::ffi_dlopen as ffi;
 // ReplicateConfig
 // ---------------------------------------------------------------------------
 
+/// Soft-pin intent of a put operation.
+///
+/// A soft pin guards an object from eviction until a deadline fixed at write
+/// time; reads never extend it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SoftPinAction {
+    /// Keep an existing unexpired soft-pin deadline. The default, so plain
+    /// puts commit ordinary cache.
+    #[default]
+    Preserve = 0,
+    /// Commit a new soft-pin lifetime when the write becomes readable.
+    Enable = 1,
+    /// Remove an existing soft pin when the write becomes readable.
+    Disable = 2,
+}
+
 /// Replication settings for a put operation.
 ///
 /// This is the Rust counterpart of `mooncake_replicate_config_t` from
@@ -49,8 +65,11 @@ use crate::ffi_dlopen as ffi;
 pub struct ReplicateConfig {
     /// Number of replicas to create (0 means use the server default).
     pub replica_num: usize,
-    /// Prefer a replica on the same NUMA node / host ("soft pin").
-    pub with_soft_pin: bool,
+    /// Soft-pin intent for this write.
+    pub soft_pin_action: SoftPinAction,
+    /// Soft-pin TTL override in milliseconds. Only valid with
+    /// [`SoftPinAction::Enable`]; `None` uses the master's default TTL.
+    pub soft_pin_ttl_ms: Option<u64>,
     /// Declare whether the object will never be evicted.
     pub with_hard_pin: bool,
     /// Whitelist of segment names that should host a replica.
@@ -73,6 +92,12 @@ impl ReplicateConfig {
         ),
         StoreError,
     > {
+        if self.soft_pin_ttl_ms.is_some() && self.soft_pin_action != SoftPinAction::Enable {
+            return Err(StoreError::InvalidArgument(
+                "soft_pin_ttl_ms is only valid with SoftPinAction::Enable".to_string(),
+            ));
+        }
+
         let strings: Vec<CString> = self
             .preferred_segments
             .iter()
@@ -83,7 +108,9 @@ impl ReplicateConfig {
 
         let c_config = ffi::mooncake_replicate_config_t {
             replica_num: self.replica_num,
-            with_soft_pin: i32::from(self.with_soft_pin),
+            soft_pin_action: self.soft_pin_action as i32,
+            has_soft_pin_ttl: i32::from(self.soft_pin_ttl_ms.is_some()),
+            soft_pin_ttl_ms: self.soft_pin_ttl_ms.unwrap_or(0),
             with_hard_pin: i32::from(self.with_hard_pin),
             preferred_segments: if ptrs.is_empty() {
                 std::ptr::null_mut()
@@ -626,14 +653,17 @@ mod tests {
     fn replicate_config_to_ffi_empty_segments() {
         let config = ReplicateConfig {
             replica_num: 2,
-            with_soft_pin: true,
+            soft_pin_action: SoftPinAction::Enable,
+            soft_pin_ttl_ms: Some(30000),
             with_hard_pin: false,
             preferred_segments: Vec::new(),
         };
 
         let (ffi_cfg, strings, ptrs) = config.to_ffi().expect("to_ffi should succeed");
         assert_eq!(ffi_cfg.replica_num, 2);
-        assert_eq!(ffi_cfg.with_soft_pin, 1);
+        assert_eq!(ffi_cfg.soft_pin_action, SoftPinAction::Enable as i32);
+        assert_eq!(ffi_cfg.has_soft_pin_ttl, 1);
+        assert_eq!(ffi_cfg.soft_pin_ttl_ms, 30000);
         assert_eq!(ffi_cfg.with_hard_pin, 0);
         assert!(ffi_cfg.preferred_segments.is_null());
         assert_eq!(ffi_cfg.preferred_segments_count, 0);
@@ -645,14 +675,17 @@ mod tests {
     fn replicate_config_to_ffi_with_segments() {
         let config = ReplicateConfig {
             replica_num: 3,
-            with_soft_pin: false,
+            soft_pin_action: SoftPinAction::Preserve,
+            soft_pin_ttl_ms: None,
             with_hard_pin: false,
             preferred_segments: vec!["seg-a".to_string(), "seg-b".to_string()],
         };
 
         let (ffi_cfg, strings, ptrs) = config.to_ffi().expect("to_ffi should succeed");
         assert_eq!(ffi_cfg.replica_num, 3);
-        assert_eq!(ffi_cfg.with_soft_pin, 0);
+        assert_eq!(ffi_cfg.soft_pin_action, SoftPinAction::Preserve as i32);
+        assert_eq!(ffi_cfg.has_soft_pin_ttl, 0);
+        assert_eq!(ffi_cfg.soft_pin_ttl_ms, 0);
         assert_eq!(ffi_cfg.with_hard_pin, 0);
         assert!(!ffi_cfg.preferred_segments.is_null());
         assert_eq!(ffi_cfg.preferred_segments_count, 2);
@@ -666,10 +699,27 @@ mod tests {
     }
 
     #[test]
+    fn replicate_config_to_ffi_rejects_ttl_without_enable() {
+        let config = ReplicateConfig {
+            replica_num: 1,
+            soft_pin_action: SoftPinAction::Disable,
+            soft_pin_ttl_ms: Some(1000),
+            with_hard_pin: false,
+            preferred_segments: Vec::new(),
+        };
+
+        assert!(matches!(
+            config.to_ffi(),
+            Err(StoreError::InvalidArgument(_))
+        ));
+    }
+
+    #[test]
     fn replicate_config_to_ffi_rejects_interior_nul() {
         let config = ReplicateConfig {
             replica_num: 1,
-            with_soft_pin: false,
+            soft_pin_action: SoftPinAction::Preserve,
+            soft_pin_ttl_ms: None,
             with_hard_pin: false,
             preferred_segments: vec!["bad\0segment".to_string()],
         };
@@ -690,7 +740,8 @@ mod tests {
     fn prepare_config_some_preserves_storage_and_values() {
         let config = ReplicateConfig {
             replica_num: 4,
-            with_soft_pin: true,
+            soft_pin_action: SoftPinAction::Enable,
+            soft_pin_ttl_ms: None,
             with_hard_pin: false,
             preferred_segments: vec!["x".to_string(), "y".to_string()],
         };
@@ -699,7 +750,9 @@ mod tests {
             MooncakeStore::prepare_config(Some(&config)).expect("prepare should succeed");
         let cfg_ref = c_cfg.as_ref().expect("expected Some config");
         assert_eq!(cfg_ref.replica_num, 4);
-        assert_eq!(cfg_ref.with_soft_pin, 1);
+        assert_eq!(cfg_ref.soft_pin_action, SoftPinAction::Enable as i32);
+        assert_eq!(cfg_ref.has_soft_pin_ttl, 0);
+        assert_eq!(cfg_ref.soft_pin_ttl_ms, 0);
         assert_eq!(cfg_ref.with_hard_pin, 0);
         assert_eq!(cfg_ref.preferred_segments_count, 2);
         assert_eq!(strings.len(), 2);

--- a/mooncake-store/src/store_c.cpp
+++ b/mooncake-store/src/store_c.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <memory>
 #include <new>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
@@ -38,14 +39,20 @@ inline const char *c_str_or(const char *s, const char *fallback) {
     return s ? s : fallback;
 }
 
-mooncake::ReplicateConfig to_replicate_config(
+std::optional<mooncake::ReplicateConfig> to_replicate_config(
     const mooncake_replicate_config_t *c_config) {
     mooncake::ReplicateConfig config;
     if (!c_config) return config;
 
+    const int action = c_config->soft_pin_action;
+    // Reject before casting: the enum's uint8_t underlying type would
+    // otherwise wrap out-of-range values into valid actions.
+    if (action < static_cast<int>(mooncake::SoftPinAction::PRESERVE) ||
+        action > static_cast<int>(mooncake::SoftPinAction::DISABLE)) {
+        return std::nullopt;
+    }
     config.replica_num = c_config->replica_num;
-    config.soft_pin_action =
-        static_cast<mooncake::SoftPinAction>(c_config->soft_pin_action);
+    config.soft_pin_action = static_cast<mooncake::SoftPinAction>(action);
     if (c_config->has_soft_pin_ttl) {
         config.soft_pin_ttl_ms = c_config->soft_pin_ttl_ms;
     }
@@ -153,8 +160,9 @@ int mooncake_store_put(mooncake_store_t store, const char *key,
     if (!value && size > 0) return -1;
     try {
         auto rc = to_replicate_config(config);
+        if (!rc) return -1;
         std::span<const char> data(static_cast<const char *>(value), size);
-        return as_client(store)->put(key, data, rc);
+        return as_client(store)->put(key, data, *rc);
     } catch (...) {
         return -1;
     }
@@ -167,7 +175,8 @@ int mooncake_store_put_from(mooncake_store_t store, const char *key,
     if (!buffer && size > 0) return -1;
     try {
         auto rc = to_replicate_config(config);
-        return as_client(store)->put_from(key, buffer, size, rc);
+        if (!rc) return -1;
+        return as_client(store)->put_from(key, buffer, size, *rc);
     } catch (...) {
         return -1;
     }
@@ -192,8 +201,9 @@ int mooncake_store_batch_put_from(mooncake_store_t store, const char **keys,
         std::vector<size_t> size_vec(sizes, sizes + count);
 
         auto rc = to_replicate_config(config);
+        if (!rc) return -1;
         auto results =
-            as_client(store)->batch_put_from(key_vec, buf_vec, size_vec, rc);
+            as_client(store)->batch_put_from(key_vec, buf_vec, size_vec, *rc);
 
         for (size_t i = 0; i < count; ++i) {
             results_out[i] = (i < results.size()) ? results[i] : -1;

--- a/mooncake-store/src/store_c.cpp
+++ b/mooncake-store/src/store_c.cpp
@@ -44,9 +44,11 @@ mooncake::ReplicateConfig to_replicate_config(
     if (!c_config) return config;
 
     config.replica_num = c_config->replica_num;
-    config.soft_pin_action = c_config->with_soft_pin != 0
-                                 ? mooncake::SoftPinAction::ENABLE
-                                 : mooncake::SoftPinAction::PRESERVE;
+    config.soft_pin_action =
+        static_cast<mooncake::SoftPinAction>(c_config->soft_pin_action);
+    if (c_config->has_soft_pin_ttl) {
+        config.soft_pin_ttl_ms = c_config->soft_pin_ttl_ms;
+    }
     config.with_hard_pin = c_config->with_hard_pin != 0;
     if (c_config->preferred_segments &&
         c_config->preferred_segments_count > 0) {


### PR DESCRIPTION
## Description

RFC #3028 replaced the `with_soft_pin` boolean in the C++ and Python APIs with an explicit `SoftPinAction` (`PRESERVE` / `ENABLE` / `DISABLE`) plus an optional request-level `soft_pin_ttl_ms` (#2909). The C ABI kept the boolean as a transitional bridge, translating `true` to `ENABLE` with the master default TTL and `false` to `PRESERVE`, so the Go and Rust wrappers inherited the boolean and cannot reach the new semantics.

This PR completes that migration for the remaining client surfaces:

- `store_c.h`: the `with_soft_pin` boolean becomes an explicit `soft_pin_action` (`enum mooncake_soft_pin_action`) with `has_soft_pin_ttl` / `soft_pin_ttl_ms` for a request-level TTL override. A zero-initialized config keeps ordinary-put behavior (`PRESERVE`, no TTL). Unknown actions and invalid action/TTL combinations are rejected client-side (the Go/Rust wrappers return their argument errors; the C ABI boundary returns `-1` for out-of-range actions), and the master remains the authority for TTLs above `max_kv_soft_pin_ttl`.
- Go binding: `ReplicateConfig.WithSoftPin` becomes `SoftPinAction` + `*uint64 SoftPinTTLMs`, with wrapper-level validation of unknown actions and invalid action/TTL combinations (`ErrInvalidArgument`).
- Rust binding: `ReplicateConfig.with_soft_pin` becomes `SoftPinAction` (default `Preserve`) + `Option<u64> soft_pin_ttl_ms`, validated in `to_ffi` (`StoreError::InvalidArgument`). The stale field doc describing soft pin as a NUMA placement hint is gone. The committed dlopen bindings are regenerated from the header.
- Docs: the Rust API reference is updated to the new fields.

With this, non-C++ clients can commit a soft pin with a custom TTL and disable an active one before expiry, instead of only toggling the master default TTL.

This is a source- and ABI-level breaking change for `store_c.h`, Go, and Rust consumers, consistent with the coordinated-upgrade stance of RFC #3028. The Python API is unaffected (it already uses the C++ `ReplicateConfig` directly).

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Docs

## Type of Change

- [x] New feature
- [x] Breaking change

## How Has This Been Tested?

**Test commands:**

```bash
# C++ build of the changed translation layer (WITH_STORE_C_SHARED=ON)
cmake --build build --target mooncake_store mooncake_store_c mooncake_master

# Rust: unit tests on both backends, example compile check, bindings drift check
cargo test --manifest-path mooncake-store/rust/Cargo.toml --lib
cargo test --manifest-path mooncake-store/rust/Cargo.toml --no-default-features --features dlopen --lib
cargo test --manifest-path mooncake-store/rust/Cargo.toml --examples --tests --no-run
cargo run --locked --manifest-path mooncake-store/rust/Cargo.toml --example generate_dlopen_bindings
git diff --exit-code -- mooncake-store/rust/src/generated/ffi_dlopen_bindings.rs

# Go: formatting, vet, integration tests against a live master
gofmt -l mooncake-store/go
CGO_ENABLED=1 CGO_CFLAGS="-I<mooncake-store/include> -I<mooncake-transfer-engine/include>" go vet ./...
MC_METADATA_SERVER=http://127.0.0.1:18080/metadata MOONCAKE_MASTER=127.0.0.1:15051 \
  go test -timeout 15m -v ./tests/...   # with mooncake_master running
```

**Test results:**
- [x] Unit tests pass (`cargo test --lib`: 9/9 on the `link` backend, 8/8 on the `dlopen` backend; includes new tests for TTL encoding and TTL-without-ENABLE rejection)
- [x] Integration tests pass (Go integration suite 7/7 against a live master, including `TestReplicateConfig` with `SoftPinEnable`, `TestReplicateConfigSoftPinTTL` exercising the request-level TTL end to end, and `TestReplicateConfigSoftPinValidation` for invalid configs; the regenerated dlopen bindings are byte-identical on Linux and macOS)
- [x] Manual testing done (the Go `Put` with `SoftPinEnable` + TTL succeeds against the master and the object is visible; invalid action/TTL combinations are rejected client-side before any RPC; a raw C program confirms out-of-range `soft_pin_action` values such as `257` and `-5` get `-1` from `mooncake_store_put` while a valid `ENABLE` + TTL put succeeds)

The Go integration test endpoints can now be overridden with `MC_METADATA_SERVER` and `MOONCAKE_MASTER` so the suite runs against a master on non-default ports; defaults are unchanged and the CI script already exports `MC_METADATA_SERVER`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (git clang-format on changed lines reports no modifications)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (covered by RFC #3028)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

<!-- If AI tools were used, briefly describe which tool and what it helped with.
     The human submitter is responsible for understanding and defending all changes. -->

This PR was drafted with AI assistance (code editing and test execution). The human submitter has reviewed every changed line.
