### PR TITLE
[TENT] Disable Nagle on HP TCP client sockets

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
@@ -176,6 +176,13 @@ class HighPerformanceTcpClient::Lane
                     self->finishIoError(error);
                     return;
                 }
+                std::error_code option_error;
+                self->socket_.set_option(asio::ip::tcp::no_delay(true),
+                                         option_error);
+                if (option_error) {
+                    self->finishIoError(option_error);
+                    return;
+                }
                 self->cancelTimer();
                 self->parent_->connections_created_.fetch_add(
                     1, std::memory_order_relaxed);


### PR DESCRIPTION
## Description

Small HP TCP WRITEs can stall between the separately sent request header and payload. Enable `TCP_NODELAY` after the client socket connects successfully, before sending the first header. Socket-option failures follow the existing I/O error path. The shared callback covers both source-bound and ordinary connections.

This is a seven-line fix in `hp_tcp_client.cpp`. It preserves the wire format, completion semantics, buffer ownership and lane scheduling.

Related-work check: [TCP_NODELAY search](https://github.com/kvcache-ai/Mooncake/issues?q=TCP_NODELAY). #2314 applied socket tuning to the classic Transfer Engine TCP implementation; this PR covers the separate TENT HP TCP client introduced in #3689 and tested at the #3861 merge commit.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Release Transfer Engine build with `USE_TENT=ON`, `USE_CUDA=OFF` passed. Manual tests used the compiled Python binding and registered CPU buffers on two x86 hosts, forced TCP over one Ethernet interface, four workers/four lanes and eight pinned CPU cores per process. The base was `2b3cefbac4d571bcb001db3aa702772b41b8c647`; the intervention was only this socket option.

For a 4-byte WRITE, each entry below is the p50 from one independent process run with three warmup requests and 40 measured requests:

| Version | Three independent p50 values (ms) |
| --- | --- |
| Base HP TCP | 44.017 / 43.981 / 43.996 |
| With this change | 0.174 / 0.135 / 0.142 |

Transfer content checks passed outside the timed loop. These are transport measurements, not training throughput. The intervention supports a Nagle-related explanation; the exact delayed-ACK packet sequence has not been captured. It does not establish a large-transfer advantage over a tuned TCP baseline.

**Local checks:**

```bash
pre-commit run --files mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
```

The per-file hooks, including the staged C++ formatting hook, passed in an isolated copy using the repository configuration and the same seven-line diff. The test harness and original measurements are retained in the author's audit workspace; no timing-sensitive CI assertion is added to this code-only fix.

**Test results:**
- [ ] Full unit suite
- [ ] Full integration suite
- [x] Manual two-host transfer validation described above

## Checklist

- [x] Agent self-review of the complete diff and socket lifecycle
- [x] Code formatted using the repository's `./scripts/code_format.sh` hook
- [x] Per-file pre-commit hooks pass
- [ ] Documentation update — no API/configuration change
- [ ] New CI test — manual latency regression above; no CI timing threshold added
- [ ] RFC — not applicable to this seven-line fix

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used 