### PR TITLE
[TransferEngine] Clear pending notify when freeing batch

### DIFF
--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -15,14 +15,17 @@
 #ifndef MULTI_TRANSPORT_H_
 #define MULTI_TRANSPORT_H_
 
+#include <functional>
 #include <unordered_map>
 
 #include "transport/transport.h"
 
 namespace mooncake {
+class TransferEngineImpl;
 class TransferEngineImplTestPeer;
 
 class MultiTransport {
+    friend class TransferEngineImpl;
     friend class TransferEngineImplTestPeer;
 
    public:
@@ -85,6 +88,9 @@ class MultiTransport {
     void *getBaseAddr();
 
    private:
+    Status freeBatchID(BatchID batch_id,
+                       const std::function<void()> &before_delete);
+
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest> &entries,
                           std::vector<size_t> *task_sizes);

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -263,14 +263,12 @@ class TransferEngineImpl {
     }
 
     Status freeBatchID(BatchID batch_id) {
-        // BatchID is pointer-derived and may be reused immediately after free.
-        // Keep release and notify cleanup atomic with notify table access.
-        RWSpinlock::WriteGuard guard(send_notifies_lock_);
-        auto status = multi_transports_->freeBatchID(batch_id);
-        if (status.ok()) {
+        return multi_transports_->freeBatchID(batch_id, [this, batch_id] {
+            // BatchID is pointer-derived. Remove side-table state before the
+            // descriptor is deleted and its address can be reused.
+            RWSpinlock::WriteGuard guard(send_notifies_lock_);
             notifies_to_send_.erase(batch_id);
-        }
-        return status;
+        });
     }
 
     int getNotifies(std::vector<TransferMetadata::NotifyDesc>& notifies);
@@ -366,16 +364,19 @@ class TransferEngineImpl {
         }
 #endif
         if (result.ok() && status.s == TransferStatusEnum::COMPLETED) {
-            // send notify
-            RWSpinlock::WriteGuard guard(send_notifies_lock_);
-            if (!notifies_to_send_.count(batch_id)) return result;
-            auto value = notifies_to_send_[batch_id];
-            auto rc = sendNotifyByID(value.first, value.second);
+            std::pair<SegmentID, TransferMetadata::NotifyDesc> value;
+            {
+                RWSpinlock::WriteGuard guard(send_notifies_lock_);
+                auto notify = notifies_to_send_.find(batch_id);
+                if (notify == notifies_to_send_.end()) return result;
+                value = std::move(notify->second);
+                notifies_to_send_.erase(notify);
+            }
+            auto rc = sendNotifyByID(value.first, std::move(value.second));
             if (rc) {
                 LOG(ERROR) << "Failed to send notify message, error code: "
                            << rc;
             }
-            notifies_to_send_.erase(batch_id);
         }
         return result;
     }

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -263,7 +263,14 @@ class TransferEngineImpl {
     }
 
     Status freeBatchID(BatchID batch_id) {
-        return multi_transports_->freeBatchID(batch_id);
+        // BatchID is pointer-derived and may be reused immediately after free.
+        // Keep release and notify cleanup atomic with notify table access.
+        RWSpinlock::WriteGuard guard(send_notifies_lock_);
+        auto status = multi_transports_->freeBatchID(batch_id);
+        if (status.ok()) {
+            notifies_to_send_.erase(batch_id);
+        }
+        return status;
     }
 
     int getNotifies(std::vector<TransferMetadata::NotifyDesc>& notifies);

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -106,6 +106,11 @@ MultiTransport::BatchID MultiTransport::allocateBatchID(size_t batch_size) {
 }
 
 Status MultiTransport::freeBatchID(BatchID batch_id) {
+    return freeBatchID(batch_id, std::function<void()>());
+}
+
+Status MultiTransport::freeBatchID(BatchID batch_id,
+                                   const std::function<void()>& before_delete) {
     auto& batch_desc = *((BatchDesc*)(batch_id));
     const size_t task_count = batch_desc.task_list.size();
     for (size_t task_id = 0; task_id < task_count; task_id++) {
@@ -113,6 +118,9 @@ Status MultiTransport::freeBatchID(BatchID batch_id) {
             return Status::BatchBusy(
                 "BatchID cannot be freed until all tasks are done");
         }
+    }
+    if (before_delete) {
+        before_delete();
     }
     delete &batch_desc;
 #ifdef CONFIG_USE_BATCH_DESC_SET

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -71,6 +71,11 @@ class TransferEngineImplTestPeer {
     static void setUseBarex(TransferEngineImpl& engine, bool use_barex) {
         engine.use_barex_ = use_barex;
     }
+
+    static size_t pendingNotifyCount(TransferEngineImpl& engine) {
+        RWSpinlock::ReadGuard guard(engine.send_notifies_lock_);
+        return engine.notifies_to_send_.size();
+    }
 };
 
 TEST(TransferEngineAutoDiscoverTest, SelectsEfaForEfaProtocol) {
@@ -269,6 +274,36 @@ class PartialFailureSubmissionTransport : public BatchResultTransport {
 
    private:
     bool extra_slice_ = false;
+};
+
+class TerminalFailureTransport : public BatchResultTransport {
+   public:
+    explicit TerminalFailureTransport(bool initially_finished)
+        : initially_finished_(initially_finished) {}
+
+    Status submitTransferTask(
+        const std::vector<TransferTask*>& tasks) override {
+        tasks_ = tasks;
+        for (auto* task : tasks_) {
+            task->is_finished = initially_finished_;
+        }
+        return Status::OK();
+    }
+
+    Status getTransferStatus(BatchID, size_t, TransferStatus& status) override {
+        status.s = TransferStatusEnum::FAILED;
+        return Status::OK();
+    }
+
+    void finishTasks() {
+        for (auto* task : tasks_) {
+            task->is_finished = true;
+        }
+    }
+
+   private:
+    bool initially_finished_;
+    std::vector<TransferTask*> tasks_;
 };
 
 class TransportTest : public ::testing::Test {
@@ -646,6 +681,74 @@ TEST_F(TransportTest, RegisterLocalMemoryBatchRollsBackAttemptedTransports) {
     EXPECT_EQ(
         engine.unregisterLocalMemoryBatch({buffer.data(), buffer.data() + 1}),
         0);
+}
+
+TEST_F(TransportTest, FreeBatchClearsPendingNotify) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<TerminalFailureTransport>(true);
+    TransferEngineImplTestPeer::replaceTransports(
+        engine, {{"terminal-failure", transport}});
+
+    constexpr SegmentID kSegmentId = 12;
+    auto descriptor = std::make_shared<TransferMetadata::SegmentDesc>();
+    descriptor->name = "remote";
+    descriptor->protocol = "terminal-failure";
+    engine.getMetadata()->addLocalSegment(kSegmentId, "remote",
+                                          std::move(descriptor));
+
+    std::array<char, 1> buffer{};
+    TransferRequest request{.opcode = TransferRequest::READ,
+                            .source = buffer.data(),
+                            .target_id = kSegmentId,
+                            .target_offset = 0,
+                            .length = buffer.size()};
+    auto batch_id = engine.allocateBatchID(1);
+    ASSERT_TRUE(
+        engine
+            .submitTransferWithNotify(batch_id, {request}, {"name", "payload"})
+            .ok());
+    ASSERT_EQ(TransferEngineImplTestPeer::pendingNotifyCount(engine), 1);
+
+    TransferStatus status;
+    ASSERT_TRUE(engine.getBatchTransferStatus(batch_id, status).ok());
+    ASSERT_EQ(status.s, TransferStatusEnum::FAILED);
+    ASSERT_TRUE(engine.freeBatchID(batch_id).ok());
+    EXPECT_EQ(TransferEngineImplTestPeer::pendingNotifyCount(engine), 0);
+}
+
+TEST_F(TransportTest, BusyBatchKeepsPendingNotify) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<TerminalFailureTransport>(false);
+    TransferEngineImplTestPeer::replaceTransports(
+        engine, {{"terminal-failure", transport}});
+
+    constexpr SegmentID kSegmentId = 12;
+    auto descriptor = std::make_shared<TransferMetadata::SegmentDesc>();
+    descriptor->name = "remote";
+    descriptor->protocol = "terminal-failure";
+    engine.getMetadata()->addLocalSegment(kSegmentId, "remote",
+                                          std::move(descriptor));
+
+    std::array<char, 1> buffer{};
+    TransferRequest request{.opcode = TransferRequest::READ,
+                            .source = buffer.data(),
+                            .target_id = kSegmentId,
+                            .target_offset = 0,
+                            .length = buffer.size()};
+    auto batch_id = engine.allocateBatchID(1);
+    ASSERT_TRUE(
+        engine
+            .submitTransferWithNotify(batch_id, {request}, {"name", "payload"})
+            .ok());
+
+    EXPECT_TRUE(engine.freeBatchID(batch_id).IsBatchBusy());
+    EXPECT_EQ(TransferEngineImplTestPeer::pendingNotifyCount(engine), 1);
+
+    transport->finishTasks();
+    ASSERT_TRUE(engine.freeBatchID(batch_id).ok());
+    EXPECT_EQ(TransferEngineImplTestPeer::pendingNotifyCount(engine), 0);
 }
 
 TEST_F(TransportTest, ScatterSubmitFailurePreservesCompletedFragments) {

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -76,6 +76,12 @@ class TransferEngineImplTestPeer {
         RWSpinlock::ReadGuard guard(engine.send_notifies_lock_);
         return engine.notifies_to_send_.size();
     }
+
+    static Status freeBatchWithCallback(
+        TransferEngineImpl& engine, BatchID batch_id,
+        const std::function<void()>& before_delete) {
+        return engine.multi_transports_->freeBatchID(batch_id, before_delete);
+    }
 };
 
 TEST(TransferEngineAutoDiscoverTest, SelectsEfaForEfaProtocol) {
@@ -749,6 +755,37 @@ TEST_F(TransportTest, BusyBatchKeepsPendingNotify) {
     transport->finishTasks();
     ASSERT_TRUE(engine.freeBatchID(batch_id).ok());
     EXPECT_EQ(TransferEngineImplTestPeer::pendingNotifyCount(engine), 0);
+}
+
+TEST_F(TransportTest, BatchCleanupRunsAfterBeforeDeleteCallback) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+
+    bool before_delete_finished = false;
+    bool cleanup_observed_callback = false;
+    struct CleanupProbe {
+        bool* before_delete_finished;
+        bool* cleanup_observed_callback;
+    };
+    CleanupProbe probe{&before_delete_finished, &cleanup_observed_callback};
+
+    auto batch_id = engine.allocateBatchID(1);
+    auto& batch = Transport::toBatchDesc(batch_id);
+    auto& task = batch.task_list.emplace_back();
+    task.is_finished = true;
+    auto* slice = new Transport::Slice();
+    slice->source_addr = &probe;
+    slice->cleanup_callback = [](Transport::Slice* released) {
+        auto* probe = static_cast<CleanupProbe*>(released->source_addr);
+        *probe->cleanup_observed_callback = *probe->before_delete_finished;
+    };
+    task.slice_list.push_back(slice);
+
+    auto status = TransferEngineImplTestPeer::freeBatchWithCallback(
+        engine, batch_id, [&] { before_delete_finished = true; });
+
+    ASSERT_TRUE(status.ok());
+    EXPECT_TRUE(cleanup_observed_callback);
 }
 
 TEST_F(TransportTest, ScatterSubmitFailurePreservesCompletedFragments) {


### PR DESCRIPTION
## Description

Fixes #3890.

Classic Transfer Engine stores notify metadata in `notifies_to_send_`, keyed by the pointer-derived `BatchID`. The entry was removed only when a batch reached `COMPLETED`. A failed batch could therefore be successfully freed while its notification payload remained in the side table, retaining memory and allowing a later batch that reused the same address to observe stale notification state.

This change aligns the notification side table with the batch lifetime:

- `MultiTransport::freeBatchID()` keeps its existing public one-argument ABI and gains a private internal overload with a `before_delete` callback.
- The callback runs only after every task is confirmed finished, so `BatchBusy` preserves the live batch and its notification.
- On a successful release, pending notification state is erased before `BatchDesc` is deleted and its pointer-derived ID can be reused.
- The callback returns before `BatchDesc`, tasks, slices, and transport cleanup callbacks are destroyed, keeping potentially expensive destruction outside the global notification spin lock.
- A completed notification is atomically moved out of the side table under the lock, then sent through RDMA/RPC after the lock is released.

The regression coverage is hardware-independent and verifies:

- a terminal failed batch clears its pending notification after successful release;
- a busy batch keeps its notification until it can be successfully released;
- the internal pre-delete callback completes before batch and slice cleanup begins.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Checks run locally:**

```bash
git diff --check

pre-commit run --files \
  mooncake-transfer-engine/include/multi_transport.h \
  mooncake-transfer-engine/include/transfer_engine_impl.h \
  mooncake-transfer-engine/src/multi_transport.cpp \
  mooncake-transfer-engine/tests/transport_uint_test.cpp
```

The applicable trailing-whitespace, end-of-file, merge-conflict, large-file, clang-format 20, and codespell hooks passed.

The updated C++ tests were not executed locally. The available host is macOS and CMake configuration stops while resolving Linux project dependencies (`yaml-cpp`, followed by the RDMA/Linux stack). The tests are hardware-independent and are expected to run in the repository's Linux CI:

```bash
ctest --test-dir build-ci-local -R transport_uint_test --output-on-failure
```

The previous PR head passed its Linux CTest lane, but that result is not claimed for this updated head; the new CI run remains authoritative.

**Test results:**

- [ ] Unit tests pass (pending Linux CI for the updated head)
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run the applicable pre-commit hooks on all changed files
- [x] I have updated the documentation (not applicable: internal lifecycle correction)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools assisted with code-path analysis, implementation, regression-test design, and static review. The human contributor reviewed every changed line of commit `107113c8`, understands the implementation, and can defend the change end-to-end. Validation limitations are stated above; no unexecuted test is represented as passing.
