### PR TITLE
[Store] Fail PutEnd closed on OpLog admission errors

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -4748,6 +4748,33 @@ auto MasterService::PutEnd(const UUID& client_id, const ObjectMeta& object_meta,
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
 
+    if (enable_oplog_ && ordered_oplog_writer_) {
+        // Admit the post-state before changing live metadata. Commit can
+        // still fail after Reserve; durability remains asynchronous.
+        std::vector<Replica::Descriptor> post;
+        post.reserve(metadata.GetAllReplicas().size());
+        for (const auto& replica : metadata.GetAllReplicas()) {
+            auto descriptor = replica.get_descriptor();
+            if (replica.is_processing() && is_target_replica(replica)) {
+                descriptor.status = ReplicaStatus::COMPLETE;
+            }
+            post.push_back(std::move(descriptor));
+        }
+
+        auto reservation = ReserveBatchOpLogSlot();
+        if (!reservation) {
+            return tl::make_unexpected(reservation.error());
+        }
+        auto persist_result = AppendReservedOpLogWithDurableFinalize(
+            std::move(reservation.value()), OpType::PUT_END,
+            object_id.tenant_id.value(), key,
+            SerializeMetadataForOpLogFromReplicaDescriptors(metadata, post),
+            nullptr);
+        if (!persist_result) {
+            return tl::make_unexpected(persist_result.error());
+        }
+    }
+
     const bool had_completed_replica =
         metadata.HasReplica(&Replica::fn_is_completed);
     bool completed_pending_replica = false;
@@ -4827,15 +4854,6 @@ auto MasterService::PutEnd(const UUID& client_id, const ObjectMeta& object_meta,
     metadata.GrantReadLease(std::chrono::milliseconds::zero());
     PublishKvStored(key, metadata, object_id.tenant_id);
 
-    if (enable_oplog_ && ordered_oplog_writer_) {
-        std::string payload = SerializeMetadataForOpLog(metadata);
-        auto result = AppendOpLogVisibleBeforeDurable(
-            OpType::PUT_END, object_id.tenant_id.value(), key, payload);
-        if (!result) {
-            LOG(WARNING) << "PutEnd: OpLog queue failed for key=" << key
-                         << ", err=" << static_cast<int>(result.error());
-        }
-    }
     return {};
 }
 

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -3240,6 +3240,124 @@ TEST_F(MasterServiceHATest, PutEndWritesBatchRecordOpLog) {
     EXPECT_EQ(2u, prefix.last_seq);
 }
 
+TEST_F(MasterServiceHATest,
+       PutEndFailsBeforeMutationWhenBatchReservationUnavailable) {
+    const std::string cluster_id = "test_put_end_reservation_failure";
+    auto backend = std::make_shared<FakeBatchHaKvBackend>();
+    auto service_config = MasterServiceConfig::builder()
+                              .set_enable_ha(true)
+                              .set_enable_oplog(true)
+                              .set_cluster_id(cluster_id)
+                              .set_oplog_batch_max_entries(1)
+                              .build();
+    MasterService service(service_config);
+    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+
+    auto mounted = PrepareSimpleSegment(service, "put_end_reservation_segment");
+    OpLogBatchStorage storage(cluster_id, *backend);
+    OpLogBatchRecord batch;
+    ReadBatchEventually(storage, 1, batch);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string key = "put_end_reservation_key";
+    ASSERT_TRUE(
+        service.PutStart(mounted.client_id, key, kDefaultTenant, 1024, config)
+            .has_value());
+
+    {
+        auto held_reservation = ReserveBatchSlotForTesting(service);
+        ASSERT_TRUE(held_reservation.has_value())
+            << toString(held_reservation.error());
+
+        auto put_end = service.PutEnd(mounted.client_id, key, kDefaultTenant,
+                                      ReplicaType::MEMORY);
+        EXPECT_FALSE(put_end.has_value());
+        if (!put_end) {
+            EXPECT_EQ(ErrorCode::TASK_PENDING_LIMIT_EXCEEDED, put_end.error());
+        }
+
+        auto descriptors =
+            ReplicaDescriptorsForTesting(service, kDefaultTenant, key);
+        ASSERT_EQ(1u, descriptors.size());
+        EXPECT_EQ(ReplicaStatus::PROCESSING, descriptors.front().status);
+
+        auto replicas = service.GetReplicaList(key, kDefaultTenant);
+        EXPECT_FALSE(replicas.has_value());
+        if (!replicas) {
+            EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, replicas.error());
+        }
+        auto exists = service.ExistKey(key, kDefaultTenant);
+        ASSERT_TRUE(exists.has_value());
+        EXPECT_FALSE(exists.value());
+    }
+
+    // Releasing capacity lets the same primary write finish normally.
+    EXPECT_TRUE(
+        service
+            .PutEnd(mounted.client_id, key, kDefaultTenant, ReplicaType::MEMORY)
+            .has_value());
+    EXPECT_TRUE(service.GetReplicaList(key, kDefaultTenant).has_value());
+}
+
+TEST_F(MasterServiceHATest, PutEndCommitFailureLeavesReplicasProcessing) {
+    const std::string cluster_id = "test_put_end_commit_failure";
+    auto backend = std::make_shared<FakeBatchHaKvBackend>();
+    auto service_config = MasterServiceConfig::builder()
+                              .set_enable_ha(true)
+                              .set_enable_oplog(true)
+                              .set_cluster_id(cluster_id)
+                              .set_oplog_batch_max_entries(1)
+                              .build();
+    MasterService service(service_config);
+    auto* writer = InstallRejectingWriter(service, backend);
+    ASSERT_NE(nullptr, writer);
+
+    auto mounted = PrepareSimpleSegment(service, "put_end_commit_segment");
+    OpLogBatchStorage storage(cluster_id, *backend);
+    OpLogBatchRecord batch;
+    ReadBatchEventually(storage, 1, batch);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string key = "put_end_commit_key";
+    ASSERT_TRUE(
+        service.PutStart(mounted.client_id, key, kDefaultTenant, 1024, config)
+            .has_value());
+
+    writer->RejectCommitsWith(ErrorCode::INVALID_PARAMS);
+    auto put_end = service.PutEnd(mounted.client_id, key, kDefaultTenant,
+                                  ReplicaType::MEMORY);
+    EXPECT_FALSE(put_end.has_value());
+    if (!put_end) {
+        EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_end.error());
+    }
+    EXPECT_EQ(1u, writer->rejected_commits());
+
+    auto descriptors =
+        ReplicaDescriptorsForTesting(service, kDefaultTenant, key);
+    ASSERT_EQ(1u, descriptors.size());
+    EXPECT_EQ(ReplicaStatus::PROCESSING, descriptors.front().status);
+
+    auto replicas = service.GetReplicaList(key, kDefaultTenant);
+    EXPECT_FALSE(replicas.has_value());
+    if (!replicas) {
+        EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, replicas.error());
+    }
+    auto exists = service.ExistKey(key, kDefaultTenant);
+    ASSERT_TRUE(exists.has_value());
+    EXPECT_FALSE(exists.value());
+
+    // A rejected Commit releases its reservation and preserves retryability.
+    writer->RejectCommitsWith(ErrorCode::OK);
+    EXPECT_TRUE(
+        service
+            .PutEnd(mounted.client_id, key, kDefaultTenant, ReplicaType::MEMORY)
+            .has_value());
+    EXPECT_TRUE(service.GetReplicaList(key, kDefaultTenant).has_value());
+    EXPECT_EQ(1u, writer->rejected_commits());
+}
+
 TEST_F(MasterServiceHATest, PutEndVisibleBeforeBatchRecordDurable) {
     const std::string cluster_id = "test_batch_record_put_end_visible";
     auto backend = std::make_shared<BlockingBatchHaKvBackend>();


### PR DESCRIPTION
## Description

On the HA whole-object OpLog path, `PutEnd` updated live replicas to `COMPLETE` and exposed the object before attempting to append the corresponding `PUT_END` record.

If OpLog reservation or `Commit` failed, the failure was only logged and `PutEnd` still returned success. This could leave live state ahead of the recoverable OpLog state.

This change builds the post-`PutEnd` replica descriptors first, reserves an OpLog slot, and commits that payload before modifying live metadata. Reservation and commit errors are now returned to the caller without applying the `COMPLETE` transition.

The resulting invariant is:

```text
no OpLog admission/Commit
    => no live COMPLETE transition
    => no successful PutEnd
```

The existing live completion path is otherwise unchanged.

Related: #3808. PR #3860 addresses separate OpLog-pressure and leadership keep-alive issues.

### Scope

This is intentionally narrower than the durable-mutation barrier tracked in #3808.

It does **not**:

* wait for durable-prefix advancement;
* implement W02 `AwaitDurable`;
* introduce RL01-RL04 lifecycle records;
* change the OpLog record format;
* add a synchronous etcd wait to `PutEnd`;
* change multi-tenant quota-settlement ordering.

A `PUT_END` accepted by the writer can therefore still be lost if the leader fails before backend durability. That remains separate roadmap work.

## Module

* [ ] Transfer Engine (`mooncake-transfer-engine`)
* [x] Mooncake Store (`mooncake-store`)
* [ ] Reshard (`mooncake-reshard`)
* [ ] Mooncake EP (`mooncake-ep`)
* [ ] Mooncake PG (`mooncake-pg`)
* [ ] Integration (`mooncake-integration`)
* [ ] P2P Store (`mooncake-p2p-store`)
* [ ] Python Wheel (`mooncake-wheel`)
* [ ] Common (`mooncake-common`)
* [ ] Mooncake RL (`mooncake-rl`)
* [ ] CI/CD
* [ ] Docs
* [ ] Other

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Other

## How Has This Been Tested?

Two deterministic HA regressions cover the failure windows:

* `MasterServiceHATest.PutEndFailsBeforeMutationWhenBatchReservationUnavailable`
* `MasterServiceHATest.PutEndCommitFailureLeavesReplicasProcessing`

Before the fix, both fault injections demonstrated the same invariant violation: `PutEnd` returned success and exposed a `COMPLETE`/readable object even though its OpLog operation had not been admitted successfully.

After the fix, both paths return the injected error, leave the replica `PROCESSING` and unreadable, and permit the original write to complete successfully after the fault is removed.

```bash
cmake --build build-putend --target master_service_ha_test --parallel 1

./build-putend/mooncake-store/tests/master_service_ha_test \
  --gtest_filter='MasterServiceHATest.*PutEnd*'

./build-putend/mooncake-store/tests/master_service_ha_test \
  --gtest_filter='MasterServiceHATest.PutEndFailsBeforeMutationWhenBatchReservationUnavailable:MasterServiceHATest.PutEndCommitFailureLeavesReplicasProcessing' \
  --gtest_repeat=20

./build-putend/mooncake-store/tests/master_service_ha_test

ctest --test-dir build-putend --output-on-failure \
  -R '^(master_service_test|master_service_tenant_quota_test|master_service_ha_test|ordered_oplog_writer_test|oplog_batch_storage_test)$'
```

Results:

* baseline HA suite: 93/93 passed;

* both new regressions failed against the unchanged implementation as expected;

* focused post-fix `PutEnd` tests: 4/4 passed;

* new regressions repeated 20 times each: 40/40 passed;

* complete post-fix HA suite: 95/95 passed;

* relevant CTest set: 283/283 tests passed across 5 targets, with no skips;

* pre-commit, changed-line formatting, and `git diff --check` passed.

* [x] Unit tests pass

* [ ] Integration tests pass (not run; the change is covered by deterministic HA fault-injection tests)

* [ ] Manual testing done

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have formatted my code using `./scripts/code_format.sh`
* [x] I have run pre-commit on the files changed in this PR and all hooks pass
* [x] Documentation update is not applicable; this is an internal HA correctness fix with no new API or configuration
* [x] I have added tests to prove my changes are effective
* [x] RFC is not required; the production change is well below the >500 LOC threshold

## AI Assistance Disclosure

* [ ] No AI tools were used
* [x] AI tools were used

GPT-6 Astra / Codex assisted with investigation, implementation, regression tests, validation, and PR drafting. The submitter reviewed the final diff and is responsible for understanding and defending the change end-to-end.