### PR TITLE
[TE] feat(efa): move AWS Neuron (Trainium) HBM directly over EFA

### DIFF
--- a/.github/workflows/_build-efa-wheel.yaml
+++ b/.github/workflows/_build-efa-wheel.yaml
@@ -1,8 +1,9 @@
 name: _build-efa-wheel
 
 # Shared AWS EFA wheel build used by pull-request CI and release workflows.
-# EFA hardware is not required to build: the distro libfabric is used for
-# compilation, then auditwheel leaves libfabric/libefa to the system runtime.
+# EFA hardware is not required to build: libfabric is built from source purely
+# to compile against, then auditwheel leaves libfabric/libefa to the system
+# runtime -- so the wheel always uses the EFA installer's libfabric on the host.
 
 on:
   workflow_call:
@@ -112,15 +113,44 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update -y
-          packages=(libfabric-dev libfabric1)
+          packages=()
           if [ "$BUILD_PROFILE" = ci ]; then
-            packages=(ninja-build "${packages[@]}")
+            packages=(ninja-build)
           fi
-          sudo apt install -y "${packages[@]}"
+          if [ ${#packages[@]} -gt 0 ]; then
+            sudo apt install -y "${packages[@]}"
+          fi
           sudo bash -x dependencies.sh -y
           if [ "$BUILD_PROFILE" = ci ]; then
             df -h
           fi
+        shell: bash
+
+        # Built from source instead of taken from apt because the EFA transport
+        # asks fi_getinfo() for FI_VERSION(1, 18) and needs FI_HMEM_NEURON
+        # (libfabric >= 1.15) to register Neuron HBM, while Ubuntu 22.04 -- the
+        # runner that fixes this wheel's glibc floor -- packages libfabric 1.11.
+        # Pinned at the minimum the code actually claims to support, so the
+        # headers cannot describe structures a supported runtime is too old to
+        # provide; hosts run whatever libfabric the EFA installer put there.
+        # Only headers and a link target are wanted, hence no providers.
+      - name: Build libfabric
+        env:
+          LIBFABRIC_VERSION: '1.18.2'
+        run: |
+          workdir=$(mktemp -d)
+          curl -fsSL -o "$workdir/libfabric.tar.bz2" \
+            "https://github.com/ofiwg/libfabric/releases/download/v${LIBFABRIC_VERSION}/libfabric-${LIBFABRIC_VERSION}.tar.bz2"
+          tar -xf "$workdir/libfabric.tar.bz2" -C "$workdir"
+          cd "$workdir/libfabric-${LIBFABRIC_VERSION}"
+          ./configure --prefix=/usr/local \
+            --disable-efa --disable-verbs --disable-psm2 --disable-psm3 \
+            --disable-opx --disable-shm --disable-rxm --disable-rxd \
+            --disable-tcp --disable-udp --disable-sockets --disable-usnic \
+            --disable-mrail
+          make -j"$(nproc)"
+          sudo make install
+          grep -q FI_HMEM_NEURON /usr/local/include/rdma/fi_domain.h
         shell: bash
 
       - name: Configure project
@@ -143,8 +173,8 @@ jobs:
           cd build
           cmake "${generator[@]}" .. \
             -DUSE_EFA=ON \
-            -DLIBFABRIC_INCLUDE_DIR=/usr/include \
-            -DLIBFABRIC_LIBRARY=/usr/lib/x86_64-linux-gnu/libfabric.so \
+            -DLIBFABRIC_INCLUDE_DIR=/usr/local/include \
+            -DLIBFABRIC_LIBRARY=/usr/local/lib/libfabric.so \
             -DENABLE_SCCACHE=ON \
             -DCMAKE_BUILD_TYPE=Release \
             "${profile_args[@]}" \

--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -2,12 +2,10 @@
 
 This document describes how to build and use Mooncake with AWS Elastic Fabric Adapter (EFA) support using libfabric.
 
-## Prerequisites
-
 (efa-prerequisites-driver)=
-### 1. AWS EFA Driver and libfabric
+## Prerequisite: AWS EFA Driver and libfabric
 
-EFA driver and libfabric should be pre-installed on AWS instances with EFA support (e.g., p6-b300.48xlarge, p6-b200.48xlarge, p5en.48xlarge, p5e.48xlarge, p5.48xlarge).
+This is the one requirement that applies in *every* case, including a `pip install` of a published wheel — those deliberately do not bundle libfabric (see [Building a Distributable Wheel](#efa-distributable-wheel)). It is normally already satisfied: EFA-enabled instances (e.g., p6-b300.48xlarge, p6-b200.48xlarge, p5en.48xlarge, p5e.48xlarge, p5.48xlarge, trn2.48xlarge) ship with the driver and libfabric pre-installed.
 
 Verify installation:
 ```bash
@@ -20,20 +18,6 @@ ls /opt/amazon/efa/include/rdma/fabric.h
 ```
 
 If not installed, follow [AWS EFA documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html).
-
-### 2. Build Dependencies
-
-Clone the repository and install all dependencies:
-
-```bash
-git clone https://github.com/kvcache-ai/Mooncake.git
-cd Mooncake
-sudo ./dependencies.sh -y
-```
-
-This installs all system packages, git submodules (pybind11), and Go.
-
-> **Note:** The EFA driver and libfabric are **not** installed by `dependencies.sh`. They must be pre-installed on the instance (see section 1 above).
 
 ## Installing from PyPI (recommended)
 
@@ -52,13 +36,27 @@ pip install mooncake-transfer-engine-efa-non-cuda
 
 The CUDA 13 wheel requires an NVIDIA 580-series or newer driver, following the [CUDA compatibility requirements](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html).
 
-> **Note:** These wheels deliberately do **not** bundle `libfabric`/`libefa` (see the runtime note in [Building a Distributable Wheel](#efa-distributable-wheel)). They resolve to the system AWS EFA installation at runtime, so the EFA driver and libfabric from the [Prerequisites](#efa-prerequisites-driver) must still be present on the instance. Make sure `/opt/amazon/efa/lib` is on `LD_LIBRARY_PATH`.
+> **Note:** These wheels deliberately do **not** bundle `libfabric`/`libefa` (see the runtime note in [Building a Distributable Wheel](#efa-distributable-wheel)). They resolve to the system AWS EFA installation at runtime, so the [EFA driver and libfabric](#efa-prerequisites-driver) must still be present on the instance. Make sure `/opt/amazon/efa/lib` is on `LD_LIBRARY_PATH`.
 
 To build from source instead (for development, an unreleased revision, or a custom configuration), follow the sections below.
 
 ## Building Mooncake with EFA Support
 
-### 1. Build with EFA Enabled
+### 1. Install Build Dependencies
+
+Clone the repository and install the build dependencies:
+
+```bash
+git clone https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+sudo ./dependencies.sh -y
+```
+
+This installs all system packages, git submodules (pybind11), and Go.
+
+> **Note:** `dependencies.sh` does **not** install the EFA driver or libfabric — those are the [prerequisite](#efa-prerequisites-driver) above and must already be on the instance. Nothing here is needed to *use* a published wheel.
+
+### 2. Build with EFA Enabled
 
 **GPU memory transfers (e.g., KV cache in vLLM):**
 
@@ -75,7 +73,7 @@ make -j$(nproc)
 
 > **Note:** `-DUSE_CUDA=ON` is required when transferring GPU memory (e.g., KV cache in vLLM). Without it, the TCP transport (used as fallback when `mooncake_protocol` is set to `"tcp"`) cannot detect GPU memory and will fail with "Bad address" (EFAULT) errors.
 
-**CPU memory transfers only (no GPU dependency):**
+**No NVIDIA GPU (CPU memory, or Neuron devices):**
 
 ```bash
 mkdir build && cd build
@@ -90,7 +88,9 @@ make -j$(nproc)
 
 > **Note:** With `-DUSE_CUDA=OFF`, the benchmark tool uses DRAM buffers allocated via `numa_alloc_onnode`. This is useful for measuring EFA transport throughput independently of GPU hardware.
 
-### 2. Install Python Package
+> **Note:** `USE_CUDA` only governs the **CUDA** memory path. Neuron HBM is handled independently of it and needs no extra flag either way — a Neuron instance has no CUDA, so `-DUSE_CUDA=OFF` is the build to use there, and it is still a device-memory build. See [AWS Neuron](#efa-neuron).
+
+### 3. Install Python Package
 
 ```bash
 # Copy built modules to wheel directory
@@ -103,15 +103,17 @@ pip install -e ../mooncake-wheel --no-build-isolation
 ```
 
 (efa-distributable-wheel)=
-### 3. Building a Distributable Wheel (optional)
+### 4. Building a Distributable Wheel (optional)
 
 To produce a relocatable wheel for distribution (instead of the editable install above), use `scripts/build_wheel.sh`, which runs `auditwheel repair` to bundle non-system dependencies:
 
 ```bash
-# After the cmake/make build above completes:
+# Run from the repository root, after the cmake/make build above completes:
 PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
-pip install dist/mooncake_transfer_engine-*.whl
+pip install mooncake-wheel/dist/*.whl
 ```
+
+> **Note:** the script must be run from the repository root (it resolves `mooncake-wheel/` and `${BUILD_DIR}` relatively), and the output directory is relative to `mooncake-wheel/` — so the wheel lands in **`mooncake-wheel/dist/`**, not `./dist/`. The `set -x` trace prints `mv repaired_wheels_3.13/... dist/` because that step runs with `mooncake-wheel/` as the working directory.
 
 To produce a wheel whose package name matches one of the published variants, set the corresponding build-variant environment variable — this is exactly what the release pipeline does:
 
@@ -126,7 +128,9 @@ EFA_CU13_BUILD=1 PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh
 EFA_NON_CUDA_BUILD=1 PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
 ```
 
-> **CI/CD:** EFA wheels are built and published automatically — see `.github/workflows/ci_efa.yml` (per-PR build validation), `.github/workflows/release-efa.yaml` (CUDA 12 release), `.github/workflows/release-efa-cuda13.yaml` (CUDA 13 release), and `.github/workflows/release-efa-non-cuda.yaml` (non-CUDA release). No EFA hardware is required to *build* the wheel: only the libfabric headers/library are needed to compile and link, which the CI runner obtains from the distro `libfabric-dev` package.
+With no variant variable set the wheel is named `mooncake_transfer_engine-*.whl`, i.e. the same distribution name as the upstream non-EFA package — a useful way to tell from the filename alone whether the flag took effect. It only changes the name pip records; the importable module is `mooncake` either way, so which variant name you build has no bearing on whether EFA or Neuron support is compiled in (that is decided by the `cmake` flags).
+
+> **CI/CD:** EFA wheels are built and published automatically — see `.github/workflows/ci_efa.yml` (per-PR build validation), `.github/workflows/release-efa.yaml` (CUDA 12 release), `.github/workflows/release-efa-cuda13.yaml` (CUDA 13 release), and `.github/workflows/release-efa-non-cuda.yaml` (non-CUDA release). No EFA hardware is required to *build* the wheel: only the libfabric headers/library are needed to compile and link, which the CI runner gets by building libfabric from source with every provider disabled. The distro `libfabric-dev` package is deliberately not used — Ubuntu 22.04, the runner that fixes this wheel's glibc floor, packages libfabric 1.11, which predates both the `FI_VERSION(1, 18)` the transport asks `fi_getinfo()` for and the `FI_HMEM_NEURON` interface needed for [Neuron device memory](#efa-neuron). The pin is the oldest libfabric the transport claims to support, so the headers cannot describe structures that a supported runtime is too old to provide.
 
 > **Important (EFA builds):** `auditwheel repair` excludes `libfabric` and `libefa` from the wheel so they resolve to the system EFA installation (`/opt/amazon/efa/lib`) at runtime. This is required because the in-process `aws-ofi-nccl` plugin (loaded by NCCL) links the **same** system `libfabric`. If the wheel bundled its own copy, the process would load two independent libfabric instances — Mooncake's bundled one and NCCL's system one — and whichever initializes first claims the EFA device, leaving the other with an empty provider list (`fi_getinfo: provider efa output empty list`). NCCL then silently falls back to the TCP provider and cross-node collectives such as `all_gather_object` hang. Excluding libfabric/libefa (see `scripts/build_wheel.sh`) keeps a single shared libfabric in the process. If you are on an older Mooncake build whose wheel still bundles libfabric, force the system copy with `export LD_PRELOAD=/opt/amazon/efa/lib/libfabric.so.1` as a workaround.
 
@@ -154,7 +158,7 @@ comma-separated device whitelist. To disable discovery, set
 
 ## Unit Tests
 
-Run the EFA transport unit tests (requires EFA hardware):
+Run the EFA transport unit tests (all but one need EFA hardware):
 
 ```bash
 ./build/mooncake-transfer-engine/tests/efa_transport_test
@@ -172,6 +176,7 @@ The test suite includes:
 | `WarmupSegmentLoopback` | `warmupSegment()` handshake path + idempotent re-call |
 | `WarmupSegmentNotFound` | `warmupSegment()` fails cleanly for an unknown segment |
 | `RegisterMemoryBatch` | `registerLocalMemoryBatch` / `unregisterLocalMemoryBatch` round-trip |
+| `EFALocalNicMapTest.InvertsPreferredHca` | `MC_EFA_NIC_SELECTION=local` map inversion — the one case that needs no hardware |
 | `LargeTransfer` | 128 MB buffer, 64 x 1 MB slices — exercises WR / CQ pacing |
 | `RepeatedOpenSegment` | `openSegment()` on the same peer repeatedly still transfers correctly |
 
@@ -187,7 +192,7 @@ cd build && ctest --output-on-failure -R 'efa'
 
 Use `transfer_engine_bench` to measure EFA transport throughput between two nodes.
 
-The following commands are the GPU-to-GPU configuration that produces the headline numbers in the [Benchmark Results](#benchmark-results) tables (≈ 350 GB/s write on a p5en.48xlarge pair, ≈ 302 GB/s on p6-b200.48xlarge). Two things matter the most:
+The following commands are the GPU-to-GPU shape used for the [Benchmark Results](#benchmark-results) tables below, which top out at 780 GB/s write on a p6-b300.48xlarge pair and 365 GB/s on p5en.48xlarge — see each table for the `threads`/`batch_size` that peaked on that host. Two things matter the most:
 
 - `--gpu_id=-1` on **both** sides — this fans buffers across every GPU, which in turn lets both NUMA nodes' NICs saturate. Pinning a single GPU (the default `--gpu_id=0`) halves throughput because half the NICs end up cross-NUMA.
 - `--block_size=1048576` (1MB, not the 64 KB default) — each block becomes one `fi_write` / `fi_read`, so larger blocks amortize per-op overhead and are the main knob for hitting line rate.
@@ -253,6 +258,8 @@ Replace `<target_hostname>:<target_port>` with the target node's address shown i
 
 > **Note:** `buffer_size` must be >= `block_size * batch_size * threads`. The benchmark auto-adjusts if too small.
 
+> On Neuron instances, `--neuron_device` replaces `--gpu_id` / `--use_vram` as the way to put buffers on the accelerator — see [AWS Neuron](#efa-neuron) for those flags and for how to build there.
+
 (benchmark-results)=
 ### Benchmark Results
 
@@ -315,7 +322,7 @@ Tested on two p5en.48xlarge instances (Intel Xeon 8488C, 8× H200 141GB, 16 EFA 
 | block=1MB, threads=32, batch=128 | 364.21 GB/s | 250.90 GB/s |
 | block=1MB, threads=48, batch=64 | 363.47 GB/s | 268.43 GB/s |
 
-> **Peak write: 365 GB/s** at `threads=16, batch=128` — ~91% of the 400 GB/s theoretical line rate (16×200 Gbps). Write saturates on batch size, so `batch=128` outperforms smaller batches as long as `threads × batch ≤ 16 × 256 = 4096` (the shared-endpoint WR cap). **Peak read: 304 GB/s** at `threads=16, batch=32` — reads tolerate smaller in-flight queues, and throughput drops as batch grows.
+> **Peak write: 365 GB/s** at `threads=16, batch=128` — ~91% of the 400 GB/s theoretical line rate (16×200 Gbps). Write saturates on batch size, so `batch=128` outperforms smaller batches as long as `threads × batch` stays under the shared-endpoint WR cap — `16 × 256 = 4096` when this sweep was taken, since the per-endpoint cap was still a fixed 256; it is now the provider's transmit depth, see the WR-cap tip under **Tuning Tips**. **Peak read: 304 GB/s** at `threads=16, batch=32` — reads tolerate smaller in-flight queues, and throughput drops as batch grows.
 
 **CPU-to-CPU** (build with `-DUSE_CUDA=OFF`, or `--use_vram=false` on a CUDA build, `--buffer_size=4294967296`):
 
@@ -353,7 +360,7 @@ Tested on two p5en.48xlarge instances (Intel Xeon 8488C, 8× H200 141GB, 16 EFA 
 
 #### 4. p5.48xlarge (H100, 32 EFA × 100 Gbps)
 
-Tested on two p5.48xlarge instances (AMD EPYC 7R13, 8× H100 80GB, 32 EFA devices) in the same AWS placement group. Per-NIC line rate is half of p5en's, but with twice the NIC count the aggregate ceiling is the same 400 GB/s. The shared-endpoint WR cap scales with NIC count: `32 NICs × 256 = 8192` in-flight slots, so `threads × batch_size ≤ 8192` (vs 4096 on p5en).
+Tested on two p5.48xlarge instances (AMD EPYC 7R13, 8× H100 80GB, 32 EFA devices) in the same AWS placement group. Per-NIC line rate is half of p5en's, but with twice the NIC count the aggregate ceiling is the same 400 GB/s. The WR cap scales with NIC count, so this host tolerated twice the in-flight slices p5en did: `32 NICs × 256 = 8192` versus 4096, with the fixed per-endpoint 256 in force when this sweep was taken.
 
 **GPU-to-GPU** (build with `-DUSE_CUDA=ON`, `--gpu_id=-1` for all 8 GPUs, `--buffer_size=4294967296`):
 
@@ -366,7 +373,7 @@ Tested on two p5.48xlarge instances (AMD EPYC 7R13, 8× H100 80GB, 32 EFA device
 | block=1MB, threads=16, batch=32 | - | 356.94 GB/s |
 | block=1MB, threads=32, batch=32 | - | 380.66 GB/s |
 
-> **Peak write: 389 GB/s** at `threads=32, batch=128` — ~97% of the 400 GB/s theoretical line rate (32×100 Gbps). The plateau is wide: any `(threads, batch)` between `(16, 128)` and `(32, 128)` lands within 0.1% of peak. **Peak read: 382 GB/s** at `threads=32, batch=128` — unlike p5en, reads on this host scale with batch size up to 128 because the wider 32-NIC fabric absorbs larger in-flight queues without backoff. `(32, 256)` and `(64, 128)` (both at the 8192 WR cap) fail with no headroom for retries.
+> **Peak write: 389 GB/s** at `threads=32, batch=128` — ~97% of the 400 GB/s theoretical line rate (32×100 Gbps). The plateau is wide: any `(threads, batch)` between `(16, 128)` and `(32, 128)` lands within 0.1% of peak. **Peak read: 382 GB/s** at `threads=32, batch=128` — unlike p5en, reads on this host scale with batch size up to 128 because the wider 32-NIC fabric absorbs larger in-flight queues without backoff. `(32, 256)` and `(64, 128)` — both exactly at that run's 8192 WR cap, with no headroom for retries — failed.
 
 **CPU-to-CPU** (build with `-DUSE_CUDA=OFF`, or `--use_vram=false` on a CUDA build, `--buffer_size=4294967296`):
 
@@ -431,6 +438,7 @@ For reference, a cross-host `put_from` of the same payload (device RDMA, 1 NIC) 
 - For **GPU-to-GPU**: pass `--gpu_id=-1` on **both** sides so buffers fan out across every GPU. Pinning a single GPU halves throughput because half the NICs end up cross-NUMA.
 - For **CPU-to-CPU**: DRAM bandwidth is the ceiling. NUMA-split (separate initiator/target instances per NUMA node) can help reduce contention when one instance can't saturate both nodes.
 - `--buffer_size` only needs `≥ block × batch × threads`; larger values do not improve throughput. The example commands use 4 GB because that is safe for any reasonable config.
+- **Leave the `MC_EFA_*` environment variables alone** — the defaults are what every number above was measured with. [Environment Variables](#efa-env-vars) explains what each one does and why overriding `MC_MAX_WR` in particular causes transfer *failures*, not slowdowns.
 
 ### First-request latency
 
@@ -514,6 +522,158 @@ submit #4:   0.09 ms
 - **Deciding whether your application needs `warmupSegment()`**: if `submit #0` in the `--warmup=0` run is acceptable for your use case, you don't need to call `warmupSegment` at all.
 - **Comparing PR branches**: run the probe on the same hardware on this PR's branch vs `main` (or whatever upstream you're benchmarking against) to see per-NIC-pair handshake cost directly, without having the number drowned in a 10-second throughput average.
 
+(efa-neuron)=
+## AWS Neuron (Trainium / Inferentia)
+
+On Neuron instances such as `trn2.48xlarge`, the EFA transport moves Neuron HBM directly, without staging through host DRAM. Nothing has to be configured for this: a registered buffer is recognised as Neuron memory from the `/dev/neuron<N>` mapping that backs it, and is then registered with `fi_mr_regattr(iface=FI_HMEM_NEURON)`. Neuron support needs no Neuron SDK at build time and no code changes in the application.
+
+Two runtime conditions have to hold. Both are already met on a stock Neuron instance, and each has a log line that names it when it is not:
+
+1. **libfabric 1.15 or newer**, for `FI_HMEM_NEURON`. The published EFA wheels satisfy this, as does any libfabric from the AWS EFA installer. A build against an older libfabric logs a warning on Neuron hosts and falls back to treating the device as unsupported rather than silently registering HBM as host memory.
+2. **`libnrt.so.1` must be findable.** libfabric reaches the Neuron runtime through `dlopen("libnrt.so.1")` while initialising its HMEM interfaces, and the Neuron SDK installs it under `/opt/aws/neuron/lib` without putting that directory on the loader path — so libfabric's own `dlopen` would fail and leave `fi_mr_regattr` returning `-FI_ENOSYS` with nothing pointing at the cause. Mooncake loads the library itself (`RTLD_GLOBAL`) before the first `fi_getinfo`, adopting the framework's already-mapped copy if there is one and otherwise trying the soname and then the SDK's default path, so a stock install needs no configuration. Only a runtime installed elsewhere needs help, and it has to be given before the process starts — glibc reads `LD_LIBRARY_PATH` once, at startup:
+
+   ```bash
+   export LD_LIBRARY_PATH=/path/to/neuron/lib:$LD_LIBRARY_PATH
+   ```
+
+   The transport logs a warning naming this cause as soon as it sees a Neuron device it cannot pair with a runtime.
+
+Set `MC_EFA_DISABLE_NEURON=1` to opt out and go back to host-memory staging.
+
+### Building on a Neuron instance
+
+Exactly the same as any other EFA build — there is no Neuron build flag and no Neuron SDK dependency at compile time. A Neuron instance has no CUDA, so use the `-DUSE_CUDA=OFF` variant from [Building Mooncake with EFA Support](#building-mooncake-with-efa-support):
+
+```bash
+sudo ./dependencies.sh -y
+mkdir build && cd build
+cmake .. -DUSE_EFA=ON -DUSE_CUDA=OFF -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+```
+
+`-DUSE_CUDA=OFF` does **not** turn Neuron off: it only drops the CUDA memory path (see the note in that section). What Neuron support does depend on is the libfabric that cmake finds, which by default is the EFA installer's copy under `/opt/amazon/efa` — new enough on any current Neuron AMI. Confirm from the configure output rather than guessing:
+
+```
+-- AWS EFA (libfabric) transport is enabled
+--   libfabric include: /opt/amazon/efa/include
+--   Neuron (FI_HMEM_NEURON): 1
+```
+
+A `0` there means the headers predate libfabric 1.15 and the build will refuse to register Neuron HBM at runtime; point `-DLIBFABRIC_INCLUDE_DIR` / `-DLIBFABRIC_LIBRARY` at a newer libfabric. To install rather than build, take the **non-CUDA** wheel (`pip install mooncake-transfer-engine-efa-non-cuda`) — the published wheels are built against a libfabric that has `FI_HMEM_NEURON`.
+
+(pcie-switch-nic-affinity)=
+### PCIe-switch NIC affinity
+
+`trn2.48xlarge` has 8 PCIe switches, each carrying 2 Neuron devices and 2 EFA NICs, and a Neuron device can only reach the NICs behind its own switch at full speed. The topology discovery therefore maps each `/dev/neuron<N>` to its switch-local NICs and publishes them as that location's preferred HCAs, which is what makes the difference between the two rows below (both measured with the recommended shape from [Benchmarking](#neuron-benchmarking): 16 devices, 4 GB buffers, 1 MB blocks, 32 threads, batch 128):
+
+| NIC selection | Throughput |
+|---|---|
+| Switch-local NICs (default) | **266.58 GB/s** |
+| All 16 NICs (`--nic_priority_matrix` overriding the default) | 23.48 GB/s |
+
+For reference, host DRAM over the same fabric tops out at 113 GB/s on this instance, so correctly routed Neuron HBM is roughly 2.4× faster than CPU-to-CPU.
+
+The affinity is verifiable from outside the benchmark, using the NIC hardware counters under `/sys/class/infiniband/<dev>/ports/1/hw_counters/tx_bytes`. A single-device run (`--neuron_device_count=1`) moves 19.27 GB/s and every byte of it appears on exactly two NICs — the two behind that device's switch — with the other fourteen flat at zero. The same counters also confirm the reported aggregate: a full-instance run reads 279.5 GB/s summed across all 16 NICs against 278.97 GB/s self-reported.
+
+(neuron-benchmarking)=
+### Benchmarking
+
+`--neuron_device` is the switch: it defaults to `-1`, which keeps the ordinary DRAM / GPU path. Pass `0` (or any valid core) to put buffers in Neuron HBM. Everything else is the ordinary two-node run from [Performance Benchmark](#performance-benchmark) — in particular `--metadata_server=P2PHANDSHAKE` is still required, since its default is an etcd address and a missing etcd is a fatal error, not a fallback.
+
+The flags below are the measured optimum on `trn2.48xlarge` (see [Tuning](#neuron-tuning)); both sides must agree on `--neuron_device_count` and `--neuron_core_stride`, because the initiator indexes the *remote* buffer list with its own buffer count:
+
+```bash
+# Target
+./build/mooncake-transfer-engine/example/transfer_engine_bench \
+    --mode=target --protocol=efa --metadata_server=P2PHANDSHAKE \
+    --buffer_size=4294967296 \
+    --neuron_device=0 --neuron_device_count=16 --neuron_fill_byte=0x00
+
+# Initiator — take <port> from the target's "listening on" startup line,
+# which is not the port in its --local_server_name
+./build/mooncake-transfer-engine/example/transfer_engine_bench \
+    --mode=initiator --protocol=efa --metadata_server=P2PHANDSHAKE \
+    --segment_id=<target>:<port> --operation=write \
+    --buffer_size=4294967296 \
+    --neuron_device=0 --neuron_device_count=16 --neuron_fill_byte=0xAB \
+    --block_size=1048576 --threads=32 --batch_size=128
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `--neuron_device` | `-1` | Logical NeuronCore to allocate the first buffer on; `-1` disables the Neuron path entirely |
+| `--neuron_device_count` | `1` | How many Neuron devices to spread buffers over, starting from `--neuron_device`. Only 2 EFA NICs sit on any one device's PCIe switch, so one device cannot drive the whole fabric — use `16` on trn2.48xlarge |
+| `--neuron_core_stride` | `0` (auto) | Logical NeuronCores per physical device, i.e. how far to step between buffers; auto-detected from sysfs `core_count / 2` (LNC=2) |
+| `--neuron_fill_byte` | `0xCC` | Byte prefilled into HBM. Give the two sides different values and the target reports on shutdown how much the peer actually overwrote — the only end-to-end check available, since the host cannot `memcmp()` device memory |
+
+> **Note:** `--operation` defaults to `read`. A write-path read-back check on a `read` run reports "0 bytes differ" and looks like a bug when it is simply not writing anything.
+
+> **Note:** `nrt_init` claims **all visible NeuronCores** regardless of `--neuron_device_count`. On a shared host, restrict the benchmark with a contiguous range, e.g. `NEURON_RT_VISIBLE_CORES=56-63`.
+
+(neuron-tuning)=
+### Tuning
+
+Everything below was swept on two `trn2.48xlarge` writing Neuron HBM to Neuron HBM over all 16 devices, one 4 GB buffer per device. Run-to-run spread is ±2%, so only differences larger than that mean anything.
+
+**`--threads` is the dominant knob**, and it peaks well before the core count — 32 threads over 16 devices is 2 per device (block 1 MB, batch sized to keep `block × batch × threads` inside the buffer):
+
+| `--threads` | `--batch_size` | Throughput |
+|---|---|---|
+| 8 | 128 | 123.83 GB/s |
+| 16 | 32 | 259.93 GB/s |
+| **32** | **128** | **266–271 GB/s** |
+| 64 | 32 | 249.38 GB/s |
+| 128 | 16 | 255.26 GB/s |
+
+**`--block_size` is flat from 512 KB up**, so the only thing to avoid is going small (at 16 threads: 256 KB 233.87, 512 KB 247.09, 1 MB 243.04, 2 MB 248.44 GB/s). 1 MB is the recommendation because it is comfortably inside the plateau.
+
+**`--buffer_size` matters only indirectly.** `check_total_buffer_size()` silently *raises* it to `block_size × batch_size × threads` per buffer, so an under-sized value is corrected rather than rejected; 4 GB is simply large enough to hold the recommended shape with room to raise `--batch_size`. It is a *per-buffer* size, so the recommended run costs 16 × 4 GB = 64 GB of the instance's 1.5 TB HBM.
+
+**Per-device throughput is the ceiling, not the fabric.** A single device sustains 19.3 GB/s and does not move between 2 and 16 threads; 16 devices reach ~270 GB/s, i.e. roughly linear in device count at ~17 GB/s each. Since EFAv3 on this instance is 3,200 Gbps = 400 GB/s aggregate and each device has two 25 GB/s NICs behind its switch, the accelerator-side path — not the NICs and not HBM (46.4 TB/s) — is what binds. Consequently:
+
+- Adding NICs per device cannot help; the switch only has 2 anyway.
+- Spreading buffers across all 64 logical NeuronCores instead of 16 (`--neuron_core_stride=1 --neuron_device_count=64`) is worth about +3% (279 vs 270 GB/s) for 2× the HBM footprint and a matching flag on both sides. Not worth it as a default, but it is the shape to reach for if you are chasing the last few percent.
+- Runs that fall far below these numbers are almost always a NIC-affinity problem rather than a tuning problem — see [PCIe-switch NIC affinity](#pcie-switch-nic-affinity) for the 11× cliff and how to confirm it from the NIC counters.
+
+(efa-env-vars)=
+## Environment Variables
+
+These apply to any Mooncake caller — the framework sections below only add the one variable each framework needs to select the transport. Every default here is what the [Benchmark Results](#benchmark-results) were measured with, so the useful default is to change nothing.
+
+| Variable | Default | Description |
+|---|---|---|
+| `MOONCAKE_PROTOCOL` | `rdma` | Set to `efa` to select this transport. Read by the vLLM / SGLang connectors |
+| `MC_MAX_WR` | provider's transmit depth | Per-NIC in-flight WR cap. **Do not set** — see below |
+| `MC_EFA_CQ_THREADS` | `1` | CQ polling threads. **Leave alone** — see below |
+| `MC_EFA_NIC_SELECTION` | `all` | `local` registers each device buffer only on its topology-local NICs — see below |
+| `MC_EFA_DISABLE_NEURON` | unset | `1` skips Neuron HBM registration and stages through host memory — see [AWS Neuron](#efa-neuron) |
+| `MC_MS_AUTO_DISC`, `MC_MS_FILTERS` | on / unset | Mooncake Store device auto-discovery — see [Verification](#verification) |
+| `FI_PROVIDER`, `FI_EFA_USE_DEVICE_RDMA`, `LD_LIBRARY_PATH` | set by the EFA installer | libfabric-side, not Mooncake's. Only needed if a container image drops them |
+
+> **Do not set `MC_MAX_WR` on EFA — the default is already the correct value.** It caps a counter that paces submission against the endpoint's transmit queue, whose depth the *provider* chooses per device (`fi_tx_attr: size` — **4096** on p5.48xlarge, **2048** on p6-b300.48xlarge, derived from the device's `max_sq_wr`), so the transport reads that depth back instead of using a compiled-in number.
+>
+> Overriding it desynchronizes the counter from the queue it paces, and **both directions of error are real transfer failures, not just slowdowns** — EFA has no transport-level retransmit, so the affected slices are reported up as `FAILED`:
+>
+> - **Too small** (e.g. the old fixed default of 256): the counter saturates while the queue is mostly empty, so submitters spin in the credit-wait loop and give up — `timed out waiting for CQ drain (wr_depth=256, max=256)` — with thousands of slots the NIC would have accepted.
+> - **Too large** (e.g. `MC_MAX_WR=16384`): the counter hands out credit the queue cannot honor, so `fi_write` refuses with `-FI_EAGAIN` while `wr_depth` sits pinned at the provider's real depth and the rest of the credit is nominally free — `1024 consecutive FI_EAGAIN waves posted nothing`.
+>
+> A value **below** the provider's depth is still honored, as a deliberate per-NIC throttle; a value above it is clamped with a warning. Verify what took effect from the per-device startup line — no probe needed:
+>
+> ```
+> EFA device (libfabric): rdmap79s0, ... (shared endpoint, max_wr=4096, provider tx queue=4096, max_cqe=12288)
+> ```
+>
+> If you genuinely need a deeper queue, raise it at the provider with **`FI_EFA_TX_SIZE`** rather than with `MC_MAX_WR`, and Mooncake will track the new depth on its own — measured on p5, `FI_EFA_TX_SIZE=16384` moves `tx_attr->size` to 16384 and the CQ to 24576, and both counters follow. `MC_MAX_WR` cannot do this: it only moves Mooncake's counter, leaving the hardware queue where it was.
+
+> **`MC_EFA_CQ_THREADS`** — caps the number of CQ polling threads. The default of `1` reaches 99.93% of peak GPU-to-GPU throughput while leaving CPU for other work, so **leave it alone**. Pollers busy-wait (the CQs are opened `FI_WAIT_NONE`, so there is no descriptor to block on), which means each extra thread burns a full core whether or not completions are arriving — the opposite of what you want in PD-disagg, where the same cores serve the inference loop. Raising it also cannot fix `FI_EAGAIN` symptoms: those mean the provider is refusing new work, not that completions are going unreaped. Set `0` to lift the cap entirely (one poller per EFA device — the pre-#2113 behavior). Values above the device count are ignored; no excess threads are created.
+>
+> ```bash
+> export MC_EFA_CQ_THREADS=1   # default: single CQ poller
+> export MC_EFA_CQ_THREADS=0   # lift cap: one poller per EFA device (legacy)
+> ```
+
+> **`MC_EFA_NIC_SELECTION`** — `all` (default) registers every buffer on every NIC, so any NIC can serve any transfer. `local` narrows a device buffer to the NICs the topology reports as closest to its GPU, which trades bandwidth for registration time: fewer NICs can serve a transfer touching that buffer, but registering one buffer on N NICs costs roughly N registrations, and for device memory a per-domain cost is paid on top. Measured on p5.48xlarge with 48 × 391 MB GPU buffers registered serially: **123.7 s across 32 NICs, 17.6 s across 4, 4.4 s on 1.** Use it when startup registration time dominates, not to chase throughput. Host (`cpu:N`) buffers are deliberately never narrowed — a NUMA node's NIC set is half the machine, not a rail group. This knob is unrelated to the Neuron switch-locality win, which comes from the topology's transfer-time NIC preference and needs no configuration.
+
 ## Usage with vLLM
 
 ### 1. Prefill Instance
@@ -582,27 +742,7 @@ export FI_EFA_USE_DEVICE_RDMA=1
 export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
 ```
 
-> **Do not set `MC_MAX_WR` on EFA — the default is already the correct value.** It caps a counter that paces submission against the endpoint's transmit queue, whose depth the *provider* chooses per device (`fi_tx_attr: size` — **4096** on p5.48xlarge, **2048** on p6-b300.48xlarge, derived from the device's `max_sq_wr`), so the transport reads that depth back instead of using a compiled-in number.
->
-> Overriding it desynchronizes the counter from the queue it paces, and **both directions of error are real transfer failures, not just slowdowns** — EFA has no transport-level retransmit, so the affected slices are reported up as `FAILED`:
->
-> - **Too small** (e.g. the old fixed default of 256): the counter saturates while the queue is mostly empty, so submitters spin in the credit-wait loop and give up — `timed out waiting for CQ drain (wr_depth=256, max=256)` — with thousands of slots the NIC would have accepted.
-> - **Too large** (e.g. `MC_MAX_WR=16384`): the counter hands out credit the queue cannot honor, so `fi_write` refuses with `-FI_EAGAIN` while `wr_depth` sits pinned at the provider's real depth and the rest of the credit is nominally free — `1024 consecutive FI_EAGAIN waves posted nothing`.
->
-> A value **below** the provider's depth is still honored, as a deliberate per-NIC throttle; a value above it is clamped with a warning. Verify what took effect from the per-device startup line — no probe needed:
->
-> ```
-> EFA device (libfabric): rdmap79s0, ... (shared endpoint, max_wr=4096, provider tx queue=4096, max_cqe=12288)
-> ```
->
-> If you genuinely need a deeper queue, raise it at the provider with **`FI_EFA_TX_SIZE`** rather than with `MC_MAX_WR`, and Mooncake will track the new depth on its own — measured on p5, `FI_EFA_TX_SIZE=16384` moves `tx_attr->size` to 16384 and the CQ to 24576, and both counters follow. `MC_MAX_WR` cannot do this: it only moves Mooncake's counter, leaving the hardware queue where it was.
-
-> **`MC_EFA_CQ_THREADS`** — caps the number of CQ polling threads. The default of `1` reaches 99.93% of peak GPU-to-GPU throughput while leaving CPU for other work, so **leave it alone**. Pollers busy-wait (the CQs are opened `FI_WAIT_NONE`, so there is no descriptor to block on), which means each extra thread burns a full core whether or not completions are arriving — the opposite of what you want in PD-disagg, where the same cores serve the inference loop. Raising it also cannot fix `FI_EAGAIN` symptoms: those mean the provider is refusing new work, not that completions are going unreaped. Set `0` to lift the cap entirely (one poller per EFA device — the pre-#2113 behavior). Values above the device count are ignored; no excess threads are created.
->
-> ```bash
-> export MC_EFA_CQ_THREADS=1   # default: single CQ poller
-> export MC_EFA_CQ_THREADS=0   # lift cap: one poller per EFA device (legacy)
-> ```
+Everything else is optional and framework-independent — see [Environment Variables](#efa-env-vars).
 
 ### 3. Prefill Instance
 
@@ -689,7 +829,7 @@ The EFA transport requests `FI_THREAD_SAFE` at the domain level and guards the s
 - Multiple submission threads may route slices through the same shared endpoint concurrently.
 - libfabric's EFA RDM endpoints are not thread-safe for concurrent `fi_write`/`fi_read` even under `FI_THREAD_SAFE` at the domain level — concurrent posts corrupt provider internals and completions silently vanish.
 
-CQs are polled by dedicated worker threads that run independently of submission threads. The poller count is `min(MC_EFA_CQ_THREADS, num_EFA_devices)`, and `MC_EFA_CQ_THREADS` defaults to `1`, so by default a single thread walks every device's CQ in a busy-wait loop (yielding only when a full pass reaped nothing). That already reaches ~99.9% of peak — see the env-var note under *Usage with SGLang* before changing it.
+CQs are polled by dedicated worker threads that run independently of submission threads. The poller count is `min(MC_EFA_CQ_THREADS, num_EFA_devices)`, and `MC_EFA_CQ_THREADS` defaults to `1`, so by default a single thread walks every device's CQ in a busy-wait loop (yielding only when a full pass reaped nothing). That already reaches ~99.9% of peak — read [Environment Variables](#efa-env-vars) before changing it.
 
 ### EFA vs RoCE RDMA
 
@@ -713,6 +853,7 @@ CQs are polled by dedicated worker threads that run independently of submission 
 - p5en.48xlarge (16 EFA devices × 200 Gbps = 3,200 Gbps, `rdmap*` naming)
 - p5e.48xlarge (32 EFA devices × 100 Gbps = 3,200 Gbps, `rdmap*` naming)
 - p5.48xlarge (32 EFA devices × 100 Gbps = 3,200 Gbps, `rdmap*` naming)
+- trn2.48xlarge (16 EFA devices × 200 Gbps = 3,200 Gbps, `rdmap*` naming; 16 Neuron devices, see [AWS Neuron](#efa-neuron))
 - Other EFA-enabled instances
 
 Use `fi_info -p efa` to list available EFA devices on your instance.
@@ -752,13 +893,27 @@ If `transfer_engine_bench` hangs with some workers never completing:
 
 1. **Ensure both nodes are running the same build** — the CQ backpressure and thread-safety fixes must be present on both sides
 2. **Reduce concurrency** to verify basic connectivity: `--threads=1 --batch_size=16`
-3. **Check CQ poller threads**: logs should show "Started N CQ polling worker threads" where N matches the number of EFA devices
+3. **Check CQ poller threads**: logs should show "Started N CQ polling worker threads", where N is `min(MC_EFA_CQ_THREADS, num_EFA_devices)` — **1 by default**, which is expected and not the cause of a hang (see [Environment Variables](#efa-env-vars))
+
+### Neuron HBM registration fails with `ENOSYS`
+
+Start from the warning the transport logs when it first sees a Neuron device — it names which of the two causes applies:
+
+- *"libnrt.so.1 could not be loaded"* — the Neuron runtime is not where Mooncake looks (an already-mapped copy, the bare soname, then `/opt/aws/neuron/lib`). Put its directory on `LD_LIBRARY_PATH` **before** starting the process; glibc reads that variable once, at startup, so setting it later cannot help.
+- *"built against a libfabric whose rdma/fi_domain.h has no FI_HMEM_NEURON"* — the build's libfabric headers predate 1.15. Rebuild against the EFA installer's copy under `/opt/amazon/efa`, or install a published wheel.
+
+Either way the deferred symptom is the same: `fi_mr_regattr` returning `-FI_ENOSYS` (`Function not implemented`) long after the real cause. See [AWS Neuron](#efa-neuron).
 
 ### Building on AWS Deep Learning AMI
 
 On AWS Deep Learning AMI (e.g., Ubuntu 24.04), the system Python and CUDA toolkit are bundled inside the `/opt/pytorch` virtual environment. You must activate it and set CUDA paths before building:
 
 ```bash
+# Build dependencies, exactly as in step 1 of the build section — run it from
+# inside the clone, since it also initializes the git submodules
+cd ~/Mooncake
+sudo ./dependencies.sh -y
+
 # Activate the PyTorch environment (provides Python 3.13 + CUDA toolkit)
 source /opt/pytorch/bin/activate
 
@@ -770,11 +925,12 @@ export LD_LIBRARY_PATH=$CUDA_HOME/lib:$LD_LIBRARY_PATH
 export LIBRARY_PATH=$CUDA_HOME/lib:$LIBRARY_PATH
 
 # Build with CUDA support
-cd ~/Mooncake
 mkdir -p build && cd build
 cmake .. -DUSE_EFA=ON -DUSE_CUDA=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 make -j$(nproc)
 ```
+
+`dependencies.sh` and the venv do not interact: it requires root, installs apt packages / git submodules / Go, and runs no `pip`, so it can go either side of the `activate` — `sudo` discards the venv environment regardless. Everything that *does* depend on which Python is active happens at `cmake` time, which is why the activation has to come before it.
 
 Without activating the environment, you may encounter:
 - `Could not find nvcc, please set CUDAToolkit_ROOT` — nvcc is not in PATH

--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -5,7 +5,7 @@ This document describes how to build and use Mooncake with AWS Elastic Fabric Ad
 (efa-prerequisites-driver)=
 ## Prerequisite: AWS EFA Driver and libfabric
 
-This is the one requirement that applies in *every* case, including a `pip install` of a published wheel — those deliberately do not bundle libfabric (see [Building a Distributable Wheel](#efa-distributable-wheel)). It is normally already satisfied: EFA-enabled instances (e.g., p6-b300.48xlarge, p6-b200.48xlarge, p5en.48xlarge, p5e.48xlarge, p5.48xlarge, trn2.48xlarge) ship with the driver and libfabric pre-installed.
+This is the one requirement that applies in *every* case, including a `pip install` of a published wheel — those deliberately do not bundle libfabric (see [Building a Distributable Wheel](#efa-distributable-wheel)). It is normally already satisfied: EFA-enabled instances (e.g., p6-b300.48xlarge, p6-b200.48xlarge, p5en.48xlarge, p5e.48xlarge, p5.48xlarge, trn2.48xlarge, trn1.32xlarge) ship with the driver and libfabric pre-installed.
 
 Verify installation:
 ```bash
@@ -390,6 +390,18 @@ Tested on two p5.48xlarge instances (AMD EPYC 7R13, 8× H100 80GB, 32 EFA device
 
 > **Peak: ~64 GB/s** on both write and read — far below the GPU-to-GPU number despite identical NIC count. The bottleneck is DDR4-3200 DRAM bandwidth on the EPYC 7R13 (Milan): `batch=16` consistently wins because larger in-flight queues only deepen DRAM contention without unlocking new NIC capacity. p5.48xlarge CPU-to-CPU runs around **3× slower than p5en** (DDR5 Xeon 8488C, ~213 GB/s) at the same NIC aggregate. For PD KV transfer, the GPU-to-GPU path is the relevant one.
 
+#### 5. Neuron instances: trn2.48xlarge and trn1.32xlarge
+
+Neuron HBM moved directly over EFA (these hosts have no GPU). Sweeps and flags in [AWS Neuron](#efa-neuron); headline write numbers, two hosts each:
+
+| | Neuron HBM | Host DRAM | EFA line rate |
+|---|---|---|---|
+| trn2.48xlarge (16 EFA × 200 Gbps, 16 Trainium2) | **266–271 GB/s** | 113 GB/s | 400 GB/s |
+| trn1.32xlarge (8 EFA × 100 Gbps, 16 Trainium1) | **88.15 GB/s** | 97.2 GB/s | 100 GB/s |
+
+> A run an order of magnitude below these is a NIC-affinity problem rather than a tuning problem: see [PCIe NIC affinity](#pcie-switch-nic-affinity).
+
+(single-host-loopback)=
 ### Single-host loopback
 
 EFA NICs have no hardware loopback short-circuit: when a transfer's source and destination resolve to the same host, the data does not go out on the wire as GPUDirect/device RDMA. libfabric handles the same-host case in software, and there are **two distinct provider knobs** that select how:
@@ -419,7 +431,7 @@ transfer — `__memcpy_avx_unaligned` ← `ofi_copy_to_mr_iov` ← `smr_copy_fro
   then fall back to device RDMA, which is GPU-aware and correct.
 ```
 
-For **host (DRAM) buffers** the SHM memcpy path is safe (host→host copy) and is the same-host fast path the measurements below exercise.
+For **host (DRAM) buffers** the SHM memcpy path is safe (host→host copy) and is the same-host fast path the measurements below exercise. For **Neuron HBM** it is neither safe nor fast, and Mooncake disables it automatically — see [Same-host transfers](#neuron-same-host).
 
 Measured on p5.48xlarge (1 NIC, ~1.2 GiB per `put_from` call, host DRAM buffer, same-host producer/consumer in **separate processes**):
 
@@ -525,7 +537,9 @@ submit #4:   0.09 ms
 (efa-neuron)=
 ## AWS Neuron (Trainium / Inferentia)
 
-On Neuron instances such as `trn2.48xlarge`, the EFA transport moves Neuron HBM directly, without staging through host DRAM. Nothing has to be configured for this: a registered buffer is recognised as Neuron memory from the `/dev/neuron<N>` mapping that backs it, and is then registered with `fi_mr_regattr(iface=FI_HMEM_NEURON)`. Neuron support needs no Neuron SDK at build time and no code changes in the application.
+On Neuron instances the EFA transport moves Neuron HBM directly, without staging through host DRAM. Nothing has to be configured for this: a registered buffer is recognised as Neuron memory from the `/dev/neuron<N>` mapping that backs it, and is then registered with `fi_mr_regattr(iface=FI_HMEM_NEURON)`. Neuron support needs no Neuron SDK at build time and no code changes in the application.
+
+Measured end to end on **`trn2.48xlarge`** (Trainium2) and **`trn1.32xlarge`** (Trainium1), which differ in PCIe layout — see [PCIe NIC affinity](#pcie-switch-nic-affinity).
 
 Two runtime conditions have to hold. Both are already met on a stock Neuron instance, and each has a log line that names it when it is not:
 
@@ -562,18 +576,43 @@ make -j$(nproc)
 A `0` there means the headers predate libfabric 1.15 and the build will refuse to register Neuron HBM at runtime; point `-DLIBFABRIC_INCLUDE_DIR` / `-DLIBFABRIC_LIBRARY` at a newer libfabric. To install rather than build, take the **non-CUDA** wheel (`pip install mooncake-transfer-engine-efa-non-cuda`) — the published wheels are built against a libfabric that has `FI_HMEM_NEURON`.
 
 (pcie-switch-nic-affinity)=
-### PCIe-switch NIC affinity
+### PCIe NIC affinity
 
-`trn2.48xlarge` has 8 PCIe switches, each carrying 2 Neuron devices and 2 EFA NICs, and a Neuron device can only reach the NICs behind its own switch at full speed. The topology discovery therefore maps each `/dev/neuron<N>` to its switch-local NICs and publishes them as that location's preferred HCAs, which is what makes the difference between the two rows below (both measured with the recommended shape from [Benchmarking](#neuron-benchmarking): 16 devices, 4 GB buffers, 1 MB blocks, 32 threads, batch 128):
+A Neuron device can only reach the EFA NICs that share its PCIe locality at full speed, so the topology discovery maps each `/dev/neuron<N>` to those NICs and publishes them as that location's preferred HCAs. This needs no configuration, and it is the single largest factor in Neuron throughput — larger than every tuning knob combined.
 
-| NIC selection | Throughput |
+The mapping is derived from sysfs by grouping devices under the bridge they hang off (`nec_get_device_pci_bdf()` for the Neuron side, `/sys/class/infiniband/*/device` for the NICs — the Neuron driver exposes its devices as *virtual* class devices with no link back to PCI, and the ordinals are not in BDF order). The grouping is by parent bridge rather than by switch because the two instance types are laid out differently:
+
+| | `trn2.48xlarge` | `trn1.32xlarge` |
+|---|---|---|
+| Groups | 8 PCIe switches, 2 Neuron + 2 EFA each | 4 root buses, 4 Neuron + 2 EFA each |
+| Parent in sysfs | switch port, `0000:b9:02.1` | host bridge, `pci0000:10` |
+| NIC line rate | 200 Gbps | 100 Gbps |
+
+Measured with the recommended shape from [Benchmarking](#neuron-benchmarking) (16 buffers, 4 GB each, 1 MB blocks, 32 threads, batch 128, write, two hosts; the trn1 column predates the placement fix below, so both its rows sat on 8 devices and are about 10% low):
+
+| NIC selection | `trn2.48xlarge` | `trn1.32xlarge` |
+|---|---|---|
+| Locality-aware (default) | **266.58 GB/s** | **82.71 GB/s** |
+| All NICs (`--nic_priority_matrix` overriding the default) | 23.48 GB/s | 0.22 GB/s |
+| Ratio | 11.4× | 376× |
+
+trn1 is the more sensitive of the two because its groups are two NUMA nodes apart rather than one switch apart, and NIC enumeration lists the far-NUMA NICs first, so an unguided device picks a cross-NUMA NIC by default. When Mooncake cannot build the mapping at all it logs *"could not group any EFA NIC by its parent PCI bus"* or *"no device could be matched to an EFA NIC"* at `WARNING`, and throughput lands in the same 0.2 GB/s range.
+
+The affinity is also verifiable from outside the benchmark, using the NIC hardware counters under `/sys/class/infiniband/<dev>/ports/1/hw_counters/tx_bytes`. On trn2 a single-device run (`--neuron_device_count=1`) moves 19.27 GB/s and every byte of it appears on exactly two NICs — the two behind that device's switch — with the other fourteen flat at zero. The same counters also confirm the reported aggregate: a full-instance run reads 279.5 GB/s summed across all 16 NICs against 278.97 GB/s self-reported.
+
+(neuron-same-host)=
+### Same-host transfers
+
+libfabric's EFA provider hands same-host peers to an internal `shm` sub-provider, and **that sub-provider cannot move Neuron HBM**: its `FI_HMEM_NEURON` op table implements `copy_to_hmem` but leaves `copy_from_hmem` returning `-FI_ENOSYS`, and every IPC entry is a no-op stub. The `/dev/neuron` mapping is then `memcpy`'d as if it were host memory, across an uncached PCIe BAR — bytes arrive intact, throughput collapses.
+
+Mooncake therefore turns the sub-provider off on Neuron hosts with `setenv("FI_EFA_ENABLE_SHM_TRANSFER", "0", 0)` before the first `fi_getinfo`, leaving same-host transfers on the Neuron-aware device-RDMA path. Measured intra-node on one `trn1.32xlarge` (two processes splitting the NeuronCores, 1 device, 1 MB blocks, 8 threads, batch 32, write):
+
+| same-host path | Throughput |
 |---|---|
-| Switch-local NICs (default) | **266.58 GB/s** |
-| All 16 NICs (`--nic_priority_matrix` overriding the default) | 23.48 GB/s |
+| device RDMA (`FI_EFA_ENABLE_SHM_TRANSFER=0`, the default Mooncake sets) | **14.21 GB/s** |
+| `shm` sub-provider (`FI_EFA_ENABLE_SHM_TRANSFER=1`) | 0.09 GB/s |
 
-For reference, host DRAM over the same fabric tops out at 113 GB/s on this instance, so correctly routed Neuron HBM is roughly 2.4× faster than CPU-to-CPU.
-
-The affinity is verifiable from outside the benchmark, using the NIC hardware counters under `/sys/class/infiniband/<dev>/ports/1/hw_counters/tx_bytes`. A single-device run (`--neuron_device_count=1`) moves 19.27 GB/s and every byte of it appears on exactly two NICs — the two behind that device's switch — with the other fourteen flat at zero. The same counters also confirm the reported aggregate: a full-instance run reads 279.5 GB/s summed across all 16 NICs against 278.97 GB/s self-reported.
+The overwrite flag is `0`, so an explicit `FI_EFA_ENABLE_SHM_TRANSFER` in the environment still wins — which is how the second row was measured with the same binary. There is no reason to set it on a Neuron host: nothing on this path uses the `shm` memcpy fast path that [Single-host loopback](#single-host-loopback) is about, and with the sub-provider off same-host costs nothing relative to the wire — 14.21 GB/s here against 14.20 for the same single-device shape between two hosts, and 19.23 against 19.26 on trn2.
 
 (neuron-benchmarking)=
 ### Benchmarking
@@ -602,18 +641,33 @@ The flags below are the measured optimum on `trn2.48xlarge` (see [Tuning](#neuro
 | Parameter | Default | Description |
 |---|---|---|
 | `--neuron_device` | `-1` | Logical NeuronCore to allocate the first buffer on; `-1` disables the Neuron path entirely |
-| `--neuron_device_count` | `1` | How many Neuron devices to spread buffers over, starting from `--neuron_device`. Only 2 EFA NICs sit on any one device's PCIe switch, so one device cannot drive the whole fabric — use `16` on trn2.48xlarge |
-| `--neuron_core_stride` | `0` (auto) | Logical NeuronCores per physical device, i.e. how far to step between buffers; auto-detected from sysfs `core_count / 2` (LNC=2) |
+| `--neuron_device_count` | `1` | How many buffers to allocate, one per step of `--neuron_core_stride` from `--neuron_device`. Only 2 EFA NICs are local to any one device, so a single device cannot drive the whole fabric — use `16` on both trn2.48xlarge and trn1.32xlarge |
+| `--neuron_core_stride` | `0` (probe) | Logical NeuronCores to step between consecutive buffers. The default steps nothing fixed: it allocates a page on each core in turn, asks which `/dev/neuron<N>` the pointer belongs to, and puts one buffer on the first core of each distinct device. Set it only to reproduce a particular placement (see [Tuning](#neuron-tuning)) |
 | `--neuron_fill_byte` | `0xCC` | Byte prefilled into HBM. Give the two sides different values and the target reports on shutdown how much the peer actually overwrote — the only end-to-end check available, since the host cannot `memcmp()` device memory |
 
 > **Note:** `--operation` defaults to `read`. A write-path read-back check on a `read` run reports "0 bytes differ" and looks like a bug when it is simply not writing anything.
 
 > **Note:** `nrt_init` claims **all visible NeuronCores** regardless of `--neuron_device_count`. On a shared host, restrict the benchmark with a contiguous range, e.g. `NEURON_RT_VISIBLE_CORES=56-63`.
 
+`trn1.32xlarge` also has 16 Neuron devices, so the same command applies with only a smaller shape — `--neuron_device_count=16 --block_size=1048576 --threads=32 --batch_size=32`, and every alternative to it is within ±2% ([Tuning](#neuron-tuning)).
+
+Either way, confirm the placement from the target's log rather than assuming it: one *"N distinct device(s) found"* line, then one *"as `neuron:N`"* line per buffer.
+
 (neuron-tuning)=
 ### Tuning
 
-Everything below was swept on two `trn2.48xlarge` writing Neuron HBM to Neuron HBM over all 16 devices, one 4 GB buffer per device. Run-to-run spread is ±2%, so only differences larger than that mean anything.
+Both instance types were swept host-to-host, writing Neuron HBM to Neuron HBM. Run-to-run spread is ±2% on either, so only differences larger than that mean anything. They are bound by different things, which is what decides whether tuning is worth the trouble at all:
+
+| | `trn2.48xlarge` | `trn1.32xlarge` |
+|---|---|---|
+| Peak Neuron HBM write | 266–271 GB/s (67% of line rate) | 88.15 GB/s (**88%** of line rate) |
+| Host DRAM over the same fabric | 113 GB/s | 97.2 GB/s |
+| What binds | the per-device accelerator path, ~17 GB/s each | the accelerator per device (14.2 GB/s), the NICs from 4 devices up |
+| Knobs that matter | `--threads`, and `--block_size` if left small | device spread, and `--threads` ≥ 16; nothing else clears the noise |
+
+#### trn2.48xlarge
+
+Swept over all 16 devices, one 4 GB buffer per device.
 
 **`--threads` is the dominant knob**, and it peaks well before the core count — 32 threads over 16 devices is 2 per device (block 1 MB, batch sized to keep `block × batch × threads` inside the buffer):
 
@@ -633,7 +687,39 @@ Everything below was swept on two `trn2.48xlarge` writing Neuron HBM to Neuron H
 
 - Adding NICs per device cannot help; the switch only has 2 anyway.
 - Spreading buffers across all 64 logical NeuronCores instead of 16 (`--neuron_core_stride=1 --neuron_device_count=64`) is worth about +3% (279 vs 270 GB/s) for 2× the HBM footprint and a matching flag on both sides. Not worth it as a default, but it is the shape to reach for if you are chasing the last few percent.
-- Runs that fall far below these numbers are almost always a NIC-affinity problem rather than a tuning problem — see [PCIe-switch NIC affinity](#pcie-switch-nic-affinity) for the 11× cliff and how to confirm it from the NIC counters.
+- Runs that fall far below these numbers are almost always a NIC-affinity problem rather than a tuning problem — see [PCIe NIC affinity](#pcie-switch-nic-affinity) for the 11× cliff and how to confirm it from the NIC counters.
+
+#### trn1.32xlarge
+
+Swept over 16 buffers of 8 GB. These predate the placement fix below, so they sat on 8 devices rather than 16 — about 8% low, evenly across every row.
+
+**Nothing except "`--threads` ≥ 16" is worth tuning.** Past 8 threads every knob lands inside the ±2% spread:
+
+| `--threads` (block 1 MB, batch 32) | | `--block_size` (32 threads, batch 32) | | `--batch_size` (32 threads, 1 MB) | |
+|---|---|---|---|---|---|
+| 8 | 40.70 GB/s | 256 KB | 79.83 GB/s | 32 | 78.70 GB/s |
+| **16** | **80.08 GB/s** | 512 KB | 77.70 GB/s | **64** | **81.59 GB/s** |
+| 32 | 78.58 GB/s | 1 MB | 79.79 GB/s | 128 | 78.63 GB/s |
+| 64 | 79.43 GB/s | 2 MB | 80.08 GB/s | 256 | 80.20 GB/s |
+| 128 | 79.09 GB/s | 4 MB | 80.55 GB/s | | |
+
+`--block_size` flat all the way down to 256 KB is the sharpest contrast with every other instance in this document, where 1 MB is worth 2–4× over the 64 KB default. It is flat because the ceiling is not the wire.
+
+**What pays is device spread, and this instance is why the benchmark now probes for placement instead of stepping a fixed number of cores**: a step derived from trn2's core fusion comes out as `1` here, which stacks two buffers on each of half the devices and leaves the rest idle, with throughput as the only symptom (32 threads, 1 MB, batch 32, 2 GB buffers):
+
+| Buffers × devices | Flags | Throughput |
+|---|---|---|
+| **16 buffers over 16 devices** | **`--neuron_device_count=16`** (the default placement) | **86.5–88.2 GB/s** |
+| 16 buffers over 8 devices | `--neuron_device_count=16 --neuron_core_stride=1` | 80.0–80.3 GB/s |
+| 8 buffers over 8 devices | `--neuron_device_count=8 --neuron_core_stride=2` | 82.67 GB/s |
+| 4 buffers over 4 devices | `--neuron_device_count=4 --neuron_core_stride=2` | 40.24 GB/s |
+| 1 buffer, 1 device | `--neuron_device_count=1` | 14.20 GB/s |
+
+The first two rows are the fix and what it replaced, otherwise the same run. The ranges are repeats across sessions, not sweeps: 16-device runs read 86.45 / 86.92 / 87.33 / 88.15 / 89.61 GB/s.
+
+Only the last row is accelerator-limited — one device sustains 14.20 GB/s of the 25 its two local NICs could carry. Above that the NICs bind, and since affinity pins each buffer to the NICs on its own root bus, a low `--neuron_device_count` leaves whole NIC pairs idle: devices 0–3 sit on only two of the four buses, so `=4` has 50 GB/s of line rate available and takes 40.24 (80%), while `=8` reaches all four buses and takes 82.67 of 100 GB/s (83%). (The buses hold devices 0,1,12,13 / 2,3,14,15 / 4,5,8,9 / 6,7,10,11 — `--v=1` logs the mapping.)
+
+**Host DRAM over the same fabric measures 97.18–97.25 GB/s**, dead flat across threads 16–64, blocks 256 KB–1 MB and batches 32–128, i.e. 97% of the 800 Gbps line rate and the practical ceiling here; Neuron HBM reaches 91% of it. That inverts trn2, where Neuron HBM (266) is 2.4× host DRAM (113) — so on trn1 the reason to move HBM directly is not raw throughput but that the staged alternative pays `nrt_tensor_read()` into host memory first, plus its buffer and CPU time, on top of whichever number you compare against.
 
 (efa-env-vars)=
 ## Environment Variables
@@ -853,7 +939,8 @@ CQs are polled by dedicated worker threads that run independently of submission 
 - p5en.48xlarge (16 EFA devices × 200 Gbps = 3,200 Gbps, `rdmap*` naming)
 - p5e.48xlarge (32 EFA devices × 100 Gbps = 3,200 Gbps, `rdmap*` naming)
 - p5.48xlarge (32 EFA devices × 100 Gbps = 3,200 Gbps, `rdmap*` naming)
-- trn2.48xlarge (16 EFA devices × 200 Gbps = 3,200 Gbps, `rdmap*` naming; 16 Neuron devices, see [AWS Neuron](#efa-neuron))
+- trn2.48xlarge (16 EFA devices × 200 Gbps = 3,200 Gbps, `rdmap*` naming; 16 Trainium2 devices, see [AWS Neuron](#efa-neuron))
+- trn1.32xlarge (8 EFA devices × 100 Gbps = 800 Gbps, `rdmap*` naming; 16 Trainium1 devices, see [AWS Neuron](#efa-neuron))
 - Other EFA-enabled instances
 
 Use `fi_info -p efa` to list available EFA devices on your instance.

--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -596,6 +596,8 @@ Measured with the recommended shape from [Benchmarking](#neuron-benchmarking) (1
 | All NICs (`--nic_priority_matrix` overriding the default) | 23.48 GB/s | 0.22 GB/s |
 | Ratio | 11.4× | 376× |
 
+A custom `--nic_priority_matrix` **replaces** this mapping rather than adding to it, so it has to key on `neuron:<N>`: a matrix carrying only `cpu:*` / `cuda:*` entries leaves every Neuron buffer with no preferred NIC, which is the second row of the table above. (It also restricts the transport to the NICs it names, which is how that row was measured.)
+
 trn1 is the more sensitive of the two because its groups are two NUMA nodes apart rather than one switch apart, and NIC enumeration lists the far-NUMA NICs first, so an unguided device picks a cross-NUMA NIC by default. When Mooncake cannot build the mapping at all it logs *"could not group any EFA NIC by its parent PCI bus"* or *"no device could be matched to an EFA NIC"* at `WARNING`, and throughput lands in the same 0.2 GB/s range.
 
 The affinity is also verifiable from outside the benchmark, using the NIC hardware counters under `/sys/class/infiniband/<dev>/ports/1/hw_counters/tx_bytes`. On trn2 a single-device run (`--neuron_device_count=1`) moves 19.27 GB/s and every byte of it appears on exactly two NICs — the two behind that device's switch — with the other fourteen flat at zero. The same counters also confirm the reported aggregate: a full-instance run reads 279.5 GB/s summed across all 16 NICs against 278.97 GB/s self-reported.

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -150,9 +150,38 @@ if(USE_EFA)
   include_directories(${LIBFABRIC_INCLUDE_DIR})
   link_directories(${LIBFABRIC_LIB_DIR})
   add_compile_definitions(USE_EFA)
+
+  # AWS Neuron device memory needs both the FI_HMEM_NEURON enumerator and
+  # fi_mr_attr::device.neuron, which arrive together and are absent from older
+  # libfabric -- including distro packages such as Ubuntu 22.04's
+  # libfabric-dev.  Probed rather than gated on a version so that a build
+  # against any libfabric keeps working; when it is missing, efa_neuron.cpp
+  # reports Neuron as unsupported instead of registering its HBM as host
+  # memory.
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${LIBFABRIC_INCLUDE_DIR})
+  check_cxx_source_compiles(
+    "
+    #include <rdma/fabric.h>
+    #include <rdma/fi_domain.h>
+    int main() {
+      struct fi_mr_attr attr = {};
+      attr.iface = FI_HMEM_NEURON;
+      attr.device.neuron = 0;
+      return 0;
+    }
+    "
+    MOONCAKE_HAVE_FI_HMEM_NEURON)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  if(MOONCAKE_HAVE_FI_HMEM_NEURON)
+    add_compile_definitions(MOONCAKE_HAVE_FI_HMEM_NEURON)
+  endif()
+
   message(STATUS "AWS EFA (libfabric) transport is enabled")
   message(STATUS "  libfabric include: ${LIBFABRIC_INCLUDE_DIR}")
   message(STATUS "  libfabric library: ${LIBFABRIC_LIBRARY}")
+  message(
+    STATUS "  Neuron (FI_HMEM_NEURON): ${MOONCAKE_HAVE_FI_HMEM_NEURON}")
 endif()
 if(USE_CXI)
   # Find libfabric headers and library; default to AWS EFA installer path

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -12,18 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <dlfcn.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <signal.h>
 #include <sys/time.h>
 
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
+#include <vector>
 
 #include "common.h"
 #include "common/base/status.h"
@@ -117,10 +121,243 @@ DEFINE_int32(gpu_id, 0,
              "GPU/NPU ID to use, -1 for all GPUs, not supported for NPUs");
 #endif
 
+#ifdef USE_EFA
+DEFINE_int32(neuron_device, -1,
+             "Allocate buffers from AWS Neuron (Trainium/Inferentia) HBM on "
+             "this logical NeuronCore instead of DRAM; -1 disables. Valid if "
+             "protocol=efa");
+DEFINE_int32(
+    neuron_device_count, 1,
+    "Number of Neuron devices to spread buffers over, starting at the "
+    "one holding --neuron_device. One buffer per device, since only two "
+    "EFA NICs sit on any one device's PCIe switch and a single device "
+    "therefore cannot use the whole fabric");
+DEFINE_int32(
+    neuron_fill_byte, 0xCC,
+    "Byte to prefill Neuron HBM with. Give the two sides different "
+    "values and --mode=target reports, on shutdown, how much of its "
+    "HBM the peer actually overwrote -- the only end-to-end check that "
+    "the bytes landed in device memory, since the host cannot memcmp() "
+    "it");
+DEFINE_int32(neuron_core_stride, 0,
+             "Logical NeuronCores per physical device, i.e. how far to step "
+             "between the buffers of --neuron_device_count. 0 auto-detects. "
+             "Check the \"Registering Neuron HBM ... as neuron:N\" lines: the "
+             "ordinals must all differ");
+#endif
+
 using namespace mooncake;
+
+#ifdef USE_EFA
+// Neuron HBM allocation for the benchmark.
+//
+// libnrt is reached through dlopen() rather than linked, so a stock build of
+// this benchmark still starts on hosts with no Neuron SDK -- the same reason
+// the transport itself takes no build flag for Neuron (see efa_neuron.h).  Note
+// that no location string is derived from FLAGS_neuron_device here: that is a
+// *logical* NeuronCore index, which NEURON_RT_VISIBLE_CORES renumbers and which
+// several cores share per physical device.  Naming is left to the transport,
+// which reads the real device ordinal back out of the pointer.
+namespace {
+struct nrt_tensor;
+
+struct NeuronRuntime {
+    int (*init)(int, const char*, const char*) = nullptr;
+    int (*tensor_allocate)(int, int, size_t, const char*,
+                           struct nrt_tensor**) = nullptr;
+    void* (*tensor_get_va)(struct nrt_tensor*) = nullptr;
+    void (*tensor_free)(struct nrt_tensor**) = nullptr;
+    int (*tensor_write)(struct nrt_tensor*, const void*, size_t,
+                        size_t) = nullptr;
+    int (*tensor_read)(struct nrt_tensor*, void*, size_t, size_t) = nullptr;
+};
+
+// Tensor handles are kept keyed by VA because allocateMemoryPool() hands its
+// caller a bare pointer and freeMemoryPool() only ever gets that pointer back.
+std::unordered_map<void*, struct nrt_tensor*> neuron_tensors;
+
+const NeuronRuntime* neuronRuntime() {
+    static NeuronRuntime rt;
+    static bool ok = [&]() -> bool {
+        // Prefer an already-loaded libnrt over a second independent copy of the
+        // device runtime in one process.
+        void* handle = dlopen("libnrt.so.1", RTLD_LAZY | RTLD_NOLOAD);
+        if (!handle) handle = dlopen("libnrt.so.1", RTLD_LAZY);
+        if (!handle)
+            handle = dlopen("/opt/aws/neuron/lib/libnrt.so.1", RTLD_LAZY);
+        if (!handle) {
+            LOG(ERROR) << "--neuron_device requires libnrt: " << dlerror();
+            return false;
+        }
+        rt.init = (decltype(rt.init))dlsym(handle, "nrt_init");
+        rt.tensor_allocate =
+            (decltype(rt.tensor_allocate))dlsym(handle, "nrt_tensor_allocate");
+        rt.tensor_get_va =
+            (decltype(rt.tensor_get_va))dlsym(handle, "nrt_tensor_get_va");
+        rt.tensor_free =
+            (decltype(rt.tensor_free))dlsym(handle, "nrt_tensor_free");
+        rt.tensor_write =
+            (decltype(rt.tensor_write))dlsym(handle, "nrt_tensor_write");
+        rt.tensor_read =
+            (decltype(rt.tensor_read))dlsym(handle, "nrt_tensor_read");
+        if (!rt.init || !rt.tensor_allocate || !rt.tensor_get_va ||
+            !rt.tensor_free) {
+            LOG(ERROR) << "libnrt is missing the tensor API";
+            return false;
+        }
+        // NRT_FRAMEWORK_TYPE_NO_FW.  Idempotent, so calling it here is safe
+        // even when a framework in the same process has already initialised the
+        // runtime.
+        int rc = rt.init(1, "", "");
+        if (rc != 0) {
+            LOG(ERROR) << "nrt_init failed with NRT_STATUS " << rc
+                       << "; check NEURON_RT_VISIBLE_CORES (the range must be "
+                          "contiguous) and that no other process owns the core";
+            return false;
+        }
+        return true;
+    }();
+    return ok ? &rt : nullptr;
+}
+
+// How far to step, in nrt_tensor_allocate() core indices, to land on the next
+// physical device.
+//
+// The step is not the physical core count sysfs reports: those indices are
+// *logical* cores, and trn2 fuses cores in pairs by default (LNC=2), so its 8
+// physical cores per device are 4 logical ones.  The fusion factor is a runtime
+// setting with no clean query -- nrt_get_visible_vnc_count() segfaults when
+// called with the signature its symbol suggests -- so it is inferred from the
+// two numbers that can be read reliably: how many logical cores the runtime
+// hands out in total, and how many devices exist.
+int neuronCoresPerDevice() {
+    static const int stride = []() -> int {
+        if (FLAGS_neuron_core_stride > 0) return FLAGS_neuron_core_stride;
+
+        int physical_cores = 0;
+        std::ifstream f(
+            "/sys/devices/virtual/neuron_device/neuron0/core_count");
+        if (!(f >> physical_cores) || physical_cores <= 0) {
+            LOG(WARNING)
+                << "Cannot read Neuron core_count from sysfs, stepping "
+                   "one core per buffer; pass --neuron_core_stride if "
+                   "the buffers land on the same device";
+            return 1;
+        }
+        // LNC=2 is the trn2 default and the only fusion factor shipped so far.
+        const int stride = physical_cores >= 2 ? physical_cores / 2 : 1;
+        LOG(INFO) << "Neuron: " << physical_cores
+                  << " physical cores per device, stepping " << stride
+                  << " logical core(s) per buffer";
+        return stride;
+    }();
+    return stride;
+}
+
+void* allocateNeuronMemory(size_t size, int buffer_id) {
+    const NeuronRuntime* rt = neuronRuntime();
+    if (!rt) return nullptr;
+
+    // One buffer per device, so step a whole device's worth of cores.
+    const int core = FLAGS_neuron_device + buffer_id * neuronCoresPerDevice();
+
+    struct nrt_tensor* tensor = nullptr;
+    // 0 == NRT_TENSOR_PLACEMENT_DEVICE, i.e. HBM rather than pinned host
+    // memory, which is the whole point of the exercise.
+    int rc = rt->tensor_allocate(0, core, size, "mooncake_bench", &tensor);
+    if (rc != 0) {
+        LOG(ERROR) << "nrt_tensor_allocate(" << size << " bytes on NeuronCore "
+                   << core << ") failed with NRT_STATUS " << rc;
+        return nullptr;
+    }
+    void* va = rt->tensor_get_va(tensor);
+    if (!va) {
+        rt->tensor_free(&tensor);
+        LOG(ERROR) << "nrt_tensor_get_va returned NULL";
+        return nullptr;
+    }
+    // The buffer is filled through the runtime, never with memset(): host
+    // stores into device HBM are exactly what the transport's Neuron path
+    // exists to avoid.  Skipped silently if libnrt predates nrt_tensor_write.
+    if (rt->tensor_write) {
+        std::vector<uint8_t> pattern(std::min<size_t>(size, 1ull << 20),
+                                     (uint8_t)FLAGS_neuron_fill_byte);
+        for (size_t off = 0; off < size; off += pattern.size()) {
+            size_t len = std::min(pattern.size(), size - off);
+            rc = rt->tensor_write(tensor, pattern.data(), off, len);
+            if (rc != 0) {
+                LOG(WARNING) << "nrt_tensor_write at offset " << off
+                             << " failed with NRT_STATUS " << rc
+                             << ", buffer left uninitialized";
+                break;
+            }
+        }
+    }
+    LOG(INFO) << "Allocated " << size << " bytes of Neuron HBM at " << va
+              << " on logical NeuronCore " << core;
+    neuron_tensors[va] = tensor;
+    return va;
+}
+
+// Reports how much of each Neuron buffer no longer holds the fill byte, i.e.
+// how much of it the peer's transfers actually landed in HBM.
+//
+// This is the only end-to-end data check available on the Neuron path: the
+// buffer is device memory, so the validator's memcmp() approach cannot look at
+// it, and a completion queue entry only says the NIC believed it wrote
+// somewhere.  Reading it back through the runtime is what distinguishes "the
+// transport reported success" from "the bytes are in HBM".
+void reportNeuronOverwrite(const std::vector<void*>& addr) {
+    const NeuronRuntime* rt = neuronRuntime();
+    if (!rt || !rt->tensor_read) {
+        LOG(WARNING) << "libnrt has no nrt_tensor_read, cannot check what the "
+                        "peer wrote into Neuron HBM";
+        return;
+    }
+
+    const size_t kWindow = 1ull << 20;
+    for (size_t i = 0; i < addr.size(); ++i) {
+        auto it = neuron_tensors.find(addr[i]);
+        if (it == neuron_tensors.end()) continue;
+
+        std::vector<uint8_t> readback(kWindow);
+        int rc = rt->tensor_read(it->second, readback.data(), 0, kWindow);
+        if (rc != 0) {
+            LOG(WARNING) << "nrt_tensor_read on buffer " << i
+                         << " failed with NRT_STATUS " << rc;
+            continue;
+        }
+        size_t changed = 0;
+        int first_new_value = -1;
+        for (size_t off = 0; off < kWindow; ++off) {
+            if (readback[off] == (uint8_t)FLAGS_neuron_fill_byte) continue;
+            if (first_new_value < 0) first_new_value = readback[off];
+            ++changed;
+        }
+        LOG(INFO) << "Neuron buffer " << i << " at " << addr[i] << ": "
+                  << changed << "/" << kWindow
+                  << " bytes of the first MiB differ from the fill byte 0x"
+                  << std::hex << (FLAGS_neuron_fill_byte & 0xff)
+                  << ", first new value 0x"
+                  << (first_new_value < 0 ? 0 : first_new_value) << std::dec;
+    }
+}
+
+void freeNeuronMemory(void* addr) {
+    const NeuronRuntime* rt = neuronRuntime();
+    auto it = neuron_tensors.find(addr);
+    if (!rt || it == neuron_tensors.end()) return;
+    rt->tensor_free(&it->second);
+    neuron_tensors.erase(it);
+}
+}  // namespace
+#endif  // USE_EFA
 
 static void* allocateMemoryPool(size_t size, int buffer_id,
                                 bool from_vram = false) {
+#ifdef USE_EFA
+    if (FLAGS_neuron_device >= 0) return allocateNeuronMemory(size, buffer_id);
+#endif
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
     defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
     defined(USE_UBSHMEM) || defined(USE_SUPA) || defined(USE_SUNRISE)
@@ -194,6 +431,12 @@ static void* allocateMemoryPool(size_t size, int buffer_id,
 }
 
 static void freeMemoryPool(void* addr, size_t size) {
+#ifdef USE_EFA
+    if (FLAGS_neuron_device >= 0) {
+        freeNeuronMemory(addr);
+        return;
+    }
+#endif
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
     defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
     defined(USE_UBSHMEM) || defined(USE_SUPA) || defined(USE_SUNRISE)
@@ -308,6 +551,14 @@ static inline void setWorkerDeviceIfNeeded() {
 
 // Common helper to determine buffer count based on GPU/NUMA configuration
 static int determineBufferCount() {
+#ifdef USE_EFA
+    if (FLAGS_neuron_device >= 0) {
+        LOG(INFO) << "Neuron HBM is used, " << FLAGS_neuron_device_count
+                  << " device(s) starting at logical NeuronCore "
+                  << FLAGS_neuron_device;
+        return std::max(1, FLAGS_neuron_device_count);
+    }
+#endif
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
     defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
     defined(USE_SUPA) || defined(USE_SUNRISE)
@@ -364,6 +615,12 @@ static void freeBuffers(std::vector<void*>& addr) {
 
 // Helper to get location name for classic backend
 static std::string getLocationName(int buffer_id) {
+#ifdef USE_EFA
+    // Deliberately unnamed: FLAGS_neuron_device is a logical NeuronCore, not
+    // the physical device ordinal the location string needs.  The transport
+    // resolves the real one from the pointer.
+    if (FLAGS_neuron_device >= 0) return kWildcardLocation;
+#endif
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
     defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
     defined(USE_UBSHMEM) || defined(USE_SUPA) || defined(USE_SUNRISE)
@@ -509,8 +766,15 @@ static Transport* installTransportFromFlags(TransferEngine* engine) {
         xport = engine->installTransport(FLAGS_protocol, nullptr);
     } else if (FLAGS_protocol == "efa") {
         // EFA needs topology discovery to find devices, but auto_discovery
-        // would auto-install RDMA transport. Manually discover instead.
-        engine->getLocalTopology()->discover({});
+        // would auto-install RDMA transport. Manually discover instead --
+        // unless an explicit matrix was given, which is then the only way to
+        // pin EFA transfers to a subset of the NICs (discovery always takes
+        // all of them).
+        if (FLAGS_nic_priority_matrix.empty()) {
+            engine->getLocalTopology()->discover({});
+        } else {
+            engine->getLocalTopology()->parse(loadNicPriorityMatrix());
+        }
         xport = engine->installTransport("efa", nullptr);
     } else if (FLAGS_protocol == "tcp" || FLAGS_protocol == "nvlink" ||
                FLAGS_protocol == "musa" || FLAGS_protocol == "hip" ||
@@ -616,6 +880,10 @@ int target() {
     }
 
     while (target_running) sleep(1);
+
+#ifdef USE_EFA
+    if (FLAGS_neuron_device >= 0) reportNeuronOverwrite(addr);
+#endif
 
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <unordered_map>
 #include <vector>
@@ -33,6 +34,12 @@
 #include "common/base/status.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
+
+#ifdef USE_EFA
+// For neuronProbeAddress(), which answers which /dev/neuron<N> a pointer
+// belongs to -- the same lookup the transport uses to name a buffer's location.
+#include "transport/efa_transport/efa_neuron.h"
+#endif
 
 #ifdef USE_TENT
 #include "tent/transfer_engine.h"
@@ -140,10 +147,13 @@ DEFINE_int32(
     "the bytes landed in device memory, since the host cannot memcmp() "
     "it");
 DEFINE_int32(neuron_core_stride, 0,
-             "Logical NeuronCores per physical device, i.e. how far to step "
-             "between the buffers of --neuron_device_count. 0 auto-detects. "
-             "Check the \"Registering Neuron HBM ... as neuron:N\" lines: the "
-             "ordinals must all differ");
+             "Logical NeuronCores to step between the buffers of "
+             "--neuron_device_count. 0 (the default) does not step a fixed "
+             "amount at all: it finds one logical core per physical device by "
+             "probing, which needs no assumption about core fusion. Set it "
+             "only to reproduce a particular placement. Either way the "
+             "\"Registering Neuron HBM ... as neuron:N\" lines say where the "
+             "buffers landed");
 #endif
 
 using namespace mooncake;
@@ -223,16 +233,79 @@ const NeuronRuntime* neuronRuntime() {
     return ok ? &rt : nullptr;
 }
 
-// How far to step, in nrt_tensor_allocate() core indices, to land on the next
-// physical device.
+// The logical core index of the first core of each distinct physical device,
+// starting the scan at --neuron_device, discovered by allocating a page on each
+// core in turn and asking the transport which device the pointer came from.
 //
-// The step is not the physical core count sysfs reports: those indices are
-// *logical* cores, and trn2 fuses cores in pairs by default (LNC=2), so its 8
-// physical cores per device are 4 logical ones.  The fusion factor is a runtime
-// setting with no clean query -- nrt_get_visible_vnc_count() segfaults when
-// called with the signature its symbol suggests -- so it is inferred from the
-// two numbers that can be read reliably: how many logical cores the runtime
-// hands out in total, and how many devices exist.
+// This exists because there is no arithmetic that gets it right on every
+// instance type.  Stepping by a fixed number of cores requires knowing the
+// core-fusion factor (LNC), which is a runtime setting with no clean query --
+// nrt_get_visible_vnc_count() segfaults when called with the signature its
+// symbol suggests -- and guessing it wrong is silent: on trn1.32xlarge, where
+// Trainium1 does not fuse cores at all, a step derived from trn2's LNC=2 puts
+// two buffers on each of half the devices, leaves the other half idle, and only
+// shows up as ~10% less throughput.  Asking where a pointer actually landed
+// needs no such guess and cannot be silently wrong.
+const std::vector<int>& neuronFirstCorePerDevice() {
+    // Bounded by the largest instance today (trn2.48xlarge: 16 devices x 4
+    // logical cores), with room to spare; the scan also stops at the first core
+    // the runtime refuses, which is the usual way out.
+    constexpr int kMaxCoreScan = 128;
+    static const std::vector<int> cores = []() {
+        std::vector<int> cores;
+        const NeuronRuntime* rt = neuronRuntime();
+        if (!rt) return cores;
+
+        // Every probe is held until the scan is over, and only then freed.  The
+        // runtime hands the *same* virtual address straight back after a free,
+        // so freeing as we went made every core look like the one before it and
+        // the whole scan reported a single device.
+        std::vector<struct nrt_tensor*> probes;
+        std::set<int> seen_devices;
+        const int first = std::max(0, FLAGS_neuron_device);
+        for (int core = first; core < first + kMaxCoreScan; ++core) {
+            struct nrt_tensor* tensor = nullptr;
+            // A page is enough: the probe reads the device ordinal out of the
+            // /dev/neuron<N> mapping the allocation sits in, not out of its
+            // size.  Anything the runtime refuses ends the scan -- that is how
+            // the last visible core is found (NRT_STATUS 2, invalid, on the
+            // first core past the visible range).
+            int rc =
+                rt->tensor_allocate(0, core, 4096, "mooncake_probe", &tensor);
+            if (rc != 0) {
+                VLOG(1) << "Neuron: logical core " << core
+                        << " refused a probe allocation (NRT_STATUS " << rc
+                        << "), ending the scan";
+                break;
+            }
+            probes.push_back(tensor);
+            void* va = rt->tensor_get_va(tensor);
+            int device_index = -1;
+            const bool found =
+                va && neuronProbeAddress(va, 4096, &device_index);
+            VLOG(1) << "Neuron: logical core " << core << " at " << va
+                    << " belongs to device "
+                    << (found ? std::to_string(device_index)
+                              : std::string("(unknown)"));
+            if (found && seen_devices.insert(device_index).second) {
+                cores.push_back(core);
+            }
+        }
+        for (auto& tensor : probes) rt->tensor_free(&tensor);
+        if (!cores.empty()) {
+            LOG(INFO) << "Neuron: " << cores.size()
+                      << " distinct device(s) found among logical cores "
+                      << first << ".." << (first + kMaxCoreScan - 1)
+                      << ", one buffer will go on each";
+        }
+        return cores;
+    }();
+    return cores;
+}
+
+// How far to step, in nrt_tensor_allocate() core indices, to land on the next
+// physical device.  The fallback for when the probe above comes up short, and
+// what --neuron_core_stride overrides.
 int neuronCoresPerDevice() {
     static const int stride = []() -> int {
         if (FLAGS_neuron_core_stride > 0) return FLAGS_neuron_core_stride;
@@ -261,8 +334,27 @@ void* allocateNeuronMemory(size_t size, int buffer_id) {
     const NeuronRuntime* rt = neuronRuntime();
     if (!rt) return nullptr;
 
-    // One buffer per device, so step a whole device's worth of cores.
-    const int core = FLAGS_neuron_device + buffer_id * neuronCoresPerDevice();
+    // One buffer per device.  The probed core list is used only when it covers
+    // every buffer asked for: a probe that came up short (an old libfabric, so
+    // neuronProbeAddress() answers false for everything, or mappings the
+    // runtime had not published yet) would otherwise quietly stack the
+    // remaining buffers onto devices already in use, which is the failure this
+    // replaced.  Falling back to the arithmetic keeps such a host exactly where
+    // it was.
+    const auto& probed = neuronFirstCorePerDevice();
+    const bool use_probed = FLAGS_neuron_core_stride <= 0 && !probed.empty() &&
+                            (int)probed.size() >= FLAGS_neuron_device_count;
+    if (FLAGS_neuron_core_stride <= 0 && !use_probed && buffer_id == 0) {
+        LOG(WARNING) << "Neuron: probed " << probed.size() << " device(s) for "
+                     << FLAGS_neuron_device_count
+                     << " buffer(s), falling back to a fixed core step of "
+                     << neuronCoresPerDevice()
+                     << "; check the \"as neuron:N\" ordinals below and pass "
+                        "--neuron_core_stride if they repeat";
+    }
+    const int core =
+        use_probed ? probed[buffer_id % probed.size()]
+                   : FLAGS_neuron_device + buffer_id * neuronCoresPerDevice();
 
     struct nrt_tensor* tensor = nullptr;
     // 0 == NRT_TENSOR_PLACEMENT_DEVICE, i.e. HBM rather than pinned host

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -815,12 +815,18 @@ std::string formatDeviceNames(const std::string& device_names) {
 std::string loadNicPriorityMatrix() {
     if (!FLAGS_nic_priority_matrix.empty()) {
         std::ifstream file(FLAGS_nic_priority_matrix);
-        if (file.is_open()) {
-            std::string content((std::istreambuf_iterator<char>(file)),
-                                std::istreambuf_iterator<char>());
-            file.close();
-            return content;
+        // Falling through to the fabricated matrix below on a typo would be
+        // silent and wrong: that matrix names --device_name (mlx5_2 by
+        // default), which exists on no Trainium host, so the run comes up with
+        // no usable NIC instead of with the ones the file asked for.
+        if (!file.is_open()) {
+            LOG(FATAL) << "Cannot open --nic_priority_matrix="
+                       << FLAGS_nic_priority_matrix;
         }
+        std::string content((std::istreambuf_iterator<char>(file)),
+                            std::istreambuf_iterator<char>());
+        file.close();
+        return content;
     }
     // Build JSON Data
     auto device_names = formatDeviceNames(FLAGS_device_name);
@@ -868,7 +874,11 @@ static Transport* installTransportFromFlags(TransferEngine* engine) {
         if (FLAGS_nic_priority_matrix.empty()) {
             engine->getLocalTopology()->discover({});
         } else {
-            engine->getLocalTopology()->parse(loadNicPriorityMatrix());
+            int rc = engine->getLocalTopology()->parse(loadNicPriorityMatrix());
+            if (rc) {
+                LOG(FATAL) << "Cannot parse --nic_priority_matrix="
+                           << FLAGS_nic_priority_matrix << ", rc " << rc;
+            }
         }
         xport = engine->installTransport("efa", nullptr);
     } else if (FLAGS_protocol == "tcp" || FLAGS_protocol == "nvlink" ||
@@ -1213,6 +1223,17 @@ void check_total_buffer_size() {
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, false);
     check_total_buffer_size();
+
+#ifdef USE_EFA
+    // Only the EFA transport can register Neuron HBM.  Any other protocol
+    // would take these buffers down a host path -- and since they are
+    // registered under the wildcard location, nothing downstream would stop
+    // preTouchMemory() from writing to device memory from the CPU.
+    if (FLAGS_neuron_device >= 0 && FLAGS_protocol != "efa") {
+        LOG(FATAL) << "--neuron_device requires --protocol=efa, got --protocol="
+                   << FLAGS_protocol;
+    }
+#endif
 
 #if defined(USE_UBSHMEM)
     if (FLAGS_gpu_id != -1) {

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -186,7 +186,10 @@ const NeuronRuntime* neuronRuntime() {
         if (!handle)
             handle = dlopen("/opt/aws/neuron/lib/libnrt.so.1", RTLD_LAZY);
         if (!handle) {
-            LOG(ERROR) << "--neuron_device requires libnrt: " << dlerror();
+            // dlerror() may return NULL; streaming a NULL const char* is UB.
+            const char* err = dlerror();
+            LOG(ERROR) << "--neuron_device requires libnrt: "
+                       << (err ? err : "no dlerror() message");
             return false;
         }
         rt.init = (decltype(rt.init))dlsym(handle, "nrt_init");

--- a/mooncake-transfer-engine/include/transport/efa_transport/efa_neuron.h
+++ b/mooncake-transfer-engine/include/transport/efa_transport/efa_neuron.h
@@ -1,0 +1,76 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EFA_NEURON_H
+#define EFA_NEURON_H
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+// AWS Neuron (Trainium / Inferentia) device-memory support for the EFA
+// transport.
+//
+// Neuron HBM reaches user space as a shared mmap of the /dev/neuron<N>
+// character device, so both questions the transport needs answered -- "is this
+// pointer device memory" and "which device is it on" -- fall straight out of
+// /proc/self/maps.  That is why this layer needs no Neuron SDK headers and no
+// link-time dependency on libnrt: a stock USE_EFA build gains Neuron support at
+// runtime, and the same binary still runs unchanged on hosts with no Neuron
+// device.
+//
+// The actual registration is libfabric's job.  Its EFA provider already
+// implements the FI_HMEM_NEURON interface (it is how the Neuron collectives
+// stack moves HBM between instances), so all the transport has to do is hand
+// fi_mr_regattr() the right iface and device ordinal.
+
+namespace mooncake {
+
+// True when this host has Neuron devices and Neuron support has not been
+// switched off with MC_EFA_DISABLE_NEURON=1.  Evaluated once and cached; cheap
+// enough to call on any path.
+bool neuronAvailable();
+
+// Reports whether [addr, addr + length) lies entirely inside one Neuron HBM
+// mapping.  On success *device_index receives the /dev/neuron<N> ordinal.
+//
+// A buffer straddling two mappings is rejected rather than registered as host
+// memory: passing device memory to fi_mr_reg() as FI_HMEM_SYSTEM would have the
+// provider walk it with CPU loads.
+bool neuronProbeAddress(const void* addr, size_t length, int* device_index);
+
+// Maps each Neuron device ordinal to the EFA NICs sharing its PCIe switch, e.g.
+// {0: {"rdmap201s0", "rdmap202s0"}}.  Empty when the mapping cannot be worked
+// out, in which case the caller should leave the topology alone.
+//
+// This is not a micro-optimisation.  Neuron HBM registers fine on any NIC, but
+// reaching it from a NIC on another switch measured 2.5 GB/s against 19.2 GB/s
+// for the switch-local pair on trn2.48xlarge -- a 7.7x penalty, and enough to
+// put an unpinned Neuron transfer (2.6 GB/s across all 16 NICs, dominated by
+// the 14 distant ones) far below plain host DRAM.
+//
+// Two properties make this usable while the topology is still being built,
+// which is the only point where adding entries cannot renumber HCA indices: it
+// needs no device allocation, and it needs no nrt_init(), so it will not claim
+// a NeuronCore out from under the framework sharing the process.
+std::map<int, std::vector<std::string>> neuronNicAffinity();
+
+// Location string Mooncake uses for Neuron memory, matching the "neuron:<N>"
+// device naming that vLLM's Neuron platform already reports.
+std::string neuronLocationName(int device_index);
+
+}  // namespace mooncake
+
+#endif  // EFA_NEURON_H

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -36,6 +36,9 @@
 #include "memory_location.h"
 #include "topology.h"
 #include "char_util.h"
+#ifdef USE_EFA
+#include "transport/efa_transport/efa_neuron.h"
+#endif
 #ifdef USE_UB
 #include <libgen.h>
 #include <urma_api.h>
@@ -594,6 +597,45 @@ static std::vector<TopologyEntry> discoverCudaTopology(
 }
 #endif
 
+#ifdef USE_EFA
+// Neuron (Trainium / Inferentia) devices cannot go through the PCI-distance
+// heuristic above: the driver presents them as *virtual* class devices with no
+// link back to their PCI function, so /sys offers nothing to measure.  The
+// runtime does know the mapping, and neuronNicAffinity() asks it -- see
+// efa_neuron.h for why that is safe to do this early.
+//
+// The distinction matters more here than it does for GPUs.  On trn2.48xlarge a
+// NIC one switch away from the device it is serving measured 2.5 GB/s against
+// 19.2 GB/s for a switch-local one, so getting this wrong does not shave a few
+// percent, it costs 7.7x and lands below plain host DRAM.
+static std::vector<TopologyEntry> discoverNeuronTopology(
+    const std::vector<InfinibandDevice> &all_hca) {
+    std::vector<TopologyEntry> topology;
+    for (const auto &entry : neuronNicAffinity()) {
+        std::vector<std::string> preferred_hca;
+        std::vector<std::string> avail_hca;
+        // Filtered against all_hca rather than trusted directly, so that a NIC
+        // the caller excluded stays excluded.  Everything else becomes
+        // avail_hca: a distant NIC is slow, not unusable, and it is the only
+        // thing left if the switch-local ones are down.
+        for (const auto &hca : all_hca) {
+            if (std::find(entry.second.begin(), entry.second.end(), hca.name) !=
+                entry.second.end()) {
+                preferred_hca.push_back(hca.name);
+            } else {
+                avail_hca.push_back(hca.name);
+            }
+        }
+        if (preferred_hca.empty()) continue;
+        topology.push_back(
+            TopologyEntry{.name = neuronLocationName(entry.first),
+                          .preferred_hca = std::move(preferred_hca),
+                          .avail_hca = std::move(avail_hca)});
+    }
+    return topology;
+}
+#endif
+
 Topology::Topology() {
     auto str = getenv("MC_PATH_ROUNDROBIN");
     if (str && (strcmp(str, "1") == 0 || strcasecmp(str, "true") == 0)) {
@@ -633,6 +675,11 @@ int Topology::discover(const std::vector<std::string> &filter) {
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
     for (auto &ent : discoverCudaTopology(all_hca)) {
+        matrix_[ent.name] = ent;
+    }
+#endif
+#ifdef USE_EFA
+    for (auto &ent : discoverNeuronTopology(all_hca)) {
         matrix_[ent.name] = ent;
     }
 #endif
@@ -797,8 +844,23 @@ int Topology::resolve() {
     hca_list_.clear();
     std::map<std::string, int> hca_id_map;
     int next_hca_map_index = 0;
-    for (auto &entry : matrix_) {
-        for (auto &hca : entry.second.preferred_hca) {
+
+    // Sorted, not matrix_ order.  A device index is not private to this object:
+    // a peer rebuilds our matrix with parse() and then indexes the device and
+    // rkey arrays we published with the numbers *its* resolve() produced.
+    // matrix_ is an unordered_map, so its iteration order depends on insertion
+    // order, and the peer inserts in a different one (JSON member order, not
+    // discovery order) -- which silently hands transfers to a NIC other than
+    // the preferred one.  Sorting by storage type makes the numbering a
+    // function of the matrix contents alone, so both ends agree.
+    std::vector<std::string> storage_types;
+    storage_types.reserve(matrix_.size());
+    for (const auto &entry : matrix_) storage_types.push_back(entry.first);
+    std::sort(storage_types.begin(), storage_types.end());
+
+    for (const auto &storage_type : storage_types) {
+        const auto &topo_entry = matrix_[storage_type];
+        for (auto &hca : topo_entry.preferred_hca) {
             if (!hca_id_map.count(hca)) {
                 hca_list_.push_back(hca);
                 hca_id_map[hca] = next_hca_map_index++;
@@ -808,12 +870,12 @@ int Topology::resolve() {
                 resolved_matrix_[kWildcardLocation]
                     .preferred_hca_name_to_index_map_[hca] = hca_id_map[hca];
             }
-            resolved_matrix_[entry.first].preferred_hca.push_back(
+            resolved_matrix_[storage_type].preferred_hca.push_back(
                 hca_id_map[hca]);
-            resolved_matrix_[entry.first]
+            resolved_matrix_[storage_type]
                 .preferred_hca_name_to_index_map_[hca] = hca_id_map[hca];
         }
-        for (auto &hca : entry.second.avail_hca) {
+        for (auto &hca : topo_entry.avail_hca) {
             if (!hca_id_map.count(hca)) {
                 hca_list_.push_back(hca);
                 hca_id_map[hca] = next_hca_map_index++;
@@ -823,8 +885,8 @@ int Topology::resolve() {
                 resolved_matrix_[kWildcardLocation]
                     .preferred_hca_name_to_index_map_[hca] = hca_id_map[hca];
             }
-            resolved_matrix_[entry.first].avail_hca.push_back(hca_id_map[hca]);
-            resolved_matrix_[entry.first].avail_hca_name_to_index_map_[hca] =
+            resolved_matrix_[storage_type].avail_hca.push_back(hca_id_map[hca]);
+            resolved_matrix_[storage_type].avail_hca_name_to_index_map_[hca] =
                 hca_id_map[hca];
         }
     }

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "cuda_alike.h"
 #include "transport/efa_transport/efa_endpoint.h"
+#include "transport/efa_transport/efa_neuron.h"
 #include "transport/efa_transport/efa_transport.h"
 #include "transport/transport.h"
 
@@ -62,7 +63,14 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
     // initialization creates a CUDA primary context on GPU 0 and leaks
     // ~616 MiB of device memory even when no GPU memory is ever registered.
     // Only set if the user hasn't explicitly configured FI_HMEM.
-    setenv("FI_HMEM", "system", 0);
+    //
+    // On a Neuron host the same guard has to name "neuron" instead: FI_HMEM
+    // takes exactly one interface, not a list, so "system" (or even
+    // "system,neuron") makes fi_getinfo() below report -FI_ENODATA once
+    // FI_MR_HMEM is in mr_mode.  Selecting "neuron" still leaves host memory
+    // registrable -- FI_HMEM_SYSTEM is always available -- and still keeps
+    // libfabric away from libcudart, which is the point of the guard.
+    setenv("FI_HMEM", neuronAvailable() ? "neuron" : "system", 0);
 #endif
 
     // Setup hints for EFA provider
@@ -100,6 +108,11 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
                                    | FI_MR_HMEM
 #endif
         ;
+    // FI_MR_HMEM is mandatory for FI_HMEM_NEURON: without it the EFA provider
+    // matches no fi_info at all (fi_getinfo -> -FI_ENODATA) rather than merely
+    // refusing the later fi_mr_regattr().  Unlike CUDA this is a runtime
+    // decision -- Neuron support costs no build flag, see efa_neuron.h.
+    if (neuronAvailable()) hints_->domain_attr->mr_mode |= FI_MR_HMEM;
     hints_->domain_attr->threading = FI_THREAD_SAFE;
 
     // Get fabric info.
@@ -556,27 +569,65 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     }
 #endif
 
+#ifdef MOONCAKE_HAVE_FI_HMEM_NEURON
+    // Neuron (Trainium/Inferentia) HBM.  Detected at runtime from the
+    // /dev/neuron<N> mapping backing the buffer, so this needs no Neuron SDK;
+    // the build flag is only about whether the libfabric we compile against
+    // knows the interface at all -- see efa_neuron.h.
+    int neuron_device = 0;
+    if (iface == FI_HMEM_SYSTEM &&
+        neuronProbeAddress(addr, length, &neuron_device)) {
+        iface = FI_HMEM_NEURON;
+        device_ordinal = neuron_device;
+    }
+#endif
+
     int ret;
     if (iface != FI_HMEM_SYSTEM) {
 #if defined(USE_CUDA)
+        // Declared out here so the context stays current until the
+        // registration below is done, but only bound for CUDA memory:
+        // device_ordinal is a CUDA device only when the iface says so, and
+        // binding to a Neuron ordinal would fail the registration outright.
         ScopedCudaContext reg_context;
-        if (!reg_context.valid() || !reg_context.bind(device_ordinal))
+        if (iface == FI_HMEM_CUDA &&
+            (!reg_context.valid() || !reg_context.bind(device_ordinal)))
             return ERR_CONTEXT;
 #endif
-        // GPU memory: use fi_mr_regattr with explicit iface and device
+        // Device memory: use fi_mr_regattr with explicit iface and device
         struct iovec iov = {.iov_base = addr, .iov_len = length};
         struct fi_mr_attr attr = {};
         attr.mr_iov = &iov;
         attr.iov_count = 1;
         attr.access = fi_access;
         attr.iface = iface;
-        attr.device.cuda = device_ordinal;
+        // fi_mr_attr::device is a union of per-interface ordinals; name the
+        // member that matches the iface we just selected.
+#ifdef MOONCAKE_HAVE_FI_HMEM_NEURON
+        if (iface == FI_HMEM_NEURON) {
+            attr.device.neuron = device_ordinal;
+        } else
+#endif
+        {
+            attr.device.cuda = device_ordinal;
+        }
 
         ret = fi_mr_regattr(domain_, &attr, 0, &mrMeta.mr);
         if (ret) {
-            LOG(ERROR) << "fi_mr_regattr failed for GPU memory " << addr
-                       << " (device " << device_ordinal
-                       << "): " << fi_strerror(-ret);
+            LOG(ERROR) << "fi_mr_regattr failed for device memory " << addr
+                       << " (iface " << (int)iface << ", device "
+                       << device_ordinal << "): " << fi_strerror(-ret);
+            if (ret == -FI_ENOSYS) {
+                // ENOSYS means libfabric never populated the op table for this
+                // interface, which for Neuron is almost always a libnrt it
+                // could not dlopen; see dlopenNeuronRuntime() in
+                // efa_neuron.cpp.
+                LOG(ERROR)
+                    << "This interface was not initialized by libfabric. "
+                       "Re-run with FI_LOG_LEVEL=warn to see why, and "
+                       "check that the device runtime library is on the "
+                       "loader path.";
+            }
             return ERR_CONTEXT;
         }
     } else {

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -73,6 +73,37 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
     setenv("FI_HMEM", neuronAvailable() ? "neuron" : "system", 0);
 #endif
 
+    // Keep libfabric's SHM sub-provider out of the way on Neuron hosts.
+    //
+    // For same-host peers the EFA provider hands the transfer to an internal
+    // shm endpoint (efa_shm_info_create() in prov/efa/src/efa_shm.c), and shm
+    // cannot move Neuron HBM.  libfabric's FI_HMEM_NEURON op table
+    // (src/hmem.c) implements copy_to_hmem only: copy_from_hmem is
+    // neuron_copy_from_dev(), whose whole body is
+    //   FI_WARN_ONCE("Copies from AWS Neuron to host memory are not
+    //                 supported."); return -FI_ENOSYS;
+    // and every IPC entry is a ofi_hmem_no_* stub, so smr_ep.c's
+    //   use_ipc = ofi_hmem_is_ipc_enabled(iface) && ...
+    // is always false and shm has no protocol left that could read out of a
+    // source Neuron buffer.  The shm provider never uses dmabuf either.
+    //
+    // Left to itself shm therefore treats the /dev/neuron mapping as ordinary
+    // host memory and memcpy()s across what is really an uncached PCIe BAR:
+    // correct bytes, 0.07 GB/s.  Disabling shm sends intra-node traffic back
+    // over the EFA device instead, measured at 19.23 GB/s -- the same as the
+    // inter-node rate for one chip, i.e. no loss at all.
+    //
+    // Declaring FI_HMEM in hints->caps, which is what the CUDA path does and
+    // what efa_shm.c keys FI_MR_HMEM off, would be worse than this: it makes
+    // shm HMEM-aware and the transfer then fails outright on that ENOSYS
+    // rather than merely crawling.
+    //
+    // Overwrite is 0, so an explicit FI_EFA_ENABLE_SHM_TRANSFER from the
+    // environment still wins.  This is process-global and also takes host
+    // memory off the shm path on Neuron hosts; that is an acceptable trade,
+    // since intra-node host transfers loop back over EFA just as well.
+    if (neuronAvailable()) setenv("FI_EFA_ENABLE_SHM_TRANSFER", "0", 0);
+
     // Setup hints for EFA provider
     hints_ = fi_allocinfo();
     if (!hints_) {
@@ -112,6 +143,10 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
     // matches no fi_info at all (fi_getinfo -> -FI_ENODATA) rather than merely
     // refusing the later fi_mr_regattr().  Unlike CUDA this is a runtime
     // decision -- Neuron support costs no build flag, see efa_neuron.h.
+    //
+    // Note that FI_HMEM is deliberately NOT added to caps here, unlike the
+    // CUDA path above.  See the FI_EFA_ENABLE_SHM_TRANSFER guard below for
+    // why declaring it would turn a slow intra-node path into a broken one.
     if (neuronAvailable()) hints_->domain_attr->mr_mode |= FI_MR_HMEM;
     hints_->domain_attr->threading = FI_THREAD_SAFE;
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_neuron.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_neuron.cpp
@@ -1,0 +1,327 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/efa_transport/efa_neuron.h"
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <glog/logging.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace mooncake {
+
+namespace {
+
+// One /dev/neuron<index> mapping as reported by /proc/self/maps.
+struct NeuronRegion {
+    uintptr_t start;
+    uintptr_t end;
+    int device_index;
+};
+
+std::mutex g_neuron_mutex;
+std::vector<NeuronRegion> g_neuron_regions;
+
+// Parses /proc/self/maps and keeps only the /dev/neuron<N> mappings.  Called
+// with g_neuron_mutex held.
+void refreshNeuronRegionsLocked() {
+    std::vector<NeuronRegion> regions;
+    std::ifstream maps("/proc/self/maps");
+    if (!maps.is_open()) {
+        LOG(WARNING) << "Neuron: cannot open /proc/self/maps, Neuron device "
+                        "memory will be treated as host memory";
+        return;
+    }
+
+    const std::string kDevPrefix = "/dev/neuron";
+    std::string line;
+    while (std::getline(maps, line)) {
+        auto dev_pos = line.find(kDevPrefix);
+        if (dev_pos == std::string::npos) continue;
+
+        // The ordinal is the digit run right after "/dev/neuron"; stop at the
+        // first non-digit so a "(deleted)" suffix does not confuse us.
+        size_t digit_pos = dev_pos + kDevPrefix.size();
+        if (digit_pos >= line.size() || !isdigit(line[digit_pos])) continue;
+        int device_index = 0;
+        while (digit_pos < line.size() && isdigit(line[digit_pos])) {
+            device_index = device_index * 10 + (line[digit_pos] - '0');
+            ++digit_pos;
+        }
+
+        uintptr_t start = 0, end = 0;
+        if (sscanf(line.c_str(), "%lx-%lx", &start, &end) != 2) continue;
+        if (end <= start) continue;
+
+        regions.push_back(NeuronRegion{start, end, device_index});
+    }
+
+    g_neuron_regions = std::move(regions);
+}
+
+// Looks up a range in the cached snapshot.  Called with g_neuron_mutex held.
+bool findRegionLocked(uintptr_t start, uintptr_t end, int* device_index) {
+    for (const auto& region : g_neuron_regions) {
+        if (start >= region.start && end <= region.end) {
+            if (device_index) *device_index = region.device_index;
+            return true;
+        }
+    }
+    return false;
+}
+
+// Maps the Neuron runtime into this process, preferring a copy that is already
+// there, and returns a handle to it (nullptr if it cannot be found).  Loading
+// it does not initialise it -- nrt_init() is the framework's business, not
+// ours.
+//
+// Doing this eagerly is not an optimisation, it is what makes FI_HMEM_NEURON
+// work at all.  libfabric's EFA provider reaches the runtime with
+// dlopen("libnrt.so.1") while initialising its HMEM interfaces, and the Neuron
+// SDK installs libnrt under /opt/aws/neuron/lib without adding that directory
+// to the loader path -- so on a default install that dlopen fails, the
+// FI_HMEM_NEURON op table is left empty, and the only symptom is
+// fi_mr_regattr() returning -FI_ENOSYS much later.  Because libfabric asks by
+// soname and libnrt's SONAME is "libnrt.so.1", a copy we have already mapped
+// satisfies its dlopen() without any filesystem search, which is why this works
+// where setting LD_LIBRARY_PATH from inside the process would not (glibc parses
+// that variable once, at startup).
+void* dlopenNeuronRuntime() {
+    static const char* kNames[] = {"libnrt.so.1",
+                                   "/opt/aws/neuron/lib/libnrt.so.1"};
+    static void* const handle = []() -> void* {
+        // Pass 0 only adopts an already-mapped libnrt: inside a Neuron
+        // inference worker the framework has loaded and initialised the runtime
+        // long before we get here, and a second independent copy of a device
+        // runtime in one process is a known source of device-arbitration
+        // failures. Pass 1 may load one, asking by soname first so that a
+        // framework-configured location (LD_LIBRARY_PATH, rpath) still wins
+        // over the SDK's default install path.
+        for (int pass = 0; pass < 2; ++pass) {
+            int flags = RTLD_LAZY | RTLD_GLOBAL | (pass == 0 ? RTLD_NOLOAD : 0);
+            for (const char* name : kNames) {
+                void* h = dlopen(name, flags);
+                if (h) return h;
+            }
+        }
+        return nullptr;
+    }();
+    return handle;
+}
+
+// nec_get_device_pci_bdf(neuron_dev, &domain, &bus, &slot, &func) -- see nec.h
+// in the Neuron runtime headers.  Returns NRT_SUCCESS (0).  This is the only
+// way to get from a /dev/neuron<N> ordinal to a PCI address: the driver exposes
+// neuron devices as *virtual* class devices
+// (/sys/devices/virtual/neuron_device) with no link back to the PCI device, and
+// the ordinals are not in BDF order -- on trn2.48xlarge neuron0 is 0000:cc:00.0
+// while neuron1 is 0000:b5:00.0.
+using NecGetDevicePciBdfFn = int (*)(int, uint32_t*, uint32_t*, uint8_t*,
+                                     uint8_t*);
+
+// "<domain>:<bus>" of the bridge a PCI device hangs off, e.g. "0000:b9" for a
+// device behind port 0000:b9:02.1.  Empty if it cannot be determined.
+//
+// This is the grouping that expresses PCIe-switch locality: on trn2.48xlarge
+// each switch carries two Neuron devices and two EFA NICs, and every device
+// under it shares this prefix.
+std::string pciParentBus(const std::string& bdf) {
+    char resolved[PATH_MAX];
+    if (!realpath(("/sys/bus/pci/devices/" + bdf).c_str(), resolved)) {
+        return std::string();
+    }
+    // .../0000:b9:02.1/0000:cc:00.0 -> parent component "0000:b9:02.1"
+    char* last = strrchr(resolved, '/');
+    if (!last) return std::string();
+    *last = '\0';
+    char* parent = strrchr(resolved, '/');
+    if (!parent) return std::string();
+    std::string port(parent + 1);
+
+    // Keep "<domain>:<bus>", dropping the ":<slot>.<func>" of the port itself.
+    auto first = port.find(':');
+    if (first == std::string::npos) return std::string();
+    auto second = port.find(':', first + 1);
+    if (second == std::string::npos) return std::string();
+    return port.substr(0, second);
+}
+
+// Groups the EFA NICs of this host by the PCIe bridge they sit behind.
+std::map<std::string, std::vector<std::string>> efaNicsByParentBus() {
+    std::map<std::string, std::vector<std::string>> by_bus;
+    DIR* dir = opendir("/sys/class/infiniband");
+    if (!dir) return by_bus;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir))) {
+        if (entry->d_name[0] == '.') continue;
+        std::string name = entry->d_name;
+        char resolved[PATH_MAX];
+        if (!realpath(("/sys/class/infiniband/" + name + "/device").c_str(),
+                      resolved)) {
+            continue;
+        }
+        const char* last = strrchr(resolved, '/');
+        if (!last) continue;
+        std::string bus = pciParentBus(last + 1);
+        if (!bus.empty()) by_bus[bus].push_back(name);
+    }
+    (void)closedir(dir);
+    return by_bus;
+}
+
+}  // namespace
+
+bool neuronAvailable() {
+    static const bool available = []() -> bool {
+        const char* disable = getenv("MC_EFA_DISABLE_NEURON");
+        if (disable && (disable[0] == '1' || disable[0] == 't' ||
+                        disable[0] == 'T' || disable[0] == 'y')) {
+            LOG(INFO) << "Neuron support disabled by MC_EFA_DISABLE_NEURON";
+            return false;
+        }
+        if (access("/dev/neuron0", F_OK) != 0) return false;
+
+#ifndef MOONCAKE_HAVE_FI_HMEM_NEURON
+        // Built against a libfabric with no FI_HMEM_NEURON, so this binary
+        // cannot register Neuron HBM however the hardware is arranged.  Report
+        // the device as unsupported and let registration fail in fi_mr_reg()
+        // rather than claim it here: the alternative -- passing device memory
+        // off as host memory -- would be silently wrong.  Warned about only on
+        // hosts that actually have a device, hence the ordering.
+        LOG(WARNING) << "Neuron devices are present but this binary was built "
+                        "against a libfabric whose rdma/fi_domain.h has no "
+                        "FI_HMEM_NEURON, so Neuron HBM cannot be registered. "
+                        "Rebuild against a libfabric that defines it (the AWS "
+                        "EFA installer's copy under /opt/amazon/efa does; "
+                        "older distro libfabric-dev packages do not).";
+        return false;
+#else
+        // Deliberately still true when libnrt is missing.  The hardware is
+        // there, so calling Neuron HBM host memory would be a lie -- and an
+        // expensive one, since "cpu:N" is what opts a buffer into CPU pre-touch
+        // stores.  Better to keep the honest answer and let registration fail
+        // loudly, with this line explaining why.
+        if (!dlopenNeuronRuntime()) {
+            LOG(WARNING)
+                << "Neuron devices are present but libnrt.so.1 could not be "
+                   "loaded ("
+                << dlerror()
+                << "); libfabric will refuse to register Neuron HBM "
+                   "(fi_mr_regattr -> ENOSYS). Add the Neuron SDK library "
+                   "directory (usually /opt/aws/neuron/lib) to "
+                   "LD_LIBRARY_PATH.";
+        }
+        LOG(INFO) << "Neuron device detected, EFA transport will register "
+                     "Neuron HBM with FI_HMEM_NEURON";
+        return true;
+#endif
+    }();
+    return available;
+}
+
+bool neuronProbeAddress(const void* addr, size_t length, int* device_index) {
+    if (!neuronAvailable() || addr == nullptr || length == 0) return false;
+
+    const uintptr_t start = reinterpret_cast<uintptr_t>(addr);
+    const uintptr_t end = start + length;
+    if (end < start) return false;  // overflow
+
+    std::lock_guard<std::mutex> guard(g_neuron_mutex);
+    if (findRegionLocked(start, end, device_index)) return true;
+
+    // A miss is re-checked against a fresh snapshot rather than answered from
+    // the cache: mappings appear as the Neuron runtime grows its pools, and
+    // misreporting device memory as host memory is not a slow path but a
+    // correctness bug -- the caller would hand it to fi_mr_reg() as
+    // FI_HMEM_SYSTEM and pre-touch it with CPU stores.  The cost is one read of
+    // /proc/self/maps per registration of a non-Neuron buffer, and only on
+    // hosts that actually have Neuron devices.
+    refreshNeuronRegionsLocked();
+    return findRegionLocked(start, end, device_index);
+}
+
+std::map<int, std::vector<std::string>> neuronNicAffinity() {
+    std::map<int, std::vector<std::string>> affinity;
+    if (!neuronAvailable()) return affinity;
+
+    void* handle = dlopenNeuronRuntime();
+    if (!handle) return affinity;
+    auto get_bdf = reinterpret_cast<NecGetDevicePciBdfFn>(
+        dlsym(handle, "nec_get_device_pci_bdf"));
+    if (!get_bdf) {
+        LOG(WARNING)
+            << "Neuron: libnrt has no nec_get_device_pci_bdf, cannot "
+               "work out which EFA NICs share a PCIe switch with each "
+               "device; Neuron transfers will use all NICs and may run "
+               "several times slower than they could";
+        return affinity;
+    }
+
+    const auto nics_by_bus = efaNicsByParentBus();
+    if (nics_by_bus.empty()) return affinity;
+
+    // Scanned rather than counted, and gaps are skipped rather than treated as
+    // the end: the ordinals a container sees need not start at 0 or be
+    // contiguous.  The bound is generous -- trn2.48xlarge, the largest today,
+    // exposes 16 -- and each miss is one access().
+    constexpr int kMaxNeuronDevices = 64;
+    for (int index = 0; index < kMaxNeuronDevices; ++index) {
+        const std::string dev = "/dev/neuron" + std::to_string(index);
+        if (access(dev.c_str(), F_OK) != 0) continue;
+
+        uint32_t domain = 0, bus = 0;
+        uint8_t slot = 0, func = 0;
+        if (get_bdf(index, &domain, &bus, &slot, &func) != 0) continue;
+
+        char bdf[32];
+        snprintf(bdf, sizeof(bdf), "%04x:%02x:%02x.%x", domain, bus, slot,
+                 func);
+        const std::string parent_bus = pciParentBus(bdf);
+        if (parent_bus.empty()) continue;
+
+        auto it = nics_by_bus.find(parent_bus);
+        if (it == nics_by_bus.end()) continue;
+
+        affinity[index] = it->second;
+        VLOG(1) << "Neuron device " << index << " (" << bdf
+                << ") shares PCIe switch " << parent_bus << " with "
+                << it->second.size() << " EFA NIC(s)";
+    }
+
+    if (affinity.empty()) {
+        LOG(WARNING)
+            << "Neuron: no device could be matched to an EFA NIC on the "
+               "same PCIe switch; Neuron transfers will use all NICs";
+    }
+    return affinity;
+}
+
+std::string neuronLocationName(int device_index) {
+    return "neuron:" + std::to_string(device_index);
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_neuron.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_neuron.cpp
@@ -220,23 +220,41 @@ bool neuronAvailable() {
                         "older distro libfabric-dev packages do not).";
         return false;
 #else
-        // Deliberately still true when libnrt is missing.  The hardware is
-        // there, so calling Neuron HBM host memory would be a lie -- and an
-        // expensive one, since "cpu:N" is what opts a buffer into CPU pre-touch
-        // stores.  Better to keep the honest answer and let registration fail
-        // loudly, with this line explaining why.
+        // Deliberately still true when libnrt cannot be loaded, because this
+        // answer is cached for the lifetime of the process (see the static
+        // above) and "false" is the more dangerous of the two mistakes.
+        //
+        // Returning false makes neuronProbeAddress() report Neuron HBM as host
+        // memory, and a "cpu" location prefix is exactly what opts a buffer
+        // into EfaTransport::preTouchMemory()'s CPU-side stores -- host writes
+        // into a device VA, for every chunk of 4 GiB or more.  Since
+        // neuronAvailable() first runs during transport install, a framework
+        // that loads libnrt and allocates its tensors afterwards would be
+        // caught by that.
+        //
+        // Returning true keeps the hints and the per-buffer classification
+        // correct.  Its cost, if libfabric's own dlopen of libnrt failed too,
+        // is a loud fi_mr_regattr -> -FI_ENOSYS at registration time, which
+        // the warning below explains in advance.  Nothing downstream is
+        // undefined either way: registration either succeeds or fails with
+        // that errno.
         if (!dlopenNeuronRuntime()) {
+            // dlerror() is allowed to return NULL -- notably when the last
+            // failure was a RTLD_NOLOAD probe -- and streaming a NULL
+            // const char* into an ostream is undefined behaviour.
+            const char* err = dlerror();
             LOG(WARNING)
                 << "Neuron devices are present but libnrt.so.1 could not be "
                    "loaded ("
-                << dlerror()
+                << (err ? err : "no dlerror() message")
                 << "); libfabric will refuse to register Neuron HBM "
                    "(fi_mr_regattr -> ENOSYS). Add the Neuron SDK library "
                    "directory (usually /opt/aws/neuron/lib) to "
                    "LD_LIBRARY_PATH.";
+        } else {
+            LOG(INFO) << "Neuron device detected, EFA transport will register "
+                         "Neuron HBM with FI_HMEM_NEURON";
         }
-        LOG(INFO) << "Neuron device detected, EFA transport will register "
-                     "Neuron HBM with FI_HMEM_NEURON";
         return true;
 #endif
     }();

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_neuron.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_neuron.cpp
@@ -145,9 +145,10 @@ using NecGetDevicePciBdfFn = int (*)(int, uint32_t*, uint32_t*, uint8_t*,
 // "<domain>:<bus>" of the bridge a PCI device hangs off, e.g. "0000:b9" for a
 // device behind port 0000:b9:02.1.  Empty if it cannot be determined.
 //
-// This is the grouping that expresses PCIe-switch locality: on trn2.48xlarge
-// each switch carries two Neuron devices and two EFA NICs, and every device
-// under it shares this prefix.
+// This is the grouping that expresses PCIe locality: on trn2.48xlarge each of
+// the eight switches carries two Neuron devices and two EFA NICs, and on
+// trn1.32xlarge each of the four root buses carries four Neuron devices and two
+// EFA NICs.  Every device in a group shares this prefix.
 std::string pciParentBus(const std::string& bdf) {
     char resolved[PATH_MAX];
     if (!realpath(("/sys/bus/pci/devices/" + bdf).c_str(), resolved)) {
@@ -161,11 +162,30 @@ std::string pciParentBus(const std::string& bdf) {
     if (!parent) return std::string();
     std::string port(parent + 1);
 
+    // The parent comes in one of two shapes, and both have to be handled.
+    //
+    // Behind a PCIe switch it is another PCI function, "0000:b9:02.1"
+    // (trn2.48xlarge), and the switch is named by its "<domain>:<bus>".
+    // Directly off the root complex it is the host bridge, "pci0000:10"
+    // (trn1.32xlarge), which already *is* the "<domain>:<bus>" once the "pci"
+    // is dropped.  trn1 puts two EFA NICs and four Neuron devices on each of
+    // its four root buses with no switch in between, so rejecting the second
+    // shape returns no grouping at all for every device on the host, the caller
+    // degrades to using all NICs, and a NIC on the wrong root bus turns out to
+    // be far worse there than a NIC one switch away is on trn2: measured
+    // 82.71 GB/s grouped against 0.19 GB/s ungrouped, 16 devices inter-node.
+    const bool root_complex = port.compare(0, 3, "pci") == 0;
+    if (root_complex) port.erase(0, 3);
+
     // Keep "<domain>:<bus>", dropping the ":<slot>.<func>" of the port itself.
     auto first = port.find(':');
     if (first == std::string::npos) return std::string();
     auto second = port.find(':', first + 1);
-    if (second == std::string::npos) return std::string();
+    if (second == std::string::npos) {
+        // A root bus has no ":<slot>.<func>" to drop.  Accepted only in the
+        // root-complex form so that a malformed path cannot slip through.
+        return root_complex ? port : std::string();
+    }
     return port.substr(0, second);
 }
 
@@ -300,7 +320,20 @@ std::map<int, std::vector<std::string>> neuronNicAffinity() {
     }
 
     const auto nics_by_bus = efaNicsByParentBus();
-    if (nics_by_bus.empty()) return affinity;
+    if (nics_by_bus.empty()) {
+        // Warned about here and not only at the end of the function, because
+        // this is the likelier of the two ways to end up with no affinity and
+        // it used to be entirely silent.  A pciParentBus() that could not parse
+        // the host's sysfs layout took this branch for every NIC, and the sole
+        // visible effect was the throughput: on trn1.32xlarge, 0.19 GB/s where
+        // the same run with grouping gives 82.71.
+        LOG(WARNING)
+            << "Neuron: could not group any EFA NIC by its parent PCI bus, so "
+               "no device can be matched to a nearby NIC; Neuron transfers "
+               "will use all NICs and may run orders of magnitude slower than "
+               "they could";
+        return affinity;
+    }
 
     // Scanned rather than counted, and gaps are skipped rather than treated as
     // the end: the ordinals a container sees need not start at 0 or be

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -35,6 +35,7 @@
 #include "config.h"
 #include "environ.h"
 #include "memory_location.h"
+#include "transport/efa_transport/efa_neuron.h"
 #include "topology.h"
 #include "transport/batch_registration.h"
 #include "transport/efa_transport/efa_context.h"
@@ -291,16 +292,35 @@ int EfaTransport::registerLocalMemoryInternal(void* addr, size_t length,
         chunks.emplace_back(addr, length);
     }
 
-    // Resolve location name once (based on original buffer)
+    // Resolve location name once (based on original buffer).
+    //
+    // The Neuron probe deliberately runs ahead of the caller-supplied hint.  A
+    // hint is normally authoritative, but a hint of "cpu:N" over Neuron HBM is
+    // not merely imprecise: "cpu" opts the buffer into the preTouchMemory()
+    // path below, which stores to every page from the CPU.  Callers whose
+    // vocabulary is only "host or CUDA" would silently corrupt device memory,
+    // so the probe wins and says so.  On hosts without Neuron devices the probe
+    // is a cached bool, so this costs nothing.
     std::string resolved_name;
-    if (name == kWildcardLocation) {
+    int neuron_device = 0;
+    if (neuronProbeAddress(addr, length, &neuron_device)) {
+        resolved_name = neuronLocationName(neuron_device);
+        if (name != kWildcardLocation && name != resolved_name) {
+            LOG(WARNING) << "Ignoring location hint \"" << name
+                         << "\" for Neuron HBM " << addr << " (" << length
+                         << " bytes), registering it as " << resolved_name;
+        } else {
+            LOG(INFO) << "Registering Neuron HBM " << addr << " (" << length
+                      << " bytes) as " << resolved_name;
+        }
+    } else if (name != kWildcardLocation) {
+        resolved_name = name;
+    } else {
         bool only_first_page = true;
         const std::vector<MemoryLocationEntry> entries =
             getMemoryLocation(addr, length, only_first_page);
         if (entries.empty()) return -1;
         resolved_name = entries[0].location;
-    } else {
-        resolved_name = name;
     }
 
     // Pre-compute NIC assignments for each chunk.

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -76,6 +76,57 @@ TEST(ToplogyTest, TestHcaList2) {
     }
 }
 
+// resolve() must number HCAs from the contents of the matrix, never from the
+// order its entries happen to sit in matrix_ (an unordered_map, so that order
+// follows insertion).  A device index is not private to one process: a peer
+// rebuilds this matrix with parse() and then indexes the device and rkey arrays
+// we published with the numbers *its* resolve() produced, so both ends have to
+// derive the same numbering or every affinity preference is silently defeated
+// on the remote side.
+//
+// Reversing the JSON text alone cannot catch a regression here -- jsoncpp
+// returns getMemberNames() sorted, so parse() inserts in the same order either
+// way.  What does catch it is pinning the numbering to the sorted keys: with
+// `for (auto &entry : matrix_)` the walk order of these six keys is not their
+// sort order, and the expectation below fails.
+TEST(ToplogyTest, TestHcaNumberingIndependentOfInsertionOrder) {
+    auto entry = [](const std::string &location, const std::string &hca) {
+        return "\"" + location + "\" : [[\"" + hca + "\"],[]]";
+    };
+    const std::vector<std::pair<std::string, std::string>> entries = {
+        {"cpu:0", "erdma_0"},    {"cpu:1", "erdma_1"},
+        {"cuda:0", "erdma_2"},   {"cuda:1", "erdma_3"},
+        {"neuron:0", "erdma_4"}, {"neuron:1", "erdma_5"}};
+
+    // Same matrix, members emitted in sorted and in reverse-sorted order.
+    std::string forward, reverse;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        const auto &e = entries[i];
+        const auto &r = entries[entries.size() - 1 - i];
+        forward += (i ? "," : "") + entry(e.first, e.second);
+        reverse += (i ? "," : "") + entry(r.first, r.second);
+    }
+
+    // entries is in sorted key order, so its HCAs are the expected numbering.
+    std::vector<std::string> expected;
+    for (const auto &e : entries) expected.push_back(e.second);
+
+    mooncake::Topology from_forward, from_reverse;
+    ASSERT_EQ(from_forward.parse("{" + forward + "}"), 0);
+    ASSERT_EQ(from_reverse.parse("{" + reverse + "}"), 0);
+    EXPECT_EQ(from_forward.getHcaList(), expected);
+    EXPECT_EQ(from_reverse.getHcaList(), expected);
+
+    // The same contract, stated the way a peer consumes it: the index handed
+    // out for a location must be the position of that location's NIC in the
+    // published device list.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        EXPECT_EQ(from_forward.selectDevice(entries[i].first),
+                  static_cast<int>(i))
+            << entries[i].first;
+    }
+}
+
 TEST(ToplogyTest, TestMatrix) {
     mooncake::Topology topology;
     std::string json_str = "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]]}";


### PR DESCRIPTION
## Description

On a Trainium (AWS Neuron) instance the EFA transport could only move host DRAM, so a Neuron deployment had to stage every buffer through the CPU. This adds direct Neuron HBM transfers: `neuron:<N>` becomes a first-class memory location, and the same `USE_EFA` binary still runs unchanged on hosts with no Neuron device.

libfabric's EFA provider already implements `FI_HMEM_NEURON` — it is how the Neuron collectives stack moves HBM between instances — so most of the work was asking for it correctly:

* **`FI_HMEM=neuron`.** The variable takes exactly one interface, not a list, so it is set from a runtime probe rather than unconditionally.
* **`FI_MR_HMEM` in `mr_mode`**, otherwise the provider never looks at the iface we pass.
* **`fi_mr_regattr()`** with `iface = FI_HMEM_NEURON` and `device.neuron` set to the ordinal the buffer lives on.
* **libnrt mapped before the first `fi_getinfo()`.** libfabric reaches the runtime with `dlopen("libnrt.so.1")` while initialising its HMEM interfaces, but the Neuron SDK installs libnrt under `/opt/aws/neuron/lib` without putting that directory on the loader path — so on a default install that dlopen fails and the only symptom is `fi_mr_regattr()` returning `-FI_ENOSYS` much later. `neuronAvailable()` dlopens it with `RTLD_GLOBAL` (adopting an already-mapped copy first, and never calling `nrt_init()`), which satisfies libfabric's later request by soname. Setting `LD_LIBRARY_PATH` from inside the process cannot work — glibc parses it once, at startup.

Neuron HBM reaches user space as a shared mmap of `/dev/neuron<N>`, so both questions the transport needs answered — *is this pointer device memory* and *which device is it on* — fall out of `/proc/self/maps`. That keeps the new file free of Neuron SDK headers and of any link-time dependency on libnrt.

The location string has to be `neuron:<N>` rather than a `cpu:N` hint, because a `cpu` prefix is what opts a buffer into `preTouchMemory()`'s host stores. The probe therefore overrides even an explicit caller hint, and logs when it does.

**PCIe-switch NIC affinity is not a micro-optimisation here.** Neuron HBM registers fine on any NIC, but a NIC one switch away from the device it serves measured **2.5 GB/s against 19.2 GB/s** for a switch-local one. Topology discovery therefore groups each Neuron device with the EFA NICs behind its PCIe bridge, using `nec_get_device_pci_bdf()` — necessary because the driver presents neuron devices as *virtual* class devices with no link back to their PCI function, and the ordinals are not in BDF order (on trn2.48xlarge `neuron0` is `0000:cc:00.0` while `neuron1` is `0000:b5:00.0`). That call needs no device allocation and no `nrt_init()`, so it cannot claim a NeuronCore out from under a framework sharing the process.

`Topology::resolve()` now numbers HCAs in **sorted storage-type order**. A device index is not private to one process: a peer rebuilds the matrix with `parse()` and then indexes the device/rkey arrays we published with the numbers *its* `resolve()` produced. `matrix_` is an `unordered_map`, so the two ends walked it in different orders (discovery order vs. JSON member order) and any affinity preference was silently defeated on the remote side. This is not a correctness bug — rkeys and device names stay consistently indexed — but it costs the whole benefit above.

One small change on the CUDA side: in `registerMemoryRegionInternal()` the `ScopedCudaContext` is still declared for the whole registration block (it has to stay current across `fi_mr_regattr()`), but it is now only *bound* when `iface == FI_HMEM_CUDA`. `device_ordinal` is a CUDA device only when the iface says so, and binding a CUDA primary context to a Neuron ordinal would fail the registration outright on a hypothetical build that has both enabled.

Also: `transfer_engine_bench`'s EFA branch now honours `--nic_priority_matrix`, which it previously ignored (it always called `discover({})`). That is what makes the affinity-off control experiment below possible.

Behaviour on non-Neuron hosts is unchanged: `neuronAvailable()` returns false on the first `access("/dev/neuron0")`, and `MC_EFA_DISABLE_NEURON=1` turns the whole path off.

### Old libfabric headers, and what the published wheels compile against

`FI_HMEM_NEURON` and `fi_mr_attr::device.neuron` arrived together in **libfabric 1.15** (checked tag by tag: 1.14.0 no, 1.15.0 yes) and are absent from older headers — including Ubuntu 22.04's `libfabric-dev`, which is 1.11. The two lines that name them therefore sit behind a configure-time `check_cxx_source_compiles()` probe, `MOONCAKE_HAVE_FI_HMEM_NEURON`, following the existing `HAVE_IBV_ACTIVE_SPEED_EX` precedent. When the probe fails, `neuronAvailable()` returns false with a message saying why, rather than letting Neuron HBM be registered as host memory — which would be silently wrong, and slow, since a `cpu` location pre-touches every page.

**The probe alone would be a trap**: it makes CI green while shipping published wheels with Neuron off. So `_build-efa-wheel.yaml` now **builds libfabric from source** (every provider `--disable`d, headers and a link target are all that is wanted) instead of installing `libfabric-dev`, pinned at **1.18.2** — the oldest release the transport actually claims to support, since it already asks `fi_getinfo()` for `FI_VERSION(1, 18)`, which jammy's 1.11 could never have satisfied anyway. Measured cost on a trn2: curl 0.3s + configure 7.8s + `make -j8` 4.7s ≈ 15s, so no caching is needed. Nothing changes at runtime — `scripts/build_wheel.sh` has an unconditional `--exclude libfabric.so*`, so the wheel still resolves to the EFA installer's copy under `/opt/amazon/efa` on the host. One edit covers everything: `ci_efa.yml` and all three `release-efa*.yaml` call this reusable workflow.

Bumping the runner to ubuntu-24.04 for libfabric 1.17 was rejected: it would raise the wheel's glibc floor.

A Neuron end-to-end CI job is not possible — GitHub-hosted runners have no Trainium hardware, which is why `ci_ascend.yml` / `ci_rocm.yml` are build-only for the same reason. CI coverage here is compile-only, and the hardware validation below is manual.

### Same-host transfers, and why `FI_HMEM` is deliberately not in `caps`

`hints_->caps` gains `FI_HMEM` only on CUDA/HIP builds, where a comment records that `FI_MR_HMEM` in `mr_mode` alone is not enough: without `FI_HMEM` in caps the SHM sub-provider initialises its copy callbacks in plain-host mode and does a host `memcpy()` into a device VA during SAR ([ofiwg/libfabric#12328](https://github.com/ofiwg/libfabric/issues/12328)). The Neuron path sets `mr_mode |= FI_MR_HMEM` and does **not** add `FI_HMEM` to caps, which was originally just an untested asymmetry. It is now a deliberate one, because the same-host path has been measured and the CUDA analogy does not hold:

* Intra-node Neuron-to-Neuron **works and is correct**, but at **0.07 GB/s** on trn2 and **0.09 GB/s** on trn1 — 200x+ off the wire rate, with every byte intact.
* The reason is that libfabric's `shm` sub-provider has no protocol that can *read* a Neuron buffer: the `FI_HMEM_NEURON` op table in `src/hmem.c` implements `copy_to_hmem` only, `copy_from_hmem` is a `FI_WARN_ONCE(...); return -FI_ENOSYS;` stub, and every IPC entry is `ofi_hmem_no_*`, so `smr_ep.c`'s `use_ipc` is always false. Left alone, shm `memcpy`s the `/dev/neuron` mapping as host memory — across an uncached PCIe BAR, hence the 0.07.
* So adding `FI_HMEM` to caps would be a **regression, not a fix**: `efa_shm.c` keys `FI_MR_HMEM` off exactly that bit, and an HMEM-aware shm fails outright on the ENOSYS above instead of merely crawling. (CUDA gets a SIGSEGV where Neuron gets slowness for the same reason: a CUDA device VA is not CPU-mappable at all, a `/dev/neuron` BAR mapping is.)
* Fixed instead by keeping shm out of the way on Neuron hosts: `setenv("FI_EFA_ENABLE_SHM_TRANSFER", "0", 0)` before the first `fi_getinfo()`. Same-host traffic then loops back over the EFA device at **19.23 GB/s** (trn2) and **14.21 GB/s** (trn1) — in both cases the same rate one device gets *between* two hosts, i.e. no loss. Overwrite is `0`, so an explicit environment value still wins, which is how the slow row above was measured with the same binary.

## Module

<!-- Please check the module(s) this PR affects -->

- [ ] Mooncake Store (mooncake-store)
- [x] Transfer Engine (mooncake-transfer-engine)
- [ ] Mooncake Master (mooncake-master)
- [ ] P2P Store (mooncake-p2p-store)
- [ ] Integration (vLLM/SGLang/etc.)
- [x] Documentation
- [x] CI/CD
- [ ] Other (please describe):

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Two `trn2.48xlarge` instances (us-east-2), 16 Neuron devices and 16 EFA NICs each, Neuron runtime 2.34.10.0 / driver 2.30.2.0, libfabric 2.4.0 from the EFA installer. All numbers are `transfer_engine_bench`. Run-to-run spread is ±2%, so only larger differences are read as real.

**Tuned shape.** Swept over block size, threads and batch at 16 devices × 4 GB buffers; `--threads` is the dominant knob and peaks well short of the core count, while block size is flat from 512 KB up (at 16 threads: 256 KB 233.87, 512 KB 247.09, 1 MB 243.04, 2 MB 248.44 GB/s):

| `--threads` | `--batch_size` | Write throughput |
| --- | --- | --- |
| 8 | 128 | 123.83 GB/s |
| 16 | 32 | 259.93 GB/s |
| **32** | **128** | **266–271 GB/s** |
| 64 | 32 | 249.38 GB/s |
| 128 | 16 | 255.26 GB/s |

**PCIe-switch affinity A/B** — identical runs at that shape apart from `--nic_priority_matrix`:

| Configuration | Throughput |
| --- | --- |
| Affinity on (this PR) | **266.58 GB/s** |
| Affinity off (all 16 NICs per device) | 23.48 GB/s |
| Host DRAM control, same fabric (CPU-to-CPU) | 113.16 GB/s |

Correctly routed Neuron HBM is ~2.4x faster than host DRAM on the same fabric; getting the routing wrong puts it ~4.8x *below* it. (An earlier sweep at 1 GB buffers / 256 KB blocks / 16 threads read 231.16 vs. 12.31 GB/s — same conclusion, the ratio just depends on the shape.)

**Verified on the wire, not just self-reported.** Cross-checked against `/sys/class/infiniband/*/ports/1/hw_counters/tx_bytes`, sampled in windows triggered on counter movement rather than on a log line — a window overlapping the MR-registration phase dilutes the rate and reads low:

| Run | Summed NIC counters | Bench self-report |
| --- | --- | --- |
| All 16 devices | 279.54 / 279.57 GB/s | 278.97 GB/s |
| One device | 19.26 / 19.27 / 19.27 GB/s | 19.26 GB/s |

The single-device run also puts **every** byte on exactly two NICs — `rdmap201s0` and `rdmap202s0`, the pair behind that device's switch — with the other fourteen flat at zero, which is the affinity claim measured from outside the process.

**Per-device throughput is the ceiling, not the fabric.** One device sustains 19.3 GB/s and does not move between 2 and 16 threads; 16 devices reach ~270, roughly linear at ~17 GB/s each. EFAv3 on this instance is 3,200 Gbps = 400 GB/s aggregate and each device has two 25 GB/s NICs behind its switch, so neither the NICs nor HBM (46.4 TB/s) nor NeuronLink-v3 (1,024 GB/s/chip) is what binds. It is also not the logical-core count: spreading buffers over all 64 logical NeuronCores (`--neuron_core_stride=1 --neuron_device_count=64`) is worth only +3% (279 vs. 270 GB/s) for twice the HBM footprint, and the same thread count on the 16-buffer shape gives 255, so that +3% comes from the core spread rather than the threads.

**The bytes actually land in HBM.** Device memory cannot go through the existing `memcmp` validator, so the two sides fill with different bytes (`--neuron_fill_byte`) and the target reports on shutdown how much of its HBM the peer overwrote. Target filled `0x00`, initiator `0xAB`; the target reported `524288/1048576 bytes ... differ from the fill byte 0x0, first new value 0xab` on both buffers — exactly the expected coverage for the block size used.

**Affinity mapping verified** against ground truth: all 16 devices resolve into 8 PCIe switches x 2 EFA NICs, matching the two `lspci`-confirmed pairs.

**Regressions:** `topology_test` and `efa_transport_test` both pass (13/13 and 11/11 on this base; 8/8 and 10/10 on the branch the work was originally developed on), and the CPU-to-CPU path is unchanged at 113.16 GB/s (256 KB blocks, 32 threads) with the sorted `resolve()` in place.

The rebased commit was rebuilt and re-validated on the same two hosts. Both instances were shared with another workload at that point, so the re-run was limited to the free NeuronCores (`NEURON_RT_VISIBLE_CORES=56-63`, 2 devices, 256 KB blocks, 8 threads): **write 46.07 GB/s, read 48.71 GB/s**, consistent with the 2-device point of the scaling curve, with the correct ordinals discovered (`neuron:14`, `neuron:15`) and the `0xAB` read-back confirmed again (524288/1048576 bytes of the first MiB of each addressed buffer).

### Also validated on two `trn1.32xlarge` (Trainium1, a second PCIe layout)

Added because trn1 is laid out differently — 4 root buses × (4 Neuron + 2 EFA), no PCIe switch in between, 8 EFA × 100 Gbps — and it found two things trn2 could not:

* **`pciParentBus()` recognised only the switch-port form** of a sysfs parent (`0000:b9:02.1`). trn1's parent is the host bridge, `pci0000:10`, so grouping returned nothing for every device, all 8 NICs were dropped, and each Neuron device fell back to using all NICs: **0.19 GB/s against 82.71 GB/s** with the grouping. Worse than a wrong switch on trn2 because trn1's groups are two NUMA nodes apart and NIC enumeration lists the far-NUMA NICs first. Also the "no device could be matched" warning sat *after* the early return this took, so the hole was completely silent; it now warns there too.
* **The `--neuron_core_stride` auto-detect (`core_count / 2`) hardcoded trn2's LNC=2 core fusion.** trn1 reports `core_count=2` and fuses nothing, so the step came out as `1` and `--neuron_device_count=16` stacked two buffers on each of devices 0–7, never touching 8–15 — with ~10% throughput as the only symptom. Replaced by a probe: allocate a page on each logical core, ask which `/dev/neuron<N>` the pointer belongs to, place one buffer on the first core of each distinct device. 86.45 GB/s over 16 devices against 80.02 before, matching an explicit `--neuron_core_stride=2` (87.33) within 1%.

Sweep at 16 buffers × 8 GB: every knob is inside the ±2% spread above 16 threads, including `--block_size` all the way down to 256 KB — the ceiling is not the wire. Peak **88.15 GB/s = 88% of the 100 GB/s line rate**; the device ladder is 14.20 (1 device) / 40.24 (4) / 82.67 (8) / 86.5–89.6 (16), which tracks how many of the four root buses the buffers reach rather than the device count itself. The **CPU-to-CPU control is 97.2 GB/s** (97% of line rate, flat over five shapes), so unlike trn2 host DRAM is slightly *faster* than the HBM path here — the case for moving HBM directly on trn1 is avoiding the `nrt_tensor_read()` staging copy, its buffer and its CPU time, not raw throughput.

The benchmark also refuses to start rather than guess: a `--nic_priority_matrix` it cannot open or parse is fatal (it used to fall through to a fabricated matrix naming `--device_name`, i.e. a NIC that exists on no Trainium host), and so is `--neuron_device` with any protocol other than `efa` -- these buffers are registered under the wildcard location on purpose, so the location string cannot be the guard.

New bench flags: `--neuron_device` (logical NeuronCore, `-1` disables), `--neuron_device_count`, `--neuron_core_stride` (0, the default, probes for one core per physical device — see the trn1 section above), `--neuron_fill_byte`. Both sides must agree on `--neuron_device_count` and `--neuron_core_stride`, since the initiator indexes the *remote* buffer list with its own buffer count — the same constraint the GPU path already has.

**Documentation:** `docs/source/design/transfer-engine/efa_transport.md` gains an AWS Neuron section covering the build (nothing Neuron-specific is needed — a stock `-DUSE_EFA=ON -DUSE_CUDA=OFF` prints `Neuron (FI_HMEM_NEURON): 1`), the PCIe affinity result on both layouts and how to confirm it from the NIC counters, the same-host caveat, the benchmark invocation at the tuned shape, and per-instance tuning sections with the sweeps above. `trn1.32xlarge` is listed as a supported instance type.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


