### PR TITLE
[Reshard] Execute bound model-weight transfers through Transfer Engine

### DIFF
--- a/docs/source/api-reference/python/transfer-engine.md
+++ b/docs/source/api-reference/python/transfer-engine.md
@@ -58,6 +58,14 @@ TransferOpcode.READ   # Read operation
 TransferOpcode.WRITE  # Write operation
 ```
 
+### Scatter Transfer Completion
+
+`ScatterTransferTicket` keeps the native operation alive and exposes:
+
+- `status`: `COMPLETED`, `FAILED_DRAINED`, or `COMPLETION_UNKNOWN`.
+- `drained`: whether the native operation reached a terminal state.
+- `drain(timeout_ms)`: wait again for an unknown operation to become terminal.
+
 ### Initialization Methods
 
 #### initialize()
@@ -351,6 +359,39 @@ Performs a batch synchronous read operation to transfer multiple data chunks fro
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
+
+#### scatter_transfer_sync_write_with_ticket() / scatter_transfer_sync_read_with_ticket()
+
+```python
+scatter_transfer_sync_write_with_ticket(
+    endpoint,
+    local_base_addresses,
+    local_capacities,
+    remote_base_addresses,
+    remote_capacities,
+    local_offsets,
+    remote_offsets,
+    lengths,
+)
+```
+
+Transfers multiple offset ranges while preserving their backing-allocation
+bounds. The write form copies local ranges to remote ranges; the read form
+copies remote ranges into local ranges.
+
+**Parameters:**
+- `endpoint` (str): The remote Transfer Engine segment.
+- `local_base_addresses` / `remote_base_addresses` (List[int]): Base addresses for each allocation pair.
+- `local_capacities` / `remote_capacities` (List[int]): Registered allocation sizes.
+- `local_offsets` / `remote_offsets` (List[List[int]]): Per-allocation fragment offsets.
+- `lengths` (List[List[int]]): Per-allocation fragment lengths.
+
+All outer lists have the same length. For each allocation pair, the local
+offset, remote offset, and length lists also have the same length. Every
+fragment must fit within both declared capacities.
+
+**Returns:**
+- `ScatterTransferTicket`: A drainable completion handle for the native scatter operation.
 
 #### batch_transfer_sync()
 

--- a/docs/source/design/model-weight-reshard-planner.md
+++ b/docs/source/design/model-weight-reshard-planner.md
@@ -106,6 +106,14 @@ framework activation remain outside this phase. Framework adapters own model
 semantics and conversion into canonical manifests; Mooncake core does not infer
 those semantics from framework objects or parameter names.
 
+The execution companion consumes a bound `TransferPlan` only after framework
+allocation guards return fresh runtime bindings. It validates the planned
+placement, lease, generation, backing allocation, and fragment evidence again
+at the native submission boundary. Live GPU-to-GPU movement lowers compact N-D
+regions to bounded Transfer Engine batches. Store-backed restore uses
+`WeightStore.load()` and `get_into_ranges` with the same target binding
+contract.
+
 ## Reproducible Contract Benchmark
 
 The following opt-in benchmark measures only Python-side planning and binding

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -15,9 +15,12 @@
 #include "transfer_engine_py.h"
 
 #include <cassert>
+#include <chrono>
 #include <cstdlib>
-#include <numeric>
 #include <fstream>
+#include <limits>
+#include <mutex>
+#include <numeric>
 
 #include <pybind11/stl.h>
 #include "shared_segment_py.h"
@@ -56,6 +59,85 @@
 static void* (*allocateMemory)(size_t) = nullptr;
 static void (*freeMemory)(void*) = nullptr;
 static std::string g_protocol;
+
+enum class ScatterTransferCompletionStatus : int {
+    COMPLETED = 0,
+    FAILED_DRAINED = -1,
+    COMPLETION_UNKNOWN = -2,
+};
+
+class ScatterTransferTicket {
+   public:
+    explicit ScatterTransferTicket(
+        std::shared_ptr<TransferEngine::ScatterTransferOperation> operation)
+        : operation_(std::move(operation)) {}
+
+    static std::shared_ptr<ScatterTransferTicket> terminal(
+        ScatterTransferCompletionStatus status) {
+        auto ticket = std::shared_ptr<ScatterTransferTicket>(
+            new ScatterTransferTicket(nullptr));
+        ticket->status_ = status;
+        ticket->drained_ = true;
+        return ticket;
+    }
+
+    ScatterTransferCompletionStatus status() const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return status_;
+    }
+
+    bool drained() const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return drained_;
+    }
+
+    ScatterTransferCompletionStatus drain(uint64_t timeout_ms) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        if (drained_) return status_;
+        if (!operation_) {
+            status_ = ScatterTransferCompletionStatus::FAILED_DRAINED;
+            drained_ = true;
+            return status_;
+        }
+
+        constexpr uint64_t kNanosPerMillis = 1000 * 1000;
+        const auto max_milliseconds =
+            static_cast<uint64_t>(std::chrono::nanoseconds::max().count()) /
+            kNanosPerMillis;
+        const auto bounded_timeout = std::chrono::milliseconds(
+            timeout_ms > max_milliseconds ? max_milliseconds : timeout_ms);
+        Status result = operation_->waitFor(bounded_timeout);
+        if (result.IsClock()) {
+            return ScatterTransferCompletionStatus::COMPLETION_UNKNOWN;
+        }
+
+        status_ = result.ok() ? ScatterTransferCompletionStatus::COMPLETED
+                              : ScatterTransferCompletionStatus::FAILED_DRAINED;
+        drained_ = true;
+        operation_.reset();
+        return status_;
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::shared_ptr<TransferEngine::ScatterTransferOperation> operation_;
+    ScatterTransferCompletionStatus status_ =
+        ScatterTransferCompletionStatus::COMPLETION_UNKNOWN;
+    bool drained_ = false;
+};
+
+namespace {
+
+uint64_t nanosToCeilingMillis(uint64_t timeout_ns) {
+    constexpr uint64_t kNanosPerMillis = 1000 * 1000;
+    if (timeout_ns >
+        std::numeric_limits<uint64_t>::max() - (kNanosPerMillis - 1)) {
+        return std::numeric_limits<uint64_t>::max() / kNanosPerMillis;
+    }
+    return (timeout_ns + kNanosPerMillis - 1) / kNanosPerMillis;
+}
+
+}  // namespace
 
 //  Handle allocateMemory function pointer based on protocol
 void initMemoryAllocator(const char* protocol) {
@@ -458,6 +540,108 @@ int TransferEnginePy::batchTransferSyncRead(
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
                              lengths, TransferOpcode::READ, nullptr,
                              transport_hint);
+}
+
+std::shared_ptr<ScatterTransferTicket>
+TransferEnginePy::scatterTransferSyncWriteWithTicket(
+    const std::string& endpoint,
+    const std::vector<uintptr_t>& local_base_addresses,
+    const std::vector<size_t>& local_capacities,
+    const std::vector<uint64_t>& remote_base_addresses,
+    const std::vector<size_t>& remote_capacities,
+    const std::vector<std::vector<size_t>>& local_offsets,
+    const std::vector<std::vector<size_t>>& remote_offsets,
+    const std::vector<std::vector<size_t>>& lengths) {
+    return scatterTransferSyncWithTicket(
+        endpoint, local_base_addresses, local_capacities, remote_base_addresses,
+        remote_capacities, local_offsets, remote_offsets, lengths,
+        TransferOpcode::WRITE);
+}
+
+std::shared_ptr<ScatterTransferTicket>
+TransferEnginePy::scatterTransferSyncReadWithTicket(
+    const std::string& endpoint,
+    const std::vector<uintptr_t>& local_base_addresses,
+    const std::vector<size_t>& local_capacities,
+    const std::vector<uint64_t>& remote_base_addresses,
+    const std::vector<size_t>& remote_capacities,
+    const std::vector<std::vector<size_t>>& local_offsets,
+    const std::vector<std::vector<size_t>>& remote_offsets,
+    const std::vector<std::vector<size_t>>& lengths) {
+    return scatterTransferSyncWithTicket(
+        endpoint, local_base_addresses, local_capacities, remote_base_addresses,
+        remote_capacities, local_offsets, remote_offsets, lengths,
+        TransferOpcode::READ);
+}
+
+std::shared_ptr<ScatterTransferTicket>
+TransferEnginePy::scatterTransferSyncWithTicket(
+    const std::string& endpoint,
+    const std::vector<uintptr_t>& local_base_addresses,
+    const std::vector<size_t>& local_capacities,
+    const std::vector<uint64_t>& remote_base_addresses,
+    const std::vector<size_t>& remote_capacities,
+    const std::vector<std::vector<size_t>>& local_offsets,
+    const std::vector<std::vector<size_t>>& remote_offsets,
+    const std::vector<std::vector<size_t>>& lengths, TransferOpcode opcode) {
+    pybind11::gil_scoped_release release;
+    const size_t range_count = local_base_addresses.size();
+    if (local_capacities.size() != range_count ||
+        remote_base_addresses.size() != range_count ||
+        remote_capacities.size() != range_count ||
+        local_offsets.size() != range_count ||
+        remote_offsets.size() != range_count || lengths.size() != range_count) {
+        LOG(ERROR) << "Scatter transfer range arrays have different sizes";
+        return ScatterTransferTicket::terminal(
+            ScatterTransferCompletionStatus::FAILED_DRAINED);
+    }
+
+    std::vector<TransferEngine::ScatterTransferRange> ranges;
+    ranges.reserve(range_count);
+    uint64_t total_length = 0;
+    for (size_t i = 0; i < range_count; ++i) {
+        const size_t fragment_count = local_offsets[i].size();
+        if (remote_offsets[i].size() != fragment_count ||
+            lengths[i].size() != fragment_count) {
+            LOG(ERROR) << "Scatter transfer fragment arrays have different "
+                          "sizes at range "
+                       << i;
+            return ScatterTransferTicket::terminal(
+                ScatterTransferCompletionStatus::FAILED_DRAINED);
+        }
+
+        TransferEngine::ScatterTransferRange range;
+        range.opcode = opcode == TransferOpcode::WRITE ? TransferRequest::WRITE
+                                                       : TransferRequest::READ;
+        range.remote_segment = endpoint;
+        range.remote_base_offset = remote_base_addresses[i];
+        range.remote_size = remote_capacities[i];
+        range.local_buffer = reinterpret_cast<void*>(local_base_addresses[i]);
+        range.local_capacity = local_capacities[i];
+        range.local_offsets = local_offsets[i];
+        range.remote_offsets = remote_offsets[i];
+        range.lengths = lengths[i];
+        ranges.push_back(std::move(range));
+
+        for (size_t length : lengths[i]) {
+            if (length > std::numeric_limits<uint64_t>::max() - total_length) {
+                total_length = std::numeric_limits<uint64_t>::max();
+                break;
+            }
+            total_length += length;
+        }
+    }
+
+    auto operation = std::make_shared<TransferEngine::ScatterTransferOperation>(
+        engine_->submitScatter(ranges));
+    auto ticket = std::make_shared<ScatterTransferTicket>(operation);
+    const uint64_t timeout_ns =
+        total_length >
+                std::numeric_limits<uint64_t>::max() - transfer_timeout_nsec_
+            ? std::numeric_limits<uint64_t>::max()
+            : transfer_timeout_nsec_ + total_length;
+    ticket->drain(nanosToCeilingMillis(timeout_ns));
+    return ticket;
 }
 
 batch_id_t TransferEnginePy::batchTransferAsyncWrite(
@@ -1248,6 +1432,32 @@ PYBIND11_MODULE(engine, m) {
         .value("Write", TransferEnginePy::TransferOpcode::WRITE)
         .export_values();
 
+    py::enum_<ScatterTransferCompletionStatus>(
+        m, "ScatterTransferCompletionStatus")
+        .value("COMPLETED", ScatterTransferCompletionStatus::COMPLETED)
+        .value("FAILED_DRAINED",
+               ScatterTransferCompletionStatus::FAILED_DRAINED)
+        .value("COMPLETION_UNKNOWN",
+               ScatterTransferCompletionStatus::COMPLETION_UNKNOWN);
+
+    py::class_<ScatterTransferTicket, std::shared_ptr<ScatterTransferTicket>>(
+        m, "ScatterTransferTicket",
+        "Keeps a scatter operation alive until native DMA is drained.")
+        .def_property_readonly("status",
+                               [](const ScatterTransferTicket& ticket) {
+                                   py::gil_scoped_release release;
+                                   return ticket.status();
+                               })
+        .def_property_readonly("drained",
+                               [](const ScatterTransferTicket& ticket) {
+                                   py::gil_scoped_release release;
+                                   return ticket.drained();
+                               })
+        .def("drain", [](ScatterTransferTicket& ticket, uint64_t timeout_ms) {
+            py::gil_scoped_release release;
+            return ticket.drain(timeout_ms);
+        });
+
     py::class_<TransferEnginePy::TransferNotify>(m, "TransferNotify")
         .def(py::init<>())
         .def(py::init<const std::string&, const std::string&>(),
@@ -1282,6 +1492,20 @@ PYBIND11_MODULE(engine, m) {
                  py::arg("target_hostname"), py::arg("buffers"),
                  py::arg("peer_buffer_addresses"), py::arg("lengths"),
                  py::arg("transport_hint") = "")
+            .def("scatter_transfer_sync_write_with_ticket",
+                 &TransferEnginePy::scatterTransferSyncWriteWithTicket,
+                 py::arg("endpoint"), py::arg("local_base_addresses"),
+                 py::arg("local_capacities"), py::arg("remote_base_addresses"),
+                 py::arg("remote_capacities"), py::arg("local_offsets"),
+                 py::arg("remote_offsets"), py::arg("lengths"),
+                 py::keep_alive<0, 1>())
+            .def("scatter_transfer_sync_read_with_ticket",
+                 &TransferEnginePy::scatterTransferSyncReadWithTicket,
+                 py::arg("endpoint"), py::arg("local_base_addresses"),
+                 py::arg("local_capacities"), py::arg("remote_base_addresses"),
+                 py::arg("remote_capacities"), py::arg("local_offsets"),
+                 py::arg("remote_offsets"), py::arg("lengths"),
+                 py::keep_alive<0, 1>())
             .def("batch_transfer_async_write",
                  &TransferEnginePy::batchTransferAsyncWrite,
                  py::arg("target_hostname"), py::arg("buffers"),

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -32,6 +32,8 @@
 
 using namespace mooncake;
 
+class ScatterTransferTicket;
+
 const static size_t kDefaultBufferCapacity = 2ull * 1024 * 1024 * 1024;
 const static size_t kSlabSizeKBTabLen = 16;
 const static size_t kMaxClassId = kSlabSizeKBTabLen - 1;
@@ -95,6 +97,26 @@ class TransferEnginePy {
                               std::vector<uintptr_t> peer_buffer_addresses,
                               std::vector<size_t> lengths,
                               const std::string &transport_hint = "");
+
+    std::shared_ptr<ScatterTransferTicket> scatterTransferSyncWriteWithTicket(
+        const std::string &endpoint,
+        const std::vector<uintptr_t> &local_base_addresses,
+        const std::vector<size_t> &local_capacities,
+        const std::vector<uint64_t> &remote_base_addresses,
+        const std::vector<size_t> &remote_capacities,
+        const std::vector<std::vector<size_t>> &local_offsets,
+        const std::vector<std::vector<size_t>> &remote_offsets,
+        const std::vector<std::vector<size_t>> &lengths);
+
+    std::shared_ptr<ScatterTransferTicket> scatterTransferSyncReadWithTicket(
+        const std::string &endpoint,
+        const std::vector<uintptr_t> &local_base_addresses,
+        const std::vector<size_t> &local_capacities,
+        const std::vector<uint64_t> &remote_base_addresses,
+        const std::vector<size_t> &remote_capacities,
+        const std::vector<std::vector<size_t>> &local_offsets,
+        const std::vector<std::vector<size_t>> &remote_offsets,
+        const std::vector<std::vector<size_t>> &lengths);
 
     batch_id_t batchTransferAsyncWrite(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
@@ -205,6 +227,16 @@ class TransferEnginePy {
     uintptr_t getEnginePtr() const { return (uintptr_t)engine_.get(); }
 
    private:
+    std::shared_ptr<ScatterTransferTicket> scatterTransferSyncWithTicket(
+        const std::string &endpoint,
+        const std::vector<uintptr_t> &local_base_addresses,
+        const std::vector<size_t> &local_capacities,
+        const std::vector<uint64_t> &remote_base_addresses,
+        const std::vector<size_t> &remote_capacities,
+        const std::vector<std::vector<size_t>> &local_offsets,
+        const std::vector<std::vector<size_t>> &remote_offsets,
+        const std::vector<std::vector<size_t>> &lengths, TransferOpcode opcode);
+
     char *allocateRawBuffer(size_t capacity);
 
     int findClassId(size_t size);

--- a/mooncake-reshard/README.md
+++ b/mooncake-reshard/README.md
@@ -1,9 +1,8 @@
 # Mooncake Reshard
 
 `mooncake-reshard` defines framework-neutral contracts, address-free N-D
-logical planning, runtime binding, and Store-backed snapshots for reusable
-runtime resources. Model-weight storage and Transfer Engine execution remain
-separate runtime phases.
+logical planning, runtime binding, Store-backed snapshots, and execution
+adapters for reusable runtime resources.
 
 Framework-owned adapters inspect framework runtime objects, normalize
 framework-specific values, and construct typed canonical manifests. Mooncake
@@ -15,8 +14,10 @@ The public Python API is split by responsibility:
 - `mooncake.reshard.contracts` exposes `ResourceManifest`,
   `PlacementManifest`, and `RuntimeBindingManifest` as structural `Protocol`
   contracts for resource-neutral identity and lifecycle;
+- `mooncake.reshard.transfer_engine` owns resource-neutral physical batches,
+  completion tracking, pending-resource quarantine, and registration leases;
 - `mooncake.reshard.weight` defines model-weight placement, runtime-binding
-  input contracts, and address-free N-D planning.
+  input contracts, N-D planning, Store, and Transfer Engine adapters.
 
 ## Weight Placement Model
 
@@ -90,6 +91,39 @@ underlying allocation. A Transfer Engine executor must acquire allocation
 guards and revalidate bindings atomically with the submission that consumes
 the plan.
 
+## Transfer Engine Execution
+
+`mooncake.reshard.transfer_engine` executes resource-neutral physical batches
+without model or framework semantics. Its completion fence retains registrations
+and framework allocation tokens when native completion is unknown, then drains
+or quarantines them before a later submission can reuse the same engine.
+
+The current flat `batch_transfer_sync_read/write` binding does not return a
+drainable completion ticket. A zero result is terminal; any non-zero result
+quarantines registrations and allocation tokens as restart-required. A ticket
+API can report a confirmed terminal failure. Registration cleanup failures use
+the same pending lifecycle and retry through `drain_pending_transfer()` before
+allocation tokens are released.
+
+Model-weight execution is exposed through `MooncakeTransferEngineReader` and
+`MooncakeTransferEngineSink`. The reader initiates bounded reads from selected
+live source bindings into one local target binding; the sink submits bounded
+writes from one selected local source binding to target bindings. Both adapters
+consume a bound `TransferPlan`, acquire framework allocation guards, verify the
+fresh binding against the planned placement, generation, lease, allocation, and
+fragment evidence, then lower N-D regions into bounded physical batches.
+
+The lowerer preserves backing-allocation ranges and submits the validated flat
+batch form supported by the current Python Transfer Engine binding.
+`max_batch_operations`, `max_region_segments`, and
+`max_total_lowered_segments` bound physical expansion before native submission.
+The C++ scatter API remains available for a later Python lowering and
+performance-focused integration.
+
+Live TE adapters accept runtime-bound source fragments. Store-backed restore
+continues through `WeightStore.load()`, which uses the same target placement and
+binding contracts with `get_into_ranges`.
+
 ## Store Snapshots
 
 `StoredResourceManifest` is the persistent resource base. The concrete
@@ -146,6 +180,10 @@ placement, runtime binding, and allocation guards required by `get_into_ranges`.
   a logical plan to typed runtime snapshots and validate physical evidence.
 - `planner.py` exposes both logical planning and runtime-binding APIs.
 - `manifest.py` preserves the public import surface.
+- `transfer_engine/` contains resource-neutral physical transfer batches,
+  registration, completion, and pending-resource lifecycle management.
+- `_te/` contains weight-specific N-D lowering plus source/target execution
+  adapters; `te.py` preserves their public import surface.
 
 `kv_cache` remains reserved as a resource discriminator. This change does not
 define a KVCache manifest; a future KVCache reshard adapter can reuse the

--- a/mooncake-reshard/README.md
+++ b/mooncake-reshard/README.md
@@ -98,12 +98,18 @@ without model or framework semantics. Its completion fence retains registrations
 and framework allocation tokens when native completion is unknown, then drains
 or quarantines them before a later submission can reuse the same engine.
 
-The current flat `batch_transfer_sync_read/write` binding does not return a
-drainable completion ticket. A zero result is terminal; any non-zero result
-quarantines registrations and allocation tokens as restart-required. A ticket
-API can report a confirmed terminal failure. Registration cleanup failures use
-the same pending lifecycle and retry through `drain_pending_transfer()` before
-allocation tokens are released.
+Range batches use
+`scatter_transfer_sync_read/write_with_ticket`, which forwards allocation
+bases, capacities, and offset vectors to `TransferEngine::submitScatter()`.
+The returned ticket distinguishes completed, failed-and-drained, and unknown
+completion. Unknown completion retains registrations and allocation tokens
+until `drain_pending_transfer()` reaches a terminal state.
+
+Engines without the scatter ticket entry point continue to use the flat
+`batch_transfer_sync_read/write` compatibility path. A zero result is terminal;
+any non-zero result quarantines registrations and allocation tokens as
+restart-required because the flat API provides no drainable operation handle.
+Registration cleanup failures use the same pending lifecycle.
 
 Model-weight execution is exposed through `MooncakeTransferEngineReader` and
 `MooncakeTransferEngineSink`. The reader initiates bounded reads from selected
@@ -113,12 +119,11 @@ consume a bound `TransferPlan`, acquire framework allocation guards, verify the
 fresh binding against the planned placement, generation, lease, allocation, and
 fragment evidence, then lower N-D regions into bounded physical batches.
 
-The lowerer preserves backing-allocation ranges and submits the validated flat
-batch form supported by the current Python Transfer Engine binding.
-`max_batch_operations`, `max_region_segments`, and
-`max_total_lowered_segments` bound physical expansion before native submission.
-The C++ scatter API remains available for a later Python lowering and
-performance-focused integration.
+The lowerer preserves backing-allocation ranges. Range batches stay grouped by
+allocation and are submitted through the scatter ticket API; flat batches use
+the compatibility entry point. `max_batch_operations`,
+`max_region_segments`, and `max_total_lowered_segments` bound physical
+expansion before native submission.
 
 Live TE adapters accept runtime-bound source fragments. Store-backed restore
 continues through `WeightStore.load()`, which uses the same target placement and

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/__init__.py
@@ -1,0 +1,39 @@
+"""Physical transfer primitives shared by reusable resource adapters."""
+
+from .completion import (
+    PendingTransferManager,
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    TransferRegistrationCleanupPendingError,
+)
+from .contracts import (
+    TransferBatch,
+    TransferBatchRange,
+    TransferBatchReceipt,
+    TransferDirection,
+)
+from .executor import MooncakeTransferEngineExecutor
+from .lifetime import (
+    AllocationFence,
+    AllocationLifetimeToken,
+    TerminalTransferState,
+)
+from .registration import BufferRegistrationLease
+
+__all__ = [
+    "BufferRegistrationLease",
+    "AllocationFence",
+    "AllocationLifetimeToken",
+    "MooncakeTransferEngineExecutor",
+    "PendingTransferManager",
+    "TransferBatch",
+    "TransferBatchRange",
+    "TransferBatchReceipt",
+    "TransferCompletionUnknownError",
+    "TransferCompletionFailedError",
+    "TransferDirection",
+    "TransferEngineError",
+    "TransferRegistrationCleanupPendingError",
+    "TerminalTransferState",
+]

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/completion.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/completion.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Sequence, Union
+from uuid import uuid4
+
+from .lifetime import (
+    AllocationLifetimeToken,
+    TerminalTransferState,
+    release_tokens_after_terminal,
+)
+
+
+class TransferEngineError(RuntimeError):
+    pass
+
+
+class TransferCompletionUnknownError(TransferEngineError):
+    def __init__(self, message: str, *, pending_transfer_id: str) -> None:
+        super().__init__(message)
+        self.pending_transfer_id = pending_transfer_id
+
+
+class TransferCompletionFailedError(TransferEngineError):
+    """Native transfer reached a known terminal failure state."""
+
+
+class TransferRegistrationCleanupPendingError(TransferEngineError):
+    """Registration cleanup is quarantined until retry reaches a terminal state."""
+
+    def __init__(self, message: str, *, pending_transfer_id: str) -> None:
+        super().__init__(message)
+        self.pending_transfer_id = pending_transfer_id
+
+
+class _CompletionUnknown(RuntimeError):
+    def __init__(self, ticket: Any) -> None:
+        super().__init__("transfer completion remains unknown")
+        self.ticket = ticket
+
+
+class _CompletionWaitInterrupted(BaseException):
+    def __init__(self, ticket: Any, interruption: BaseException) -> None:
+        super().__init__(str(interruption))
+        self.ticket = ticket
+        self.interruption = interruption
+
+
+class _PendingCompletionWaitInterrupted(BaseException):
+    def __init__(
+        self,
+        pending_transfer_id: str,
+        interruption: BaseException,
+    ) -> None:
+        super().__init__(str(interruption))
+        self.pending_transfer_id = pending_transfer_id
+        self.interruption = interruption
+
+
+class _UndrainableCompletionUnknownTicket:
+    status = "COMPLETION_UNKNOWN"
+    restart_required = True
+
+    def drain(self, timeout_ms: int) -> str:
+        return self.status
+
+
+class _TerminalCleanupTicket:
+    restart_required = False
+
+    def __init__(self, status: str) -> None:
+        self.status = status
+
+    def drain(self, timeout_ms: int) -> str:
+        return self.status
+
+
+def _canonical_engine_identity(engine: Any) -> tuple[str, int]:
+    try:
+        get_engine_ptr = getattr(engine, "get_engine_ptr", None)
+    except Exception as error:
+        raise TransferEngineError(
+            "failed to resolve canonical engine identity"
+        ) from error
+    if not callable(get_engine_ptr):
+        return ("python", id(engine))
+    try:
+        engine_ptr = get_engine_ptr()
+    except Exception as error:
+        raise TransferEngineError(
+            "failed to resolve canonical engine identity"
+        ) from error
+    if type(engine_ptr) is not int or engine_ptr <= 0:
+        raise TransferEngineError(
+            "get_engine_ptr returned an invalid canonical engine identity"
+        )
+    return ("native", engine_ptr)
+
+
+@dataclass
+class _PendingTransfer:
+    engine: Any
+    engine_identity: tuple[str, int]
+    ticket: Any
+    registrations: set[int]
+    resources: tuple[Any, ...]
+    allocation_tokens: tuple[AllocationLifetimeToken, ...]
+    restart_required: bool
+    terminal_state: TerminalTransferState | None = None
+    resources_handed_off: bool = False
+    draining: bool = False
+
+
+_pending_transfer_lock = Lock()
+_pending_transfers: dict[str, _PendingTransfer] = {}
+_active_submission_engine_ids: set[tuple[str, int]] = set()
+
+
+def _completion_status_name(status: Any) -> str:
+    name = getattr(status, "name", None)
+    if isinstance(name, str):
+        return name
+    try:
+        value = int(status)
+    except (TypeError, ValueError):
+        value = None
+    by_value = {
+        0: "COMPLETED",
+        -1: "FAILED_DRAINED",
+        -2: "COMPLETION_UNKNOWN",
+    }
+    if value in by_value:
+        return by_value[value]
+    text = str(status)
+    for candidate in by_value.values():
+        if candidate in text:
+            return candidate
+    return text
+
+
+def _batch_transfer_with_completion_fence(
+    engine: Any,
+    *,
+    ticket_method_name: str,
+    legacy_method_name: str,
+    arguments: tuple[Any, ...],
+    max_drain_attempts: int,
+    drain_timeout_ms: int,
+) -> Union[int, str]:
+    ticket_method = getattr(engine, ticket_method_name, None)
+    if not callable(ticket_method):
+        try:
+            result = getattr(engine, legacy_method_name)(*arguments)
+        except Exception as error:
+            # A legacy call does not return a drainable completion token. Once
+            # it throws, the caller cannot prove whether DMA was submitted.
+            raise _CompletionUnknown(_UndrainableCompletionUnknownTicket()) from error
+        except BaseException as error:
+            raise _CompletionWaitInterrupted(
+                _UndrainableCompletionUnknownTicket(),
+                error,
+            ) from error
+        if result != 0:
+            # The legacy synchronous API has no ticket. A non-zero result can
+            # represent a timeout while native DMA still owns the allocation.
+            raise _CompletionUnknown(_UndrainableCompletionUnknownTicket())
+        return result
+
+    try:
+        ticket = ticket_method(*arguments)
+    except Exception as error:
+        # A ticket-bearing entry point can also cross the native submission
+        # boundary before throwing. With no ticket to drain, fail closed and
+        # require engine restart rather than releasing caller allocations.
+        raise _CompletionUnknown(_UndrainableCompletionUnknownTicket()) from error
+    except BaseException as error:
+        # The call may have crossed the native submission boundary before the
+        # interruption. Without a returned ticket, only restart is safe.
+        raise _CompletionWaitInterrupted(
+            _UndrainableCompletionUnknownTicket(),
+            error,
+        ) from error
+    try:
+        status_name = _completion_status_name(ticket.status)
+    except Exception as error:
+        # A ticket exists but its status cannot be observed. DMA may still
+        # reference caller allocations, so retain the ticket for quarantine.
+        raise _CompletionUnknown(ticket) from error
+    except BaseException as error:
+        raise _CompletionWaitInterrupted(ticket, error) from error
+    for _ in range(max_drain_attempts):
+        if status_name != "COMPLETION_UNKNOWN":
+            break
+        try:
+            status = ticket.drain(drain_timeout_ms)
+        except Exception:
+            # UNKNOWN means native DMA may still reference caller buffers.
+            continue
+        except BaseException as error:
+            raise _CompletionWaitInterrupted(ticket, error) from error
+        status_name = _completion_status_name(status)
+    if status_name == "COMPLETION_UNKNOWN":
+        raise _CompletionUnknown(ticket)
+    return 0 if status_name == "COMPLETED" else status_name
+
+
+class PendingTransferManager:
+    """Own completion quarantine and submission state for one engine identity."""
+
+    def __init__(self, engine: Any) -> None:
+        self.engine = engine
+        self.engine_identity = _canonical_engine_identity(engine)
+
+    def _retain_pending_ticket(
+        self,
+        ticket: Any,
+        *,
+        terminal_state: TerminalTransferState | None = None,
+    ) -> str:
+        pending_transfer_id = uuid4().hex
+        with _pending_transfer_lock:
+            _pending_transfers[pending_transfer_id] = _PendingTransfer(
+                engine=self.engine,
+                engine_identity=self.engine_identity,
+                ticket=ticket,
+                registrations=set(),
+                resources=(),
+                allocation_tokens=(),
+                restart_required=getattr(ticket, "restart_required", False),
+                terminal_state=terminal_state,
+            )
+        return pending_transfer_id
+
+    def _retain_pending_registration_cleanup(
+        self,
+        *,
+        terminal_state: TerminalTransferState,
+        registrations: Sequence[int],
+        resources: Sequence[Any],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> str:
+        if not isinstance(terminal_state, TerminalTransferState):
+            raise TypeError("terminal_state must be a TerminalTransferState")
+        status = {
+            TerminalTransferState.ABORTED: "ABORTED",
+            TerminalTransferState.COMPLETED: "COMPLETED",
+            TerminalTransferState.FAILED_DRAINED: "FAILED_DRAINED",
+        }[terminal_state]
+        token_ids: set[str] = set()
+        for token in allocation_tokens:
+            token_id = token.fence.token_id
+            if token_id in token_ids:
+                raise TransferEngineError(
+                    "pending registration cleanup has duplicate allocation lifetime token"
+                )
+            token_ids.add(token_id)
+        pending_transfer_id = uuid4().hex
+        with _pending_transfer_lock:
+            _pending_transfers[pending_transfer_id] = _PendingTransfer(
+                engine=self.engine,
+                engine_identity=self.engine_identity,
+                ticket=_TerminalCleanupTicket(status),
+                registrations=set(registrations),
+                resources=tuple(resources),
+                allocation_tokens=tuple(allocation_tokens),
+                restart_required=False,
+                terminal_state=terminal_state,
+                resources_handed_off=True,
+            )
+        return pending_transfer_id
+
+    def _retain_pending_resources(
+        self,
+        pending_transfer_id: str,
+        *,
+        registrations: Sequence[int],
+        resources: Sequence[Any],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> None:
+        with _pending_transfer_lock:
+            pending = _pending_transfers.get(pending_transfer_id)
+            if pending is None:
+                raise TransferEngineError(
+                    f"pending transfer does not exist: {pending_transfer_id}"
+                )
+            if pending.engine_identity != self.engine_identity:
+                raise TransferEngineError(
+                    f"pending transfer does not exist: {pending_transfer_id}"
+                )
+            if pending.resources_handed_off:
+                raise TransferEngineError(
+                    "pending transfer resources were already handed off: "
+                    f"{pending_transfer_id}"
+                )
+            pending.registrations.update(registrations)
+            pending.resources += tuple(resources)
+            token_ids = {token.fence.token_id for token in pending.allocation_tokens}
+            for token in allocation_tokens:
+                if token.fence.token_id in token_ids:
+                    raise TransferEngineError(
+                        "pending transfer has duplicate allocation lifetime token"
+                    )
+                token_ids.add(token.fence.token_id)
+            pending.allocation_tokens += tuple(allocation_tokens)
+            pending.resources_handed_off = True
+
+    def _reserve_submission(self) -> None:
+        with _pending_transfer_lock:
+            pending = sorted(
+                (
+                    transfer_id,
+                    transfer,
+                )
+                for transfer_id, transfer in _pending_transfers.items()
+                if transfer.engine_identity == self.engine_identity
+            )
+            if pending:
+                pending_transfer_id, transfer = pending[0]
+                if transfer.restart_required:
+                    raise TransferEngineError(
+                        "transfer engine is blocked by restart-required pending "
+                        f"transfer {pending_transfer_id}; restart before submitting "
+                        "another transfer"
+                    )
+                raise TransferEngineError(
+                    f"transfer engine has pending transfer {pending_transfer_id}; "
+                    "call drain_pending_transfer before submitting another transfer, "
+                    "or restart if it cannot be drained"
+                )
+            if self.engine_identity in _active_submission_engine_ids:
+                raise TransferEngineError(
+                    "transfer engine already has an active resource transfer submission"
+                )
+            _active_submission_engine_ids.add(self.engine_identity)
+
+    def _release_submission(self) -> None:
+        with _pending_transfer_lock:
+            _active_submission_engine_ids.remove(self.engine_identity)
+
+    def _get_pending_transfer(
+        self,
+        pending_transfer_id: str,
+    ) -> _PendingTransfer:
+        pending = _pending_transfers.get(pending_transfer_id)
+        if pending is None or pending.engine_identity != self.engine_identity:
+            raise TransferEngineError(
+                f"pending transfer does not exist: {pending_transfer_id}"
+            )
+        return pending
+
+    def pending_transfer_ids(self) -> tuple[str, ...]:
+        with _pending_transfer_lock:
+            return tuple(
+                sorted(
+                    transfer_id
+                    for transfer_id, pending in _pending_transfers.items()
+                    if pending.engine_identity == self.engine_identity
+                )
+            )
+
+    def pending_transfer_status(self, pending_transfer_id: str) -> str:
+        with _pending_transfer_lock:
+            pending = self._get_pending_transfer(pending_transfer_id)
+            if not pending.resources_handed_off:
+                raise TransferEngineError(
+                    "pending transfer resource handoff is incomplete: "
+                    f"{pending_transfer_id}"
+                )
+            status = _completion_status_name(pending.ticket.status)
+            if pending.restart_required and status == "COMPLETION_UNKNOWN":
+                return "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+            return status
+
+    def drain_pending_transfer(
+        self,
+        pending_transfer_id: str,
+        *,
+        timeout_ms: int = 1000,
+    ) -> str:
+        if timeout_ms < 0:
+            raise ValueError("timeout_ms must be non-negative")
+        with _pending_transfer_lock:
+            pending = self._get_pending_transfer(pending_transfer_id)
+            if not pending.resources_handed_off:
+                raise TransferEngineError(
+                    "pending transfer resource handoff is incomplete: "
+                    f"{pending_transfer_id}"
+                )
+            if pending.draining:
+                raise TransferEngineError(
+                    f"pending transfer is already being drained: {pending_transfer_id}"
+                )
+            pending.draining = True
+            ticket = pending.ticket
+            cleanup_engine = pending.engine
+        try:
+            try:
+                status_name = _completion_status_name(ticket.drain(timeout_ms))
+            except Exception:
+                return "COMPLETION_UNKNOWN"
+            if status_name == "COMPLETION_UNKNOWN":
+                return status_name
+
+            with _pending_transfer_lock:
+                current = _pending_transfers.get(pending_transfer_id)
+                if current is None:
+                    raise TransferEngineError(
+                        f"pending transfer does not exist: {pending_transfer_id}"
+                    )
+                owned = set(current.registrations)
+                terminal_state = current.terminal_state
+            failures = []
+            failed_addresses = set()
+            for address in sorted(owned, reverse=True):
+                try:
+                    result = cleanup_engine.unregister_memory(address)
+                except Exception as error:
+                    failures.append((address, repr(error)))
+                    failed_addresses.add(address)
+                    continue
+                if result != 0:
+                    failures.append((address, result))
+                    failed_addresses.add(address)
+            with _pending_transfer_lock:
+                if failures:
+                    current = _pending_transfers.get(pending_transfer_id)
+                    if current is not None:
+                        current.registrations = failed_addresses
+                else:
+                    current = _pending_transfers.get(pending_transfer_id)
+                    if current is None:
+                        raise TransferEngineError(
+                            f"pending transfer does not exist: {pending_transfer_id}"
+                        )
+                    allocation_tokens = current.allocation_tokens
+                    current.allocation_tokens = ()
+            if failures:
+                raise TransferEngineError(
+                    f"pending transfer registration cleanup failed: {failures}"
+                )
+            if terminal_state is None:
+                terminal_state = (
+                    TerminalTransferState.COMPLETED
+                    if status_name == "COMPLETED"
+                    else TerminalTransferState.FAILED_DRAINED
+                )
+            try:
+                release_tokens_after_terminal(allocation_tokens, terminal_state)
+            except Exception as error:
+                with _pending_transfer_lock:
+                    current = _pending_transfers.get(pending_transfer_id)
+                    if current is not None:
+                        current.allocation_tokens = allocation_tokens
+                raise TransferEngineError(
+                    f"pending transfer allocation lifetime release failed: {error}"
+                ) from error
+            with _pending_transfer_lock:
+                _pending_transfers.pop(pending_transfer_id, None)
+            return status_name
+        finally:
+            with _pending_transfer_lock:
+                pending = _pending_transfers.get(pending_transfer_id)
+                if pending is not None:
+                    pending.draining = False

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/contracts.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/contracts.py
@@ -1,0 +1,164 @@
+"""Resource-neutral physical transfer batches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+_MAX_U64 = (1 << 64) - 1
+
+
+class TransferDirection(str, Enum):
+    READ = "read"
+    WRITE = "write"
+
+
+@dataclass(frozen=True)
+class TransferBatchRange:
+    """Fragments sharing one contiguous source and target allocation."""
+
+    source_base_address: int
+    source_capacity: int
+    target_base_address: int
+    target_capacity: int
+    source_offsets: tuple[int, ...]
+    target_offsets: tuple[int, ...]
+    sizes: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        for name in (
+            "source_base_address",
+            "source_capacity",
+            "target_base_address",
+            "target_capacity",
+        ):
+            value = getattr(self, name)
+            if type(value) is not int or value <= 0 or value > _MAX_U64:
+                raise ValueError(f"transfer range {name} is invalid")
+        for side in ("source", "target"):
+            base = getattr(self, f"{side}_base_address")
+            capacity = getattr(self, f"{side}_capacity")
+            if capacity > _MAX_U64 - base:
+                raise ValueError(f"transfer range {side} allocation overflows")
+
+        object.__setattr__(self, "source_offsets", tuple(self.source_offsets))
+        object.__setattr__(self, "target_offsets", tuple(self.target_offsets))
+        object.__setattr__(self, "sizes", tuple(self.sizes))
+        lengths = {
+            len(self.source_offsets),
+            len(self.target_offsets),
+            len(self.sizes),
+        }
+        if lengths != {len(self.sizes)} or not self.sizes:
+            raise ValueError("transfer range fragments must be non-empty and aligned")
+        for index, size in enumerate(self.sizes):
+            if type(size) is not int or size <= 0 or size > _MAX_U64:
+                raise ValueError("transfer range size is invalid")
+            for side in ("source", "target"):
+                offset = getattr(self, f"{side}_offsets")[index]
+                capacity = getattr(self, f"{side}_capacity")
+                if type(offset) is not int or offset < 0 or offset > _MAX_U64:
+                    raise ValueError(f"transfer range {side} offset is invalid")
+                if offset > capacity or size > capacity - offset:
+                    raise ValueError(f"transfer range exceeds {side} allocation bounds")
+
+    @property
+    def operation_count(self) -> int:
+        return len(self.sizes)
+
+
+@dataclass(frozen=True)
+class TransferBatch:
+    endpoint: str
+    source_addresses: tuple[int, ...]
+    target_addresses: tuple[int, ...]
+    sizes: tuple[int, ...]
+    ranges: tuple[TransferBatchRange, ...] = ()
+
+    def __post_init__(self) -> None:
+        if type(self.endpoint) is not str or not self.endpoint:
+            raise ValueError("transfer endpoint must be a non-empty string")
+        object.__setattr__(self, "source_addresses", tuple(self.source_addresses))
+        object.__setattr__(self, "target_addresses", tuple(self.target_addresses))
+        object.__setattr__(self, "sizes", tuple(self.sizes))
+        object.__setattr__(self, "ranges", tuple(self.ranges))
+        lengths = {
+            len(self.source_addresses),
+            len(self.target_addresses),
+            len(self.sizes),
+        }
+        if lengths != {len(self.sizes)} or not self.sizes:
+            raise ValueError("transfer batch ranges must be non-empty and aligned")
+        for name, values in (
+            ("source address", self.source_addresses),
+            ("target address", self.target_addresses),
+            ("size", self.sizes),
+        ):
+            for value in values:
+                if type(value) is not int or value <= 0 or value > _MAX_U64:
+                    raise ValueError(f"transfer batch {name} is invalid")
+        if self.ranges:
+            if not all(isinstance(item, TransferBatchRange) for item in self.ranges):
+                raise ValueError("transfer batch ranges are invalid")
+            range_source_addresses = tuple(
+                item.source_base_address + offset
+                for item in self.ranges
+                for offset in item.source_offsets
+            )
+            range_target_addresses = tuple(
+                item.target_base_address + offset
+                for item in self.ranges
+                for offset in item.target_offsets
+            )
+            range_sizes = tuple(size for item in self.ranges for size in item.sizes)
+            if (
+                range_source_addresses != self.source_addresses
+                or range_target_addresses != self.target_addresses
+                or range_sizes != self.sizes
+            ):
+                raise ValueError(
+                    "transfer batch ranges do not match flattened addresses"
+                )
+
+    @classmethod
+    def from_ranges(
+        cls,
+        *,
+        endpoint: str,
+        ranges: tuple[TransferBatchRange, ...],
+    ) -> TransferBatch:
+        ranges = tuple(ranges)
+        if not ranges:
+            raise ValueError("transfer batch ranges must not be empty")
+        return cls(
+            endpoint=endpoint,
+            source_addresses=tuple(
+                item.source_base_address + offset
+                for item in ranges
+                for offset in item.source_offsets
+            ),
+            target_addresses=tuple(
+                item.target_base_address + offset
+                for item in ranges
+                for offset in item.target_offsets
+            ),
+            sizes=tuple(size for item in ranges for size in item.sizes),
+            ranges=ranges,
+        )
+
+    @property
+    def operation_count(self) -> int:
+        return len(self.sizes)
+
+    @property
+    def nbytes(self) -> int:
+        return sum(self.sizes)
+
+
+@dataclass(frozen=True)
+class TransferBatchReceipt:
+    endpoint: str
+    direction: TransferDirection
+    operation_count: int
+    nbytes: int

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/executor.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/executor.py
@@ -1,0 +1,194 @@
+"""Resource-neutral Mooncake Transfer Engine batch execution."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from collections.abc import Iterator
+from typing import Any, Sequence
+
+from .completion import (
+    PendingTransferManager,
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    _CompletionUnknown,
+    _CompletionWaitInterrupted,
+    _PendingCompletionWaitInterrupted,
+    _batch_transfer_with_completion_fence,
+)
+from .contracts import TransferBatch, TransferBatchReceipt, TransferDirection
+from .lifetime import AllocationLifetimeToken
+
+
+class MooncakeTransferEngineExecutor:
+    """Submit address ranges without owning weight or KV semantics."""
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        max_completion_drain_attempts: int = 3,
+        completion_drain_timeout_ms: int = 1000,
+    ) -> None:
+        if (
+            type(max_completion_drain_attempts) is not int
+            or max_completion_drain_attempts < 0
+        ):
+            raise ValueError("max_completion_drain_attempts must be non-negative")
+        if (
+            type(completion_drain_timeout_ms) is not int
+            or completion_drain_timeout_ms < 0
+        ):
+            raise ValueError("completion_drain_timeout_ms must be non-negative")
+        self.engine = engine
+        self.max_completion_drain_attempts = max_completion_drain_attempts
+        self.completion_drain_timeout_ms = completion_drain_timeout_ms
+        self.pending_manager = PendingTransferManager(engine)
+
+    @contextmanager
+    def submission(self) -> Iterator[None]:
+        """Reserve the native engine across all batches of one resource plan."""
+
+        self.pending_manager._reserve_submission()
+        try:
+            yield
+        finally:
+            self.pending_manager._release_submission()
+
+    def execute_batch(
+        self,
+        batch: TransferBatch,
+        direction: TransferDirection,
+    ) -> TransferBatchReceipt:
+        """Execute one standalone batch with engine-wide admission fencing."""
+
+        with self.submission():
+            return self._execute_reserved_batch(batch, direction)
+
+    def _execute_reserved_batch(
+        self,
+        batch: TransferBatch,
+        direction: TransferDirection,
+    ) -> TransferBatchReceipt:
+        """Execute a batch inside an already reserved resource submission."""
+
+        if not isinstance(batch, TransferBatch):
+            raise TypeError("batch must be a TransferBatch")
+        if not isinstance(direction, TransferDirection):
+            raise TypeError("direction must be a TransferDirection")
+
+        if direction is TransferDirection.READ:
+            ticket_method_name = "batch_transfer_sync_read_with_ticket"
+            legacy_method_name = "batch_transfer_sync_read"
+            arguments = (
+                batch.endpoint,
+                list(batch.target_addresses),
+                list(batch.source_addresses),
+                list(batch.sizes),
+            )
+            failure_label = f"from {batch.endpoint}"
+        else:
+            ticket_method_name = "batch_transfer_sync_write_with_ticket"
+            legacy_method_name = "batch_transfer_sync_write"
+            arguments = (
+                batch.endpoint,
+                list(batch.source_addresses),
+                list(batch.target_addresses),
+                list(batch.sizes),
+            )
+            failure_label = f"to {batch.endpoint}"
+
+        try:
+            result = _batch_transfer_with_completion_fence(
+                self.engine,
+                ticket_method_name=ticket_method_name,
+                legacy_method_name=legacy_method_name,
+                arguments=arguments,
+                max_drain_attempts=self.max_completion_drain_attempts,
+                drain_timeout_ms=self.completion_drain_timeout_ms,
+            )
+        except _CompletionUnknown as error:
+            pending_transfer_id = self.pending_manager._retain_pending_ticket(
+                error.ticket
+            )
+            restart_required = getattr(error.ticket, "restart_required", False)
+            suffix = (
+                "; legacy API exposes no drainable ticket, so this engine is "
+                "restart-required"
+                if restart_required
+                else ""
+            )
+            raise TransferCompletionUnknownError(
+                "batch transfer completion is unknown; registrations remain "
+                f"quarantined as {pending_transfer_id}{suffix}",
+                pending_transfer_id=pending_transfer_id,
+            ) from error
+        except _CompletionWaitInterrupted as error:
+            pending_transfer_id = self.pending_manager._retain_pending_ticket(
+                error.ticket
+            )
+            raise _PendingCompletionWaitInterrupted(
+                pending_transfer_id,
+                error.interruption,
+            ) from error
+        except Exception as error:
+            raise TransferEngineError(
+                f"batch transfer {failure_label} failed: {error}"
+            ) from error
+        if result != 0:
+            raise TransferCompletionFailedError(
+                f"batch transfer {failure_label} failed: {result}"
+            )
+        return TransferBatchReceipt(
+            endpoint=batch.endpoint,
+            direction=direction,
+            operation_count=batch.operation_count,
+            nbytes=batch.nbytes,
+        )
+
+    def retain_pending_resources(
+        self,
+        pending_transfer_id: str,
+        *,
+        registrations: Sequence[int],
+        resources: Sequence[Any],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> None:
+        self.pending_manager._retain_pending_resources(
+            pending_transfer_id,
+            registrations=registrations,
+            resources=resources,
+            allocation_tokens=allocation_tokens,
+        )
+
+    def _retain_pending_resources(
+        self,
+        pending_transfer_id: str,
+        *,
+        registrations: Sequence[int],
+        resources: Sequence[Any],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> None:
+        self.retain_pending_resources(
+            pending_transfer_id,
+            registrations=registrations,
+            resources=resources,
+            allocation_tokens=allocation_tokens,
+        )
+
+    def pending_transfer_ids(self) -> tuple[str, ...]:
+        return self.pending_manager.pending_transfer_ids()
+
+    def pending_transfer_status(self, pending_transfer_id: str) -> str:
+        return self.pending_manager.pending_transfer_status(pending_transfer_id)
+
+    def drain_pending_transfer(
+        self,
+        pending_transfer_id: str,
+        *,
+        timeout_ms: int = 1000,
+    ) -> str:
+        return self.pending_manager.drain_pending_transfer(
+            pending_transfer_id,
+            timeout_ms=timeout_ms,
+        )

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/executor.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/executor.py
@@ -77,7 +77,57 @@ class MooncakeTransferEngineExecutor:
         if not isinstance(direction, TransferDirection):
             raise TypeError("direction must be a TransferDirection")
 
-        if direction is TransferDirection.READ:
+        scatter_method_name = (
+            "scatter_transfer_sync_read_with_ticket"
+            if direction is TransferDirection.READ
+            else "scatter_transfer_sync_write_with_ticket"
+        )
+        scatter_method = getattr(self.engine, scatter_method_name, None)
+        if batch.ranges and callable(scatter_method):
+            ticket_method_name = scatter_method_name
+            legacy_method_name = (
+                "batch_transfer_sync_read"
+                if direction is TransferDirection.READ
+                else "batch_transfer_sync_write"
+            )
+            if direction is TransferDirection.READ:
+                local_base_addresses = [
+                    item.target_base_address for item in batch.ranges
+                ]
+                local_capacities = [item.target_capacity for item in batch.ranges]
+                remote_base_addresses = [
+                    item.source_base_address for item in batch.ranges
+                ]
+                remote_capacities = [item.source_capacity for item in batch.ranges]
+                local_offsets = [list(item.target_offsets) for item in batch.ranges]
+                remote_offsets = [list(item.source_offsets) for item in batch.ranges]
+            else:
+                local_base_addresses = [
+                    item.source_base_address for item in batch.ranges
+                ]
+                local_capacities = [item.source_capacity for item in batch.ranges]
+                remote_base_addresses = [
+                    item.target_base_address for item in batch.ranges
+                ]
+                remote_capacities = [item.target_capacity for item in batch.ranges]
+                local_offsets = [list(item.source_offsets) for item in batch.ranges]
+                remote_offsets = [list(item.target_offsets) for item in batch.ranges]
+            arguments = (
+                batch.endpoint,
+                local_base_addresses,
+                local_capacities,
+                remote_base_addresses,
+                remote_capacities,
+                local_offsets,
+                remote_offsets,
+                [list(item.sizes) for item in batch.ranges],
+            )
+            failure_label = (
+                f"from {batch.endpoint}"
+                if direction is TransferDirection.READ
+                else f"to {batch.endpoint}"
+            )
+        elif direction is TransferDirection.READ:
             ticket_method_name = "batch_transfer_sync_read_with_ticket"
             legacy_method_name = "batch_transfer_sync_read"
             arguments = (

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/lifetime.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/lifetime.py
@@ -1,0 +1,17 @@
+"""Compatibility exports for Transfer Engine allocation lifetime contracts."""
+
+from ..lifetime import (
+    AllocationFence,
+    AllocationLifetimeToken,
+    AllocationTokenSet,
+    TerminalTransferState,
+    release_tokens_after_terminal,
+)
+
+__all__ = [
+    "AllocationFence",
+    "AllocationLifetimeToken",
+    "AllocationTokenSet",
+    "TerminalTransferState",
+    "release_tokens_after_terminal",
+]

--- a/mooncake-reshard/python/mooncake/reshard/transfer_engine/registration.py
+++ b/mooncake-reshard/python/mooncake/reshard/transfer_engine/registration.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Generator, NoReturn, Optional, Protocol, Sequence, Union
+
+from ..contracts import LeaseId, RuntimeBindingFragment, RuntimeFragmentId
+from .completion import (
+    _PendingCompletionWaitInterrupted,
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    TransferRegistrationCleanupPendingError,
+)
+from .lifetime import AllocationLifetimeToken, AllocationTokenSet, TerminalTransferState
+
+
+class _RegistrationEngine(Protocol):
+    def register_memory(self, address: int, nbytes: int) -> int: ...
+
+    def unregister_memory(self, address: int) -> int: ...
+
+
+class _PendingResourceOwner(Protocol):
+    def _retain_pending_resources(
+        self,
+        pending_transfer_id: str,
+        *,
+        registrations: Sequence[int],
+        resources: Sequence[object],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> None: ...
+
+    def _retain_pending_registration_cleanup(
+        self,
+        *,
+        terminal_state: TerminalTransferState,
+        registrations: Sequence[int],
+        resources: Sequence[object],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class BufferRegistrationLease:
+    """Lease for one registered allocation plus its bound tensor view."""
+
+    fragment_id: RuntimeFragmentId
+    worker_id: str
+    device: str
+    address: int
+    nbytes: int
+    itemsize: int
+    local_shape: tuple[int, ...]
+    strides_bytes: tuple[int, ...]
+    storage_address: int
+    storage_nbytes: int
+    storage_offset_bytes: int
+    lease_generation: int
+    runtime_lease_id: Optional[LeaseId] = None
+
+    def __post_init__(self) -> None:
+        if not self.fragment_id or not self.worker_id or not self.device:
+            raise ValueError("registration lease identifiers must not be empty")
+        for name in (
+            "address",
+            "nbytes",
+            "itemsize",
+            "storage_address",
+            "storage_nbytes",
+            "storage_offset_bytes",
+            "lease_generation",
+        ):
+            value = getattr(self, name)
+            if type(value) is not int:
+                raise ValueError(f"registration lease {name} must be an integer")
+        if (
+            self.address <= 0
+            or self.nbytes <= 0
+            or self.itemsize <= 0
+            or self.storage_address <= 0
+            or self.storage_nbytes <= 0
+            or self.storage_offset_bytes < 0
+            or self.lease_generation < 0
+        ):
+            raise ValueError("registration lease values are invalid")
+        local_shape = tuple(self.local_shape)
+        strides_bytes = tuple(self.strides_bytes)
+        if (
+            not local_shape
+            or len(local_shape) != len(strides_bytes)
+            or any(type(value) is not int or value <= 0 for value in local_shape)
+            or any(type(value) is not int or value <= 0 for value in strides_bytes)
+        ):
+            raise ValueError("registration lease tensor geometry is invalid")
+        object.__setattr__(self, "local_shape", local_shape)
+        object.__setattr__(self, "strides_bytes", strides_bytes)
+        if self.address != self.storage_address + self.storage_offset_bytes:
+            raise ValueError("registration lease view address is invalid")
+        if self.storage_offset_bytes > self.storage_nbytes - self.nbytes:
+            raise ValueError("registration lease view exceeds allocation")
+        if self.runtime_lease_id is not None and (
+            type(self.runtime_lease_id) is not str or not self.runtime_lease_id
+        ):
+            raise ValueError("registration runtime_lease_id must be a non-empty string")
+
+    @classmethod
+    def from_fragment(
+        cls,
+        fragment: RuntimeBindingFragment,
+        *,
+        lease_generation: int,
+        runtime_lease_id: LeaseId,
+    ) -> BufferRegistrationLease:
+        return cls(
+            fragment_id=fragment.fragment_id,
+            worker_id=fragment.worker_id,
+            device=fragment.device,
+            address=fragment.address,
+            nbytes=fragment.nbytes,
+            itemsize=fragment.itemsize,
+            local_shape=fragment.local_shape,
+            strides_bytes=fragment.strides_bytes,
+            storage_address=fragment.storage_address,
+            storage_nbytes=fragment.storage_nbytes,
+            storage_offset_bytes=fragment.storage_offset_bytes,
+            lease_generation=lease_generation,
+            runtime_lease_id=runtime_lease_id,
+        )
+
+
+def same_runtime_snapshot(
+    current: RuntimeBindingFragment,
+    planned: RuntimeBindingFragment,
+) -> bool:
+    return (
+        current.placement_fragment_id == planned.placement_fragment_id
+        and current.fragment_id == planned.fragment_id
+        and current.address == planned.address
+        and current.nbytes == planned.nbytes
+        and current.worker_id == planned.worker_id
+        and current.endpoint == planned.endpoint
+        and current.device == planned.device
+        and current.itemsize == planned.itemsize
+        and current.local_shape == planned.local_shape
+        and current.strides_bytes == planned.strides_bytes
+        and current.storage_address == planned.storage_address
+        and current.storage_nbytes == planned.storage_nbytes
+        and current.storage_offset_bytes == planned.storage_offset_bytes
+    )
+
+
+def registration_map(
+    registrations: Optional[Sequence[BufferRegistrationLease]],
+    label: str,
+) -> dict[RuntimeFragmentId, BufferRegistrationLease]:
+    if registrations is None:
+        raise TransferEngineError(f"{label} registration leases are required")
+    result: dict[RuntimeFragmentId, BufferRegistrationLease] = {}
+    for registration in registrations:
+        if registration.fragment_id in result:
+            raise TransferEngineError(
+                f"duplicate {label} registration lease: {registration.fragment_id}"
+            )
+        result[registration.fragment_id] = registration
+    return result
+
+
+def validate_registration(
+    fragment: RuntimeBindingFragment,
+    registrations: dict[RuntimeFragmentId, BufferRegistrationLease],
+    label: str,
+    *,
+    lease_generation: int,
+    runtime_lease_id: LeaseId,
+) -> None:
+    registration = registrations.get(fragment.fragment_id)
+    if registration is None or (
+        registration.worker_id != fragment.worker_id
+        or registration.device != fragment.device
+        or registration.address != fragment.address
+        or registration.nbytes != fragment.nbytes
+        or registration.itemsize != fragment.itemsize
+        or registration.local_shape != fragment.local_shape
+        or registration.strides_bytes != fragment.strides_bytes
+        or registration.storage_address != fragment.storage_address
+        or registration.storage_nbytes != fragment.storage_nbytes
+        or registration.storage_offset_bytes != fragment.storage_offset_bytes
+        or registration.lease_generation != lease_generation
+        or registration.runtime_lease_id != runtime_lease_id
+    ):
+        raise TransferEngineError(
+            f"{label} registration lease mismatch: {fragment.fragment_id}"
+        )
+
+
+def _handoff_pending_resources(
+    pending_owner: _PendingResourceOwner,
+    error: Union[TransferCompletionUnknownError, _PendingCompletionWaitInterrupted],
+    *,
+    registrations: Sequence[int],
+    resources: Sequence[object],
+    lifetime_tokens: Optional[AllocationTokenSet] = None,
+) -> BaseException:
+    allocation_tokens = lifetime_tokens.tokens if lifetime_tokens is not None else ()
+    pending_owner._retain_pending_resources(
+        error.pending_transfer_id,
+        registrations=registrations,
+        resources=resources,
+        allocation_tokens=allocation_tokens,
+    )
+    if lifetime_tokens is not None:
+        lifetime_tokens.handoff_to_pending()
+    if isinstance(error, _PendingCompletionWaitInterrupted):
+        return error.interruption
+    return error
+
+
+def _cleanup_terminal_state(
+    primary_error: Optional[BaseException],
+    *,
+    body_entered: bool,
+) -> TerminalTransferState:
+    if primary_error is None:
+        return TerminalTransferState.COMPLETED
+    if isinstance(primary_error, TransferCompletionFailedError):
+        return TerminalTransferState.FAILED_DRAINED
+    if body_entered:
+        return TerminalTransferState.FAILED_DRAINED
+    return TerminalTransferState.ABORTED
+
+
+def _raise_pending_registration_cleanup(
+    pending_owner: _PendingResourceOwner,
+    *,
+    label: str,
+    failures: Sequence[tuple[int, Union[str, int]]],
+    primary_error: Optional[BaseException],
+    body_entered: bool,
+    resources: Sequence[object],
+    lifetime_tokens: Optional[AllocationTokenSet],
+) -> NoReturn:
+    terminal_state = _cleanup_terminal_state(
+        primary_error,
+        body_entered=body_entered,
+    )
+    pending_transfer_id = pending_owner._retain_pending_registration_cleanup(
+        terminal_state=terminal_state,
+        registrations=tuple(address for address, _ in failures),
+        resources=resources,
+        allocation_tokens=(
+            lifetime_tokens.tokens if lifetime_tokens is not None else ()
+        ),
+    )
+    if lifetime_tokens is not None:
+        lifetime_tokens.handoff_to_pending()
+    detail = (
+        f"{label} unregister_memory failed: {list(failures)}; registration "
+        f"cleanup is quarantined as {pending_transfer_id}"
+    )
+    error = TransferRegistrationCleanupPendingError(
+        detail,
+        pending_transfer_id=pending_transfer_id,
+    )
+    if primary_error is not None:
+        raise error from primary_error
+    raise error
+
+
+@contextmanager
+def registered_sources(
+    engine: _RegistrationEngine,
+    pending_owner: _PendingResourceOwner,
+    fragments: Sequence[RuntimeBindingFragment],
+    *,
+    pre_registered: bool,
+    registrations: Optional[Sequence[BufferRegistrationLease]],
+    lease_generation: int,
+    runtime_lease_id: LeaseId,
+    resources: Sequence[object],
+    lifetime_tokens: Optional[AllocationTokenSet] = None,
+) -> Generator[None, None, None]:
+    if pre_registered:
+        registration_by_id = registration_map(registrations, "source")
+        for fragment in fragments:
+            validate_registration(
+                fragment,
+                registration_by_id,
+                "source",
+                lease_generation=lease_generation,
+                runtime_lease_id=runtime_lease_id,
+            )
+        try:
+            yield
+        except (
+            TransferCompletionUnknownError,
+            _PendingCompletionWaitInterrupted,
+        ) as error:
+            raise _handoff_pending_resources(
+                pending_owner,
+                error,
+                registrations=(),
+                resources=resources,
+                lifetime_tokens=lifetime_tokens,
+            )
+        return
+    if registrations is not None:
+        raise TransferEngineError(
+            "source registration leases require source_pre_registered=True"
+        )
+
+    sizes_by_address = _registered_allocations(fragments, "source")
+    owned: list[int] = []
+    body_entered = False
+    primary_error: Optional[BaseException] = None
+    try:
+        for address, nbytes in sizes_by_address.items():
+            try:
+                result = engine.register_memory(address, nbytes)
+            except Exception as error:
+                raise TransferEngineError(
+                    f"source register_memory failed for {address}: {error}"
+                ) from error
+            if result != 0:
+                raise TransferEngineError(
+                    f"source register_memory failed for {address}: {result}"
+                )
+            owned.append(address)
+        body_entered = True
+        yield
+    except BaseException as error:
+        primary_error = error
+
+    if isinstance(
+        primary_error,
+        (
+            TransferCompletionUnknownError,
+            _PendingCompletionWaitInterrupted,
+        ),
+    ):
+        raise _handoff_pending_resources(
+            pending_owner,
+            primary_error,
+            registrations=owned,
+            resources=resources,
+            lifetime_tokens=lifetime_tokens,
+        )
+
+    failures: list[tuple[int, Union[str, int]]] = []
+    for address in reversed(owned):
+        try:
+            result = engine.unregister_memory(address)
+        except Exception as error:
+            failures.append((address, repr(error)))
+            continue
+        if result != 0:
+            failures.append((address, result))
+    if failures:
+        _raise_pending_registration_cleanup(
+            pending_owner,
+            label="source",
+            failures=failures,
+            primary_error=primary_error,
+            body_entered=body_entered,
+            resources=resources,
+            lifetime_tokens=lifetime_tokens,
+        )
+    if primary_error is not None:
+        raise primary_error
+
+
+# Preserve the weight TE public name while exposing a resource-neutral name.
+MemoryRegistrationLease = BufferRegistrationLease
+
+
+@contextmanager
+def registered_targets(
+    engine: _RegistrationEngine,
+    pending_owner: _PendingResourceOwner,
+    fragments: Sequence[RuntimeBindingFragment],
+    *,
+    pre_registered: bool,
+    resources: Sequence[object],
+    lifetime_tokens: Optional[AllocationTokenSet] = None,
+) -> Generator[None, None, None]:
+    if pre_registered:
+        try:
+            yield
+        except (
+            TransferCompletionUnknownError,
+            _PendingCompletionWaitInterrupted,
+        ) as error:
+            raise _handoff_pending_resources(
+                pending_owner,
+                error,
+                registrations=(),
+                resources=resources,
+                lifetime_tokens=lifetime_tokens,
+            )
+        return
+
+    sizes_by_address = _registered_allocations(fragments, "target")
+    owned: list[int] = []
+    body_entered = False
+    primary_error: Optional[BaseException] = None
+    try:
+        for address, nbytes in sizes_by_address.items():
+            try:
+                result = engine.register_memory(address, nbytes)
+            except Exception as error:
+                raise TransferEngineError(
+                    f"target register_memory failed for {address}: {error}"
+                ) from error
+            if result != 0:
+                raise TransferEngineError(
+                    f"target register_memory failed for {address}: {result}"
+                )
+            owned.append(address)
+        body_entered = True
+        yield
+    except BaseException as error:
+        primary_error = error
+
+    if isinstance(
+        primary_error,
+        (
+            TransferCompletionUnknownError,
+            _PendingCompletionWaitInterrupted,
+        ),
+    ):
+        raise _handoff_pending_resources(
+            pending_owner,
+            primary_error,
+            registrations=owned,
+            resources=resources,
+            lifetime_tokens=lifetime_tokens,
+        )
+
+    failures: list[tuple[int, Union[str, int]]] = []
+    for address in reversed(owned):
+        try:
+            result = engine.unregister_memory(address)
+        except Exception as error:
+            failures.append((address, repr(error)))
+            continue
+        if result != 0:
+            failures.append((address, result))
+    if failures:
+        _raise_pending_registration_cleanup(
+            pending_owner,
+            label="target",
+            failures=failures,
+            primary_error=primary_error,
+            body_entered=body_entered,
+            resources=resources,
+            lifetime_tokens=lifetime_tokens,
+        )
+    if primary_error is not None:
+        raise primary_error
+
+
+def _registered_allocations(
+    fragments: Sequence[RuntimeBindingFragment],
+    label: str,
+) -> dict[int, int]:
+    allocations: dict[int, int] = {}
+    for fragment in fragments:
+        existing = allocations.get(fragment.storage_address)
+        if existing is not None and existing != fragment.storage_nbytes:
+            raise TransferEngineError(
+                f"{label} allocation capacity mismatch: {fragment.storage_address}"
+            )
+        allocations[fragment.storage_address] = fragment.storage_nbytes
+    return allocations

--- a/mooncake-reshard/python/mooncake/reshard/weight/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/__init__.py
@@ -53,6 +53,19 @@ from .store import (
     WeightStore,
     WeightStoreError,
 )
+from .te import (
+    DirectReadReceipt,
+    DirectTransferReceipt,
+    MemoryRegistrationLease,
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    TransferRegistrationCleanupPendingError,
+    WeightAllocationGuardProvider,
+    WeightAllocationGuardProviders,
+)
 
 __all__ = [
     "ParallelRank",
@@ -106,4 +119,15 @@ __all__ = [
     "plan_stored_transfer_to_target_placement",
     "resolve_executor_plan",
     "resolve_executor_plans",
+    "DirectReadReceipt",
+    "DirectTransferReceipt",
+    "MemoryRegistrationLease",
+    "MooncakeTransferEngineReader",
+    "MooncakeTransferEngineSink",
+    "TransferCompletionFailedError",
+    "TransferCompletionUnknownError",
+    "TransferEngineError",
+    "TransferRegistrationCleanupPendingError",
+    "WeightAllocationGuardProvider",
+    "WeightAllocationGuardProviders",
 ]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/__init__.py
@@ -1,0 +1,24 @@
+from .completion import (
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    TransferRegistrationCleanupPendingError,
+)
+from .reader import DirectReadReceipt, MooncakeTransferEngineReader
+from .registration import MemoryRegistrationLease
+from .lifetime import WeightAllocationGuardProvider, WeightAllocationGuardProviders
+from .sink import DirectTransferReceipt, MooncakeTransferEngineSink
+
+__all__ = [
+    "DirectReadReceipt",
+    "DirectTransferReceipt",
+    "MemoryRegistrationLease",
+    "WeightAllocationGuardProvider",
+    "WeightAllocationGuardProviders",
+    "MooncakeTransferEngineReader",
+    "MooncakeTransferEngineSink",
+    "TransferCompletionUnknownError",
+    "TransferCompletionFailedError",
+    "TransferEngineError",
+    "TransferRegistrationCleanupPendingError",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/batching.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/batching.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+from ...transfer_engine import TransferBatch, TransferBatchRange
+from ..planner import BoundWeightFragment, LiveTransferOperation
+
+
+def iter_transfer_batches(
+    endpoint: str,
+    operations: Iterable[
+        tuple[LiveTransferOperation, BoundWeightFragment, BoundWeightFragment]
+    ],
+    *,
+    max_batch_operations: int,
+    max_region_segments: int,
+) -> Iterator[TransferBatch]:
+    """Preserve allocation boundaries while bounding physical operations."""
+
+    ranges: list[TransferBatchRange] = []
+    batch_operation_count = 0
+
+    for operation, source, target in operations:
+        source_offsets: list[int] = []
+        target_offsets: list[int] = []
+        sizes: list[int] = []
+
+        for source_offset, target_offset, nbytes in operation.iter_segments(
+            max_segments=max_region_segments
+        ):
+            source_offsets.append(source_offset)
+            target_offsets.append(target_offset)
+            sizes.append(nbytes)
+            batch_operation_count += 1
+
+            if batch_operation_count == max_batch_operations:
+                ranges.append(
+                    _range_from_fragments(
+                        source,
+                        target,
+                        source_offsets,
+                        target_offsets,
+                        sizes,
+                    )
+                )
+                yield TransferBatch.from_ranges(
+                    endpoint=endpoint,
+                    ranges=tuple(ranges),
+                )
+                ranges = []
+                batch_operation_count = 0
+                source_offsets = []
+                target_offsets = []
+                sizes = []
+
+        if sizes:
+            ranges.append(
+                _range_from_fragments(
+                    source,
+                    target,
+                    source_offsets,
+                    target_offsets,
+                    sizes,
+                )
+            )
+
+    if ranges:
+        yield TransferBatch.from_ranges(
+            endpoint=endpoint,
+            ranges=tuple(ranges),
+        )
+
+
+def _range_from_fragments(
+    source: BoundWeightFragment,
+    target: BoundWeightFragment,
+    source_offsets: list[int],
+    target_offsets: list[int],
+    sizes: list[int],
+) -> TransferBatchRange:
+    return TransferBatchRange(
+        source_base_address=source.storage_address,
+        source_capacity=source.storage_nbytes,
+        target_base_address=target.storage_address,
+        target_capacity=target.storage_nbytes,
+        source_offsets=tuple(
+            source.storage_offset_bytes + offset for offset in source_offsets
+        ),
+        target_offsets=tuple(
+            target.storage_offset_bytes + offset for offset in target_offsets
+        ),
+        sizes=tuple(sizes),
+    )

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/completion.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/completion.py
@@ -1,0 +1,15 @@
+"""Compatibility exports for the resource-neutral completion coordinator."""
+
+from ...transfer_engine.completion import (
+    PendingTransferManager,
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+
+__all__ = [
+    "PendingTransferManager",
+    "TransferCompletionFailedError",
+    "TransferCompletionUnknownError",
+    "TransferEngineError",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/completion.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/completion.py
@@ -5,6 +5,7 @@ from ...transfer_engine.completion import (
     TransferCompletionFailedError,
     TransferCompletionUnknownError,
     TransferEngineError,
+    TransferRegistrationCleanupPendingError,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "TransferCompletionFailedError",
     "TransferCompletionUnknownError",
     "TransferEngineError",
+    "TransferRegistrationCleanupPendingError",
 ]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/execution.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/execution.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from typing import Sequence, Union, cast
+
+from ..manifest import (
+    RuntimeBindingFragment,
+    WeightPlacementManifest,
+    WeightRuntimeBindingManifest,
+    validate_runtime_binding,
+)
+from ..planner import (
+    BoundWeightFragment,
+    ExecutableTransferOperation,
+    ExecutorTransferPlan,
+    LiveTransferOperation,
+    TransferPlan,
+    resolve_executor_plans,
+)
+from .completion import TransferEngineError
+
+
+def validate_lowering_limits(
+    *,
+    max_batch_operations: int,
+    max_region_segments: int,
+    max_total_lowered_segments: int,
+    max_completion_drain_attempts: int,
+    completion_drain_timeout_ms: int,
+) -> None:
+    if (
+        max_batch_operations <= 0
+        or max_region_segments <= 0
+        or max_total_lowered_segments <= 0
+        or max_completion_drain_attempts <= 0
+        or completion_drain_timeout_ms < 0
+    ):
+        raise ValueError("transfer lowering limits must be positive")
+
+
+def validate_lowering_budget(
+    operations: Sequence[object],
+    *,
+    max_region_segments: int,
+    max_total_lowered_segments: int,
+) -> None:
+    """Reject an executable lowering before any range expansion starts."""
+
+    total_segments = 0
+    for operation in operations:
+        segment_count = getattr(operation, "segment_count", None)
+        if type(segment_count) is not int or segment_count <= 0:
+            raise TransferEngineError("transfer operation has invalid segment_count")
+        if segment_count > max_region_segments:
+            raise TransferEngineError(
+                "transfer region exceeds max_region_segments: "
+                f"{segment_count} > {max_region_segments}"
+            )
+        total_segments += segment_count
+        if total_segments > max_total_lowered_segments:
+            raise TransferEngineError(
+                "transfer plan exceeds max_total_lowered_segments: "
+                f"{total_segments} > {max_total_lowered_segments}"
+            )
+
+
+def validate_plan_identity(
+    plan: TransferPlan,
+    placement: WeightPlacementManifest,
+    label: str,
+) -> None:
+    if not isinstance(plan, TransferPlan):
+        raise TransferEngineError("plan must be a TransferPlan")
+    if not isinstance(placement, WeightPlacementManifest):
+        raise TransferEngineError(
+            f"{label} placement must be a WeightPlacementManifest"
+        )
+    if placement.resource_id != plan.resource_id:
+        raise TransferEngineError(f"{label} resource_id mismatch")
+    if placement.revision != plan.revision:
+        raise TransferEngineError(f"{label} revision mismatch")
+    if placement.weight_generation != plan.weight_generation:
+        raise TransferEngineError(f"{label} weight_generation mismatch")
+
+
+def validate_manifest_pair(
+    plan: TransferPlan,
+    placement: WeightPlacementManifest,
+    binding: WeightRuntimeBindingManifest,
+    label: str,
+) -> None:
+    try:
+        validate_runtime_binding(placement, binding)
+    except ValueError as error:
+        raise TransferEngineError(
+            f"invalid {label} runtime binding: {error}"
+        ) from error
+    validate_plan_identity(plan, placement, label)
+
+
+def runtime_binding_fragment(
+    fragment: Union[RuntimeBindingFragment, BoundWeightFragment],
+) -> RuntimeBindingFragment:
+    if isinstance(fragment, RuntimeBindingFragment):
+        return fragment
+    if isinstance(fragment, BoundWeightFragment):
+        return fragment.binding
+    raise TransferEngineError(
+        "transfer plan physical fragment must be a RuntimeBindingFragment "
+        "or expose one as .binding"
+    )
+
+
+def require_live_transfer_operation(
+    operation: ExecutableTransferOperation,
+) -> LiveTransferOperation:
+    """Reject Store-backed or non-canonical operations before TE submission."""
+
+    if not isinstance(operation.source, BoundWeightFragment) or not isinstance(
+        operation.target, BoundWeightFragment
+    ):
+        raise TransferEngineError(
+            "live TE execution requires runtime-bound source and target fragments"
+        )
+    return cast(LiveTransferOperation, operation)
+
+
+def pair_manifests(
+    placement: WeightPlacementManifest,
+    bindings: Sequence[WeightRuntimeBindingManifest],
+    label: str,
+) -> tuple[tuple[WeightPlacementManifest, WeightRuntimeBindingManifest], ...]:
+    if not isinstance(placement, WeightPlacementManifest):
+        raise TransferEngineError(
+            f"{label} placement must be a WeightPlacementManifest"
+        )
+    binding_items = tuple(bindings)
+    if not all(
+        isinstance(binding, WeightRuntimeBindingManifest) for binding in binding_items
+    ):
+        raise TransferEngineError(
+            f"{label} binding must be a WeightRuntimeBindingManifest"
+        )
+    participant_ids = [binding.participant_id for binding in binding_items]
+    if len(participant_ids) != len(set(participant_ids)):
+        raise TransferEngineError(f"duplicate {label} runtime binding participant")
+    if any(binding.placement_id != placement.placement_id for binding in binding_items):
+        raise TransferEngineError(f"{label} placement and binding IDs differ")
+    return tuple((placement, binding) for binding in binding_items)
+
+
+def validate_execution_input_types(
+    plan: TransferPlan,
+    source_placement: WeightPlacementManifest,
+    source_bindings: Sequence[WeightRuntimeBindingManifest],
+    target_placement: WeightPlacementManifest,
+    target_bindings: Sequence[WeightRuntimeBindingManifest],
+) -> None:
+    if not isinstance(plan, TransferPlan):
+        raise TransferEngineError("plan must be a TransferPlan")
+    for label, placement in (
+        ("source", source_placement),
+        ("target", target_placement),
+    ):
+        if not isinstance(placement, WeightPlacementManifest):
+            raise TransferEngineError(
+                f"{label} placement must be a WeightPlacementManifest"
+            )
+    for label, bindings in (
+        ("source", source_bindings),
+        ("target", target_bindings),
+    ):
+        if not all(
+            isinstance(binding, WeightRuntimeBindingManifest) for binding in bindings
+        ):
+            raise TransferEngineError(
+                f"{label} binding must be a WeightRuntimeBindingManifest"
+            )
+
+
+def resolve_runtime_executors(
+    plan: TransferPlan,
+    placement: WeightPlacementManifest,
+    binding: WeightRuntimeBindingManifest,
+    label: str,
+) -> tuple[ExecutorTransferPlan, ...]:
+    return resolve_executor_plans(plan, placement, binding, label)
+
+
+def validate_selected_executor_snapshot(
+    plan: TransferPlan,
+    placement: WeightPlacementManifest,
+    binding: WeightRuntimeBindingManifest,
+    label: str,
+) -> tuple[ExecutorTransferPlan, ...]:
+    """Validate a planned participant before its framework guard is acquired.
+
+    The guard is the allocation-lifetime authority, but it must never be asked
+    to pin an arbitrary participant or fragment set. This check uses only the
+    manifest snapshot and plan identity; the executor repeats the same check
+    against the fresh binding returned under the framework pin.
+    """
+
+    expected_participants = {
+        executor.participant_id
+        for executor in (
+            plan.source_executors if label == "source" else plan.target_executors
+        )
+    }
+    if binding.participant_id not in expected_participants:
+        return ()
+    try:
+        return resolve_runtime_executors(plan, placement, binding, label)
+    except (KeyError, ValueError) as error:
+        raise TransferEngineError(str(error)) from error

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/lifetime.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/lifetime.py
@@ -1,0 +1,19 @@
+"""Compatibility exports for weight allocation lifetime acquisition."""
+
+from .._lifetime import (
+    AcquiredWeightBinding,
+    WeightAllocationGuardProvider,
+    WeightAllocationGuardProviders,
+    acquire_weight_binding_token,
+    acquire_weight_lifetime_tokens,
+    weight_allocation_fence,
+)
+
+__all__ = [
+    "AcquiredWeightBinding",
+    "WeightAllocationGuardProvider",
+    "WeightAllocationGuardProviders",
+    "acquire_weight_binding_token",
+    "acquire_weight_lifetime_tokens",
+    "weight_allocation_fence",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/reader.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/reader.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+from uuid import uuid4
+
+from ...contracts import LeaseId, RuntimeFragmentId
+from ...transfer_engine import (
+    MooncakeTransferEngineExecutor,
+    TransferCompletionFailedError,
+    TransferBatch,
+    TransferDirection,
+    TransferEngineError,
+)
+from ..manifest import (
+    ParallelRank,
+    RuntimeBindingFragment,
+    WeightPlacementManifest,
+    WeightRuntimeBindingManifest,
+)
+from ..planner import BoundWeightFragment, LiveTransferOperation, TransferPlan
+from .batching import iter_transfer_batches
+from .execution import (
+    pair_manifests,
+    resolve_runtime_executors,
+    validate_selected_executor_snapshot,
+    require_live_transfer_operation,
+    runtime_binding_fragment,
+    validate_execution_input_types,
+    validate_lowering_budget,
+    validate_lowering_limits,
+    validate_manifest_pair,
+)
+from .registration import (
+    MemoryRegistrationLease,
+    registered_targets,
+    registration_map,
+    same_runtime_snapshot,
+    validate_registration,
+)
+from .lifetime import (
+    WeightAllocationGuardProviders,
+    acquire_weight_lifetime_tokens,
+)
+from ...transfer_engine.lifetime import AllocationTokenSet, TerminalTransferState
+
+
+@dataclass(frozen=True)
+class DirectReadReceipt:
+    source_endpoint: str
+    target_worker_id: str
+    operation_count: int
+    nbytes: int
+
+
+class MooncakeTransferEngineReader:
+    """Execute a local target plan with target-initiated zero-copy reads."""
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        max_batch_operations: int = 1024,
+        max_region_segments: int = 1_000_000,
+        max_total_lowered_segments: int = 10_000_000,
+        max_completion_drain_attempts: int = 3,
+        completion_drain_timeout_ms: int = 1000,
+    ) -> None:
+        validate_lowering_limits(
+            max_batch_operations=max_batch_operations,
+            max_region_segments=max_region_segments,
+            max_total_lowered_segments=max_total_lowered_segments,
+            max_completion_drain_attempts=max_completion_drain_attempts,
+            completion_drain_timeout_ms=completion_drain_timeout_ms,
+        )
+        self.engine = engine
+        self.max_batch_operations = max_batch_operations
+        self.max_region_segments = max_region_segments
+        self.max_total_lowered_segments = max_total_lowered_segments
+        self.max_completion_drain_attempts = max_completion_drain_attempts
+        self.completion_drain_timeout_ms = completion_drain_timeout_ms
+        self.transfer_executor = MooncakeTransferEngineExecutor(
+            engine,
+            max_completion_drain_attempts=max_completion_drain_attempts,
+            completion_drain_timeout_ms=completion_drain_timeout_ms,
+        )
+        self._pending = self.transfer_executor.pending_manager
+
+    def execute(
+        self,
+        plan: TransferPlan,
+        source_placement: WeightPlacementManifest,
+        source_bindings: Sequence[WeightRuntimeBindingManifest],
+        target_placement: WeightPlacementManifest,
+        target_binding: WeightRuntimeBindingManifest,
+        *,
+        target_worker_id: Optional[str] = None,
+        source_pre_registered: bool = True,
+        source_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        target_pre_registered: bool = False,
+        target_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        source_allocation_guards: Optional[WeightAllocationGuardProviders] = None,
+        target_allocation_guards: Optional[WeightAllocationGuardProviders] = None,
+        transfer_id: Optional[str] = None,
+    ) -> tuple[DirectReadReceipt, ...]:
+        validate_execution_input_types(
+            plan,
+            source_placement,
+            source_bindings,
+            target_placement,
+            (target_binding,),
+        )
+        # This preflight is diagnostic only. The executor repeats validation
+        # after framework guards return a freshly pinned binding snapshot.
+        validate_manifest_pair(plan, target_placement, target_binding, "target")
+        validate_selected_executor_snapshot(
+            plan,
+            target_placement,
+            target_binding,
+            "target",
+        )
+        for binding in source_bindings:
+            validate_manifest_pair(plan, source_placement, binding, "source")
+            validate_selected_executor_snapshot(
+                plan,
+                source_placement,
+                binding,
+                "source",
+            )
+        with self.transfer_executor.submission():
+            transfer_id = transfer_id or uuid4().hex
+            source_keys = {
+                (executor.instance_id, executor.participant_id)
+                for executor in plan.source_executors
+            }
+            target_keys = {
+                (executor.instance_id, executor.participant_id)
+                for executor in plan.target_executors
+            }
+            source_tokens: Optional[AllocationTokenSet] = None
+            target_tokens: Optional[AllocationTokenSet] = None
+            lifetime_tokens: Optional[AllocationTokenSet] = None
+            terminal_state = TerminalTransferState.ABORTED
+            try:
+                acquired_sources, source_tokens = acquire_weight_lifetime_tokens(
+                    transfer_id=transfer_id,
+                    plan=plan,
+                    bindings=tuple(
+                        binding
+                        for binding in source_bindings
+                        if (binding.instance_id, binding.participant_id) in source_keys
+                    ),
+                    side="source",
+                    providers=source_allocation_guards,
+                )
+                acquired_targets, target_tokens = acquire_weight_lifetime_tokens(
+                    transfer_id=transfer_id,
+                    plan=plan,
+                    bindings=(target_binding,)
+                    if (target_binding.instance_id, target_binding.participant_id)
+                    in target_keys
+                    else (),
+                    side="target",
+                    providers=target_allocation_guards,
+                )
+                lifetime_tokens = AllocationTokenSet(
+                    (*source_tokens.tokens, *target_tokens.tokens)
+                )
+                if len(acquired_targets) != 1:
+                    raise TransferEngineError(
+                        "target allocation guards did not acquire one local binding"
+                    )
+                result = self._execute_reserved(
+                    plan,
+                    source_placement,
+                    acquired_sources,
+                    target_placement,
+                    acquired_targets[0],
+                    target_worker_id=target_worker_id,
+                    source_pre_registered=source_pre_registered,
+                    source_registrations=source_registrations,
+                    target_pre_registered=target_pre_registered,
+                    target_registrations=target_registrations,
+                    lifetime_tokens=lifetime_tokens,
+                )
+                terminal_state = TerminalTransferState.COMPLETED
+                return result
+            except TransferCompletionFailedError:
+                terminal_state = TerminalTransferState.FAILED_DRAINED
+                raise
+            finally:
+                if lifetime_tokens is not None:
+                    lifetime_tokens.release_after_terminal(terminal_state)
+                else:
+                    if target_tokens is not None:
+                        target_tokens.release_after_terminal(terminal_state)
+                    if source_tokens is not None:
+                        source_tokens.release_after_terminal(terminal_state)
+
+    def _execute_reserved(
+        self,
+        plan: TransferPlan,
+        source_placement: WeightPlacementManifest,
+        source_bindings: Sequence[WeightRuntimeBindingManifest],
+        target_placement: WeightPlacementManifest,
+        target_binding: WeightRuntimeBindingManifest,
+        *,
+        target_worker_id: Optional[str] = None,
+        source_pre_registered: bool = True,
+        source_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        target_pre_registered: bool = False,
+        target_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        lifetime_tokens: Optional[AllocationTokenSet] = None,
+    ) -> tuple[DirectReadReceipt, ...]:
+        if not source_pre_registered:
+            raise TransferEngineError("remote source memory must be pre-registered")
+        source_registration_by_id = registration_map(source_registrations, "source")
+        if target_registrations is not None and not target_pre_registered:
+            raise TransferEngineError(
+                "target_registrations require target_pre_registered=True"
+            )
+        validate_manifest_pair(plan, target_placement, target_binding, "target")
+        try:
+            target_executors = resolve_runtime_executors(
+                plan, target_placement, target_binding, "target"
+            )
+        except ValueError as error:
+            raise TransferEngineError(str(error)) from error
+        if target_worker_id is not None:
+            target_executors = tuple(
+                executor
+                for executor in target_executors
+                if executor.worker_id == target_worker_id
+            )
+        if len(target_executors) != 1:
+            raise TransferEngineError(
+                "target binding requires exactly one local worker executor"
+            )
+        target_executor = target_executors[0]
+
+        sources: dict[RuntimeFragmentId, RuntimeBindingFragment] = {}
+        source_runtime_lease_ids: dict[RuntimeFragmentId, LeaseId] = {}
+        source_generations: dict[RuntimeFragmentId, int] = {}
+        source_executor_keys: set[tuple[ParallelRank, str]] = set()
+        expected_source_participants = {
+            executor.participant_id for executor in plan.source_executors
+        }
+        source_pairs = pair_manifests(source_placement, source_bindings, "source")
+        for placement, binding in source_pairs:
+            validate_manifest_pair(plan, placement, binding, "source")
+            if binding.participant_id not in expected_source_participants:
+                continue
+            try:
+                executors = resolve_runtime_executors(
+                    plan, placement, binding, "source"
+                )
+            except ValueError as error:
+                raise TransferEngineError(str(error)) from error
+            for executor in executors:
+                executor_key = (executor.rank, executor.worker_id)
+                if executor_key in source_executor_keys:
+                    raise TransferEngineError(
+                        f"duplicate source executor rank and worker: {executor_key}"
+                    )
+                source_executor_keys.add(executor_key)
+            for fragment in binding.fragments:
+                if fragment.fragment_id in sources:
+                    raise TransferEngineError(
+                        f"duplicate source fragment: {fragment.fragment_id}"
+                    )
+                sources[fragment.fragment_id] = fragment
+                source_runtime_lease_ids[fragment.fragment_id] = binding.lease_id
+                source_generations[fragment.fragment_id] = binding.generation
+        expected_source_executor_keys = {
+            (executor.rank, executor.worker_id) for executor in plan.source_executors
+        }
+        if source_executor_keys != expected_source_executor_keys:
+            raise TransferEngineError("source executor set is incomplete")
+
+        targets = {
+            fragment.fragment_id: fragment for fragment in target_binding.fragments
+        }
+        registration_by_id = (
+            registration_map(target_registrations, "target")
+            if target_pre_registered
+            else {}
+        )
+        operations_by_endpoint: dict[
+            str,
+            list[
+                tuple[
+                    LiveTransferOperation,
+                    BoundWeightFragment,
+                    BoundWeightFragment,
+                ]
+            ],
+        ] = {}
+        used_targets: dict[RuntimeFragmentId, RuntimeBindingFragment] = {}
+        for index in plan.operation_indices_for_executor(target_executor, "target"):
+            operation = require_live_transfer_operation(plan.operations[index])
+            planned_source = runtime_binding_fragment(operation.source)
+            planned_target = runtime_binding_fragment(operation.target)
+            source = sources.get(planned_source.fragment_id)
+            target = targets.get(planned_target.fragment_id)
+            if source is None or not same_runtime_snapshot(source, planned_source):
+                raise TransferEngineError(
+                    f"stale source fragment: {planned_source.fragment_id}"
+                )
+            runtime_lease_id = source_runtime_lease_ids[source.fragment_id]
+            validate_registration(
+                source,
+                source_registration_by_id,
+                "source",
+                lease_generation=source_generations[source.fragment_id],
+                runtime_lease_id=runtime_lease_id,
+            )
+            if target is None or not same_runtime_snapshot(target, planned_target):
+                raise TransferEngineError(
+                    f"stale target fragment: {planned_target.fragment_id}"
+                )
+            if target_pre_registered:
+                validate_registration(
+                    target,
+                    registration_by_id,
+                    "target",
+                    lease_generation=target_binding.generation,
+                    runtime_lease_id=target_binding.lease_id,
+                )
+            operation.validate_bounds()
+            if operation.repeat > self.max_region_segments:
+                raise TransferEngineError(
+                    f"transfer region exceeds max_region_segments: "
+                    f"{operation.tensor_id}: {operation.repeat} > "
+                    f"{self.max_region_segments}"
+                )
+            used_targets[target.fragment_id] = target
+            operations_by_endpoint.setdefault(source.endpoint, []).append(
+                (operation, operation.source, operation.target)
+            )
+
+        validate_lowering_budget(
+            tuple(
+                operation
+                for operations in operations_by_endpoint.values()
+                for operation, _, _ in operations
+            ),
+            max_region_segments=self.max_region_segments,
+            max_total_lowered_segments=self.max_total_lowered_segments,
+        )
+
+        with registered_targets(
+            self.engine,
+            self._pending,
+            tuple(used_targets.values()),
+            pre_registered=target_pre_registered,
+            resources=(
+                source_placement,
+                tuple(source_bindings),
+                target_placement,
+                target_binding,
+                source_registrations,
+                target_registrations,
+            ),
+            lifetime_tokens=lifetime_tokens,
+        ):
+            receipts: list[DirectReadReceipt] = []
+            for endpoint in sorted(operations_by_endpoint):
+                operations = sorted(
+                    operations_by_endpoint[endpoint],
+                    key=lambda item: (
+                        item[2].address + item[0].target_offset,
+                        item[1].address + item[0].source_offset,
+                    ),
+                )
+                operation_count = 0
+                total_bytes = 0
+                for batch in iter_transfer_batches(
+                    endpoint,
+                    operations,
+                    max_batch_operations=self.max_batch_operations,
+                    max_region_segments=self.max_region_segments,
+                ):
+                    self._transfer_batch(batch)
+                    operation_count += batch.operation_count
+                    total_bytes += batch.nbytes
+                receipts.append(
+                    DirectReadReceipt(
+                        source_endpoint=endpoint,
+                        target_worker_id=target_executor.worker_id,
+                        operation_count=operation_count,
+                        nbytes=total_bytes,
+                    )
+                )
+        return tuple(receipts)
+
+    def _transfer_batch(
+        self,
+        batch: TransferBatch,
+    ) -> None:
+        self.transfer_executor._execute_reserved_batch(
+            batch,
+            TransferDirection.READ,
+        )
+
+    def pending_transfer_ids(self) -> tuple[str, ...]:
+        return self._pending.pending_transfer_ids()
+
+    def pending_transfer_status(self, pending_transfer_id: str) -> str:
+        return self._pending.pending_transfer_status(pending_transfer_id)
+
+    def drain_pending_transfer(
+        self,
+        pending_transfer_id: str,
+        *,
+        timeout_ms: int = 1000,
+    ) -> str:
+        return self._pending.drain_pending_transfer(
+            pending_transfer_id,
+            timeout_ms=timeout_ms,
+        )

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/registration.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/registration.py
@@ -1,0 +1,21 @@
+"""Compatibility exports for resource-neutral buffer registration."""
+
+from ...transfer_engine.registration import (
+    BufferRegistrationLease,
+    MemoryRegistrationLease,
+    registered_sources,
+    registered_targets,
+    registration_map,
+    same_runtime_snapshot,
+    validate_registration,
+)
+
+__all__ = [
+    "BufferRegistrationLease",
+    "MemoryRegistrationLease",
+    "registered_sources",
+    "registered_targets",
+    "registration_map",
+    "same_runtime_snapshot",
+    "validate_registration",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_te/sink.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_te/sink.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+from uuid import uuid4
+
+from ...contracts import LeaseId, RuntimeFragmentId
+from ...transfer_engine import (
+    MooncakeTransferEngineExecutor,
+    TransferCompletionFailedError,
+    TransferBatch,
+    TransferDirection,
+    TransferEngineError,
+)
+from ..manifest import (
+    ParallelRank,
+    RuntimeBindingFragment,
+    WeightPlacementManifest,
+    WeightRuntimeBindingManifest,
+)
+from ..planner import BoundWeightFragment, LiveTransferOperation, TransferPlan
+from .batching import iter_transfer_batches
+from .execution import (
+    pair_manifests,
+    resolve_runtime_executors,
+    validate_selected_executor_snapshot,
+    require_live_transfer_operation,
+    runtime_binding_fragment,
+    validate_execution_input_types,
+    validate_lowering_budget,
+    validate_lowering_limits,
+    validate_manifest_pair,
+)
+from .registration import (
+    MemoryRegistrationLease,
+    registered_sources,
+    registration_map,
+    same_runtime_snapshot,
+    validate_registration,
+)
+from .lifetime import (
+    WeightAllocationGuardProviders,
+    acquire_weight_lifetime_tokens,
+)
+from ...transfer_engine.lifetime import AllocationTokenSet, TerminalTransferState
+from ...transfer_engine.lifetime import AllocationLifetimeToken
+
+
+@dataclass(frozen=True)
+class DirectTransferReceipt:
+    source_worker_id: str
+    target_endpoint: str
+    operation_count: int
+    nbytes: int
+
+
+class MooncakeTransferEngineSink:
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        max_batch_operations: int = 1024,
+        max_region_segments: int = 1_000_000,
+        max_total_lowered_segments: int = 10_000_000,
+        max_completion_drain_attempts: int = 3,
+        completion_drain_timeout_ms: int = 1000,
+    ) -> None:
+        validate_lowering_limits(
+            max_batch_operations=max_batch_operations,
+            max_region_segments=max_region_segments,
+            max_total_lowered_segments=max_total_lowered_segments,
+            max_completion_drain_attempts=max_completion_drain_attempts,
+            completion_drain_timeout_ms=completion_drain_timeout_ms,
+        )
+        self.engine = engine
+        self.transfer_executor = MooncakeTransferEngineExecutor(
+            engine,
+            max_completion_drain_attempts=max_completion_drain_attempts,
+            completion_drain_timeout_ms=completion_drain_timeout_ms,
+        )
+        self._pending = self.transfer_executor.pending_manager
+        self._engine_identity = self._pending.engine_identity
+        self.max_batch_operations = max_batch_operations
+        self.max_region_segments = max_region_segments
+        self.max_total_lowered_segments = max_total_lowered_segments
+        self.max_completion_drain_attempts = max_completion_drain_attempts
+        self.completion_drain_timeout_ms = completion_drain_timeout_ms
+
+    def execute(
+        self,
+        plan: TransferPlan,
+        source_placement: WeightPlacementManifest,
+        source_binding: WeightRuntimeBindingManifest,
+        target_placement: WeightPlacementManifest,
+        target_bindings: Sequence[WeightRuntimeBindingManifest],
+        *,
+        source_worker_id: Optional[str] = None,
+        target_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        source_pre_registered: bool = False,
+        source_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        source_allocation_guards: Optional[WeightAllocationGuardProviders] = None,
+        target_allocation_guards: Optional[WeightAllocationGuardProviders] = None,
+        transfer_id: Optional[str] = None,
+    ) -> tuple[DirectTransferReceipt, ...]:
+        validate_execution_input_types(
+            plan,
+            source_placement,
+            (source_binding,),
+            target_placement,
+            target_bindings,
+        )
+        # This preflight is diagnostic only. The executor repeats validation
+        # after framework guards return a freshly pinned binding snapshot.
+        validate_manifest_pair(plan, source_placement, source_binding, "source")
+        planned_source_participant_ids = {
+            executor.participant_id for executor in plan.source_executors
+        }
+        if source_binding.participant_id not in planned_source_participant_ids:
+            return ()
+        planned_source_keys = {
+            (executor.instance_id, executor.participant_id)
+            for executor in plan.source_executors
+        }
+        validate_selected_executor_snapshot(
+            plan,
+            source_placement,
+            source_binding,
+            "source",
+        )
+        for binding in target_bindings:
+            validate_manifest_pair(plan, target_placement, binding, "target")
+            validate_selected_executor_snapshot(
+                plan,
+                target_placement,
+                binding,
+                "target",
+            )
+        with self.transfer_executor.submission():
+            transfer_id = transfer_id or uuid4().hex
+            source_keys = planned_source_keys
+            target_keys = {
+                (executor.instance_id, executor.participant_id)
+                for executor in plan.target_executors
+            }
+            source_tokens: Optional[AllocationTokenSet] = None
+            target_tokens: Optional[AllocationTokenSet] = None
+            lifetime_tokens: Optional[AllocationTokenSet] = None
+            terminal_state = TerminalTransferState.ABORTED
+            try:
+                acquired_sources, source_tokens = acquire_weight_lifetime_tokens(
+                    transfer_id=transfer_id,
+                    plan=plan,
+                    bindings=(source_binding,)
+                    if (source_binding.instance_id, source_binding.participant_id)
+                    in source_keys
+                    else (),
+                    side="source",
+                    providers=source_allocation_guards,
+                )
+                acquired_targets, target_tokens = acquire_weight_lifetime_tokens(
+                    transfer_id=transfer_id,
+                    plan=plan,
+                    bindings=tuple(
+                        binding
+                        for binding in target_bindings
+                        if (binding.instance_id, binding.participant_id) in target_keys
+                    ),
+                    side="target",
+                    providers=target_allocation_guards,
+                )
+                lifetime_tokens = AllocationTokenSet(
+                    (*source_tokens.tokens, *target_tokens.tokens)
+                )
+                if len(acquired_sources) != 1:
+                    raise TransferEngineError(
+                        "source allocation guards did not acquire one local binding"
+                    )
+                result = self._execute_reserved(
+                    plan,
+                    source_placement,
+                    acquired_sources[0],
+                    target_placement,
+                    acquired_targets,
+                    source_worker_id=source_worker_id,
+                    target_registrations=target_registrations,
+                    source_pre_registered=source_pre_registered,
+                    source_registrations=source_registrations,
+                    lifetime_tokens=lifetime_tokens,
+                )
+                terminal_state = TerminalTransferState.COMPLETED
+                return result
+            except TransferCompletionFailedError:
+                terminal_state = TerminalTransferState.FAILED_DRAINED
+                raise
+            finally:
+                if lifetime_tokens is not None:
+                    lifetime_tokens.release_after_terminal(terminal_state)
+                else:
+                    if target_tokens is not None:
+                        target_tokens.release_after_terminal(terminal_state)
+                    if source_tokens is not None:
+                        source_tokens.release_after_terminal(terminal_state)
+
+    def _execute_reserved(
+        self,
+        plan: TransferPlan,
+        source_placement: WeightPlacementManifest,
+        source_binding: WeightRuntimeBindingManifest,
+        target_placement: WeightPlacementManifest,
+        target_bindings: Sequence[WeightRuntimeBindingManifest],
+        *,
+        source_worker_id: Optional[str] = None,
+        target_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        source_pre_registered: bool = False,
+        source_registrations: Optional[Sequence[MemoryRegistrationLease]] = None,
+        lifetime_tokens: Optional[AllocationTokenSet] = None,
+    ) -> tuple[DirectTransferReceipt, ...]:
+        validate_manifest_pair(plan, source_placement, source_binding, "source")
+        try:
+            source_executors = resolve_runtime_executors(
+                plan, source_placement, source_binding, "source"
+            )
+        except ValueError as error:
+            raise TransferEngineError(str(error)) from error
+        if source_worker_id is not None:
+            source_executors = tuple(
+                executor
+                for executor in source_executors
+                if executor.worker_id == source_worker_id
+            )
+        source_workers = {executor.worker_id for executor in source_executors}
+        if len(source_workers) != 1:
+            raise TransferEngineError(
+                "source binding requires exactly one local worker executor"
+            )
+        local_source_worker_id = next(iter(source_workers))
+
+        targets: dict[RuntimeFragmentId, RuntimeBindingFragment] = {}
+        target_runtime_lease_ids: dict[RuntimeFragmentId, LeaseId] = {}
+        target_generations: dict[RuntimeFragmentId, int] = {}
+        target_executor_keys: set[tuple[ParallelRank, str]] = set()
+        expected_target_participants = {
+            executor.participant_id for executor in plan.target_executors
+        }
+        target_pairs = pair_manifests(target_placement, target_bindings, "target")
+        for placement, binding in target_pairs:
+            validate_manifest_pair(plan, placement, binding, "target")
+            if binding.participant_id not in expected_target_participants:
+                continue
+            try:
+                executors = resolve_runtime_executors(
+                    plan, placement, binding, "target"
+                )
+            except ValueError as error:
+                raise TransferEngineError(str(error)) from error
+            for executor in executors:
+                executor_key = (executor.rank, executor.worker_id)
+                if executor_key in target_executor_keys:
+                    raise TransferEngineError(
+                        f"duplicate target executor rank and worker: {executor_key}"
+                    )
+                target_executor_keys.add(executor_key)
+            for fragment in binding.fragments:
+                if fragment.fragment_id in targets:
+                    raise TransferEngineError(
+                        f"duplicate target fragment: {fragment.fragment_id}"
+                    )
+                targets[fragment.fragment_id] = fragment
+                target_runtime_lease_ids[fragment.fragment_id] = binding.lease_id
+                target_generations[fragment.fragment_id] = binding.generation
+        expected_target_executor_keys = {
+            (executor.rank, executor.worker_id) for executor in plan.target_executors
+        }
+        if target_executor_keys != expected_target_executor_keys:
+            raise TransferEngineError("target executor set is incomplete")
+
+        local_operations = [
+            require_live_transfer_operation(plan.operations[index])
+            for executor in source_executors
+            for index in plan.operation_indices_for_executor(executor, "source")
+        ]
+        if not local_operations:
+            return ()
+
+        local = {
+            fragment.fragment_id: fragment for fragment in source_binding.fragments
+        }
+        target_registration_by_id = registration_map(
+            target_registrations,
+            "target",
+        )
+
+        operations_by_endpoint: dict[
+            str,
+            list[
+                tuple[
+                    LiveTransferOperation,
+                    BoundWeightFragment,
+                    BoundWeightFragment,
+                ]
+            ],
+        ] = {}
+        used_sources: dict[RuntimeFragmentId, RuntimeBindingFragment] = {}
+        for operation in local_operations:
+            planned_source = runtime_binding_fragment(operation.source)
+            planned_target = runtime_binding_fragment(operation.target)
+            current = local.get(planned_source.fragment_id)
+            if current is None or not same_runtime_snapshot(current, planned_source):
+                raise TransferEngineError(
+                    f"stale source fragment: {planned_source.fragment_id}"
+                )
+            target = targets.get(planned_target.fragment_id)
+            if target is None:
+                raise TransferEngineError(
+                    f"missing planned target fragment: {planned_target.fragment_id}"
+                )
+            if not same_runtime_snapshot(target, planned_target):
+                raise TransferEngineError(
+                    f"stale target fragment: {planned_target.fragment_id}"
+                )
+            if not target.endpoint:
+                raise TransferEngineError(
+                    f"target endpoint is empty: {operation.target.fragment_id}"
+                )
+            try:
+                operation.validate_bounds()
+            except ValueError as error:
+                raise TransferEngineError(
+                    f"invalid copy range for {operation.tensor_id}: {error}"
+                ) from error
+            if operation.repeat > self.max_region_segments:
+                raise TransferEngineError(
+                    f"transfer region exceeds max_region_segments: "
+                    f"{operation.tensor_id}: {operation.repeat} > "
+                    f"{self.max_region_segments}"
+                )
+            validate_registration(
+                target,
+                target_registration_by_id,
+                "target",
+                lease_generation=target_generations[target.fragment_id],
+                runtime_lease_id=target_runtime_lease_ids[target.fragment_id],
+            )
+            used_sources[current.fragment_id] = current
+            operations_by_endpoint.setdefault(target.endpoint, []).append(
+                (operation, operation.source, operation.target)
+            )
+
+        validate_lowering_budget(
+            tuple(
+                operation
+                for operations in operations_by_endpoint.values()
+                for operation, _, _ in operations
+            ),
+            max_region_segments=self.max_region_segments,
+            max_total_lowered_segments=self.max_total_lowered_segments,
+        )
+
+        with registered_sources(
+            self.engine,
+            self,
+            tuple(used_sources.values()),
+            pre_registered=source_pre_registered,
+            registrations=source_registrations,
+            lease_generation=source_binding.generation,
+            runtime_lease_id=source_binding.lease_id,
+            resources=(
+                source_placement,
+                source_binding,
+                target_placement,
+                tuple(target_bindings),
+                source_registrations,
+                target_registrations,
+            ),
+            lifetime_tokens=lifetime_tokens,
+        ):
+            receipts: list[DirectTransferReceipt] = []
+            for endpoint in sorted(operations_by_endpoint):
+                operations = sorted(
+                    operations_by_endpoint[endpoint],
+                    key=lambda item: (
+                        item[2].address + item[0].target_offset,
+                        item[1].address + item[0].source_offset,
+                    ),
+                )
+                operation_count = 0
+                total_bytes = 0
+                for batch in iter_transfer_batches(
+                    endpoint,
+                    operations,
+                    max_batch_operations=self.max_batch_operations,
+                    max_region_segments=self.max_region_segments,
+                ):
+                    self._transfer_batch(batch)
+                    operation_count += batch.operation_count
+                    total_bytes += batch.nbytes
+                receipts.append(
+                    DirectTransferReceipt(
+                        source_worker_id=local_source_worker_id,
+                        target_endpoint=endpoint,
+                        operation_count=operation_count,
+                        nbytes=total_bytes,
+                    )
+                )
+        return tuple(receipts)
+
+    def _transfer_batch(
+        self,
+        batch: TransferBatch,
+    ) -> None:
+        self.transfer_executor._execute_reserved_batch(
+            batch,
+            TransferDirection.WRITE,
+        )
+
+    def _retain_pending_ticket(self, ticket: Any) -> str:
+        return self._pending._retain_pending_ticket(ticket)
+
+    def _retain_pending_resources(
+        self,
+        pending_transfer_id: str,
+        *,
+        registrations: Sequence[int],
+        resources: Sequence[Any],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> None:
+        self._pending._retain_pending_resources(
+            pending_transfer_id,
+            registrations=registrations,
+            resources=resources,
+            allocation_tokens=allocation_tokens,
+        )
+
+    def _retain_pending_registration_cleanup(
+        self,
+        *,
+        terminal_state: TerminalTransferState,
+        registrations: Sequence[int],
+        resources: Sequence[object],
+        allocation_tokens: Sequence[AllocationLifetimeToken] = (),
+    ) -> str:
+        return self._pending._retain_pending_registration_cleanup(
+            terminal_state=terminal_state,
+            registrations=registrations,
+            resources=resources,
+            allocation_tokens=allocation_tokens,
+        )
+
+    def _reserve_submission(self) -> None:
+        self._pending._reserve_submission()
+
+    def _release_submission(self) -> None:
+        self._pending._release_submission()
+
+    def pending_transfer_ids(self) -> tuple[str, ...]:
+        return self._pending.pending_transfer_ids()
+
+    def pending_transfer_status(self, pending_transfer_id: str) -> str:
+        return self._pending.pending_transfer_status(pending_transfer_id)
+
+    def drain_pending_transfer(
+        self,
+        pending_transfer_id: str,
+        *,
+        timeout_ms: int = 1000,
+    ) -> str:
+        return self._pending.drain_pending_transfer(
+            pending_transfer_id,
+            timeout_ms=timeout_ms,
+        )

--- a/mooncake-reshard/python/mooncake/reshard/weight/te.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/te.py
@@ -1,0 +1,29 @@
+"""Stable public facade for Mooncake transfer-engine execution."""
+
+from ._te import (
+    DirectReadReceipt,
+    DirectTransferReceipt,
+    MemoryRegistrationLease,
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferCompletionFailedError,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    TransferRegistrationCleanupPendingError,
+    WeightAllocationGuardProvider,
+    WeightAllocationGuardProviders,
+)
+
+__all__ = [
+    "DirectReadReceipt",
+    "DirectTransferReceipt",
+    "MemoryRegistrationLease",
+    "MooncakeTransferEngineReader",
+    "MooncakeTransferEngineSink",
+    "TransferCompletionUnknownError",
+    "TransferCompletionFailedError",
+    "TransferEngineError",
+    "TransferRegistrationCleanupPendingError",
+    "WeightAllocationGuardProvider",
+    "WeightAllocationGuardProviders",
+]

--- a/mooncake-reshard/tests/global_placement_helpers.py
+++ b/mooncake-reshard/tests/global_placement_helpers.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from mooncake.reshard.weight import (
+    ParallelRank,
+    ParallelTopology,
+    PlacementFragment,
+    RuntimeBindingFragment,
+    TensorDescriptor,
+    TopologyParticipant,
+    WeightPlacementManifest,
+    WeightRuntimeBindingManifest,
+)
+
+
+def participant_id(prefix: str, rank: ParallelRank) -> str:
+    return f"{prefix}-d{rank.dp}-p{rank.pp}-e{rank.ep}-t{rank.tp}"
+
+
+def contiguous_strides_bytes(
+    local_shape: Sequence[int], itemsize: int
+) -> tuple[int, ...]:
+    stride = itemsize
+    result = []
+    for extent in reversed(local_shape):
+        result.append(stride)
+        stride *= extent
+    return tuple(reversed(result))
+
+
+def runtime_fragment(
+    *,
+    placement: PlacementFragment,
+    tensor: TensorDescriptor,
+    fragment_id: str,
+    address: int,
+    worker_id: str,
+    endpoint: str,
+    device: str = "cuda:0",
+    storage_address: int | None = None,
+    storage_nbytes: int | None = None,
+    owner=None,
+) -> RuntimeBindingFragment:
+    storage_address = address if storage_address is None else storage_address
+    storage_nbytes = placement.nbytes if storage_nbytes is None else storage_nbytes
+    return RuntimeBindingFragment(
+        placement_fragment_id=placement.placement_fragment_id,
+        fragment_id=fragment_id,
+        address=address,
+        nbytes=placement.nbytes,
+        worker_id=worker_id,
+        endpoint=endpoint,
+        device=device,
+        itemsize=tensor.itemsize,
+        local_shape=placement.local_shape,
+        strides_bytes=contiguous_strides_bytes(placement.local_shape, tensor.itemsize),
+        storage_address=storage_address,
+        storage_nbytes=storage_nbytes,
+        storage_offset_bytes=address - storage_address,
+        owner=owner,
+    )
+
+
+def global_placement(
+    *,
+    resource_id: str,
+    revision: str,
+    placement_set_id: str,
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[PlacementFragment],
+    ranks: Sequence[ParallelRank] | None = None,
+    weight_generation: int = 1,
+) -> WeightPlacementManifest:
+    rank_items = tuple(
+        sorted(
+            set(ranks or (fragment.rank for fragment in fragments)),
+            key=lambda rank: (rank.dp, rank.pp, rank.ep, rank.tp),
+        )
+    )
+    if not rank_items:
+        raise ValueError("test placement ranks must not be empty")
+    topology = ParallelTopology(
+        tp_size=max(rank.tp for rank in rank_items) + 1,
+        pp_size=max(rank.pp for rank in rank_items) + 1,
+        ep_size=max(rank.ep for rank in rank_items) + 1,
+        dp_size=max(rank.dp for rank in rank_items) + 1,
+        participants=tuple(
+            TopologyParticipant(
+                participant_id(placement_set_id, rank),
+                rank,
+            )
+            for rank in rank_items
+        ),
+    )
+    return WeightPlacementManifest.from_fragments(
+        resource_id=resource_id,
+        revision=revision,
+        weight_generation=weight_generation,
+        placement_set_id=placement_set_id,
+        topology=topology,
+        tensors=tuple(tensors),
+        fragments=tuple(fragments),
+    )
+
+
+def runtime_bindings(
+    placement: WeightPlacementManifest,
+    *,
+    instance_prefix: str,
+    address_for_fragment: Callable[[int, PlacementFragment], int] | None = None,
+    generation: int = 1,
+) -> tuple[WeightRuntimeBindingManifest, ...]:
+    tensors = {tensor.tensor_id: tensor for tensor in placement.tensors}
+    fragment_index = {
+        fragment.placement_fragment_id: index
+        for index, fragment in enumerate(placement.fragments)
+    }
+    address_for_fragment = address_for_fragment or (
+        lambda index, fragment: 0x100000 + index * 0x10000
+    )
+    return tuple(
+        WeightRuntimeBindingManifest(
+            resource_id=placement.resource_id,
+            revision=placement.revision,
+            placement_id=placement.placement_id,
+            placement_digest=placement.digest,
+            participant_id=part.participant_id,
+            instance_id=f"{instance_prefix}-{part.participant_id}",
+            generation=generation,
+            lease_id=f"lease-{instance_prefix}-{part.participant_id}",
+            fragments=tuple(
+                runtime_fragment(
+                    placement=fragment,
+                    tensor=tensors[fragment.tensor_id],
+                    fragment_id=(
+                        f"runtime-{instance_prefix}-{fragment.placement_fragment_id}"
+                    ),
+                    address=address_for_fragment(
+                        fragment_index[fragment.placement_fragment_id], fragment
+                    ),
+                    worker_id=part.participant_id,
+                    endpoint=f"{part.participant_id}:12345",
+                )
+                for fragment in part.fragments
+            ),
+        )
+        for part in placement.parts
+    )

--- a/mooncake-reshard/tests/model_weight_te/__init__.py
+++ b/mooncake-reshard/tests/model_weight_te/__init__.py
@@ -1,0 +1,1 @@
+"""Transfer-engine executor tests grouped by responsibility."""

--- a/mooncake-reshard/tests/model_weight_te/helpers.py
+++ b/mooncake-reshard/tests/model_weight_te/helpers.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from math import prod
+from typing import Sequence
+
+from mooncake.reshard.weight.manifest import (
+    ParallelRank,
+    PlacementFragment,
+    ReplicatedAxis,
+    RuntimeBindingFragment,
+    SplitAxis,
+    TensorDescriptor,
+    WeightRuntimeBindingManifest,
+)
+from mooncake.reshard.weight.te import MemoryRegistrationLease
+from mooncake.reshard.weight._te.lifetime import (
+    AcquiredWeightBinding,
+    weight_allocation_fence,
+)
+from mooncake.reshard.transfer_engine.lifetime import TerminalTransferState
+
+from global_placement_helpers import global_placement
+from model_weight_planner.helpers import (
+    RuntimeInputs,
+    plan_transfer as plan_transfer,
+    plan_transfer_to_local_target as plan_transfer_to_local_target,
+)
+
+
+class FakeTransferEngine:
+    def __init__(self) -> None:
+        self.calls = []
+        self.fail_endpoint: str | None = None
+        self.read_result: int | None = None
+        self.register_calls: list[tuple[int, int]] = []
+        self.unregister_calls: list[int] = []
+
+    def register_memory(self, address: int, nbytes: int) -> int:
+        self.register_calls.append((address, nbytes))
+        return 0
+
+    def unregister_memory(self, address: int) -> int:
+        self.unregister_calls.append(address)
+        return 0
+
+    def batch_transfer_sync_write(
+        self,
+        endpoint: str,
+        source_addresses: list[int],
+        target_addresses: list[int],
+        sizes: list[int],
+    ) -> int:
+        self.calls.append((endpoint, source_addresses, target_addresses, sizes))
+        return -5 if endpoint == self.fail_endpoint else 0
+
+    def batch_transfer_sync_read(
+        self,
+        endpoint: str,
+        target_addresses: list[int],
+        source_addresses: list[int],
+        sizes: list[int],
+    ) -> int:
+        self.calls.append((endpoint, target_addresses, source_addresses, sizes))
+        if self.read_result is not None:
+            return self.read_result
+        return -5 if endpoint == self.fail_endpoint else 0
+
+
+class FakeAllocationLifetimeToken:
+    def __init__(self, fence) -> None:
+        self._fence = fence
+        self.released_states: list[TerminalTransferState] = []
+
+    @property
+    def fence(self):
+        return self._fence
+
+    def release_after_terminal(self, terminal_state: TerminalTransferState) -> None:
+        self.released_states.append(terminal_state)
+
+
+class FakeWeightAllocationGuard:
+    def __init__(self, binding: WeightRuntimeBindingManifest) -> None:
+        self.binding = binding
+        self.acquisitions: list[tuple[str, tuple[str, ...]]] = []
+        self.tokens: list[FakeAllocationLifetimeToken] = []
+
+    def acquire(
+        self,
+        *,
+        transfer_id: str,
+        expected_binding: WeightRuntimeBindingManifest,
+        required_fragment_ids: tuple[str, ...],
+    ) -> AcquiredWeightBinding:
+        assert expected_binding == self.binding
+        self.acquisitions.append((transfer_id, tuple(required_fragment_ids)))
+        token = FakeAllocationLifetimeToken(
+            weight_allocation_fence(
+                self.binding,
+                required_fragment_ids,
+                token_id=(
+                    f"{self.binding.instance_id}-{self.binding.participant_id}-"
+                    f"{len(self.tokens)}"
+                ),
+            )
+        )
+        self.tokens.append(token)
+        return AcquiredWeightBinding(binding=self.binding, token=token)
+
+
+class FakeBatchTransferTicket:
+    def __init__(
+        self,
+        statuses: list[str],
+        *,
+        on_drain=None,
+    ) -> None:
+        self._statuses = list(statuses)
+        self._on_drain = on_drain
+        self.drain_calls: list[int] = []
+
+    @property
+    def status(self):
+        return FakeCompletionStatus(self._statuses[0])
+
+    @property
+    def drained(self) -> bool:
+        return self._statuses[0] != "COMPLETION_UNKNOWN"
+
+    def drain(self, timeout_ms: int):
+        self.drain_calls.append(timeout_ms)
+        if self._on_drain is not None:
+            self._on_drain()
+        if len(self._statuses) > 1:
+            self._statuses.pop(0)
+        return FakeCompletionStatus(self._statuses[0])
+
+
+class FakeCompletionStatus:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def contiguous_strides_bytes(
+    shape: tuple[int, ...],
+    itemsize: int,
+) -> tuple[int, ...]:
+    stride = itemsize
+    result = []
+    for extent in reversed(shape):
+        result.append(stride)
+        stride *= extent
+    return tuple(reversed(result))
+
+
+def runtime_fragment(
+    *,
+    placement_fragment_id: str,
+    fragment_id: str,
+    address: int,
+    nbytes: int,
+    worker_id: str,
+    endpoint: str,
+    local_shape: tuple[int, ...],
+    itemsize: int,
+    storage_address: int | None = None,
+    storage_nbytes: int | None = None,
+) -> RuntimeBindingFragment:
+    storage_address = address if storage_address is None else storage_address
+    storage_nbytes = nbytes if storage_nbytes is None else storage_nbytes
+    return RuntimeBindingFragment(
+        placement_fragment_id=placement_fragment_id,
+        fragment_id=fragment_id,
+        address=address,
+        nbytes=nbytes,
+        worker_id=worker_id,
+        endpoint=endpoint,
+        device="cuda:0",
+        itemsize=itemsize,
+        local_shape=local_shape,
+        strides_bytes=contiguous_strides_bytes(local_shape, itemsize),
+        storage_address=storage_address,
+        storage_nbytes=storage_nbytes,
+        storage_offset_bytes=address - storage_address,
+    )
+
+
+def manifests(
+    tp: int,
+    prefix: str,
+    address_base: int,
+    *,
+    tensor: TensorDescriptor | None = None,
+) -> RuntimeInputs:
+    tensor = tensor or TensorDescriptor(
+        tensor_id="layers.0.mlp.gate_up",
+        global_shape=(8,),
+        dtype="uint8",
+        itemsize=1,
+        shard_dims=(0,),
+        layer_id=0,
+        layout_fingerprint="sglang:qwen3.5:uint8:test",
+        parallel_axes=(
+            ReplicatedAxis("dp"),
+            SplitAxis("tp", dim=0),
+        ),
+    )
+    (dim,) = tensor.shard_dims
+    extent = tensor.global_shape[dim] // tp
+    fragments = []
+    participant_inputs = []
+    ranks = []
+    nbytes_by_fragment = {}
+    bindings = []
+    for tp_rank in range(tp):
+        worker_id = f"{prefix}-t{tp_rank}"
+        rank = ParallelRank(tp=tp_rank)
+        local_shape = list(tensor.global_shape)
+        local_shape[dim] = extent
+        global_offset = [0] * len(tensor.global_shape)
+        global_offset[dim] = tp_rank * extent
+        placement_fragment_id = f"{worker_id}-placement"
+        nbytes = prod(local_shape) * tensor.itemsize
+        fragments.append(
+            PlacementFragment(
+                placement_fragment_id=placement_fragment_id,
+                tensor_id=tensor.tensor_id,
+                global_offset=tuple(global_offset),
+                local_shape=tuple(local_shape),
+                nbytes=nbytes,
+                rank=rank,
+            )
+        )
+        ranks.append(rank)
+        participant_inputs.append((tp_rank, worker_id, rank, placement_fragment_id))
+        nbytes_by_fragment[placement_fragment_id] = nbytes
+
+    placement = global_placement(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id=prefix,
+        tensors=(tensor,),
+        fragments=fragments,
+        ranks=ranks,
+    )
+    participant_by_rank = {
+        participant.rank: participant.participant_id
+        for participant in placement.topology.participants
+    }
+    for tp_rank, worker_id, rank, placement_fragment_id in participant_inputs:
+        nbytes = nbytes_by_fragment[placement_fragment_id]
+        bindings.append(
+            WeightRuntimeBindingManifest(
+                resource_id=placement.resource_id,
+                revision=placement.revision,
+                placement_id=placement.placement_id,
+                placement_digest=placement.digest,
+                participant_id=participant_by_rank[rank],
+                instance_id=worker_id,
+                generation=1,
+                lease_id=f"{worker_id}-runtime-lease",
+                fragments=(
+                    runtime_fragment(
+                        placement_fragment_id=placement_fragment_id,
+                        fragment_id=f"{worker_id}-fragment",
+                        address=address_base + tp_rank * 0x1000,
+                        nbytes=nbytes,
+                        worker_id=worker_id,
+                        endpoint=f"{worker_id}:12345",
+                        local_shape=tuple(local_shape),
+                        itemsize=tensor.itemsize,
+                    ),
+                ),
+            )
+        )
+    return RuntimeInputs(placement, tuple(bindings))
+
+
+def registration_leases(inputs: RuntimeInputs) -> tuple[MemoryRegistrationLease, ...]:
+    return tuple(
+        MemoryRegistrationLease.from_fragment(
+            fragment,
+            lease_generation=binding.generation,
+            runtime_lease_id=binding.lease_id,
+        )
+        for binding in inputs.bindings
+        for fragment in binding.fragments
+    )
+
+
+def allocation_guards(
+    inputs: RuntimeInputs,
+) -> dict[tuple[str, str], FakeWeightAllocationGuard]:
+    return allocation_guards_for_bindings(inputs.bindings)
+
+
+def allocation_guards_for_bindings(
+    bindings: Sequence[WeightRuntimeBindingManifest],
+) -> dict[tuple[str, str], FakeWeightAllocationGuard]:
+    return {
+        (binding.instance_id, binding.participant_id): FakeWeightAllocationGuard(
+            binding
+        )
+        for binding in bindings
+    }
+
+
+def participant_inputs(inputs: RuntimeInputs, index: int) -> RuntimeInputs:
+    return RuntimeInputs(inputs.placement, (inputs.bindings[index],))
+
+
+def with_revision(inputs: RuntimeInputs, revision: str) -> RuntimeInputs:
+    placement = global_placement(
+        resource_id=inputs.placement.resource_id,
+        revision=revision,
+        weight_generation=inputs.placement.weight_generation,
+        placement_set_id=inputs.placement.placement_set_id,
+        tensors=inputs.placement.tensors,
+        fragments=inputs.placement.fragments,
+        ranks=tuple(
+            participant.rank for participant in inputs.placement.topology.participants
+        ),
+    )
+    return RuntimeInputs(
+        placement,
+        tuple(
+            replace(
+                binding,
+                revision=revision,
+                placement_id=placement.placement_id,
+                placement_digest=placement.digest,
+            )
+            for binding in inputs.bindings
+        ),
+    )
+
+
+def execute_sink(
+    sink,
+    plan,
+    source: RuntimeInputs,
+    targets: RuntimeInputs,
+    *,
+    source_binding_index: int = 0,
+    **kwargs,
+):
+    kwargs.setdefault("source_allocation_guards", allocation_guards(source))
+    kwargs.setdefault("target_allocation_guards", allocation_guards(targets))
+    return sink.execute(
+        plan,
+        source.placement,
+        source.bindings[source_binding_index],
+        targets.placement,
+        targets.bindings,
+        **kwargs,
+    )
+
+
+def execute_reader(
+    reader,
+    plan,
+    sources: RuntimeInputs,
+    target: RuntimeInputs,
+    *,
+    target_binding_index: int = 0,
+    **kwargs,
+):
+    kwargs.setdefault("source_allocation_guards", allocation_guards(sources))
+    kwargs.setdefault("target_allocation_guards", allocation_guards(target))
+    return reader.execute(
+        plan,
+        sources.placement,
+        sources.bindings,
+        target.placement,
+        target.bindings[target_binding_index],
+        **kwargs,
+    )
+
+
+def multi_dim_te_manifests(
+    prefix: str,
+    address_base: int,
+    *,
+    source: bool,
+) -> RuntimeInputs:
+    tensor = TensorDescriptor(
+        tensor_id="layers.0.experts.w1",
+        global_shape=(4, 6, 8),
+        dtype="uint8",
+        itemsize=1,
+        layer_id=0,
+        expert_id=None,
+        layout_fingerprint="framework:logical-contiguous:v2",
+        shard_dims=(0,) if source else (2,),
+        parallel_axes=(SplitAxis("ep" if source else "tp", dim=0 if source else 2),),
+    )
+    fragments = []
+    participant_inputs = []
+    ranks = []
+    bindings = []
+    for rank in range(2):
+        worker_id = f"{prefix}-{rank}"
+        offset = (rank * 2, 0, 0) if source else (0, 0, rank * 4)
+        shape = (2, 6, 8) if source else (4, 6, 4)
+        parallel_rank = ParallelRank(ep=rank) if source else ParallelRank(tp=rank)
+        placement_fragment_id = f"{worker_id}-placement"
+        fragments.append(
+            PlacementFragment(
+                placement_fragment_id=placement_fragment_id,
+                tensor_id=tensor.tensor_id,
+                global_offset=offset,
+                local_shape=shape,
+                nbytes=prod(shape),
+                rank=parallel_rank,
+            )
+        )
+        ranks.append(parallel_rank)
+        participant_inputs.append(
+            (rank, worker_id, parallel_rank, placement_fragment_id, prod(shape))
+        )
+
+    placement = global_placement(
+        resource_id="qwen-family-moe",
+        revision="step-42",
+        placement_set_id=prefix,
+        tensors=(tensor,),
+        fragments=fragments,
+        ranks=ranks,
+    )
+    participant_by_rank = {
+        participant.rank: participant.participant_id
+        for participant in placement.topology.participants
+    }
+    for (
+        rank,
+        worker_id,
+        parallel_rank,
+        placement_fragment_id,
+        nbytes,
+    ) in participant_inputs:
+        bindings.append(
+            WeightRuntimeBindingManifest(
+                resource_id=placement.resource_id,
+                revision=placement.revision,
+                placement_id=placement.placement_id,
+                placement_digest=placement.digest,
+                participant_id=participant_by_rank[parallel_rank],
+                instance_id=worker_id,
+                generation=1,
+                lease_id=f"{worker_id}-runtime-lease",
+                fragments=(
+                    runtime_fragment(
+                        placement_fragment_id=placement_fragment_id,
+                        fragment_id=f"{worker_id}-fragment",
+                        address=address_base + rank * 0x1000,
+                        nbytes=nbytes,
+                        worker_id=worker_id,
+                        endpoint=f"{worker_id}:12345",
+                        local_shape=shape,
+                        itemsize=tensor.itemsize,
+                    ),
+                ),
+            )
+        )
+    return RuntimeInputs(placement, tuple(bindings))

--- a/mooncake-reshard/tests/model_weight_te/test_batch_lowering_limits.py
+++ b/mooncake-reshard/tests/model_weight_te/test_batch_lowering_limits.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight.manifest import SplitAxis, TensorDescriptor
+from mooncake.reshard.weight.planner import (
+    TransferRegion,
+)
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferEngineError,
+)
+from mooncake.reshard.weight._te.batching import iter_transfer_batches
+
+from global_placement_helpers import global_placement
+
+from .helpers import (
+    FakeTransferEngine,
+    RuntimeInputs,
+    execute_reader,
+    execute_sink,
+    manifests,
+    multi_dim_te_manifests,
+    participant_inputs,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    registration_leases,
+    runtime_fragment,
+)
+
+
+def _dp_sources() -> RuntimeInputs:
+    source_dp0 = manifests(tp=1, prefix="source-d0", address_base=0x10000)
+    dp0_fragment = source_dp0.placement.fragments[0]
+    dp1_rank = replace(dp0_fragment.rank, dp=1)
+    placement_fragment = replace(
+        dp0_fragment,
+        placement_fragment_id="source-d1-placement",
+        rank=dp1_rank,
+    )
+    placement = global_placement(
+        resource_id=source_dp0.placement.resource_id,
+        revision=source_dp0.placement.revision,
+        weight_generation=source_dp0.placement.weight_generation,
+        placement_set_id="source-dp",
+        tensors=source_dp0.placement.tensors,
+        fragments=(dp0_fragment, placement_fragment),
+        ranks=(dp0_fragment.rank, dp1_rank),
+    )
+    participant_by_rank = {
+        participant.rank: participant.participant_id
+        for participant in placement.topology.participants
+    }
+    dp0_binding = replace(
+        source_dp0.bindings[0],
+        placement_id=placement.placement_id,
+        placement_digest=placement.digest,
+        participant_id=participant_by_rank[dp0_fragment.rank],
+    )
+    binding_fragment = replace(
+        dp0_binding.fragments[0],
+        placement_fragment_id=placement_fragment.placement_fragment_id,
+        fragment_id="source-d1-fragment",
+        address=0x20000,
+        storage_address=0x20000,
+        worker_id="source-d1-t0",
+        endpoint="source-d1-t0:12345",
+    )
+    binding = replace(
+        dp0_binding,
+        placement_id=placement.placement_id,
+        placement_digest=placement.digest,
+        participant_id=participant_by_rank[dp1_rank],
+        instance_id="source-d1-t0",
+        lease_id="source-d1-t0-runtime-lease",
+        fragments=(binding_fragment,),
+    )
+    return RuntimeInputs(placement, (dp0_binding, binding))
+
+
+def test_te_sink_lowers_multi_dim_regions_in_bounded_batches() -> None:
+    sources = multi_dim_te_manifests("source", 0x10000, source=True)
+    targets = multi_dim_te_manifests("target", 0x40000, source=False)
+    plan = plan_transfer(sources, targets)
+    engine = FakeTransferEngine()
+
+    receipts = execute_sink(
+        MooncakeTransferEngineSink(
+            engine,
+            max_batch_operations=5,
+            max_region_segments=12,
+        ),
+        plan,
+        sources,
+        targets,
+        target_registrations=registration_leases(targets),
+    )
+
+    assert [receipt.operation_count for receipt in receipts] == [12, 12]
+    assert [receipt.nbytes for receipt in receipts] == [48, 48]
+    assert [len(call[3]) for call in engine.calls] == [5, 5, 2, 5, 5, 2]
+    assert max(len(call[3]) for call in engine.calls) == 5
+
+
+def test_te_reader_lowers_multi_dim_regions_in_bounded_batches() -> None:
+    sources = multi_dim_te_manifests("source", 0x10000, source=True)
+    target = participant_inputs(
+        multi_dim_te_manifests("target", 0x40000, source=False), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    engine = FakeTransferEngine()
+
+    receipts = execute_reader(
+        MooncakeTransferEngineReader(
+            engine,
+            max_batch_operations=5,
+            max_region_segments=12,
+        ),
+        plan,
+        sources,
+        target,
+        source_registrations=registration_leases(sources),
+        target_pre_registered=True,
+        target_registrations=registration_leases(target),
+    )
+
+    assert [receipt.operation_count for receipt in receipts] == [12, 12]
+    assert [receipt.nbytes for receipt in receipts] == [48, 48]
+    assert [len(call[3]) for call in engine.calls] == [5, 5, 2, 5, 5, 2]
+    assert max(len(call[3]) for call in engine.calls) == 5
+
+
+@pytest.mark.parametrize("executor", ["sink", "reader"])
+def test_te_rejects_multi_dim_region_above_lowering_limit(executor: str) -> None:
+    sources = multi_dim_te_manifests("source", 0x10000, source=True)
+    targets = multi_dim_te_manifests("target", 0x40000, source=False)
+    engine = FakeTransferEngine()
+
+    with pytest.raises(TransferEngineError, match="max_region_segments"):
+        if executor == "sink":
+            plan = plan_transfer(sources, targets)
+            execute_sink(
+                MooncakeTransferEngineSink(engine, max_region_segments=11),
+                plan,
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+        else:
+            target = participant_inputs(targets, 1)
+            plan = plan_transfer_to_local_target(sources, target)
+            execute_reader(
+                MooncakeTransferEngineReader(engine, max_region_segments=11),
+                plan,
+                sources,
+                target,
+                source_registrations=registration_leases(sources),
+                target_pre_registered=True,
+                target_registrations=registration_leases(target),
+            )
+
+    assert engine.calls == []
+    assert engine.register_calls == []
+
+
+def test_te_sink_lowers_canonical_transfer_region() -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    planned = plan_transfer(sources, targets)
+    region = planned.operations[0]
+    assert isinstance(region, TransferRegion)
+    engine = FakeTransferEngine()
+
+    receipts = execute_sink(
+        MooncakeTransferEngineSink(engine),
+        planned,
+        sources,
+        targets,
+        target_registrations=registration_leases(targets),
+    )
+
+    assert receipts[0].nbytes == sources.placement.fragments[0].nbytes
+    assert len(engine.calls) == 1
+
+
+def test_te_sink_expands_compact_ranges_in_bounded_batches() -> None:
+    tensor = TensorDescriptor(
+        tensor_id="layers.0.mlp.down_proj.weight",
+        global_shape=(5, 8),
+        dtype="uint8",
+        itemsize=1,
+        shard_dims=(1,),
+        layer_id=0,
+        layout_fingerprint="sglang:qwen3.5:uint8:test",
+        parallel_axes=(SplitAxis("tp", dim=1),),
+    )
+    sources = manifests(
+        tp=2,
+        prefix="source",
+        address_base=0x10000,
+        tensor=tensor,
+    )
+    targets = manifests(
+        tp=4,
+        prefix="target",
+        address_base=0x40000,
+        tensor=tensor,
+    )
+    plan = plan_transfer(sources, targets)
+    engine = FakeTransferEngine()
+
+    receipts = execute_sink(
+        MooncakeTransferEngineSink(engine, max_batch_operations=2),
+        plan,
+        sources,
+        targets,
+        target_registrations=registration_leases(targets),
+    )
+
+    assert [len(call[1]) for call in engine.calls] == [2, 2, 1, 2, 2, 1]
+    assert sum(receipt.operation_count for receipt in receipts) == 10
+    assert sum(receipt.nbytes for receipt in receipts) == 20
+
+
+def test_te_sink_skips_an_unselected_source_without_an_executor() -> None:
+    sources = _dp_sources()
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    assert {executor.rank.dp for executor in plan.source_executors} == {0}
+    engine = FakeTransferEngine()
+
+    receipts = execute_sink(
+        MooncakeTransferEngineSink(engine),
+        plan,
+        sources,
+        targets,
+        source_binding_index=1,
+        target_registrations=registration_leases(targets),
+    )
+
+    assert receipts == ()
+    assert engine.calls == []
+    assert engine.register_calls == []
+
+
+def test_te_sink_skips_a_stale_unselected_source_without_acquiring_a_guard() -> None:
+    sources = _dp_sources()
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    stale = RuntimeInputs(
+        sources.placement,
+        (
+            sources.bindings[0],
+            replace(
+                sources.bindings[1],
+                generation=2,
+                fragments=(
+                    replace(
+                        sources.bindings[1].fragments[0],
+                        address=0x90000,
+                        storage_address=0x90000,
+                        endpoint="source-d1-t0:54321",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    engine = FakeTransferEngine()
+    receipts = execute_sink(
+        MooncakeTransferEngineSink(engine),
+        plan,
+        stale,
+        targets,
+        source_binding_index=1,
+        target_registrations=registration_leases(targets),
+    )
+
+    assert receipts == ()
+    assert engine.calls == []
+    assert engine.register_calls == []
+
+
+def test_te_reader_batches_large_repeats_without_segment_tuple_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repeat = 8192
+    tensor = TensorDescriptor(
+        tensor_id="layers.0.mlp.down_proj.weight",
+        global_shape=(repeat, 8),
+        dtype="uint8",
+        itemsize=1,
+        shard_dims=(1,),
+        layer_id=0,
+        layout_fingerprint="sglang:qwen3.5:uint8:test",
+        parallel_axes=(SplitAxis("tp", dim=1),),
+    )
+    sources = manifests(
+        tp=2,
+        prefix="source",
+        address_base=0x10000,
+        tensor=tensor,
+    )
+    target = participant_inputs(
+        manifests(
+            tp=1,
+            prefix="target",
+            address_base=0x40000,
+            tensor=tensor,
+        ),
+        0,
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    state = {"yielded": 0, "exhausted": False, "first_batch": None}
+
+    class StreamingProbeTransferEngine(FakeTransferEngine):
+        def batch_transfer_sync_read(
+            self,
+            endpoint,
+            target_addresses,
+            source_addresses,
+            sizes,
+        ):
+            if state["first_batch"] is None:
+                state["first_batch"] = (state["yielded"], state["exhausted"])
+            return super().batch_transfer_sync_read(
+                endpoint,
+                target_addresses,
+                source_addresses,
+                sizes,
+            )
+
+    engine = StreamingProbeTransferEngine()
+
+    assert [operation.repeat for operation in plan.operations] == [repeat, repeat]
+    assert all(isinstance(operation, TransferRegion) for operation in plan.operations)
+
+    original_iter_segments = TransferRegion.iter_segments
+
+    def observe_streaming_segments(
+        self: TransferRegion,
+        *,
+        max_segments: int,
+    ):
+        try:
+            for segment in original_iter_segments(self, max_segments=max_segments):
+                state["yielded"] += 1
+                yield segment
+        finally:
+            state["exhausted"] = True
+
+    monkeypatch.setattr(TransferRegion, "iter_segments", observe_streaming_segments)
+
+    receipts = execute_reader(
+        MooncakeTransferEngineReader(engine, max_batch_operations=1024),
+        plan,
+        sources,
+        target,
+        source_registrations=registration_leases(sources),
+        target_pre_registered=True,
+        target_registrations=registration_leases(target),
+    )
+
+    endpoints = [call[0] for call in engine.calls]
+    assert endpoints == ["source-t0:12345"] * 8 + ["source-t1:12345"] * 8
+    assert all(len(call[3]) == 1024 for call in engine.calls)
+    assert [receipt.operation_count for receipt in receipts] == [repeat, repeat]
+    assert [receipt.nbytes for receipt in receipts] == [repeat * 4, repeat * 4]
+    assert state["first_batch"] == (1024, False)
+    assert engine.calls[0][1][0] == 0x40000
+    assert engine.calls[7][1][-1] == 0x40000 + (repeat - 1) * 8
+    assert engine.calls[8][1][0] == 0x40004
+    assert engine.calls[15][1][-1] == 0x40004 + (repeat - 1) * 8
+
+
+def test_te_ranges_use_allocation_bases_and_view_relative_offsets() -> None:
+    class Operation:
+        @staticmethod
+        def iter_segments(*, max_segments: int):
+            assert max_segments >= 2
+            yield 1, 2, 3
+            yield 4, 8, 2
+
+    source = runtime_fragment(
+        placement_fragment_id="source-placement",
+        fragment_id="source-fragment",
+        address=0x1100,
+        nbytes=16,
+        worker_id="source",
+        endpoint="source:12345",
+        local_shape=(16,),
+        itemsize=1,
+        storage_address=0x1000,
+        storage_nbytes=0x1000,
+    )
+    target = runtime_fragment(
+        placement_fragment_id="target-placement",
+        fragment_id="target-fragment",
+        address=0x2280,
+        nbytes=16,
+        worker_id="target",
+        endpoint="target:12345",
+        local_shape=(16,),
+        itemsize=1,
+        storage_address=0x2000,
+        storage_nbytes=0x1000,
+    )
+
+    (batch,) = tuple(
+        iter_transfer_batches(
+            target.endpoint,
+            ((Operation(), source, target),),
+            max_batch_operations=8,
+            max_region_segments=2,
+        )
+    )
+    (transfer_range,) = batch.ranges
+
+    assert transfer_range.source_base_address == source.storage_address
+    assert transfer_range.source_capacity == source.storage_nbytes
+    assert transfer_range.target_base_address == target.storage_address
+    assert transfer_range.target_capacity == target.storage_nbytes
+    assert transfer_range.source_offsets == (0x101, 0x104)
+    assert transfer_range.target_offsets == (0x282, 0x288)
+    assert batch.source_addresses == (source.address + 1, source.address + 4)
+    assert batch.target_addresses == (target.address + 2, target.address + 8)

--- a/mooncake-reshard/tests/model_weight_te/test_common_contracts.py
+++ b/mooncake-reshard/tests/model_weight_te/test_common_contracts.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferEngineError,
+)
+from mooncake.reshard.weight._te.registration import registered_sources
+
+from .helpers import (
+    FakeTransferEngine,
+    RuntimeInputs,
+    execute_reader,
+    execute_sink,
+    manifests,
+    participant_inputs,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    registration_leases,
+    runtime_fragment,
+)
+
+
+@pytest.mark.parametrize(
+    ("executor_kind", "side"),
+    [
+        ("sink", "source"),
+        ("sink", "target"),
+        ("reader", "source"),
+        ("reader", "target"),
+    ],
+)
+@pytest.mark.parametrize("mismatch", ["registration", "manifest"])
+def test_te_pre_registered_paths_fence_runtime_lease_id_before_native_calls(
+    executor_kind: str,
+    side: str,
+    mismatch: str,
+) -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=2, prefix="target", address_base=0x40000)
+    plan = (
+        plan_transfer(sources, targets)
+        if executor_kind == "sink"
+        else plan_transfer_to_local_target(sources, participant_inputs(targets, 0))
+    )
+    current_sources = sources
+    current_targets = targets
+    if mismatch == "manifest":
+        if side == "source":
+            current_sources = RuntimeInputs(
+                sources.placement,
+                (
+                    replace(
+                        sources.bindings[0],
+                        lease_id="rotated-source-runtime-lease",
+                    ),
+                    *sources.bindings[1:],
+                ),
+            )
+        else:
+            current_targets = RuntimeInputs(
+                targets.placement,
+                (
+                    replace(
+                        targets.bindings[0],
+                        lease_id="rotated-target-runtime-lease",
+                    ),
+                    *targets.bindings[1:],
+                ),
+            )
+
+    source_registrations = list(registration_leases(current_sources))
+    target_registrations = list(registration_leases(current_targets))
+    if mismatch == "registration":
+        registrations = (
+            source_registrations if side == "source" else target_registrations
+        )
+        registrations[0] = replace(
+            registrations[0],
+            runtime_lease_id=f"stale-{side}-runtime-lease",
+        )
+
+    engine = FakeTransferEngine()
+    expected_error = (
+        f"{side} registration lease mismatch"
+        if mismatch == "registration"
+        else f"{side} executor snapshot mismatch"
+    )
+    with pytest.raises(TransferEngineError, match=expected_error):
+        try:
+            if executor_kind == "sink":
+                execute_sink(
+                    MooncakeTransferEngineSink(engine),
+                    plan,
+                    current_sources,
+                    current_targets,
+                    target_registrations=tuple(target_registrations),
+                    source_pre_registered=True,
+                    source_registrations=tuple(source_registrations),
+                )
+            else:
+                execute_reader(
+                    MooncakeTransferEngineReader(engine),
+                    plan,
+                    current_sources,
+                    participant_inputs(current_targets, 0),
+                    source_registrations=tuple(source_registrations),
+                    target_pre_registered=True,
+                    target_registrations=tuple(target_registrations),
+                )
+        finally:
+            assert engine.calls == []
+            assert engine.register_calls == []
+            assert engine.unregister_calls == []
+
+
+def test_te_registration_deduplicates_views_of_one_storage_allocation() -> None:
+    engine = FakeTransferEngine()
+    fragments = tuple(
+        runtime_fragment(
+            placement_fragment_id=f"placement-{index}",
+            fragment_id=f"fragment-{index}",
+            address=0x1000 + offset,
+            nbytes=0x100,
+            worker_id="worker",
+            endpoint="worker:12345",
+            local_shape=(0x100,),
+            itemsize=1,
+            storage_address=0x1000,
+            storage_nbytes=0x1000,
+        )
+        for index, offset in enumerate((0x100, 0x300))
+    )
+
+    with registered_sources(
+        engine,
+        object(),
+        fragments,
+        pre_registered=False,
+        registrations=None,
+        lease_generation=1,
+        runtime_lease_id="runtime-lease",
+        resources=(),
+    ):
+        assert engine.register_calls == [(0x1000, 0x1000)]
+        assert engine.unregister_calls == []
+
+    assert engine.unregister_calls == [0x1000]
+
+
+@pytest.mark.parametrize("executor_kind", ["sink", "reader"])
+@pytest.mark.parametrize("side", ["source", "target"])
+def test_te_execution_rejects_storage_snapshot_mismatch_before_native_calls(
+    executor_kind: str,
+    side: str,
+) -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=2, prefix="target", address_base=0x40000)
+    plan = (
+        plan_transfer(sources, targets)
+        if executor_kind == "sink"
+        else plan_transfer_to_local_target(sources, participant_inputs(targets, 0))
+    )
+    current = sources if side == "source" else targets
+    fragment = current.bindings[0].fragments[0]
+    changed_fragment = replace(
+        fragment,
+        storage_address=fragment.address - 1,
+        storage_nbytes=fragment.nbytes + 1,
+        storage_offset_bytes=1,
+    )
+    changed = RuntimeInputs(
+        current.placement,
+        (
+            replace(current.bindings[0], fragments=(changed_fragment,)),
+            *current.bindings[1:],
+        ),
+    )
+    current_sources = changed if side == "source" else sources
+    current_targets = changed if side == "target" else targets
+    engine = FakeTransferEngine()
+
+    with pytest.raises(TransferEngineError, match=f"{side} executor snapshot mismatch"):
+        if executor_kind == "sink":
+            execute_sink(
+                MooncakeTransferEngineSink(engine),
+                plan,
+                current_sources,
+                current_targets,
+                target_registrations=registration_leases(current_targets),
+            )
+        else:
+            execute_reader(
+                MooncakeTransferEngineReader(engine),
+                plan,
+                current_sources,
+                participant_inputs(current_targets, 0),
+                source_registrations=registration_leases(current_sources),
+                target_pre_registered=True,
+                target_registrations=registration_leases(
+                    participant_inputs(current_targets, 0)
+                ),
+            )
+
+    assert engine.calls == []
+    assert engine.register_calls == []
+    assert engine.unregister_calls == []

--- a/mooncake-reshard/tests/model_weight_te/test_completion_fence.py
+++ b/mooncake-reshard/tests/model_weight_te/test_completion_fence.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+
+from .helpers import (
+    FakeBatchTransferTicket,
+    FakeTransferEngine,
+    allocation_guards,
+    execute_reader,
+    execute_sink,
+    manifests,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    registration_leases,
+)
+
+
+def _guard_tokens(*guard_maps):
+    return tuple(
+        token
+        for guard_map in guard_maps
+        for guard in guard_map.values()
+        for token in guard.tokens
+    )
+
+
+@pytest.mark.parametrize(
+    ("executor", "terminal_status", "expect_error"),
+    [
+        ("sink", "COMPLETED", False),
+        ("sink", "FAILED_DRAINED", True),
+        ("reader", "COMPLETED", False),
+        ("reader", "FAILED_DRAINED", True),
+    ],
+)
+def test_te_ticket_path_keeps_registration_until_completion_is_known(
+    executor: str,
+    terminal_status: str,
+    expect_error: bool,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(
+        ["COMPLETION_UNKNOWN", "COMPLETION_UNKNOWN", terminal_status],
+        on_drain=lambda: (
+            pytest.fail("registration released before transfer drained")
+            if engine.unregister_calls
+            else None
+        ),
+    )
+
+    def write_with_ticket(endpoint, source_addresses, target_addresses, sizes):
+        engine.calls.append((endpoint, source_addresses, target_addresses, sizes))
+        return ticket
+
+    def read_with_ticket(endpoint, target_addresses, source_addresses, sizes):
+        engine.calls.append((endpoint, target_addresses, source_addresses, sizes))
+        return ticket
+
+    engine.batch_transfer_sync_write_with_ticket = write_with_ticket
+    engine.batch_transfer_sync_read_with_ticket = read_with_ticket
+
+    if executor == "sink":
+        plan = plan_transfer(sources, targets)
+
+        def execute():
+            return execute_sink(
+                MooncakeTransferEngineSink(engine),
+                plan,
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+
+        expected_unregister = [0x10000]
+    else:
+        plan = plan_transfer_to_local_target(sources, targets)
+
+        def execute():
+            return execute_reader(
+                MooncakeTransferEngineReader(engine),
+                plan,
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+        expected_unregister = [0x40000]
+
+    if expect_error:
+        with pytest.raises(TransferEngineError, match="FAILED_DRAINED"):
+            execute()
+    else:
+        execute()
+
+    assert ticket.drain_calls == [1000, 1000]
+    assert engine.unregister_calls == expected_unregister
+
+
+@pytest.mark.parametrize("executor_name", ("sink", "reader"))
+def test_te_legacy_nonzero_result_requires_restart_before_releasing_guards(
+    executor_name: str,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    source_guards = allocation_guards(sources)
+    target_guards = allocation_guards(targets)
+    engine = FakeTransferEngine()
+
+    if executor_name == "sink":
+        executor = MooncakeTransferEngineSink(engine)
+        engine.batch_transfer_sync_write = lambda *args: -1
+
+        def execute() -> None:
+            execute_sink(
+                executor,
+                plan_transfer(sources, targets),
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+                source_allocation_guards=source_guards,
+                target_allocation_guards=target_guards,
+            )
+
+    else:
+        executor = MooncakeTransferEngineReader(engine)
+        engine.batch_transfer_sync_read = lambda *args: -1
+
+        def execute() -> None:
+            execute_reader(
+                executor,
+                plan_transfer_to_local_target(sources, targets),
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+                source_allocation_guards=source_guards,
+                target_allocation_guards=target_guards,
+            )
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        execute()
+
+    pending_id = raised.value.pending_transfer_id
+    assert engine.unregister_calls == []
+    assert (
+        executor.pending_transfer_status(pending_id)
+        == "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+    )
+    assert all(
+        token.released_states == []
+        for token in _guard_tokens(source_guards, target_guards)
+    )
+    with pytest.raises(TransferEngineError, match="restart-required"):
+        execute()
+
+
+@pytest.mark.parametrize("executor_name", ["sink", "reader"])
+def test_te_unknown_completion_moves_registration_to_queryable_quarantine(
+    executor_name: str,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 4)
+
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+    engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+
+    if executor_name == "sink":
+        executor = MooncakeTransferEngineSink(
+            engine,
+            max_completion_drain_attempts=2,
+        )
+
+        def execute():
+            return execute_sink(
+                executor,
+                plan_transfer(sources, targets),
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+
+        expected_unregister = [0x10000]
+    else:
+        executor = MooncakeTransferEngineReader(
+            engine,
+            max_completion_drain_attempts=2,
+        )
+
+        def execute():
+            return execute_reader(
+                executor,
+                plan_transfer_to_local_target(sources, targets),
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+        expected_unregister = [0x40000]
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        execute()
+
+    pending_id = raised.value.pending_transfer_id
+    assert ticket.drain_calls == [1000, 1000]
+    assert engine.unregister_calls == []
+    assert executor.pending_transfer_ids() == (pending_id,)
+    assert executor.pending_transfer_status(pending_id) == "COMPLETION_UNKNOWN"
+
+    ticket._statuses = ["COMPLETED"]
+    assert executor.drain_pending_transfer(pending_id) == "COMPLETED"
+    assert engine.unregister_calls == expected_unregister
+    assert executor.pending_transfer_ids() == ()
+
+
+@pytest.mark.parametrize("executor_name", ["sink", "reader"])
+@pytest.mark.parametrize("interruption_type", [KeyboardInterrupt, SystemExit])
+def test_te_interrupted_unknown_completion_quarantines_before_reraising(
+    executor_name: str,
+    interruption_type: type[BaseException],
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+
+    def interrupt_drain() -> None:
+        raise interruption_type("stop transfer wait")
+
+    ticket = FakeBatchTransferTicket(
+        ["COMPLETION_UNKNOWN"],
+        on_drain=interrupt_drain,
+    )
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+    engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+
+    if executor_name == "sink":
+        executor = MooncakeTransferEngineSink(
+            engine,
+            max_completion_drain_attempts=1,
+        )
+
+        def execute():
+            execute_sink(
+                executor,
+                plan_transfer(sources, targets),
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+
+        expected_unregister = [0x10000]
+    else:
+        executor = MooncakeTransferEngineReader(
+            engine,
+            max_completion_drain_attempts=1,
+        )
+
+        def execute():
+            execute_reader(
+                executor,
+                plan_transfer_to_local_target(sources, targets),
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+        expected_unregister = [0x40000]
+
+    with pytest.raises(interruption_type, match="stop transfer wait"):
+        execute()
+
+    pending_ids = executor.pending_transfer_ids()
+    assert len(pending_ids) == 1
+    pending_id = pending_ids[0]
+    assert engine.unregister_calls == []
+    assert executor.pending_transfer_status(pending_id) == "COMPLETION_UNKNOWN"
+
+    ticket._on_drain = None
+    ticket._statuses = ["COMPLETED"]
+    assert executor.drain_pending_transfer(pending_id) == "COMPLETED"
+    assert engine.unregister_calls == expected_unregister
+    assert executor.pending_transfer_ids() == ()
+
+
+@pytest.mark.parametrize("executor_name", ["sink", "reader"])
+@pytest.mark.parametrize("interruption_type", [KeyboardInterrupt, SystemExit])
+def test_te_interrupted_native_submission_requires_restart_before_unregister(
+    executor_name: str,
+    interruption_type: type[BaseException],
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+
+    def interrupt_submission(*args):
+        raise interruption_type("stop native submission")
+
+    engine.batch_transfer_sync_write_with_ticket = interrupt_submission
+    engine.batch_transfer_sync_read_with_ticket = interrupt_submission
+
+    if executor_name == "sink":
+        executor = MooncakeTransferEngineSink(engine)
+
+        def execute():
+            execute_sink(
+                executor,
+                plan_transfer(sources, targets),
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+
+    else:
+        executor = MooncakeTransferEngineReader(engine)
+
+        def execute():
+            execute_reader(
+                executor,
+                plan_transfer_to_local_target(sources, targets),
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+    with pytest.raises(interruption_type, match="stop native submission"):
+        execute()
+
+    pending_ids = executor.pending_transfer_ids()
+    assert len(pending_ids) == 1
+    assert engine.unregister_calls == []
+    assert (
+        executor.pending_transfer_status(pending_ids[0])
+        == "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+    )
+    with pytest.raises(TransferEngineError, match="restart-required"):
+        execute()
+
+
+def test_te_continuous_drain_errors_remain_quarantined_until_terminal() -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+
+    def fail_drain() -> None:
+        raise RuntimeError("backend unavailable")
+
+    ticket = FakeBatchTransferTicket(
+        ["COMPLETION_UNKNOWN"],
+        on_drain=fail_drain,
+    )
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+    sink = MooncakeTransferEngineSink(
+        engine,
+        max_completion_drain_attempts=2,
+    )
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        execute_sink(
+            sink,
+            plan_transfer(sources, targets),
+            sources,
+            targets,
+            target_registrations=registration_leases(targets),
+        )
+
+    pending_id = raised.value.pending_transfer_id
+    assert ticket.drain_calls == [1000, 1000]
+    assert engine.unregister_calls == []
+    assert sink.drain_pending_transfer(pending_id) == "COMPLETION_UNKNOWN"
+    assert engine.unregister_calls == []
+
+    ticket._on_drain = None
+    ticket._statuses = ["FAILED_DRAINED"]
+    assert sink.drain_pending_transfer(pending_id) == "FAILED_DRAINED"
+    assert engine.unregister_calls == [0x10000]

--- a/mooncake-reshard/tests/model_weight_te/test_engine_identity_restart.py
+++ b/mooncake-reshard/tests/model_weight_te/test_engine_identity_restart.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+
+from .helpers import (
+    FakeTransferEngine,
+    execute_reader,
+    execute_sink,
+    manifests,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    registration_leases,
+)
+
+
+def test_te_reader_quarantines_legacy_completion_unknown_without_ticket() -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+    engine.read_result = -2
+    reader = MooncakeTransferEngineReader(engine)
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        execute_reader(
+            reader,
+            plan_transfer_to_local_target(sources, targets),
+            sources,
+            targets,
+            source_registrations=registration_leases(sources),
+        )
+
+    pending_id = raised.value.pending_transfer_id
+    assert "restart-required" in str(raised.value)
+    assert reader.pending_transfer_ids() == (pending_id,)
+    assert reader.pending_transfer_status(pending_id) == (
+        "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+    )
+    assert reader.drain_pending_transfer(pending_id, timeout_ms=0) == (
+        "COMPLETION_UNKNOWN"
+    )
+    assert engine.unregister_calls == []
+
+
+def test_te_legacy_completion_unknown_blocks_same_engine_until_restart() -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    plan = plan_transfer_to_local_target(sources, targets)
+    engine = FakeTransferEngine()
+    engine.read_result = -2
+    reader = MooncakeTransferEngineReader(engine)
+
+    with pytest.raises(TransferCompletionUnknownError):
+        execute_reader(
+            reader,
+            plan,
+            sources,
+            targets,
+            source_registrations=registration_leases(sources),
+        )
+
+    call_count = len(engine.calls)
+    register_count = len(engine.register_calls)
+    engine.read_result = 0
+    with pytest.raises(TransferEngineError, match="restart-required"):
+        execute_sink(
+            MooncakeTransferEngineSink(engine),
+            plan_transfer(sources, targets),
+            sources,
+            targets,
+            target_registrations=registration_leases(targets),
+        )
+    with pytest.raises(TransferEngineError, match="restart-required"):
+        execute_reader(
+            MooncakeTransferEngineReader(engine),
+            plan,
+            sources,
+            targets,
+            source_registrations=registration_leases(sources),
+        )
+
+    assert len(engine.calls) == call_count
+    assert len(engine.register_calls) == register_count
+    assert engine.unregister_calls == []
+
+
+def test_te_canonical_engine_identity_fails_closed_for_broken_getter() -> None:
+    engine = FakeTransferEngine()
+
+    def fail_get_engine_ptr() -> int:
+        raise RuntimeError("native engine handle unavailable")
+
+    engine.get_engine_ptr = fail_get_engine_ptr
+    with pytest.raises(TransferEngineError, match="canonical engine identity"):
+        MooncakeTransferEngineSink(engine)

--- a/mooncake-reshard/tests/model_weight_te/test_lifetime_guards.py
+++ b/mooncake-reshard/tests/model_weight_te/test_lifetime_guards.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    TransferCompletionFailedError,
+    MooncakeTransferEngineSink,
+    TransferCompletionUnknownError,
+)
+from mooncake.reshard.transfer_engine.lifetime import TerminalTransferState
+
+from .helpers import (
+    FakeBatchTransferTicket,
+    FakeTransferEngine,
+    allocation_guards,
+    manifests,
+    plan_transfer,
+    registration_leases,
+)
+
+
+def _all_tokens(*guard_maps):
+    return tuple(
+        token
+        for guard_map in guard_maps
+        for guard in guard_map.values()
+        for token in guard.tokens
+    )
+
+
+def test_live_te_rejects_raw_bindings_without_allocation_guards() -> None:
+    source = manifests(tp=1, prefix="source", address_base=0x10000)
+    target = manifests(tp=1, prefix="target", address_base=0x40000)
+
+    with pytest.raises(ValueError, match="source allocation guard providers"):
+        MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+            plan_transfer(source, target),
+            source.placement,
+            source.bindings[0],
+            target.placement,
+            target.bindings,
+            target_registrations=registration_leases(target),
+        )
+
+
+def test_live_te_holds_source_and_target_guards_until_known_completion() -> None:
+    source = manifests(tp=1, prefix="source", address_base=0x10000)
+    target = manifests(tp=1, prefix="target", address_base=0x40000)
+    source_guards = allocation_guards(source)
+    target_guards = allocation_guards(target)
+
+    MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+        plan_transfer(source, target),
+        source.placement,
+        source.bindings[0],
+        target.placement,
+        target.bindings,
+        target_registrations=registration_leases(target),
+        source_allocation_guards=source_guards,
+        target_allocation_guards=target_guards,
+    )
+
+    assert _all_tokens(source_guards, target_guards)
+    assert all(
+        token.released_states == [TerminalTransferState.COMPLETED]
+        for token in _all_tokens(source_guards, target_guards)
+    )
+
+
+def test_pending_transfer_keeps_guards_until_drain_reaches_terminal() -> None:
+    source = manifests(tp=1, prefix="source", address_base=0x10000)
+    target = manifests(tp=1, prefix="target", address_base=0x40000)
+    source_guards = allocation_guards(source)
+    target_guards = allocation_guards(target)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 3)
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+    sink = MooncakeTransferEngineSink(engine, max_completion_drain_attempts=1)
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        sink.execute(
+            plan_transfer(source, target),
+            source.placement,
+            source.bindings[0],
+            target.placement,
+            target.bindings,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=source_guards,
+            target_allocation_guards=target_guards,
+        )
+
+    assert all(
+        token.released_states == []
+        for token in _all_tokens(source_guards, target_guards)
+    )
+    ticket._statuses = ["COMPLETED"]
+    assert sink.drain_pending_transfer(raised.value.pending_transfer_id) == "COMPLETED"
+    assert all(
+        token.released_states == [TerminalTransferState.COMPLETED]
+        for token in _all_tokens(source_guards, target_guards)
+    )
+
+
+def test_known_native_failure_releases_guards_after_failed_drain() -> None:
+    source = manifests(tp=1, prefix="source", address_base=0x10000)
+    target = manifests(tp=1, prefix="target", address_base=0x40000)
+    source_guards = allocation_guards(source)
+    target_guards = allocation_guards(target)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["FAILED_DRAINED"])
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+
+    with pytest.raises(TransferCompletionFailedError, match="target-t0:12345"):
+        MooncakeTransferEngineSink(engine).execute(
+            plan_transfer(source, target),
+            source.placement,
+            source.bindings[0],
+            target.placement,
+            target.bindings,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=source_guards,
+            target_allocation_guards=target_guards,
+        )
+
+    assert all(
+        token.released_states == [TerminalTransferState.FAILED_DRAINED]
+        for token in _all_tokens(source_guards, target_guards)
+    )
+
+
+def test_native_exception_without_completion_ticket_keeps_guards_quarantined() -> None:
+    source = manifests(tp=1, prefix="source", address_base=0x10000)
+    target = manifests(tp=1, prefix="target", address_base=0x40000)
+    source_guards = allocation_guards(source)
+    target_guards = allocation_guards(target)
+    engine = FakeTransferEngine()
+
+    def fail_without_ticket(*args, **kwargs):
+        raise RuntimeError("native submission raised")
+
+    engine.batch_transfer_sync_write = fail_without_ticket
+    sink = MooncakeTransferEngineSink(engine)
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        sink.execute(
+            plan_transfer(source, target),
+            source.placement,
+            source.bindings[0],
+            target.placement,
+            target.bindings,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=source_guards,
+            target_allocation_guards=target_guards,
+        )
+
+    assert (
+        sink.pending_transfer_status(raised.value.pending_transfer_id)
+        == "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+    )
+    assert all(
+        token.released_states == []
+        for token in _all_tokens(source_guards, target_guards)
+    )

--- a/mooncake-reshard/tests/model_weight_te/test_pending_lifecycle.py
+++ b/mooncake-reshard/tests/model_weight_te/test_pending_lifecycle.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+
+from .helpers import (
+    FakeBatchTransferTicket,
+    FakeTransferEngine,
+    execute_reader,
+    execute_sink,
+    manifests,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    registration_leases,
+)
+
+
+@pytest.mark.parametrize("healthy_executor", ("sink", "reader"))
+def test_te_pending_transfer_backpressure_is_engine_scoped(
+    healthy_executor: str,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    blocked_engine = FakeTransferEngine()
+    blocked_engine.read_result = -2
+
+    with pytest.raises(TransferCompletionUnknownError):
+        execute_reader(
+            MooncakeTransferEngineReader(blocked_engine),
+            plan_transfer_to_local_target(sources, targets),
+            sources,
+            targets,
+            source_registrations=registration_leases(sources),
+        )
+
+    healthy_engine = FakeTransferEngine()
+    if healthy_executor == "sink":
+        receipts = execute_sink(
+            MooncakeTransferEngineSink(healthy_engine),
+            plan_transfer(sources, targets),
+            sources,
+            targets,
+            target_registrations=registration_leases(targets),
+        )
+    else:
+        receipts = execute_reader(
+            MooncakeTransferEngineReader(healthy_engine),
+            plan_transfer_to_local_target(sources, targets),
+            sources,
+            targets,
+            source_registrations=registration_leases(sources),
+        )
+
+    assert len(receipts) == 1
+    assert len(healthy_engine.calls) == 1
+
+
+@pytest.mark.parametrize("recovery_executor", ("sink", "reader"))
+def test_te_pending_transfer_allows_new_transfer_after_drain_cleanup(
+    recovery_executor: str,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+    pending_ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 2)
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: pending_ticket
+    sink = MooncakeTransferEngineSink(engine, max_completion_drain_attempts=1)
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        execute_sink(
+            sink,
+            plan_transfer(sources, targets),
+            sources,
+            targets,
+            target_registrations=registration_leases(targets),
+        )
+
+    completed_ticket = FakeBatchTransferTicket(["COMPLETED"])
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: completed_ticket
+    engine.batch_transfer_sync_read_with_ticket = lambda *args: completed_ticket
+
+    def recover() -> None:
+        if recovery_executor == "sink":
+            execute_sink(
+                MooncakeTransferEngineSink(engine),
+                plan_transfer(sources, targets),
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+        else:
+            execute_reader(
+                MooncakeTransferEngineReader(engine),
+                plan_transfer_to_local_target(sources, targets),
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+    with pytest.raises(TransferEngineError, match="drain_pending_transfer"):
+        recover()
+
+    pending_ticket._statuses = ["COMPLETED"]
+    assert sink.drain_pending_transfer(raised.value.pending_transfer_id) == "COMPLETED"
+    assert sink.pending_transfer_ids() == ()
+    recover()
+
+
+@pytest.mark.parametrize(
+    ("first_executor_name", "second_executor_name", "use_wrapper_aliases"),
+    [
+        pytest.param("sink", "sink", False, id="sink-sink"),
+        pytest.param("reader", "reader", False, id="reader-reader"),
+        pytest.param("sink", "reader", False, id="sink-reader"),
+        pytest.param("sink", "sink", True, id="wrapper-alias"),
+    ],
+)
+def test_te_submission_reservation_is_atomic(
+    first_executor_name: str,
+    second_executor_name: str,
+    use_wrapper_aliases: bool,
+) -> None:
+    class EngineAlias:
+        def __init__(self, wrapped_engine) -> None:
+            self._wrapped_engine = wrapped_engine
+
+        def __getattr__(self, name: str):
+            return getattr(self._wrapped_engine, name)
+
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    sink_plan = plan_transfer(sources, targets)
+    reader_plan = plan_transfer_to_local_target(sources, targets)
+    engine = FakeTransferEngine()
+    first_engine = engine
+    second_engine = engine
+    if use_wrapper_aliases:
+        engine.get_engine_ptr = lambda: 0xCA110CA1
+        first_engine = EngineAlias(engine)
+        second_engine = EngineAlias(engine)
+
+    first_entered = threading.Event()
+    allow_first_to_finish = threading.Event()
+    submission_lock = threading.Lock()
+    submission_count = 0
+    pending_ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 2)
+    completed_ticket = FakeBatchTransferTicket(["COMPLETED"])
+
+    def transfer_with_ticket(*args):
+        nonlocal submission_count
+        with submission_lock:
+            submission_count += 1
+            call_number = submission_count
+        if call_number == 1:
+            first_entered.set()
+            assert allow_first_to_finish.wait(timeout=2)
+            return pending_ticket
+        return completed_ticket
+
+    engine.batch_transfer_sync_write_with_ticket = transfer_with_ticket
+    engine.batch_transfer_sync_read_with_ticket = transfer_with_ticket
+
+    def make_executor(executor_name: str, transfer_engine):
+        executor_type = (
+            MooncakeTransferEngineSink
+            if executor_name == "sink"
+            else MooncakeTransferEngineReader
+        )
+        return executor_type(
+            transfer_engine,
+            max_completion_drain_attempts=1,
+        )
+
+    def execute(executor_name: str, executor) -> None:
+        if executor_name == "sink":
+            execute_sink(
+                executor,
+                sink_plan,
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+        else:
+            execute_reader(
+                executor,
+                reader_plan,
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+    first_executor = make_executor(first_executor_name, first_engine)
+    second_executor = make_executor(second_executor_name, second_engine)
+    first_errors = []
+    second_errors = []
+
+    def capture_error(executor_name: str, executor, errors: list) -> None:
+        try:
+            execute(executor_name, executor)
+        except Exception as error:
+            errors.append(error)
+
+    first = threading.Thread(
+        target=capture_error,
+        args=(first_executor_name, first_executor, first_errors),
+    )
+    second = threading.Thread(
+        target=capture_error,
+        args=(second_executor_name, second_executor, second_errors),
+    )
+    first.start()
+    try:
+        assert first_entered.wait(timeout=2)
+        second.start()
+        second.join(timeout=2)
+        assert not second.is_alive()
+        register_calls_while_active = tuple(engine.register_calls)
+        unregister_calls_while_active = tuple(engine.unregister_calls)
+    finally:
+        allow_first_to_finish.set()
+        first.join(timeout=2)
+        if second.ident is not None:
+            second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert len(first_errors) == 1
+    assert isinstance(first_errors[0], TransferCompletionUnknownError)
+    pending_id = first_errors[0].pending_transfer_id
+    visible_pending_ids = second_executor.pending_transfer_ids()
+    pending_ticket._statuses = ["COMPLETED"]
+    assert second_executor.drain_pending_transfer(pending_id) == "COMPLETED"
+
+    first_fragment = (
+        sources.bindings[0].fragments[0]
+        if first_executor_name == "sink"
+        else targets.bindings[0].fragments[0]
+    )
+    assert visible_pending_ids == (pending_id,)
+    assert submission_count == 1
+    assert register_calls_while_active == (
+        (first_fragment.address, first_fragment.nbytes),
+    )
+    assert unregister_calls_while_active == ()
+    assert engine.unregister_calls == [first_fragment.address]
+    assert len(second_errors) == 1
+    assert isinstance(second_errors[0], TransferEngineError)
+    assert "active resource transfer submission" in str(second_errors[0])
+
+
+def test_te_rejects_concurrent_drain_for_same_pending_transfer() -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 2)
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+    sink = MooncakeTransferEngineSink(
+        engine,
+        max_completion_drain_attempts=1,
+    )
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        execute_sink(
+            sink,
+            plan_transfer(sources, targets),
+            sources,
+            targets,
+            target_registrations=registration_leases(targets),
+        )
+
+    pending_id = raised.value.pending_transfer_id
+    first_entered = threading.Event()
+    allow_first_to_finish = threading.Event()
+
+    def block_first_drain() -> None:
+        first_entered.set()
+        assert allow_first_to_finish.wait(timeout=2)
+
+    ticket._statuses = ["COMPLETED"]
+    ticket._on_drain = block_first_drain
+    statuses = []
+    errors = []
+
+    def drain() -> None:
+        try:
+            statuses.append(sink.drain_pending_transfer(pending_id))
+        except Exception as error:
+            errors.append(error)
+
+    first = threading.Thread(target=drain)
+    second = threading.Thread(target=drain)
+    first.start()
+    assert first_entered.wait(timeout=2)
+    second.start()
+    second.join(timeout=0.2)
+    allow_first_to_finish.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert statuses == ["COMPLETED"]
+    assert len(errors) == 1
+    assert isinstance(errors[0], TransferEngineError)
+    assert "already being drained" in str(errors[0])
+    assert engine.unregister_calls == [0x10000]

--- a/mooncake-reshard/tests/model_weight_te/test_quarantine_cleanup.py
+++ b/mooncake-reshard/tests/model_weight_te/test_quarantine_cleanup.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import gc
+import threading
+import weakref
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+    TransferRegistrationCleanupPendingError,
+)
+from mooncake.reshard.transfer_engine.lifetime import TerminalTransferState
+
+from .helpers import (
+    FakeBatchTransferTicket,
+    FakeTransferEngine,
+    RuntimeInputs,
+    allocation_guards,
+    execute_reader,
+    execute_sink,
+    manifests,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    registration_leases,
+)
+
+
+def _guard_tokens(*guard_maps):
+    return tuple(
+        token
+        for guard_map in guard_maps
+        for guard in guard_map.values()
+        for token in guard.tokens
+    )
+
+
+@pytest.mark.parametrize("executor_name", ("sink", "reader"))
+@pytest.mark.parametrize(
+    ("ticket_status", "expected_terminal_state"),
+    (
+        ("COMPLETED", TerminalTransferState.COMPLETED),
+        ("FAILED_DRAINED", TerminalTransferState.FAILED_DRAINED),
+    ),
+)
+def test_te_unregister_failure_quarantines_until_retry_succeeds(
+    executor_name: str,
+    ticket_status: str,
+    expected_terminal_state: TerminalTransferState,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    source_guards = allocation_guards(sources)
+    target_guards = allocation_guards(targets)
+    engine = FakeTransferEngine()
+    unregister_results = [-7, -8, 0]
+
+    def unregister_memory(address: int) -> int:
+        engine.unregister_calls.append(address)
+        return unregister_results.pop(0)
+
+    engine.unregister_memory = unregister_memory
+    if executor_name == "sink":
+        executor = MooncakeTransferEngineSink(engine)
+        ticket = FakeBatchTransferTicket([ticket_status])
+        engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+        plan = plan_transfer(sources, targets)
+        expected_address = 0x10000
+
+        def execute() -> None:
+            execute_sink(
+                executor,
+                plan,
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+                source_allocation_guards=source_guards,
+                target_allocation_guards=target_guards,
+            )
+
+    else:
+        executor = MooncakeTransferEngineReader(engine)
+        ticket = FakeBatchTransferTicket([ticket_status])
+        engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+        plan = plan_transfer_to_local_target(sources, targets)
+        expected_address = 0x40000
+
+        def execute() -> None:
+            execute_reader(
+                executor,
+                plan,
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+                source_allocation_guards=source_guards,
+                target_allocation_guards=target_guards,
+            )
+
+    with pytest.raises(TransferRegistrationCleanupPendingError) as raised:
+        execute()
+
+    pending_id = raised.value.pending_transfer_id
+    assert engine.unregister_calls == [expected_address]
+    assert executor.pending_transfer_ids() == (pending_id,)
+    assert executor.pending_transfer_status(pending_id) == ticket_status
+    assert all(
+        token.released_states == []
+        for token in _guard_tokens(source_guards, target_guards)
+    )
+    with pytest.raises(TransferEngineError, match="pending transfer"):
+        execute()
+
+    with pytest.raises(TransferEngineError, match="registration cleanup failed"):
+        executor.drain_pending_transfer(pending_id)
+    assert executor.pending_transfer_ids() == (pending_id,)
+    assert all(
+        token.released_states == []
+        for token in _guard_tokens(source_guards, target_guards)
+    )
+
+    assert executor.drain_pending_transfer(pending_id) == ticket_status
+    assert engine.unregister_calls == [
+        expected_address,
+        expected_address,
+        expected_address,
+    ]
+    assert executor.pending_transfer_ids() == ()
+    assert all(
+        token.released_states == [expected_terminal_state]
+        for token in _guard_tokens(source_guards, target_guards)
+    )
+
+
+@pytest.mark.parametrize("executor_name", ("sink", "reader"))
+def test_te_pending_transfer_cannot_drain_before_resource_handoff(
+    executor_name: str,
+) -> None:
+    sources = manifests(tp=1, prefix="source", address_base=0x10000)
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 2)
+    engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+    engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+
+    if executor_name == "sink":
+        executor = MooncakeTransferEngineSink(
+            engine,
+            max_completion_drain_attempts=1,
+        )
+
+        def execute() -> None:
+            execute_sink(
+                executor,
+                plan_transfer(sources, targets),
+                sources,
+                targets,
+                target_registrations=registration_leases(targets),
+            )
+
+        pending_owner = executor
+        owned_address = sources.bindings[0].fragments[0].address
+    else:
+        executor = MooncakeTransferEngineReader(
+            engine,
+            max_completion_drain_attempts=1,
+        )
+
+        def execute() -> None:
+            execute_reader(
+                executor,
+                plan_transfer_to_local_target(sources, targets),
+                sources,
+                targets,
+                source_registrations=registration_leases(sources),
+            )
+
+        pending_owner = executor._pending
+        owned_address = targets.bindings[0].fragments[0].address
+
+    original_retain = pending_owner._retain_pending_resources
+    handoff_entered = threading.Event()
+    allow_handoff = threading.Event()
+    pending_ids = []
+
+    def block_resource_handoff(
+        pending_transfer_id: str,
+        *,
+        registrations,
+        resources,
+        allocation_tokens=(),
+    ) -> None:
+        pending_ids.append(pending_transfer_id)
+        handoff_entered.set()
+        assert allow_handoff.wait(timeout=2)
+        original_retain(
+            pending_transfer_id,
+            registrations=registrations,
+            resources=resources,
+            allocation_tokens=allocation_tokens,
+        )
+
+    pending_owner._retain_pending_resources = block_resource_handoff
+    execution_errors = []
+
+    def run_execute() -> None:
+        try:
+            execute()
+        except Exception as error:
+            execution_errors.append(error)
+
+    worker = threading.Thread(target=run_execute)
+    worker.start()
+    assert handoff_entered.wait(timeout=2)
+    pending_id = pending_ids[0]
+    ticket._statuses = ["COMPLETED"]
+    drain_calls_before_handoff = tuple(ticket.drain_calls)
+    try:
+        with pytest.raises(TransferEngineError, match="resource handoff"):
+            executor.drain_pending_transfer(pending_id)
+        assert tuple(ticket.drain_calls) == drain_calls_before_handoff
+        assert engine.unregister_calls == []
+    finally:
+        allow_handoff.set()
+        worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert len(execution_errors) == 1
+    assert isinstance(execution_errors[0], TransferCompletionUnknownError)
+    assert executor.pending_transfer_status(pending_id) == "COMPLETED"
+    assert executor.drain_pending_transfer(pending_id) == "COMPLETED"
+    assert engine.unregister_calls == [owned_address]
+
+
+def test_te_pending_transfer_retains_fragment_owner_until_terminal() -> None:
+    class Owner:
+        pass
+
+    def create_pending():
+        sources = manifests(tp=1, prefix="source", address_base=0x10000)
+        targets = manifests(tp=1, prefix="target", address_base=0x40000)
+        owner = Owner()
+        owned_fragment = replace(targets.bindings[0].fragments[0], owner=owner)
+        owned_target = RuntimeInputs(
+            targets.placement,
+            (replace(targets.bindings[0], fragments=(owned_fragment,)),),
+        )
+        engine = FakeTransferEngine()
+        ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 4)
+        engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+        reader = MooncakeTransferEngineReader(
+            engine,
+            max_completion_drain_attempts=1,
+        )
+        try:
+            execute_reader(
+                reader,
+                plan_transfer_to_local_target(sources, owned_target),
+                sources,
+                owned_target,
+                source_registrations=registration_leases(sources),
+            )
+        except TransferCompletionUnknownError as error:
+            pending_id = error.pending_transfer_id
+        else:
+            raise AssertionError("transfer must remain pending")
+        return reader, ticket, pending_id, weakref.ref(owner)
+
+    reader, ticket, pending_id, owner_ref = create_pending()
+    gc.collect()
+    assert owner_ref() is not None
+
+    ticket._statuses = ["COMPLETED"]
+    assert reader.drain_pending_transfer(pending_id) == "COMPLETED"
+    gc.collect()
+    assert owner_ref() is None
+
+
+def test_te_pending_transfer_survives_executor_destruction() -> None:
+    class Owner:
+        pass
+
+    def create_pending():
+        sources = manifests(tp=1, prefix="source", address_base=0x10000)
+        targets = manifests(tp=1, prefix="target", address_base=0x40000)
+        owner = Owner()
+        owned_fragment = replace(targets.bindings[0].fragments[0], owner=owner)
+        owned_target = RuntimeInputs(
+            targets.placement,
+            (replace(targets.bindings[0], fragments=(owned_fragment,)),),
+        )
+        engine = FakeTransferEngine()
+        ticket = FakeBatchTransferTicket(["COMPLETION_UNKNOWN"] * 4)
+        engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+        reader = MooncakeTransferEngineReader(
+            engine,
+            max_completion_drain_attempts=1,
+        )
+        with pytest.raises(TransferCompletionUnknownError) as raised:
+            execute_reader(
+                reader,
+                plan_transfer_to_local_target(sources, owned_target),
+                sources,
+                owned_target,
+                source_registrations=registration_leases(sources),
+            )
+        return engine, ticket, raised.value.pending_transfer_id, weakref.ref(owner)
+
+    engine, ticket, pending_id, owner_ref = create_pending()
+    gc.collect()
+    assert owner_ref() is not None
+
+    recovery_reader = MooncakeTransferEngineReader(engine)
+    assert recovery_reader.pending_transfer_status(pending_id) == "COMPLETION_UNKNOWN"
+    ticket._statuses = ["COMPLETED"]
+    assert recovery_reader.drain_pending_transfer(pending_id) == "COMPLETED"
+    assert engine.unregister_calls == [0x40000]
+    gc.collect()
+    assert owner_ref() is None
+
+
+@pytest.mark.parametrize("executor_name", ("sink", "reader"))
+def test_te_pre_registered_unknown_retains_external_owner_until_terminal(
+    executor_name: str,
+) -> None:
+    class ExternalOwner:
+        pass
+
+    def create_pending():
+        sources = manifests(tp=1, prefix="source", address_base=0x10000)
+        targets = manifests(tp=1, prefix="target", address_base=0x40000)
+        engine = FakeTransferEngine()
+        ticket = FakeBatchTransferTicket(
+            ["COMPLETION_UNKNOWN", "COMPLETION_UNKNOWN"],
+            on_drain=lambda: (
+                pytest.fail("external registration released before transfer drained")
+                if engine.unregister_calls
+                else None
+            ),
+        )
+        owner = ExternalOwner()
+        if executor_name == "sink":
+            owned_fragment = replace(sources.bindings[0].fragments[0], owner=owner)
+            sources = RuntimeInputs(
+                sources.placement,
+                (replace(sources.bindings[0], fragments=(owned_fragment,)),),
+            )
+            executor = MooncakeTransferEngineSink(
+                engine,
+                max_completion_drain_attempts=1,
+            )
+            engine.batch_transfer_sync_write_with_ticket = lambda *args: ticket
+        else:
+            owned_fragment = replace(targets.bindings[0].fragments[0], owner=owner)
+            targets = RuntimeInputs(
+                targets.placement,
+                (replace(targets.bindings[0], fragments=(owned_fragment,)),),
+            )
+            executor = MooncakeTransferEngineReader(
+                engine,
+                max_completion_drain_attempts=1,
+            )
+            engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+
+        external_address = owned_fragment.address
+        assert engine.register_memory(external_address, owned_fragment.nbytes) == 0
+        with pytest.raises(TransferCompletionUnknownError) as raised:
+            if executor_name == "sink":
+                execute_sink(
+                    executor,
+                    plan_transfer(sources, targets),
+                    sources,
+                    targets,
+                    target_registrations=registration_leases(targets),
+                    source_pre_registered=True,
+                    source_registrations=registration_leases(sources),
+                )
+            else:
+                execute_reader(
+                    executor,
+                    plan_transfer_to_local_target(sources, targets),
+                    sources,
+                    targets,
+                    source_registrations=registration_leases(sources),
+                    target_pre_registered=True,
+                    target_registrations=registration_leases(targets),
+                )
+        return (
+            engine,
+            ticket,
+            raised.value.pending_transfer_id,
+            type(executor),
+            external_address,
+            weakref.ref(owner),
+        )
+
+    engine, ticket, pending_id, executor_type, external_address, owner_ref = (
+        create_pending()
+    )
+    gc.collect()
+    assert engine.unregister_calls == []
+    assert owner_ref() is not None
+
+    recovery = executor_type(engine)
+    assert recovery.pending_transfer_status(pending_id) == "COMPLETION_UNKNOWN"
+    ticket._statuses = ["COMPLETED"]
+    assert recovery.drain_pending_transfer(pending_id) == "COMPLETED"
+    assert engine.unregister_calls == []
+    gc.collect()
+    assert owner_ref() is None
+
+    assert engine.unregister_memory(external_address) == 0
+    assert engine.unregister_calls == [external_address]

--- a/mooncake-reshard/tests/model_weight_te/test_reader.py
+++ b/mooncake-reshard/tests/model_weight_te/test_reader.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    MooncakeTransferEngineReader,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+
+from .helpers import (
+    allocation_guards,
+    FakeBatchTransferTicket,
+    FakeTransferEngine,
+    RuntimeInputs,
+    manifests,
+    participant_inputs,
+    plan_transfer_to_local_target,
+    registration_leases,
+)
+
+
+def test_te_reader_pulls_local_target_ranges_without_source_rpc() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    target = participant_inputs(targets, 1)
+    plan = plan_transfer_to_local_target(sources, target)
+    engine = FakeTransferEngine()
+
+    receipts = MooncakeTransferEngineReader(engine).execute(
+        plan,
+        sources.placement,
+        sources.bindings,
+        target.placement,
+        target.bindings[0],
+        source_registrations=registration_leases(sources),
+        target_pre_registered=True,
+        target_registrations=registration_leases(target),
+        source_allocation_guards=allocation_guards(sources),
+        target_allocation_guards=allocation_guards(target),
+    )
+
+    assert receipts[0].source_endpoint == "source-t0:12345"
+    assert receipts[0].target_worker_id == "target-t1"
+    assert receipts[0].nbytes == 2
+    assert engine.calls == [("source-t0:12345", [0x41000], [0x10002], [2])]
+    assert engine.register_calls == []
+    assert engine.unregister_calls == []
+
+
+def test_te_reader_wraps_target_registration_exception() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    engine = FakeTransferEngine()
+
+    def fail_register(*args, **kwargs):
+        raise RuntimeError("register exploded")
+
+    engine.register_memory = fail_register
+
+    with pytest.raises(TransferEngineError, match="register exploded"):
+        MooncakeTransferEngineReader(engine).execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=registration_leases(sources),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+
+def test_te_reader_requires_generation_bound_source_registration_leases() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    reader = MooncakeTransferEngineReader(FakeTransferEngine())
+    target_leases = registration_leases(target)
+
+    with pytest.raises(TransferEngineError, match="source registration leases"):
+        reader.execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            target_pre_registered=True,
+            target_registrations=target_leases,
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+    stale_generation = list(registration_leases(sources))
+    stale_generation[0] = replace(stale_generation[0], lease_generation=2)
+    with pytest.raises(TransferEngineError, match="source registration lease mismatch"):
+        reader.execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=stale_generation,
+            target_pre_registered=True,
+            target_registrations=target_leases,
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+    stale_runtime_lease = list(registration_leases(sources))
+    stale_runtime_lease[0] = replace(
+        stale_runtime_lease[0],
+        runtime_lease_id="stale-runtime-lease",
+    )
+    with pytest.raises(TransferEngineError, match="source registration lease mismatch"):
+        reader.execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=stale_runtime_lease,
+            target_pre_registered=True,
+            target_registrations=target_leases,
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"address": 0x90000, "storage_address": 0x90000},
+        {"nbytes": 1},
+        {"lease_generation": 2},
+        {"runtime_lease_id": "stale-runtime-lease"},
+    ],
+)
+def test_te_reader_rejects_source_registration_snapshot_mismatch(
+    changes: dict[str, object],
+) -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    leases = list(registration_leases(sources))
+    leases[0] = replace(leases[0], **changes)
+
+    with pytest.raises(TransferEngineError, match="source registration lease mismatch"):
+        MooncakeTransferEngineReader(FakeTransferEngine()).execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=leases,
+            target_pre_registered=True,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+
+def test_te_reader_requires_registrations_only_for_used_source_fragments() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    used_fragment_ids = {operation.source.fragment_id for operation in plan.operations}
+    source_registrations = tuple(
+        registration
+        for registration in registration_leases(sources)
+        if registration.fragment_id in used_fragment_ids
+    )
+
+    receipts = MooncakeTransferEngineReader(FakeTransferEngine()).execute(
+        plan,
+        sources.placement,
+        sources.bindings,
+        target.placement,
+        target.bindings[0],
+        source_registrations=source_registrations,
+        target_pre_registered=True,
+        target_registrations=registration_leases(target),
+        source_allocation_guards=allocation_guards(sources),
+        target_allocation_guards=allocation_guards(target),
+    )
+
+    assert sum(receipt.nbytes for receipt in receipts) == 2
+
+
+def test_te_reader_requires_complete_planned_source_executor_set() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=1, prefix="target", address_base=0x40000), 0
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    partial_sources = RuntimeInputs(sources.placement, sources.bindings[:1])
+
+    with pytest.raises(TransferEngineError, match="source executor set is incomplete"):
+        MooncakeTransferEngineReader(FakeTransferEngine()).execute(
+            plan,
+            partial_sources.placement,
+            partial_sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=registration_leases(partial_sources),
+            target_pre_registered=True,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=allocation_guards(partial_sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+
+def test_te_reader_surfaces_source_endpoint_failure() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["FAILED_DRAINED"])
+    engine.batch_transfer_sync_read_with_ticket = lambda *args: ticket
+
+    with pytest.raises(TransferEngineError, match="source-t0:12345"):
+        MooncakeTransferEngineReader(engine).execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=registration_leases(sources),
+            target_pre_registered=True,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+
+def test_te_reader_quarantines_positive_legacy_transfer_status() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    engine = FakeTransferEngine()
+    engine.read_result = 5
+    reader = MooncakeTransferEngineReader(engine)
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        reader.execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=registration_leases(sources),
+            target_pre_registered=True,
+            target_registrations=registration_leases(target),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+    assert (
+        reader.pending_transfer_status(raised.value.pending_transfer_id)
+        == "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+    )
+
+
+def test_te_reader_rejects_leases_without_pre_registered_mode() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    target = participant_inputs(
+        manifests(tp=4, prefix="target", address_base=0x40000), 1
+    )
+    plan = plan_transfer_to_local_target(sources, target)
+    engine = FakeTransferEngine()
+
+    with pytest.raises(TransferEngineError, match="target_pre_registered"):
+        MooncakeTransferEngineReader(engine).execute(
+            plan,
+            sources.placement,
+            sources.bindings,
+            target.placement,
+            target.bindings[0],
+            source_registrations=registration_leases(sources),
+            target_registrations=registration_leases(target),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(target),
+        )
+
+    assert engine.register_calls == []
+    assert engine.unregister_calls == []

--- a/mooncake-reshard/tests/model_weight_te/test_sink.py
+++ b/mooncake-reshard/tests/model_weight_te/test_sink.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight.te import (
+    TransferCompletionUnknownError,
+    MooncakeTransferEngineSink,
+    TransferEngineError,
+)
+
+from .helpers import (
+    allocation_guards,
+    allocation_guards_for_bindings,
+    FakeBatchTransferTicket,
+    FakeTransferEngine,
+    RuntimeInputs,
+    manifests,
+    plan_transfer,
+    registration_leases,
+    with_revision,
+)
+
+
+def test_te_sink_executes_local_source_ranges_without_staging_buffer() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    engine = FakeTransferEngine()
+    sink = MooncakeTransferEngineSink(engine)
+
+    receipts = sink.execute(
+        plan,
+        sources.placement,
+        sources.bindings[0],
+        targets.placement,
+        targets.bindings,
+        target_registrations=registration_leases(targets),
+        source_allocation_guards=allocation_guards(sources),
+        target_allocation_guards=allocation_guards(targets),
+    )
+
+    assert receipts[0].source_worker_id == "source-t0"
+    assert sum(receipt.nbytes for receipt in receipts) == 4
+    assert engine.calls == [
+        ("target-t0:12345", [0x10000], [0x40000], [2]),
+        ("target-t1:12345", [0x10002], [0x41000], [2]),
+    ]
+    assert engine.register_calls == [(0x10000, 4)]
+    assert engine.unregister_calls == [0x10000]
+
+
+def test_te_sink_lowers_nonzero_views_to_flat_transfer_addresses() -> None:
+    source_inputs = manifests(tp=2, prefix="source", address_base=0x10000)
+    source_fragment = replace(
+        source_inputs.bindings[0].fragments[0],
+        storage_address=0xF000,
+        storage_nbytes=0x2000,
+        storage_offset_bytes=0x1000,
+    )
+    sources = RuntimeInputs(
+        source_inputs.placement,
+        (
+            replace(source_inputs.bindings[0], fragments=(source_fragment,)),
+            *source_inputs.bindings[1:],
+        ),
+    )
+    target_inputs = manifests(tp=4, prefix="target", address_base=0x40000)
+    target_fragments = (
+        replace(
+            target_inputs.bindings[0].fragments[0],
+            storage_address=0x3F000,
+            storage_nbytes=0x2000,
+            storage_offset_bytes=0x1000,
+        ),
+        replace(
+            target_inputs.bindings[1].fragments[0],
+            storage_address=0x40800,
+            storage_nbytes=0x1000,
+            storage_offset_bytes=0x800,
+        ),
+    )
+    targets = RuntimeInputs(
+        target_inputs.placement,
+        (
+            replace(target_inputs.bindings[0], fragments=(target_fragments[0],)),
+            replace(target_inputs.bindings[1], fragments=(target_fragments[1],)),
+            *target_inputs.bindings[2:],
+        ),
+    )
+    engine = FakeTransferEngine()
+
+    MooncakeTransferEngineSink(engine).execute(
+        plan_transfer(sources, targets),
+        sources.placement,
+        sources.bindings[0],
+        targets.placement,
+        targets.bindings,
+        target_registrations=registration_leases(targets),
+        source_allocation_guards=allocation_guards(sources),
+        target_allocation_guards=allocation_guards(targets),
+    )
+
+    assert engine.register_calls == [(0xF000, 0x2000)]
+    assert engine.unregister_calls == [0xF000]
+    assert engine.calls == [
+        ("target-t0:12345", [0x10000], [0x40000], [2]),
+        ("target-t1:12345", [0x10002], [0x41000], [2]),
+    ]
+
+
+def test_te_sink_requires_generation_bound_target_registration_leases() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    sink = MooncakeTransferEngineSink(FakeTransferEngine())
+
+    with pytest.raises(TransferEngineError, match="target registration"):
+        sink.execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            targets.bindings,
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+    stale_leases = list(registration_leases(targets))
+    stale_leases[0] = replace(stale_leases[0], lease_generation=2)
+    with pytest.raises(TransferEngineError, match="target registration"):
+        sink.execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            targets.bindings,
+            target_registrations=tuple(stale_leases),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+
+def test_te_sink_surfaces_endpoint_failure() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    engine = FakeTransferEngine()
+    ticket = FakeBatchTransferTicket(["FAILED_DRAINED"])
+
+    def write_with_ticket(endpoint, *args):
+        return (
+            ticket
+            if endpoint == "target-t1:12345"
+            else FakeBatchTransferTicket(["COMPLETED"])
+        )
+
+    engine.batch_transfer_sync_write_with_ticket = write_with_ticket
+
+    with pytest.raises(TransferEngineError, match="target-t1:12345"):
+        MooncakeTransferEngineSink(engine).execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            targets.bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+
+def test_te_sink_quarantines_write_exception_without_completion_ticket() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    engine = FakeTransferEngine()
+
+    def fail_write(*args, **kwargs):
+        raise RuntimeError("write exploded")
+
+    engine.batch_transfer_sync_write = fail_write
+
+    sink = MooncakeTransferEngineSink(engine)
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        sink.execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            targets.bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+    assert engine.unregister_calls == []
+    assert (
+        sink.pending_transfer_status(raised.value.pending_transfer_id)
+        == "COMPLETION_UNKNOWN_RESTART_REQUIRED"
+    )
+
+
+def test_te_sink_rejects_stale_source_generation() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    stale_binding = replace(sources.bindings[0], generation=2)
+
+    with pytest.raises(TransferEngineError, match="source executor snapshot mismatch"):
+        MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+            plan,
+            sources.placement,
+            stale_binding,
+            targets.placement,
+            targets.bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards_for_bindings((stale_binding,)),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+
+def test_te_sink_rejects_generation_scoped_source_id_rollover() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    replacement = replace(
+        sources.bindings[0].fragments[0],
+        fragment_id="replacement-source-fragment",
+        worker_id="replacement-source-worker",
+    )
+    current_binding = replace(
+        sources.bindings[0],
+        instance_id="replacement-source-instance",
+        generation=2,
+        fragments=(replacement,),
+    )
+
+    with pytest.raises(TransferEngineError, match="source executor snapshot mismatch"):
+        MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+            plan,
+            sources.placement,
+            current_binding,
+            targets.placement,
+            targets.bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards_for_bindings((current_binding,)),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+
+def test_te_sink_rejects_stale_target_address_and_generation() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    replacement = replace(
+        targets.bindings[0].fragments[0],
+        address=0x90000,
+        storage_address=0x90000,
+    )
+    current_bindings = (
+        replace(targets.bindings[0], fragments=(replacement,), generation=2),
+        *targets.bindings[1:],
+    )
+
+    with pytest.raises(TransferEngineError, match="target executor snapshot mismatch"):
+        MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            current_bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards_for_bindings(current_bindings),
+        )
+
+
+def test_te_sink_rejects_generation_scoped_target_id_rollover() -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    replacement = replace(
+        targets.bindings[0].fragments[0],
+        fragment_id="replacement-target-fragment",
+    )
+    current_bindings = (
+        replace(targets.bindings[0], fragments=(replacement,), generation=2),
+        *targets.bindings[1:],
+    )
+
+    with pytest.raises(TransferEngineError, match="target executor snapshot mismatch"):
+        MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            current_bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards_for_bindings(current_bindings),
+        )
+
+
+@pytest.mark.parametrize("side", ["source", "target"])
+def test_te_sink_rejects_revision_mismatch(side: str) -> None:
+    sources = manifests(tp=2, prefix="source", address_base=0x10000)
+    targets = manifests(tp=4, prefix="target", address_base=0x40000)
+    plan = plan_transfer(sources, targets)
+    if side == "source":
+        sources = with_revision(sources, "step-43")
+    else:
+        targets = with_revision(targets, "step-43")
+
+    with pytest.raises(TransferEngineError, match="revision mismatch"):
+        MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+            plan,
+            sources.placement,
+            sources.bindings[0],
+            targets.placement,
+            targets.bindings,
+            target_registrations=registration_leases(targets),
+            source_allocation_guards=allocation_guards(sources),
+            target_allocation_guards=allocation_guards(targets),
+        )
+
+
+def test_te_receipt_identifies_worker_instead_of_serving_instance() -> None:
+    source = manifests(tp=1, prefix="source", address_base=0x10000)
+    source = RuntimeInputs(
+        source.placement,
+        (
+            replace(
+                source.bindings[0],
+                instance_id="serving-instance",
+            ),
+        ),
+    )
+    targets = manifests(tp=1, prefix="target", address_base=0x40000)
+    plan = plan_transfer(source, targets)
+
+    receipts = MooncakeTransferEngineSink(FakeTransferEngine()).execute(
+        plan,
+        source.placement,
+        source.bindings[0],
+        targets.placement,
+        targets.bindings,
+        target_registrations=registration_leases(targets),
+        source_allocation_guards=allocation_guards(source),
+        target_allocation_guards=allocation_guards(targets),
+    )
+
+    assert receipts[0].source_worker_id == "source-t0"

--- a/mooncake-reshard/tests/reshard_transfer_engine/test_executor.py
+++ b/mooncake-reshard/tests/reshard_transfer_engine/test_executor.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard.transfer_engine import (
+    MooncakeTransferEngineExecutor,
+    TransferBatch,
+    TransferBatchRange,
+    TransferDirection,
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+
+
+class CompletedTicket:
+    status = "COMPLETED"
+
+
+class TicketEngine:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def get_engine_ptr(self) -> int:
+        return id(self)
+
+    def batch_transfer_sync_read_with_ticket(self, *arguments):
+        self.calls.append(("read", arguments))
+        return CompletedTicket()
+
+    def batch_transfer_sync_write_with_ticket(self, *arguments):
+        self.calls.append(("write", arguments))
+        return CompletedTicket()
+
+
+class LegacyEngine:
+    """Match the flat synchronous batch API exposed by the current binding."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def get_engine_ptr(self) -> int:
+        return id(self)
+
+    def batch_transfer_sync_read(self, *arguments) -> int:
+        self.calls.append(("read", arguments))
+        return 0
+
+    def batch_transfer_sync_write(self, *arguments) -> int:
+        self.calls.append(("write", arguments))
+        return 0
+
+
+def batch() -> TransferBatch:
+    return TransferBatch(
+        endpoint="worker-1:12345",
+        source_addresses=(0x1000, 0x2000),
+        target_addresses=(0x3000, 0x4000),
+        sizes=(64, 128),
+    )
+
+
+def range_batch() -> TransferBatch:
+    return TransferBatch.from_ranges(
+        endpoint="worker-1:12345",
+        ranges=(
+            TransferBatchRange(
+                source_base_address=0x1000,
+                source_capacity=0x400,
+                target_base_address=0x3000,
+                target_capacity=0x800,
+                source_offsets=(0x20, 0x100),
+                target_offsets=(0x40, 0x200),
+                sizes=(64, 128),
+            ),
+            TransferBatchRange(
+                source_base_address=0x5000,
+                source_capacity=0x100,
+                target_base_address=0x7000,
+                target_capacity=0x100,
+                source_offsets=(0,),
+                target_offsets=(0x20,),
+                sizes=(32,),
+            ),
+        ),
+    )
+
+
+def test_resource_neutral_executor_supports_ticket_capable_binding() -> None:
+    engine = TicketEngine()
+    executor = MooncakeTransferEngineExecutor(engine)
+
+    read = executor.execute_batch(batch(), TransferDirection.READ)
+    write = executor.execute_batch(batch(), TransferDirection.WRITE)
+
+    assert [call[0] for call in engine.calls] == ["read", "write"]
+    assert read.operation_count == write.operation_count == 2
+    assert read.nbytes == write.nbytes == 192
+    assert read.endpoint == write.endpoint == "worker-1:12345"
+
+
+def test_transfer_batch_rejects_mismatched_or_invalid_ranges() -> None:
+    for values in (
+        {"source_addresses": (0x1000,), "target_addresses": (), "sizes": (1,)},
+        {
+            "source_addresses": (0x1000,),
+            "target_addresses": (0x2000,),
+            "sizes": (0,),
+        },
+    ):
+        try:
+            TransferBatch(endpoint="worker-1:12345", **values)
+        except ValueError:
+            continue
+        raise AssertionError("invalid transfer batch was accepted")
+
+
+def test_transfer_batch_ranges_preserve_allocation_bounds_and_flattening() -> None:
+    value = range_batch()
+
+    assert value.source_addresses == (0x1020, 0x1100, 0x5000)
+    assert value.target_addresses == (0x3040, 0x3200, 0x7020)
+    assert value.sizes == (64, 128, 32)
+    assert value.operation_count == 3
+
+    with pytest.raises(ValueError, match="source allocation bounds"):
+        TransferBatchRange(
+            source_base_address=0x1000,
+            source_capacity=64,
+            target_base_address=0x2000,
+            target_capacity=128,
+            source_offsets=(32,),
+            target_offsets=(0,),
+            sizes=(64,),
+        )
+
+
+def test_executor_flattens_range_batches_for_the_current_python_binding() -> None:
+    engine = LegacyEngine()
+    executor = MooncakeTransferEngineExecutor(engine)
+
+    executor.execute_batch(range_batch(), TransferDirection.READ)
+
+    assert engine.calls == [
+        (
+            "read",
+            (
+                "worker-1:12345",
+                [0x3040, 0x3200, 0x7020],
+                [0x1020, 0x1100, 0x5000],
+                [64, 128, 32],
+            ),
+        )
+    ]
+
+
+class UnknownTicket:
+    status = "COMPLETION_UNKNOWN"
+
+    def drain(self, timeout_ms: int) -> str:
+        return self.status
+
+
+class StatusReadFailsTicket:
+    def __init__(self) -> None:
+        self._first_read = True
+
+    @property
+    def status(self) -> str:
+        if self._first_read:
+            self._first_read = False
+            raise RuntimeError("native ticket status is unavailable")
+        return "COMPLETED"
+
+    def drain(self, timeout_ms: int) -> str:
+        return "COMPLETED"
+
+
+def test_ticket_status_failure_quarantines_returned_ticket() -> None:
+    ticket = StatusReadFailsTicket()
+    engine = TicketEngine()
+    engine.batch_transfer_sync_write_with_ticket = lambda *arguments: ticket
+    executor = MooncakeTransferEngineExecutor(engine)
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        executor.execute_batch(batch(), TransferDirection.WRITE)
+
+    pending_transfer_id = raised.value.pending_transfer_id
+    executor.retain_pending_resources(
+        pending_transfer_id,
+        registrations=(),
+        resources=(),
+    )
+    assert executor.drain_pending_transfer(pending_transfer_id) == "COMPLETED"
+
+
+class SharedEngine(TicketEngine):
+    def __init__(self, engine_ptr: int, ticket: UnknownTicket) -> None:
+        super().__init__()
+        self.engine_ptr = engine_ptr
+        self.ticket = ticket
+
+    def get_engine_ptr(self) -> int:
+        return self.engine_ptr
+
+    def batch_transfer_sync_write_with_ticket(self, *arguments):
+        self.calls.append(("write", arguments))
+        return self.ticket
+
+
+def test_pending_engine_fence_is_shared_across_resource_executors() -> None:
+    ticket = UnknownTicket()
+    weight = MooncakeTransferEngineExecutor(SharedEngine(0xCAFE, ticket))
+    kv = MooncakeTransferEngineExecutor(SharedEngine(0xCAFE, CompletedTicket()))
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        weight.execute_batch(batch(), TransferDirection.WRITE)
+    weight.retain_pending_resources(
+        raised.value.pending_transfer_id,
+        registrations=(),
+        resources=(ticket,),
+    )
+
+    with pytest.raises(TransferEngineError, match="pending transfer"):
+        kv.execute_batch(batch(), TransferDirection.WRITE)
+
+    ticket.status = "COMPLETED"
+    assert (
+        weight.drain_pending_transfer(raised.value.pending_transfer_id) == "COMPLETED"
+    )
+    assert kv.execute_batch(batch(), TransferDirection.WRITE).operation_count == 2

--- a/mooncake-reshard/tests/reshard_transfer_engine/test_executor.py
+++ b/mooncake-reshard/tests/reshard_transfer_engine/test_executor.py
@@ -32,6 +32,16 @@ class TicketEngine:
         return CompletedTicket()
 
 
+class ScatterTicketEngine(TicketEngine):
+    def scatter_transfer_sync_read_with_ticket(self, *arguments):
+        self.calls.append(("scatter_read", arguments))
+        return CompletedTicket()
+
+    def scatter_transfer_sync_write_with_ticket(self, *arguments):
+        self.calls.append(("scatter_write", arguments))
+        return CompletedTicket()
+
+
 class LegacyEngine:
     """Match the flat synchronous batch API exposed by the current binding."""
 
@@ -153,11 +163,80 @@ def test_executor_flattens_range_batches_for_the_current_python_binding() -> Non
     ]
 
 
+def test_executor_uses_scatter_ticket_for_range_read() -> None:
+    engine = ScatterTicketEngine()
+    executor = MooncakeTransferEngineExecutor(engine)
+
+    receipt = executor.execute_batch(range_batch(), TransferDirection.READ)
+
+    assert engine.calls == [
+        (
+            "scatter_read",
+            (
+                "worker-1:12345",
+                [0x3000, 0x7000],
+                [0x800, 0x100],
+                [0x1000, 0x5000],
+                [0x400, 0x100],
+                [[0x40, 0x200], [0x20]],
+                [[0x20, 0x100], [0]],
+                [[64, 128], [32]],
+            ),
+        )
+    ]
+    assert receipt.operation_count == 3
+    assert receipt.nbytes == 224
+
+
+def test_executor_uses_scatter_ticket_for_range_write() -> None:
+    engine = ScatterTicketEngine()
+    executor = MooncakeTransferEngineExecutor(engine)
+
+    receipt = executor.execute_batch(range_batch(), TransferDirection.WRITE)
+
+    assert engine.calls == [
+        (
+            "scatter_write",
+            (
+                "worker-1:12345",
+                [0x1000, 0x5000],
+                [0x400, 0x100],
+                [0x3000, 0x7000],
+                [0x800, 0x100],
+                [[0x20, 0x100], [0]],
+                [[0x40, 0x200], [0x20]],
+                [[64, 128], [32]],
+            ),
+        )
+    ]
+    assert receipt.operation_count == 3
+    assert receipt.nbytes == 224
+
+
 class UnknownTicket:
     status = "COMPLETION_UNKNOWN"
 
     def drain(self, timeout_ms: int) -> str:
         return self.status
+
+
+def test_scatter_unknown_ticket_is_retained_until_later_drain() -> None:
+    ticket = UnknownTicket()
+    engine = ScatterTicketEngine()
+    engine.scatter_transfer_sync_write_with_ticket = lambda *arguments: ticket
+    executor = MooncakeTransferEngineExecutor(engine)
+
+    with pytest.raises(TransferCompletionUnknownError) as raised:
+        executor.execute_batch(range_batch(), TransferDirection.WRITE)
+
+    pending_transfer_id = raised.value.pending_transfer_id
+    executor.retain_pending_resources(
+        pending_transfer_id,
+        registrations=(),
+        resources=(ticket,),
+    )
+    ticket.status = "COMPLETED"
+    assert executor.drain_pending_transfer(pending_transfer_id) == "COMPLETED"
 
 
 class StatusReadFailsTicket:

--- a/mooncake-reshard/tests/reshard_transfer_engine/test_weight_adapter.py
+++ b/mooncake-reshard/tests/reshard_transfer_engine/test_weight_adapter.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from global_placement_helpers import global_placement
+from model_weight_te.helpers import allocation_guards_for_bindings
+
+from mooncake.reshard.transfer_engine import MooncakeTransferEngineExecutor
+from mooncake.reshard.weight import (
+    MemoryRegistrationLease,
+    MooncakeTransferEngineReader,
+    MooncakeTransferEngineSink,
+    ParallelRank,
+    PlacementFragment,
+    RuntimeBindingFragment,
+    TensorDescriptor,
+    SplitAxis,
+    WeightPlacementManifest,
+    WeightRuntimeBindingManifest,
+    bind_logical_transfer_plan,
+    plan_placement_transfer,
+)
+
+
+class FakeEngine:
+    def get_engine_ptr(self) -> int:
+        return id(self)
+
+
+class CompletedTicket:
+    status = "COMPLETED"
+
+
+class RecordingEngine(FakeEngine):
+    def __init__(self) -> None:
+        self.calls = []
+
+    def batch_transfer_sync_read_with_ticket(self, *arguments):
+        self.calls.append(("read", arguments))
+        return CompletedTicket()
+
+    def batch_transfer_sync_write_with_ticket(self, *arguments):
+        self.calls.append(("write", arguments))
+        return CompletedTicket()
+
+
+def placement_and_bindings(
+    placement_set_id: str,
+    address_base: int,
+) -> tuple[
+    WeightPlacementManifest,
+    tuple[WeightRuntimeBindingManifest, ...],
+]:
+    ranks = (ParallelRank(tp=0), ParallelRank(tp=1))
+    tensor = TensorDescriptor(
+        tensor_id="weight",
+        global_shape=(4,),
+        dtype="float32",
+        itemsize=4,
+        shard_dims=(0,),
+        layout_fingerprint="contiguous",
+        parallel_axes=(SplitAxis("tp", dim=0),),
+    )
+    placement = global_placement(
+        resource_id="model",
+        revision="revision",
+        placement_set_id=placement_set_id,
+        tensors=(tensor,),
+        fragments=tuple(
+            PlacementFragment(
+                placement_fragment_id=f"{placement_set_id}-{index}",
+                tensor_id=tensor.tensor_id,
+                global_offset=(index * 2,),
+                local_shape=(2,),
+                nbytes=8,
+                rank=rank,
+            )
+            for index, rank in enumerate(ranks)
+        ),
+        ranks=ranks,
+    )
+    participant_by_rank = {
+        participant.rank: participant.participant_id
+        for participant in placement.topology.participants
+    }
+    bindings = tuple(
+        WeightRuntimeBindingManifest(
+            resource_id=placement.resource_id,
+            revision=placement.revision,
+            placement_id=placement.placement_id,
+            placement_digest=placement.digest,
+            participant_id=participant_by_rank[fragment.rank],
+            instance_id=f"{placement_set_id}-{index}",
+            generation=1,
+            lease_id=f"lease-{placement_set_id}-{index}",
+            fragments=(
+                RuntimeBindingFragment(
+                    placement_fragment_id=fragment.placement_fragment_id,
+                    fragment_id=f"runtime-{fragment.placement_fragment_id}",
+                    address=address_base + index * 0x1000,
+                    nbytes=fragment.nbytes,
+                    worker_id=participant_by_rank[fragment.rank],
+                    endpoint=f"{participant_by_rank[fragment.rank]}:12345",
+                    device="cuda:0",
+                    itemsize=tensor.itemsize,
+                    local_shape=fragment.local_shape,
+                    strides_bytes=(tensor.itemsize,),
+                    storage_address=address_base + index * 0x1000,
+                    storage_nbytes=fragment.nbytes,
+                    storage_offset_bytes=0,
+                ),
+            ),
+        )
+        for index, fragment in enumerate(placement.fragments)
+    )
+    return placement, bindings
+
+
+def registration_leases(
+    bindings: tuple[WeightRuntimeBindingManifest, ...],
+) -> tuple[MemoryRegistrationLease, ...]:
+    return tuple(
+        MemoryRegistrationLease.from_fragment(
+            fragment,
+            lease_generation=binding.generation,
+            runtime_lease_id=binding.lease_id,
+        )
+        for binding in bindings
+        for fragment in binding.fragments
+    )
+
+
+def test_weight_reader_and_sink_share_resource_neutral_executor() -> None:
+    reader = MooncakeTransferEngineReader(FakeEngine())
+    sink = MooncakeTransferEngineSink(FakeEngine())
+
+    assert isinstance(reader.transfer_executor, MooncakeTransferEngineExecutor)
+    assert isinstance(sink.transfer_executor, MooncakeTransferEngineExecutor)
+
+
+def test_weight_reader_and_sink_execute_each_participant_from_global_placements() -> (
+    None
+):
+    source_placement, source_bindings = placement_and_bindings("source", 0x1000)
+    target_placement, target_bindings = placement_and_bindings("target", 0x3000)
+    logical_plan = plan_placement_transfer(source_placement, target_placement)
+    plan = bind_logical_transfer_plan(
+        logical_plan,
+        target_bindings,
+        source_bindings=source_bindings,
+    )
+
+    read_engine = RecordingEngine()
+    reader = MooncakeTransferEngineReader(read_engine)
+    source_registrations = registration_leases(source_bindings)
+    read_receipts = tuple(
+        receipt
+        for target_binding in target_bindings
+        for receipt in reader.execute(
+            plan,
+            source_placement,
+            source_bindings,
+            target_placement,
+            target_binding,
+            source_registrations=source_registrations,
+            target_pre_registered=True,
+            target_registrations=registration_leases((target_binding,)),
+            source_allocation_guards=allocation_guards_for_bindings(source_bindings),
+            target_allocation_guards=allocation_guards_for_bindings((target_binding,)),
+        )
+    )
+
+    write_engine = RecordingEngine()
+    sink = MooncakeTransferEngineSink(write_engine)
+    write_receipts = tuple(
+        receipt
+        for source_binding in source_bindings
+        for receipt in sink.execute(
+            plan,
+            source_placement,
+            source_binding,
+            target_placement,
+            target_bindings,
+            target_registrations=registration_leases(target_bindings),
+            source_pre_registered=True,
+            source_registrations=registration_leases((source_binding,)),
+            source_allocation_guards=allocation_guards_for_bindings((source_binding,)),
+            target_allocation_guards=allocation_guards_for_bindings(target_bindings),
+        )
+    )
+
+    assert [
+        (
+            receipt.source_endpoint,
+            receipt.target_worker_id,
+            receipt.operation_count,
+            receipt.nbytes,
+        )
+        for receipt in read_receipts
+    ] == [
+        ("source-d0-p0-e0-t0:12345", "target-d0-p0-e0-t0", 1, 8),
+        ("source-d0-p0-e0-t1:12345", "target-d0-p0-e0-t1", 1, 8),
+    ]
+    assert read_engine.calls == [
+        (
+            "read",
+            ("source-d0-p0-e0-t0:12345", [0x3000], [0x1000], [8]),
+        ),
+        (
+            "read",
+            ("source-d0-p0-e0-t1:12345", [0x4000], [0x2000], [8]),
+        ),
+    ]
+
+    assert [
+        (
+            receipt.source_worker_id,
+            receipt.target_endpoint,
+            receipt.operation_count,
+            receipt.nbytes,
+        )
+        for receipt in write_receipts
+    ] == [
+        ("source-d0-p0-e0-t0", "target-d0-p0-e0-t0:12345", 1, 8),
+        ("source-d0-p0-e0-t1", "target-d0-p0-e0-t1:12345", 1, 8),
+    ]
+    assert write_engine.calls == [
+        (
+            "write",
+            ("target-d0-p0-e0-t0:12345", [0x1000], [0x3000], [8]),
+        ),
+        (
+            "write",
+            ("target-d0-p0-e0-t1:12345", [0x2000], [0x4000], [8]),
+        ),
+    ]

--- a/mooncake-reshard/tests/test_te_module_layout.py
+++ b/mooncake-reshard/tests/test_te_module_layout.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from inspect import signature
+
+import pytest
+
+from mooncake.reshard.weight import te
+from mooncake.reshard.weight._te.completion import (
+    TransferCompletionUnknownError,
+    TransferEngineError,
+)
+from mooncake.reshard.weight._te.reader import (
+    DirectReadReceipt,
+    MooncakeTransferEngineReader,
+)
+from mooncake.reshard.weight._te.execution import validate_manifest_pair
+from mooncake.reshard.weight._te.registration import (
+    MemoryRegistrationLease,
+    same_runtime_snapshot,
+    validate_registration,
+)
+from mooncake.reshard.weight._te.sink import (
+    DirectTransferReceipt,
+    MooncakeTransferEngineSink,
+)
+from mooncake.reshard.weight.manifest import (
+    ParallelRank,
+    PlacementFragment,
+    RuntimeBindingFragment,
+    TensorDescriptor,
+    SplitAxis,
+    WeightRuntimeBindingManifest,
+)
+
+from global_placement_helpers import global_placement
+
+
+def manifest_pair():
+    tensor = TensorDescriptor(
+        tensor_id="layers.0.weight",
+        global_shape=(4,),
+        dtype="uint8",
+        itemsize=1,
+        shard_dims=(0,),
+        layout_fingerprint="test:contiguous:v1",
+        parallel_axes=(SplitAxis("tp", dim=0),),
+    )
+    placement = global_placement(
+        resource_id="qwen",
+        revision="step-1",
+        placement_set_id="te-module-layout",
+        tensors=(tensor,),
+        fragments=(
+            PlacementFragment(
+                placement_fragment_id="placement-0",
+                tensor_id=tensor.tensor_id,
+                global_offset=(0,),
+                local_shape=(4,),
+                nbytes=4,
+                rank=ParallelRank(),
+            ),
+        ),
+    )
+    participant = placement.topology.participants[0]
+    binding = WeightRuntimeBindingManifest(
+        resource_id=placement.resource_id,
+        revision=placement.revision,
+        placement_id=placement.placement_id,
+        placement_digest=placement.digest,
+        participant_id=participant.participant_id,
+        instance_id="worker-0",
+        generation=7,
+        lease_id="runtime-lease-7",
+        fragments=(
+            RuntimeBindingFragment(
+                placement_fragment_id="placement-0",
+                fragment_id="runtime-placement-0",
+                address=0x1100,
+                nbytes=4,
+                worker_id=participant.participant_id,
+                endpoint=f"{participant.participant_id}:12345",
+                device="cuda:0",
+                itemsize=1,
+                local_shape=(4,),
+                strides_bytes=(1,),
+                storage_address=0x1000,
+                storage_nbytes=0x1000,
+                storage_offset_bytes=0x100,
+            ),
+        ),
+    )
+    return placement, binding
+
+
+def test_te_responsibility_modules_preserve_public_identity() -> None:
+    assert te.TransferEngineError is TransferEngineError
+    assert te.TransferCompletionUnknownError is TransferCompletionUnknownError
+    assert te.MemoryRegistrationLease is MemoryRegistrationLease
+    assert te.DirectTransferReceipt is DirectTransferReceipt
+    assert te.DirectReadReceipt is DirectReadReceipt
+    assert te.MooncakeTransferEngineSink is MooncakeTransferEngineSink
+    assert te.MooncakeTransferEngineReader is MooncakeTransferEngineReader
+
+
+def test_te_execution_contract_uses_explicit_placement_and_binding() -> None:
+    sink_parameters = tuple(signature(MooncakeTransferEngineSink.execute).parameters)
+    assert sink_parameters[:6] == (
+        "self",
+        "plan",
+        "source_placement",
+        "source_binding",
+        "target_placement",
+        "target_bindings",
+    )
+
+    reader_parameters = tuple(
+        signature(MooncakeTransferEngineReader.execute).parameters
+    )
+    assert reader_parameters[:6] == (
+        "self",
+        "plan",
+        "source_placement",
+        "source_bindings",
+        "target_placement",
+        "target_binding",
+    )
+
+
+def test_te_registration_keeps_generation_and_lease_fences() -> None:
+    _, binding = manifest_pair()
+    fragment = binding.fragments[0]
+    registration = MemoryRegistrationLease.from_fragment(
+        fragment,
+        lease_generation=binding.generation,
+        runtime_lease_id=binding.lease_id,
+    )
+    assert registration.device == fragment.device
+    assert registration.address == fragment.address
+    assert registration.nbytes == fragment.nbytes
+    assert registration.itemsize == fragment.itemsize
+    assert registration.local_shape == fragment.local_shape
+    assert registration.strides_bytes == fragment.strides_bytes
+    assert registration.storage_address == fragment.storage_address
+    assert registration.storage_nbytes == fragment.storage_nbytes
+    assert registration.storage_offset_bytes == fragment.storage_offset_bytes
+
+    validate_registration(
+        fragment,
+        {fragment.fragment_id: registration},
+        "source",
+        lease_generation=binding.generation,
+        runtime_lease_id=binding.lease_id,
+    )
+    with pytest.raises(TransferEngineError, match="registration lease mismatch"):
+        validate_registration(
+            fragment,
+            {fragment.fragment_id: replace(registration, lease_generation=8)},
+            "source",
+            lease_generation=binding.generation,
+            runtime_lease_id=binding.lease_id,
+        )
+    with pytest.raises(TransferEngineError, match="registration lease mismatch"):
+        validate_registration(
+            fragment,
+            {fragment.fragment_id: replace(registration, device="cuda:1")},
+            "source",
+            lease_generation=binding.generation,
+            runtime_lease_id=binding.lease_id,
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"itemsize": 2},
+        {"local_shape": (2,)},
+        {"strides_bytes": (2,)},
+        {"storage_address": 0xF00, "storage_offset_bytes": 0x200},
+        {"storage_nbytes": 0x2000},
+        {"storage_address": 0xE00, "storage_offset_bytes": 0x300},
+    ],
+)
+def test_te_registration_rejects_runtime_storage_evidence_mismatch(
+    changes: dict[str, object],
+) -> None:
+    _, binding = manifest_pair()
+    fragment = binding.fragments[0]
+    registration = MemoryRegistrationLease.from_fragment(
+        fragment,
+        lease_generation=binding.generation,
+        runtime_lease_id=binding.lease_id,
+    )
+
+    with pytest.raises(TransferEngineError, match="registration lease mismatch"):
+        validate_registration(
+            fragment,
+            {fragment.fragment_id: replace(registration, **changes)},
+            "source",
+            lease_generation=binding.generation,
+            runtime_lease_id=binding.lease_id,
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"itemsize": 2},
+        {"local_shape": (2,)},
+        {"strides_bytes": (2,)},
+        {"storage_address": 0xF00, "storage_offset_bytes": 0x200},
+        {"storage_nbytes": 0x2000},
+    ],
+)
+def test_te_snapshot_identity_includes_runtime_storage_evidence(
+    changes: dict[str, object],
+) -> None:
+    _, binding = manifest_pair()
+    fragment = binding.fragments[0]
+
+    assert not same_runtime_snapshot(fragment, replace(fragment, **changes))
+
+
+def test_te_snapshot_identity_excludes_runtime_owner() -> None:
+    _, binding = manifest_pair()
+    fragment = binding.fragments[0]
+
+    assert same_runtime_snapshot(fragment, replace(fragment, owner=object()))
+
+
+def test_te_rejects_binding_for_different_placement_digest() -> None:
+    placement, binding = manifest_pair()
+
+    with pytest.raises(TransferEngineError, match="placement digest"):
+        validate_manifest_pair(
+            type("Plan", (), {"resource_id": "qwen", "revision": "step-1"})(),
+            placement,
+            replace(binding, placement_digest="0" * 64),
+            "source",
+        )

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -64,7 +65,8 @@ void waitBeforeNextPoll(uint64_t poll_count);
 struct TaskInfo {
     TransportType type{UNSPEC};
     int sub_task_id{-1};
-    bool derived{false};                  // merged by other tasks
+    bool derived{false};  // merged by other tasks
+    size_t physical_owner_task_id{std::numeric_limits<size_t>::max()};
     int xport_priority{0};                // transport priority (for fallback)
     int failover_count{0};                // number of failover attempts
     int metadata_refresh_retry_count{0};  // same-transport stale-cache retries
@@ -102,6 +104,7 @@ struct TaskInfo {
         : type(other.type),
           sub_task_id(other.sub_task_id),
           derived(other.derived),
+          physical_owner_task_id(other.physical_owner_task_id),
           xport_priority(other.xport_priority),
           failover_count(other.failover_count),
           metadata_refresh_retry_count(other.metadata_refresh_retry_count),
@@ -125,6 +128,7 @@ struct TaskInfo {
         : type(other.type),
           sub_task_id(other.sub_task_id),
           derived(other.derived),
+          physical_owner_task_id(other.physical_owner_task_id),
           xport_priority(other.xport_priority),
           failover_count(other.failover_count),
           metadata_refresh_retry_count(other.metadata_refresh_retry_count),
@@ -149,6 +153,7 @@ struct TaskInfo {
             type = other.type;
             sub_task_id = other.sub_task_id;
             derived = other.derived;
+            physical_owner_task_id = other.physical_owner_task_id;
             xport_priority = other.xport_priority;
             failover_count = other.failover_count;
             metadata_refresh_retry_count = other.metadata_refresh_retry_count;
@@ -178,6 +183,7 @@ struct TaskInfo {
             type = other.type;
             sub_task_id = other.sub_task_id;
             derived = other.derived;
+            physical_owner_task_id = other.physical_owner_task_id;
             xport_priority = other.xport_priority;
             failover_count = other.failover_count;
             metadata_refresh_retry_count = other.metadata_refresh_retry_count;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1907,10 +1907,10 @@ Status TransferEngineImpl::commitPreparedSubmit(
         if (merged_task_id_map.count(merged_task_id)) {
             task = merged_task_id_map[merged_task_id];
             task.derived = true;
-            if (task.type != UNSPEC) {
-                auto owner_it =
-                    owner_task_id_by_merged_task.find(merged_task_id);
-                if (owner_it != owner_task_id_by_merged_task.end()) {
+            auto owner_it = owner_task_id_by_merged_task.find(merged_task_id);
+            if (owner_it != owner_task_id_by_merged_task.end()) {
+                task.physical_owner_task_id = owner_it->second;
+                if (task.type != UNSPEC) {
                     public_tasks_by_physical_owner[owner_it->second].push_back(
                         task_id);
                 }
@@ -1929,6 +1929,8 @@ Status TransferEngineImpl::commitPreparedSubmit(
         task.type = owner.route.transport;
         task.device_mask = owner.route.device_mask;
         if (owner.route.qp_pool) task.qp_pool = *owner.route.qp_pool;
+        task.physical_owner_task_id = task_id;
+        owner_task_id_by_merged_task[merged_task_id] = task_id;
         if (task.type == UNSPEC) {
             LOG(WARNING) << "Unable to find registered buffer for request: "
                          << printRequest(merged_request);
@@ -1970,7 +1972,6 @@ Status TransferEngineImpl::commitPreparedSubmit(
         task.sub_task_id = -1;
         task.derived = false;
         physical_task_id_list[task.type].push_back(task_id);
-        owner_task_id_by_merged_task[merged_task_id] = task_id;
         public_tasks_by_physical_owner[task_id].push_back(task_id);
         merged_task_id_map[merged_task_id] = task;
     }
@@ -2471,6 +2472,7 @@ Status TransferEngineImpl::cancelTransfer(BatchID batch_id, size_t task_id) {
     }
 
     size_t owner_task_id = task_id;
+    bool queued_owner_resolved = false;
     if (runtime_queue_config_.enabled && batch->queue_token != 0) {
         QueueOwnerId owner_id = 0;
         auto resolve_status =
@@ -2487,6 +2489,7 @@ Status TransferEngineImpl::cancelTransfer(BatchID batch_id, size_t task_id) {
                                  "queued owner metadata missing" LOC_MARK);
             }
             owner_task_id = queued_it->second.owner_task_id;
+            queued_owner_resolved = true;
             if (!queued_it->second.in_dispatch_window) {
                 CHECK_STATUS(cancelQueuedOwner(owner_id));
                 CHECK_STATUS(refillDispatchWindow());
@@ -2494,6 +2497,14 @@ Status TransferEngineImpl::cancelTransfer(BatchID batch_id, size_t task_id) {
                 return Status::OK();
             }
         }
+    }
+    const auto& public_task = batch->task_list[task_id];
+    if (public_task.derived && !queued_owner_resolved) {
+        if (public_task.physical_owner_task_id >= batch->task_list.size()) {
+            return Status::InvalidArgument(
+                "derived task has no physical owner" LOC_MARK);
+        }
+        owner_task_id = public_task.physical_owner_task_id;
     }
 
     auto& owner = batch->task_list[owner_task_id];
@@ -2520,8 +2531,12 @@ Status TransferEngineImpl::cancelTransfer(BatchID batch_id, size_t task_id) {
     CHECK_STATUS(transport->cancelTransferTask(sub_batch, owner.sub_task_id));
     // Merged public tasks share one physical transport task. Mark every alias
     // so polling any of them cannot trigger failover after cancellation.
-    for (auto& task : batch->task_list) {
-        if (task.type == owner.type && task.sub_task_id == owner.sub_task_id) {
+    for (size_t alias_id = 0; alias_id < batch->task_list.size(); ++alias_id) {
+        auto& task = batch->task_list[alias_id];
+        if (alias_id == owner_task_id ||
+            (task.derived && task.physical_owner_task_id == owner_task_id) ||
+            (task.type == owner.type &&
+             task.sub_task_id == owner.sub_task_id)) {
             task.cancel_requested = true;
         }
     }
@@ -2762,6 +2777,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     const size_t public_task_id = task_id;
     size_t poll_task_id = task_id;
+    const auto& public_task = batch->task_list[public_task_id];
+    bool queued_owner_resolved = false;
     CHECK_STATUS(refillDispatchWindow());
     if (runtime_queue_config_.enabled && batch->queue_token != 0) {
         QueueOwnerId owner_id = 0;
@@ -2785,8 +2802,16 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
             if (batch->task_list[public_task_id].derived &&
                 queued_it != queued_owners_.end()) {
                 poll_task_id = queued_it->second.owner_task_id;
+                queued_owner_resolved = true;
             }
         }
+    }
+    if (public_task.derived && !queued_owner_resolved) {
+        if (public_task.physical_owner_task_id >= batch->task_list.size()) {
+            return Status::InvalidArgument(
+                "derived task has no physical owner" LOC_MARK);
+        }
+        poll_task_id = public_task.physical_owner_task_id;
     }
     auto& task = batch->task_list[poll_task_id];
     auto prev_status = task.status;

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -93,6 +93,7 @@ class FakeTransport : public Transport {
     // Number of individual requests handed to submitTransferTasks().
     std::atomic<int> submitted_request_count{0};
     std::atomic<int> status_calls{0};
+    std::atomic<int> cancel_calls{0};
     std::atomic<int> add_mem_calls{0};
 
     Status install(std::string& /*local_segment_name*/,
@@ -145,12 +146,26 @@ class FakeTransport : public Transport {
             return Status::InvalidArgument("bad task_id" LOC_MARK);
         }
         ++fb->poll_counts[task_id];
-        if (poll_status_factory_) {
+        if (fb->statuses[task_id].s == TransferStatusEnum::CANCELED) {
+            status = fb->statuses[task_id];
+        } else if (poll_status_factory_) {
             status = poll_status_factory_(fb->requests[task_id],
                                           fb->poll_counts[task_id]);
         } else {
             status = fb->statuses[task_id];
         }
+        return Status::OK();
+    }
+
+    bool supportsCancellation() const override { return true; }
+
+    Status cancelTransferTask(SubBatchRef batch, int task_id) override {
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fb->statuses.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        ++cancel_calls;
+        fb->statuses[task_id] = {TransferStatusEnum::CANCELED, 0};
         return Status::OK();
     }
 
@@ -1526,6 +1541,111 @@ TEST(EngineFailoverE2E, SubmitStageFailoverWithDerivedTasks) {
 
     EXPECT_TRUE(engine.freeBatch(batch_id).ok());
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+TEST(EngineFailoverE2E, PollStageFailoverWithDerivedTasksRunsOnce) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("merge_requests", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::StatusFactory{}, [](const Request&, int) {
+            return TransferStatus{TransferStatusEnum::FAILED, 0};
+        });
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string segment_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(segment_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(segment_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kHalf = 2048;
+    std::vector<uint8_t> buffer(kHalf * 2, 0x4b);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch_id = engine.allocateBatch(2);
+    ASSERT_NE(batch_id, static_cast<BatchID>(0));
+    Request first;
+    first.opcode = Request::WRITE;
+    first.source = buffer.data();
+    first.target_id = LOCAL_SEGMENT_ID;
+    first.target_offset = reinterpret_cast<uint64_t>(buffer.data());
+    first.length = kHalf;
+    Request second = first;
+    second.source = buffer.data() + kHalf;
+    second.target_offset += kHalf;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {first, second}).ok());
+
+    auto derived_status = pollUntilDone(engine, batch_id, 1);
+    auto owner_status = pollUntilDone(engine, batch_id, 0);
+    EXPECT_EQ(derived_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(owner_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+    EXPECT_EQ(fake_tcp->submitted_request_count.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(EngineFailoverE2E, DerivedCancellationFollowsPollStageFailoverOwner) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("merge_requests", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::StatusFactory{}, [](const Request&, int) {
+            return TransferStatus{TransferStatusEnum::FAILED, 0};
+        });
+    auto fake_tcp = std::make_shared<FakeTransport>(
+        TCP, FakeTransport::StatusFactory{}, [](const Request&, int) {
+            return TransferStatus{TransferStatusEnum::PENDING, 0};
+        });
+    std::string segment_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(segment_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(segment_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kHalf = 2048;
+    std::vector<uint8_t> buffer(kHalf * 2, 0x5c);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch_id = engine.allocateBatch(2);
+    ASSERT_NE(batch_id, static_cast<BatchID>(0));
+    Request first;
+    first.opcode = Request::WRITE;
+    first.source = buffer.data();
+    first.target_id = LOCAL_SEGMENT_ID;
+    first.target_offset = reinterpret_cast<uint64_t>(buffer.data());
+    first.length = kHalf;
+    Request second = first;
+    second.source = buffer.data() + kHalf;
+    second.target_offset += kHalf;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {first, second}).ok());
+
+    TransferStatus derived{};
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, 1, derived).ok());
+    EXPECT_EQ(derived.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+
+    ASSERT_TRUE(engine.cancelTransfer(batch_id, 1).ok());
+    EXPECT_EQ(fake_rdma->cancel_calls.load(), 0);
+    EXPECT_EQ(fake_tcp->cancel_calls.load(), 1);
+
+    TransferStatus owner{};
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, 0, owner).ok());
+    EXPECT_EQ(owner.s, TransferStatusEnum::CANCELED);
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, 1, derived).ok());
+    EXPECT_EQ(derived.s, TransferStatusEnum::CANCELED);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }
 
 TEST(EngineFailoverE2E, QueuedPathSubmitStageFailover) {

--- a/mooncake-wheel/tests/transfer_engine_initiator_test.py
+++ b/mooncake-wheel/tests/transfer_engine_initiator_test.py
@@ -175,6 +175,111 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             f"[✓] {circles} rounds of batch_write_read passed, batch size {batch_size}."
         )
 
+    def test_scatter_write_read(self):
+        """Transfer allocation-bounded offset vectors through one operation."""
+
+        adaptor = self.adaptor
+        base_src_addr = self._ensure_buffer_available()
+        base_dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
+        self.assertNotEqual(base_dst_addr, 0, "Target server has no registered buffers")
+
+        payloads = (b"scatter-range-a", b"scatter-range-b", b"scatter-range-c")
+        write_local_offsets = ((0, 128), (1024,))
+        remote_offsets = ((256, 512), (1536,))
+        lengths = ((len(payloads[0]), len(payloads[1])), (len(payloads[2]),))
+        for address, payload in zip(
+            (
+                base_src_addr + write_local_offsets[0][0],
+                base_src_addr + write_local_offsets[0][1],
+                base_src_addr + write_local_offsets[1][0],
+            ),
+            payloads,
+            strict=True,
+        ):
+            self.assertEqual(
+                adaptor.write_bytes_to_buffer(address, payload, len(payload)),
+                0,
+            )
+
+        write_ticket = adaptor.scatter_transfer_sync_write_with_ticket(
+            self.target_server_name,
+            [base_src_addr, base_src_addr],
+            [4096, 4096],
+            [base_dst_addr, base_dst_addr],
+            [4096, 4096],
+            [list(offsets) for offsets in write_local_offsets],
+            [list(offsets) for offsets in remote_offsets],
+            [list(sizes) for sizes in lengths],
+        )
+        self.assertTrue(write_ticket.drained)
+        self.assertIn("COMPLETED", str(write_ticket.status))
+
+        read_local_offsets = ((2048, 2304), (3072,))
+        read_ticket = adaptor.scatter_transfer_sync_read_with_ticket(
+            self.target_server_name,
+            [base_src_addr, base_src_addr],
+            [4096, 4096],
+            [base_dst_addr, base_dst_addr],
+            [4096, 4096],
+            [list(offsets) for offsets in read_local_offsets],
+            [list(offsets) for offsets in remote_offsets],
+            [list(sizes) for sizes in lengths],
+        )
+        self.assertTrue(read_ticket.drained)
+        self.assertIn("COMPLETED", str(read_ticket.status))
+
+        for address, payload in zip(
+            (
+                base_src_addr + read_local_offsets[0][0],
+                base_src_addr + read_local_offsets[0][1],
+                base_src_addr + read_local_offsets[1][0],
+            ),
+            payloads,
+            strict=True,
+        ):
+            self.assertEqual(
+                adaptor.read_bytes_from_buffer(address, len(payload)),
+                payload,
+            )
+
+    def test_scatter_rejects_mismatched_fragment_vectors(self):
+        adaptor = self.adaptor
+        base_src_addr = self._ensure_buffer_available()
+        base_dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
+        self.assertNotEqual(base_dst_addr, 0, "Target server has no registered buffers")
+
+        ticket = adaptor.scatter_transfer_sync_write_with_ticket(
+            self.target_server_name,
+            [base_src_addr],
+            [4096],
+            [base_dst_addr],
+            [4096],
+            [[0, 128]],
+            [[256]],
+            [[16, 16]],
+        )
+        self.assertTrue(ticket.drained)
+        self.assertIn("FAILED_DRAINED", str(ticket.status))
+
+    def test_scatter_rejects_fragment_outside_allocation(self):
+        adaptor = self.adaptor
+        base_src_addr = self._ensure_buffer_available()
+        base_dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
+        self.assertNotEqual(base_dst_addr, 0, "Target server has no registered buffers")
+
+        ticket = adaptor.scatter_transfer_sync_write_with_ticket(
+            self.target_server_name,
+            [base_src_addr],
+            [4096],
+            [base_dst_addr],
+            [4096],
+            [[4088]],
+            [[0]],
+            [[16]],
+        )
+        self.assertTrue(ticket.drained)
+        self.assertIn("FAILED_DRAINED", str(ticket.status))
+
     def test_async_batch_write_read(self):
         """Test batch_transfer_async_write and batch_transfer_async_read for batch write/read consistency."""
         import random


### PR DESCRIPTION
## Description

This PR adds Transfer Engine execution for bound heterogeneous model-weight
reshard plans.

The new resource-neutral `mooncake.reshard.transfer_engine` layer owns
physical transfer batches, registration leases, completion fencing, and
pending-resource quarantine. The model-weight adapter lowers validated N-D
regions into bounded flat batches and provides both source-initiated writes
and target-initiated reads through `MooncakeTransferEngineSink` and
`MooncakeTransferEngineReader`.

Execution revalidates the selected placement, runtime binding, generation,
lease, allocation range, and fragment evidence after framework allocation
guards pin the participating allocations. Unknown native completion retains
registrations and allocation tokens until an explicit terminal drain. The
current Python TE binding uses `batch_transfer_sync_read/write`; C++ scatter
lowering remains a later performance integration.

Related RFC: https://github.com/kvcache-ai/Mooncake/issues/3111

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
PYTHONPATH=mooncake-wheel:mooncake-reshard/python:mooncake-reshard/tests \
  python3 -m pytest -q mooncake-reshard/tests

npx --yes pyright --project mooncake-reshard/pyrightconfig.json

python3 -m pre_commit run --files $(git diff --name-only origin/main...HEAD)

git diff --check origin/main...HEAD
```

**Test results:**
- [x] Unit tests pass: `630 passed, 1 skipped`
- [x] Integration tests pass: exact-SHA H20 RDMA managed-memory TE E2E passed
  for TP2 -> TP1 with 2 MiB byte-for-byte validation.
- [x] Manual testing done: built the exact branch's native `engine` on H20-8
  and verified that the Python binding exposes the current flat batch API.
  A CUDA allocation RDMA-registration attempt reached the native TE boundary
  and was blocked by the host GDR environment (`Bad address [14]`); this is
  recorded as an environment validation boundary rather than a passing GPU
  G2G result.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3111)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used for implementation support, test harness preparation,
and review. The human submitter reviewed the design, code, and validation
results and remains responsible for this change.