### PR TITLE
[Bugfix] Reconnect NoF io qpairs after a target outage

### DIFF
--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -53,6 +53,21 @@ class SpdkWrapper {
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);
 
+    /** @brief Whether the io qpair of a NoF segment has entered a failed
+     * state, e.g. because the target went away. */
+    bool IsNofSegmentFailed(const nof_seg_handle *seg_handle);
+
+    /**
+     * @brief Reconnect the io qpair of a NoF segment after a transport
+     * failure, resetting the controller when the whole nvme association is
+     * gone.
+     *
+     * SPDK requires the io qpair to be reconnected from the same thread that
+     * submits requests to and polls completions of that qpair, so callers
+     * must invoke this from their own submit/poll thread.
+     */
+    bool ReconnectNofSegment(nof_seg_handle *seg_handle);
+
    private:
     struct ProbeBuffer {
         void *ptr{nullptr};

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -85,6 +85,7 @@ void ApplyCtrlrOptsFromEnv(struct spdk_nvme_ctrlr_opts *opts) {
 struct nof_seg_handle {
     struct spdk_nvme_qpair *qpair;
     struct spdk_nvme_ns *ns;
+    ctrlr_info *owner;
 };
 
 struct tr_info {
@@ -355,11 +356,64 @@ nof_seg_handle *SpdkWrapper::OpenNofSegment(const std::string &tr_str) {
         auto new_seg = std::make_unique<nof_seg_handle>();
         new_seg->qpair = qpair;
         new_seg->ns = ns;
+        new_seg->owner = info;
         seg_handle = new_seg.get();
         ns_seg[tr.ns] = std::move(new_seg);
     }
 
     return seg_handle;
+}
+
+bool SpdkWrapper::IsNofSegmentFailed(const nof_seg_handle *seg_handle) {
+    if (!seg_handle || !seg_handle->qpair) {
+        return true;
+    }
+
+    return spdk_nvme_qpair_get_failure_reason(seg_handle->qpair) !=
+           SPDK_NVME_QPAIR_FAILURE_NONE;
+}
+
+bool SpdkWrapper::ReconnectNofSegment(nof_seg_handle *seg_handle) {
+    if (!seg_handle || !seg_handle->qpair || !seg_handle->owner ||
+        !seg_handle->owner->ctrlr) {
+        return false;
+    }
+
+    ctrlr_info *info = seg_handle->owner;
+    std::lock_guard<std::mutex> lock(info->ns_mutex);
+    if (spdk_nvme_qpair_get_failure_reason(seg_handle->qpair) ==
+        SPDK_NVME_QPAIR_FAILURE_NONE) {
+        // Another segment of the same controller already recovered it.
+        return true;
+    }
+
+    int ret = spdk_nvme_ctrlr_reconnect_io_qpair(seg_handle->qpair);
+    if (ret == 0) {
+        LOG(INFO) << "NoF io qpair reconnected";
+        return true;
+    }
+
+    // Only the io connection can be reconnected on its own. When the target
+    // restarts, the whole nvme association is gone and the controller has to
+    // be reset before its io qpairs can be connected again.
+    LOG(WARNING) << "reconnect NoF io qpair failed, ret " << ret
+                 << ", resetting controller";
+    ret = spdk_nvme_ctrlr_reset(info->ctrlr);
+    if (ret != 0) {
+        LOG(ERROR) << "reset NoF controller failed, ret " << ret;
+        return false;
+    }
+
+    ret = spdk_nvme_ctrlr_reconnect_io_qpair(seg_handle->qpair);
+    if (ret != 0) {
+        LOG(ERROR) << "reconnect NoF io qpair after controller reset failed, "
+                      "ret "
+                   << ret;
+        return false;
+    }
+
+    LOG(INFO) << "NoF controller reset, io qpair reconnected";
+    return true;
 }
 
 uint32_t SpdkWrapper::GetBlockSize(const nof_seg_handle *seg_handle) {
@@ -434,6 +488,16 @@ bool SpdkWrapper::ProbeNofSegment(const std::string &tr_str,
     if (!seg_handle) {
         if (error_reason) {
             *error_reason = "open_fail";
+        }
+        return false;
+    }
+
+    // OpenNofSegment caches one qpair per namespace, so a qpair that failed
+    // while the target was down would otherwise be reused forever and the
+    // segment would never be probed successfully again.
+    if (IsNofSegmentFailed(seg_handle) && !ReconnectNofSegment(seg_handle)) {
+        if (error_reason) {
+            *error_reason = "reconnect_fail";
         }
         return false;
     }

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -149,6 +149,50 @@ static void nvmf_io_complete(void* ctx, const struct spdk_nvme_cpl* cpl) {
 
     sub_task->sub_task_pool->push(sub_task);
 }
+
+// A reconnect attempt goes over the fabric and blocks for up to the fabrics
+// connect timeout, so back off between attempts while the target is still
+// down.
+constexpr int kSpdkNofReconnectIntervalMs = 1000;
+
+// Heal a segment whose io qpair failed, e.g. because the NoF target went away.
+// SpdkWrapper caches one qpair per namespace, so without this the worker would
+// keep submitting to the failed qpair and never recover once the target is
+// back. The reconnect must happen on the worker thread that owns the qpair.
+static void MaybeReconnectSpdkNofSegment(
+    mooncake::nof_seg_handle* seg_handle,
+    std::map<mooncake::nof_seg_handle*, std::chrono::steady_clock::time_point>&
+        next_reconnect_at,
+    int work_idx) {
+    auto& wrapper = mooncake::SpdkWrapper::GetInstance();
+    if (!wrapper.IsNofSegmentFailed(seg_handle)) {
+        next_reconnect_at.erase(seg_handle);
+        return;
+    }
+
+    auto it = next_reconnect_at.find(seg_handle);
+    if (it != next_reconnect_at.end() &&
+        std::chrono::steady_clock::now() < it->second) {
+        return;
+    }
+
+    if (wrapper.ReconnectNofSegment(seg_handle)) {
+        LOG(INFO) << "work " << work_idx << ", seg " << seg_handle
+                  << " io qpair reconnected";
+        next_reconnect_at.erase(seg_handle);
+        return;
+    }
+
+    // The interval is measured from the end of a failed attempt, not its
+    // start. A connect to a target that is still down blocks for up to the
+    // fabrics connect timeout, which is well over kSpdkNofReconnectIntervalMs,
+    // so a deadline taken before the call would already be in the past when it
+    // returns and the next sweep would retry with no delay at all. That is the
+    // long outage this backoff exists for.
+    next_reconnect_at[seg_handle] =
+        std::chrono::steady_clock::now() +
+        std::chrono::milliseconds(kSpdkNofReconnectIntervalMs);
+}
 #endif
 namespace mooncake {
 
@@ -413,6 +457,8 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
     int64_t total_outstanding_io = 0;
     // std::set<nof_seg_handle *> seg_set;
     std::map<nof_seg_handle*, std::unique_ptr<SpdkNofQos>> seg_to_qos;
+    std::map<nof_seg_handle*, std::chrono::steady_clock::time_point>
+        seg_next_reconnect_at;
     std::stack<SpdkNofSubTask*> sub_task_pool;
     std::vector<SpdkNofSubTask*> sub_task_chunks;
     auto& task_queue = task_queue_[work_idx];
@@ -484,6 +530,10 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
         }
 
         for (auto& [seg_handle, nof_qos] : seg_to_qos) {
+            if (!nof_qos->Empty()) {
+                MaybeReconnectSpdkNofSegment(seg_handle, seg_next_reconnect_at,
+                                             work_idx);
+            }
             uint32_t block_size =
                 SpdkWrapper::GetInstance().GetBlockSize(seg_handle);
             for (int i = 0; i < kSpdkNofOpNum; ++i) {

--- a/mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh
+++ b/mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh
@@ -61,6 +61,39 @@ count_pattern() {
   grep -c "$pattern" "$file" 2>/dev/null || true
 }
 
+start_target() {
+  local log_suffix=$1
+  "$REPO_ROOT/extern/spdk/build/bin/nvmf_tgt" -m 0x1 -u --iova-mode=va --wait-for-rpc >"$LOG_DIR/target$log_suffix.log" 2>&1 &
+  TARGET_PID=$!
+  sleep 3
+
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_start_init >/dev/null
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_wait_init >/dev/null
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" bdev_malloc_create -b Malloc0 64 4096 >/dev/null
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_transport -t TCP >/dev/null || true
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_subsystem "$TARGET_NQN" -a -s SPDK00000000000001 >/dev/null || true
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_ns "$TARGET_NQN" Malloc0 >/dev/null || true
+  python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_listener "$TARGET_NQN" -t tcp -a "$TARGET_HOST" -s "$TARGET_PORT" >/dev/null || true
+}
+
+register_nof_segment() {
+  local log_suffix=$1
+  PYTHONPATH="$BUILD_DIR/mooncake-integration" MC_NOF_TRTYPE=TCP python3 - <<PY >"$LOG_DIR/register$log_suffix.log" 2>&1
+import store
+ret = store.MooncakeDistributedNoFRegister().real_register(
+    "$TARGET_NQN",
+    1,
+    "$TARGET_HOST",
+    int("$TARGET_PORT"),
+    0,
+    int("$NOF_SIZE"),
+    "$MASTER_RPC",
+)
+print(f"register_ret {ret}", flush=True)
+raise SystemExit(0 if ret == 0 else 1)
+PY
+}
+
 rm -rf "$LOG_DIR"
 mkdir -p "$LOG_DIR"
 
@@ -75,17 +108,7 @@ pkill -f 'mooncake_master' >/dev/null 2>&1 || true
 pkill -f 'http_metadata_server.py' >/dev/null 2>&1 || true
 sleep 1
 
-"$REPO_ROOT/extern/spdk/build/bin/nvmf_tgt" -m 0x1 -u --iova-mode=va --wait-for-rpc >"$LOG_DIR/target.log" 2>&1 &
-TARGET_PID=$!
-sleep 3
-
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_start_init >/dev/null
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_wait_init >/dev/null
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" bdev_malloc_create -b Malloc0 64 4096 >/dev/null
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_transport -t TCP >/dev/null || true
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_subsystem "$TARGET_NQN" -a -s SPDK00000000000001 >/dev/null || true
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_ns "$TARGET_NQN" Malloc0 >/dev/null || true
-python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_listener "$TARGET_NQN" -t tcp -a "$TARGET_HOST" -s "$TARGET_PORT" >/dev/null || true
+start_target ""
 
 python3 "$REPO_ROOT/mooncake-wheel/mooncake/http_metadata_server.py" --host "$METADATA_HOST" --port "$METADATA_PORT" >"$LOG_DIR/metadata.log" 2>&1 &
 META_PID=$!
@@ -102,20 +125,7 @@ sleep 2
 MASTER_PID=$!
 sleep 3
 
-PYTHONPATH="$BUILD_DIR/mooncake-integration" MC_NOF_TRTYPE=TCP python3 - <<PY >"$LOG_DIR/register.log" 2>&1
-import store
-ret = store.MooncakeDistributedNoFRegister().real_register(
-    "$TARGET_NQN",
-    1,
-    "$TARGET_HOST",
-    int("$TARGET_PORT"),
-    0,
-    int("$NOF_SIZE"),
-    "$MASTER_RPC",
-)
-print(f"register_ret {ret}", flush=True)
-raise SystemExit(0 if ret == 0 else 1)
-PY
+register_nof_segment ""
 
 PYTHONPATH="$BUILD_DIR/mooncake-integration" python3 "$SCRIPT_DIR/store_client_e2e.py" \
   --local-hostname "127.0.0.1:50071" \
@@ -151,6 +161,7 @@ fi
 pre_fault_line_count=$(wc -l <"$LOG_DIR/client.log")
 
 kill "$TARGET_PID" >/dev/null 2>&1 || true
+wait "$TARGET_PID" >/dev/null 2>&1 || true
 TARGET_PID=""
 
 if ! wait_for_pattern "$LOG_DIR/master.log" 'action=unmount_nof_segment_by_heartbeat' $((HEARTBEAT_INTERVAL * HEARTBEAT_FAILURES + 20)); then
@@ -178,6 +189,39 @@ while (( SECONDS < observation_deadline )); do
   fi
   sleep 1
 done
+
+# The target comes back and the segment is registered again. Both the master and
+# the still running client cached the nvme qpair of the dead target, so they
+# only recover if that qpair is reconnected instead of reused.
+pre_recovery_unmounts=$(count_pattern "$LOG_DIR/master.log" 'action=unmount_nof_segment_by_heartbeat')
+post_recovery_line_count=$(wc -l <"$LOG_DIR/client.log")
+
+start_target "_restart"
+if ! register_nof_segment "_restart"; then
+  echo "failed to register nof segment after target recovery"
+  exit 1
+fi
+
+# A segment whose heartbeat still probes the stale qpair is unmounted again
+# after the failure threshold, so staying mounted proves the probe recovered.
+recovery_observation_sec=$((HEARTBEAT_INTERVAL * (HEARTBEAT_FAILURES + 2) + 5))
+sleep "$recovery_observation_sec"
+
+post_recovery_unmounts=$(count_pattern "$LOG_DIR/master.log" 'action=unmount_nof_segment_by_heartbeat')
+if (( post_recovery_unmounts > pre_recovery_unmounts )); then
+  echo "nof segment was unmounted again after target recovery"
+  exit 1
+fi
+
+post_recovery_successes=$(awk -v start="$post_recovery_line_count" '
+  NR > start && ($0 ~ /put_ok/ || $0 ~ /get_ok/) { count++ }
+  END { print count + 0 }
+' "$LOG_DIR/client.log")
+
+if [[ "$CLIENT_GLOBAL_SEGMENT_SIZE" -eq 0 ]] && (( post_recovery_successes <= 0 )); then
+  echo "client did not recover nof IO after target recovery"
+  exit 1
+fi
 
 kill "$CLIENT_PID" >/dev/null 2>&1 || true
 wait "$CLIENT_PID" >/dev/null 2>&1 || true
@@ -220,6 +264,8 @@ fi
   cat "$LOG_DIR/hugepages.log"
   echo "=== register ==="
   cat "$LOG_DIR/register.log"
+  echo "=== register after recovery ==="
+  cat "$LOG_DIR/register_restart.log"
   echo "=== client ==="
   cat "$LOG_DIR/client.log"
   echo "=== master tail ==="
@@ -228,11 +274,14 @@ fi
   tail -n 80 "$LOG_DIR/metadata.log"
   echo "=== target tail ==="
   tail -n 120 "$LOG_DIR/target.log"
+  echo "=== target after recovery tail ==="
+  tail -n 120 "$LOG_DIR/target_restart.log"
   echo "=== verdict ==="
   echo "post_fault_successes=$post_fault_successes"
   echo "post_fault_failures=$post_fault_failures"
   echo "post_unmount_successes=$post_unmount_successes"
   echo "post_unmount_failures=$post_unmount_failures"
+  echo "post_recovery_successes=$post_recovery_successes"
   echo "pre_fault_put_ok=$put_ok_count"
   echo "pre_fault_get_ok=$get_ok_count"
   echo "pre_fault_line_count=$pre_fault_line_count"


### PR DESCRIPTION
# NoF qpair recovery after target restart (issue #3863)

## 1. Root cause

`SpdkWrapper::OpenNofSegment()` (`mooncake-store/src/spdk/spdk_wrapper.cpp`)
memoizes exactly one `nof_seg_handle` per `(controller, namespace)` pair, and
each handle owns exactly one `spdk_nvme_qpair` allocated on first use:

```cpp
auto ns_it = ns_seg.find(tr.ns);
if (ns_it != ns_seg.end()) {
    return ns_it->second.get();   // cached forever, never health-checked
}
```

Nothing in the tree ever inspected the qpair's health or called
`spdk_nvme_ctrlr_reconnect_io_qpair()` / `spdk_nvme_ctrlr_reset()`. When the
NoF target goes away the qpair enters a permanent failure state, so from that
moment on:

* `spdk_nvme_ns_cmd_read/write()` (via `SpdkWrapper::SubmitRequest`) returns
  `-ENXIO`, and `SpdkNofWorkerPool::workerThread()` just marks the task failed;
* `spdk_nvme_qpair_process_completions()` returns `-ENXIO`, and the worker only
  logs `poll completion error`;
* `SpdkWrapper::ProbeNofSegment()` reuses the same dead handle, so the master's
  NoF heartbeat fails forever.

Because the handle is cached, this does not clear itself when the target comes
back. The master unmounts the segment after the failure threshold, but once the
segment is registered again the heartbeat still probes the stale qpair and
unmounts it again, and client I/O submitted through
`TransferSubmitter::submitSpdkNofOperation()` keeps hitting the same dead
qpair. That is the "keeps reusing failed qpairs and cannot automatically
recover I/O after target recovery" behaviour reported in the issue.

## 2. The fix and why

Keep the cached handle (its address is used as a map key by
`SpdkNofWorkerPool::seg_to_worker_` and by the per-worker `seg_to_qos` map, so
it must stay stable), but heal the qpair inside it instead of reusing a failed
one.

`SpdkWrapper` gains two methods:

* `IsNofSegmentFailed()` — `spdk_nvme_qpair_get_failure_reason() !=
  SPDK_NVME_QPAIR_FAILURE_NONE`. Cheap enough to call on every submit round.
* `ReconnectNofSegment()` — tries `spdk_nvme_ctrlr_reconnect_io_qpair()` first,
  which is enough when only the I/O connection dropped. When the target
  restarted the whole NVMe association is gone and the io qpair cannot be
  connected on its own, so it falls back to `spdk_nvme_ctrlr_reset()` followed
  by another `spdk_nvme_ctrlr_reconnect_io_qpair()`. `nof_seg_handle` now
  carries a back pointer to its `ctrlr_info` so the controller and its mutex
  are reachable from a handle; the controller mutex serialises concurrent
  recovery of several namespaces on the same controller and makes the "someone
  else already fixed it" case a no-op.

Both I/O paths call it:

* `SpdkWrapper::ProbeNofSegment()` reconnects before probing, so the master's
  NoF heartbeat starts succeeding again once the target is back (and fails fast
  with `reconnect_fail` while it is still down, instead of waiting out the
  probe timeout on a dead qpair).
* `SpdkNofWorkerPool::workerThread()` reconnects a failed segment right before
  submitting its queued batch. SPDK requires the reconnect to happen on the
  thread that submits to and polls that qpair, which is exactly the bound
  worker thread; doing it from `submitSpdkNofOperation()` on the caller thread
  would violate that. Attempts are limited to one per second per segment
  (`kSpdkNofReconnectIntervalMs`) because a reconnect goes over the fabric and
  blocks for up to the fabrics connect timeout, and are only made for segments
  that actually have queued work, so an idle dead segment cannot stall a
  healthy one sharing the same worker.

If a reconnect fails, behaviour is unchanged from today: the submit fails the
task and the probe reports a heartbeat failure, and the next round tries again.

## 3. Files changed

* `mooncake-store/include/spdk/spdk_wrapper.h` — declare `IsNofSegmentFailed()`
  and `ReconnectNofSegment()`.
* `mooncake-store/src/spdk/spdk_wrapper.cpp` — implement them, give
  `nof_seg_handle` an owning `ctrlr_info *`, and reconnect in
  `ProbeNofSegment()`.
* `mooncake-store/src/transfer_task.cpp` — reconnect a failed segment from the
  owning worker thread before submitting, with per-segment back off.
* `mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh` — extend the existing
  NoF heartbeat e2e with a target recovery phase.

## 4. Risk and uncertainty

* `spdk_nvme_ctrlr_reset()` is documented as requiring that no other thread is
  actively using the controller. With several namespaces of one controller
  bound to different `SpdkNofWorkerPool` workers, a reset issued by one worker
  can race with another worker polling its own qpair. The controller mutex
  serialises the recovery calls themselves but cannot stop an unrelated worker
  from polling. In practice the reset only runs when the fabric is already down
  and every qpair of that controller has failed, and the deployments in
  `docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md` and the e2e script
  use a single namespace. Fully closing this would need a controller-wide
  quiesce across workers, which is a larger change than this issue warrants.
* The reconnect back off is a fixed 1s rather than exponential. During a long
  outage each worker spends up to one fabrics-connect timeout per second per
  segment with queued work.
* `ProbeNofSegment()` can now return the new `reconnect_fail` reason. The
  heartbeat treats every non-`completion_timeout` reason the same way, so only
  the log/metric label changes.
* Not verified against real SPDK: this environment has no SPDK, no NVMe-oF
  target and no hugepages, and `USE_NOF` is `OFF` by default, so the NoF code
  is not part of the normal build here.

## 5. How I verified it

* Compiled both new code paths against a faithful stub of the SPDK 23.01.1 API
  (the version pinned by `dependencies.sh`), matching the real signatures of
  `spdk_nvme_qpair_get_failure_reason`, `spdk_nvme_ctrlr_reconnect_io_qpair`
  and `spdk_nvme_ctrlr_reset`:
  `g++ -std=c++17 -fsyntax-only -DUSE_NOF ... mooncake-store/src/spdk/spdk_wrapper.cpp`
  and the same for the extracted `MaybeReconnectSpdkNofSegment()` helper. Both
  pass. A full build was not possible here (no SPDK, and the store's other
  third-party headers are not installed).
* `clang-format` (the formatter driven by the repo's pre-commit
  `mooncake-code-format` hook) reports no changes for the three C++ files.
  `pre-commit` itself is not installed in this environment.
* `bash -n mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh` passes.
* The e2e script now covers the regression. It already killed the NVMe-oF
  target and asserted the master unmounts the segment; it now restarts the
  target, re-registers the segment, and asserts that the segment is **not**
  unmounted a second time. Before this change the master's heartbeat keeps
  probing the stale qpair, so the segment is unmounted again within
  `HEARTBEAT_INTERVAL * HEARTBEAT_FAILURES` and the assertion fails. The
  client process is deliberately kept alive across the outage so its cached
  qpair is exercised too, and in NoF-only mode
  (`CLIENT_GLOBAL_SEGMENT_SIZE=0`) the script additionally requires that the
  same client resumes successful put/get after recovery. Running it needs an
  SPDK build, hugepages and root, none of which are available here.