### PR TITLE
[Store][NoF] Bound stalled SPDK I/O with a local qpair abort

### DIFF
--- a/docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md
+++ b/docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md
@@ -286,5 +286,17 @@ extra_config:
 | `MC_NOF_WORKERS` | Number of worker threads used to process SPDK NoF I/O operations. | 4 |
 | `MC_NOF_SUBMIT_CHUNK_BYTES` | Size of each I/O operation submitted to SPDK. | 128KB |
 | `MC_NOF_INFLIGHT_BYTES_LIMIT` | Maximum number of in-flight I/O bytes allowed in the system. | 32MB |
+| `MC_NOF_IO_TIMEOUT_MS` | Timeout for a single SPDK sub-I/O, in milliseconds, measured from the moment it is handed to the SPDK transport. `0` disables it. | 30000 |
 
-These three parameters together provide QoS control for SPDK NoF I/O.
+The first three parameters together provide QoS control for SPDK NoF I/O.
+
+`MC_NOF_IO_TIMEOUT_MS` bounds I/O that the target neither completes nor fails
+(for example a target that stalls while its connection stays up). When a
+sub-I/O exceeds it, the worker that owns the segment disconnects the
+segment's io qpair locally, which completes every request still outstanding
+on that qpair as aborted, and the affected transfers fail only after all of
+their sub-I/Os have been reclaimed, so the caller's buffers are never
+reused while SPDK can still write into them. The qpair stays disconnected
+afterwards: further transfers to that segment fail immediately until the
+qpair is reconnected. Time spent waiting in Mooncake's own submission
+queue does not count toward the timeout.

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -38,8 +38,18 @@ class SpdkWrapper {
 
     void Free(void *ptr);
 
+    /**
+     * @brief Poll completions of a NoF segment's io qpair.
+     *
+     * Completion callbacks run on the calling thread before this returns.
+     * When @p io_timed_out is not null it is set to whether SPDK reported,
+     * during this poll, an I/O of this qpair that exceeded
+     * MC_NOF_IO_TIMEOUT_MS since it was handed to the transport. Nothing has
+     * been aborted at that point; the caller decides.
+     */
     int64_t NvmePollProcessCompletion(nof_seg_handle *seg,
-                                      uint32_t complete_per_seg);
+                                      uint32_t complete_per_seg,
+                                      bool *io_timed_out = nullptr);
 
     /** @brief Open a NoF segment. */
     nof_seg_handle *OpenNofSegment(const std::string &tr_str);
@@ -52,6 +62,22 @@ class SpdkWrapper {
 
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);
+
+    /**
+     * @brief Abort every outstanding I/O of a NoF segment locally.
+     *
+     * Disconnects the segment's io qpair. SPDK then completes each request
+     * still outstanding on that qpair through its completion callback with
+     * ABORTED - SQ DELETION; with the pinned SPDK (v23.01, TCP and RDMA in
+     * the default synchronous mode) this happens before the call returns.
+     * Unlike the NVMe Abort admin command it needs no response from the
+     * target, so it also works when the target is stalled.
+     *
+     * The qpair stays disconnected: SubmitRequest() fails with -ENXIO until
+     * it is reconnected. Must be called from the thread that submits to and
+     * polls this segment, and never from inside a completion callback.
+     */
+    void AbortNofSegmentIo(nof_seg_handle *seg_handle);
 
    private:
     struct ProbeBuffer {
@@ -94,6 +120,10 @@ class SpdkWrapper {
     void RecycleProbeRequestContext(ProbeRequestContext *ctx);
     void ReplenishProbeRequestContextPoolLocked(size_t count);
     static void ProbeReadComplete(void *ctx, const struct spdk_nvme_cpl *cpl);
+    static void NofIoTimeoutCallback(void *cb_arg,
+                                     struct spdk_nvme_ctrlr *ctrlr,
+                                     struct spdk_nvme_qpair *qpair,
+                                     uint16_t cid);
 
     std::atomic<bool> initialized{false};
     std::mutex init_mutex;

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
@@ -21,6 +22,8 @@
 #include "storage_backend.h"
 #include "client_metric.h"
 #ifdef USE_NOF
+#include <glog/logging.h>
+
 #include "spdk/spdk_wrapper.h"
 #endif
 
@@ -369,6 +372,7 @@ struct SpdkNofTask {
     int idx;  // subop idx
     bool failed;
     bool on_chain;
+    bool completed;  // caller has been notified (exactly once)
     std::shared_ptr<SpdkNofOperationState> state;
     int64_t* io_count;
     SpdkNofQos* nof_qos;
@@ -386,6 +390,7 @@ struct SpdkNofTask {
           idx(0),
           failed(false),
           on_chain(false),
+          completed(false),
           state(std::move(s)),
           io_count(nullptr),
           nof_qos(nullptr),
@@ -398,6 +403,28 @@ struct SpdkNofSubTask {
     std::stack<SpdkNofSubTask*>* sub_task_pool;
 };
 
+/**
+ * @brief Stall-handling state of one NoF segment (io qpair) in its worker.
+ *
+ * kActive:   normal submission and polling.
+ * kDraining: SPDK reported an I/O timeout on the qpair and the worker aborted
+ *            the qpair locally. Nothing is submitted to the segment until
+ *            every sub-I/O that was outstanding has come back through its
+ *            completion callback, so neither a SpdkNofSubTask slot nor a
+ *            caller buffer is reused while SPDK can still reference it. The
+ *            segment returns to kActive once drained; its qpair stays
+ *            disconnected until something reconnects it, and submissions to
+ *            it fail fast meanwhile.
+ */
+enum class SpdkNofSegmentState { kActive = 0, kDraining = 1 };
+
+/** @brief What the worker has to do after SpdkNofAdvanceStallState(). */
+enum class SpdkNofStallAction {
+    kNone = 0,
+    kAbort = 1,    // abort the qpair locally (SpdkWrapper::AbortNofSegmentIo)
+    kDrained = 2,  // every outstanding sub-I/O has been reclaimed
+};
+
 constexpr int kDefaultSpdkNofSubmitChunkBytes = (1 << 17);    // 128k
 constexpr int kDefaultSpdkNofInflightBytesLimit = (1 << 25);  // 32M
 struct SpdkNofQos {
@@ -406,12 +433,21 @@ struct SpdkNofQos {
     int inflight_blocks_limit;
     SpdkNofTask* head[kSpdkNofOpNum];
     SpdkNofTask* tail[kSpdkNofOpNum];
+    SpdkNofSegmentState state{SpdkNofSegmentState::kActive};
+    // Sub-I/Os reclaimed during the current drain, i.e. aborted ones.
+    int drained_sub_io{0};
+    std::chrono::steady_clock::time_point drain_started{};
 
     explicit SpdkNofQos(uint32_t block_size);
 
     bool Empty() const {
         return (head[kSpdkNofOpRead] == nullptr &&
                 head[kSpdkNofOpWrite] == nullptr);
+    }
+
+    int InflightBlocks() const {
+        return inflight_blocks[kSpdkNofOpRead] +
+               inflight_blocks[kSpdkNofOpWrite];
     }
 
     void PushTask(SpdkNofTask* task) {
@@ -431,6 +467,95 @@ struct SpdkNofQos {
         }
     }
 };
+
+/**
+ * @brief Finish a task once all of its LBAs are submitted and all of its
+ * sub-I/Os have completed.
+ *
+ * Both the completion callback and the submit loop call this, possibly for
+ * the same task, so the caller is notified exactly once. The task is freed
+ * only when it is off the QoS chain and no sub-I/O can still reference it.
+ */
+inline void SpdkNofTaskCompletion(SpdkNofTask* task) {
+    if (task->remaining_lba != 0 || task->outstanding_sub_io != 0) {
+        return;
+    }
+    if (!task->completed) {
+        task->completed = true;
+        task->state->set_completed(task->failed ? ErrorCode::TRANSFER_FAIL
+                                                : ErrorCode::OK);
+    }
+    if (!task->on_chain) {
+        delete task;
+    }
+}
+
+/**
+ * @brief Account one finished sub-I/O and return its slot to the pool.
+ *
+ * Transport-independent half of the SPDK completion callback, and the only
+ * place a SpdkNofSubTask goes back to the free list: a slot is never reused
+ * while SPDK still holds it as a callback context. Completions produced by a
+ * local qpair abort come through here like any other completion.
+ */
+inline void SpdkNofCompleteSubTask(SpdkNofSubTask* sub_task, bool failed) {
+    SpdkNofTask* task = sub_task->task;
+    SpdkNofQos* nof_qos = task->nof_qos;
+    const int op = task->op;
+    if (--(*task->io_count) < 0) {
+        LOG(ERROR) << "total outstanding io < 0";
+    }
+    if (--(task->outstanding_sub_io) < 0) {
+        LOG(ERROR) << "task outstanding io < 0";
+    }
+    nof_qos->inflight_blocks[op] -= sub_task->submit_lba_count;
+    if (nof_qos->inflight_blocks[op] < 0) {
+        LOG(ERROR) << "segment inflight blocks < 0";
+    }
+    if (nof_qos->state == SpdkNofSegmentState::kDraining) {
+        ++nof_qos->drained_sub_io;
+    }
+    if (failed) {
+        task->remaining_lba = 0;
+        task->failed = true;
+    }
+    SpdkNofTaskCompletion(task);
+    sub_task->task = nullptr;
+    sub_task->sub_task_pool->push(sub_task);
+}
+
+/**
+ * @brief Advance the stall state of a segment after it has been polled.
+ *
+ * @param io_timed_out whether SPDK reported an I/O timeout on the segment's
+ *        qpair during that poll.
+ * @return the action the worker must take. kAbort is returned once per stall;
+ *         kDrained once every sub-I/O outstanding at that point has been
+ *         reclaimed through its completion callback.
+ */
+inline SpdkNofStallAction SpdkNofAdvanceStallState(
+    SpdkNofQos& nof_qos, bool io_timed_out,
+    std::chrono::steady_clock::time_point now) {
+    switch (nof_qos.state) {
+        case SpdkNofSegmentState::kActive:
+            if (!io_timed_out) {
+                return SpdkNofStallAction::kNone;
+            }
+            nof_qos.state = SpdkNofSegmentState::kDraining;
+            nof_qos.drain_started = now;
+            nof_qos.drained_sub_io = 0;
+            return SpdkNofStallAction::kAbort;
+        case SpdkNofSegmentState::kDraining:
+            // A second timeout report while draining changes nothing: the
+            // abort was already issued and only completions can end this.
+            if (nof_qos.InflightBlocks() > 0) {
+                return SpdkNofStallAction::kNone;
+            }
+            nof_qos.state = SpdkNofSegmentState::kActive;
+            return SpdkNofStallAction::kDrained;
+    }
+    return SpdkNofStallAction::kNone;
+}
 
 /**
  * @brief Thread pool for asynchronous spdk nvmf operations

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -38,6 +38,34 @@ bool ParseEnvBool(const char *name, bool *out) {
     return true;
 }
 
+// Per-I/O timeout in milliseconds, measured by SPDK from the moment a request
+// is handed to the transport. 0 disables the timeout. The upper bound keeps
+// the tick conversion inside spdk_nvme_ctrlr_register_timeout_callback() from
+// overflowing on high-frequency TSCs.
+constexpr uint64_t kDefaultNofIoTimeoutMs = 30 * 1000;
+constexpr uint64_t kMaxNofIoTimeoutMs = 3600 * 1000;
+
+uint64_t GetNofIoTimeoutMs() {
+    static const uint64_t value = []() {
+        uint64_t parsed = kDefaultNofIoTimeoutMs;
+        if (ParseEnvU64("MC_NOF_IO_TIMEOUT_MS", &parsed) &&
+            parsed > kMaxNofIoTimeoutMs) {
+            LOG(WARNING) << "MC_NOF_IO_TIMEOUT_MS=" << parsed
+                         << " exceeds the maximum, using "
+                         << kMaxNofIoTimeoutMs;
+            parsed = kMaxNofIoTimeoutMs;
+        }
+        return parsed;
+    }();
+    return value;
+}
+
+// The segment whose qpair the current thread is polling. SPDK invokes the
+// timeout callback from inside spdk_nvme_qpair_process_completions() on the
+// polling thread, so this is how the callback finds its segment without a
+// lock or a qpair-to-segment map.
+thread_local nof_seg_handle *tls_polling_seg = nullptr;
+
 void ApplyCtrlrOptsFromEnv(struct spdk_nvme_ctrlr_opts *opts) {
     uint64_t v = 0;
     bool bv = false;
@@ -85,6 +113,14 @@ void ApplyCtrlrOptsFromEnv(struct spdk_nvme_ctrlr_opts *opts) {
 struct nof_seg_handle {
     struct spdk_nvme_qpair *qpair;
     struct spdk_nvme_ns *ns;
+    // Set by NofIoTimeoutCallback() while the qpair is being polled, read
+    // back by NvmePollProcessCompletion() on the same thread.
+    std::atomic<bool> io_timed_out{false};
+    // AbortNofSegmentIo() disconnected the qpair and nothing has reconnected
+    // it since. A qpair disconnected this way still reports
+    // SPDK_NVME_QPAIR_FAILURE_NONE, so recovery logic must look here as well.
+    // Whoever reconnects the qpair must clear it.
+    std::atomic<bool> disconnected{false};
 };
 
 struct tr_info {
@@ -232,8 +268,53 @@ void SpdkWrapper::RecycleProbeRequestContext(ProbeRequestContext *ctx) {
 }
 
 int64_t SpdkWrapper::NvmePollProcessCompletion(nof_seg_handle *seg,
-                                               uint32_t complete_per_seg) {
-    return spdk_nvme_qpair_process_completions(seg->qpair, complete_per_seg);
+                                               uint32_t complete_per_seg,
+                                               bool *io_timed_out) {
+    // Cleared before the poll so the flag only ever reflects this poll, even
+    // when an earlier caller did not ask for it.
+    seg->io_timed_out.store(false, std::memory_order_relaxed);
+    tls_polling_seg = seg;
+    int64_t ret =
+        spdk_nvme_qpair_process_completions(seg->qpair, complete_per_seg);
+    tls_polling_seg = nullptr;
+    if (io_timed_out) {
+        *io_timed_out = seg->io_timed_out.load(std::memory_order_relaxed);
+    }
+    return ret;
+}
+
+void SpdkWrapper::NofIoTimeoutCallback(void * /*cb_arg*/,
+                                       struct spdk_nvme_ctrlr * /*ctrlr*/,
+                                       struct spdk_nvme_qpair *qpair,
+                                       uint16_t cid) {
+    nof_seg_handle *seg = tls_polling_seg;
+    if (qpair == nullptr) {
+        // Admin queue. Mooncake never polls it, so this is not expected.
+        LOG(WARNING) << "NoF admin command cid " << cid << " timed out";
+        return;
+    }
+    if (seg == nullptr || seg->qpair != qpair) {
+        LOG(WARNING) << "NoF I/O cid " << cid
+                     << " timed out on a qpair not being polled through "
+                        "NvmePollProcessCompletion";
+        return;
+    }
+    // Only flag it here: tearing the qpair down from inside
+    // process_completions is not allowed. The owner acts after the poll.
+    seg->io_timed_out.store(true, std::memory_order_relaxed);
+    VLOG(1) << "NoF I/O cid " << cid << " timed out on seg " << seg;
+}
+
+void SpdkWrapper::AbortNofSegmentIo(nof_seg_handle *seg_handle) {
+    if (!seg_handle || !seg_handle->qpair) {
+        return;
+    }
+    // Local teardown of the io connection. Every request still outstanding
+    // on the qpair is completed through its callback (ABORTED - SQ DELETION)
+    // and every request queued inside SPDK is failed as well; the target is
+    // not involved, so this is bounded even when it never answers again.
+    spdk_nvme_ctrlr_disconnect_io_qpair(seg_handle->qpair);
+    seg_handle->disconnected.store(true, std::memory_order_relaxed);
 }
 
 int SpdkWrapper::ParseTransPortStr(const std::string &tr_str, tr_info *info) {
@@ -322,6 +403,19 @@ nof_seg_handle *SpdkWrapper::OpenNofSegment(const std::string &tr_str) {
                 return nullptr;
             }
 
+            uint64_t io_timeout_ms = GetNofIoTimeoutMs();
+            if (io_timeout_ms > 0) {
+                // SPDK reports, from process_completions() on the polling
+                // thread, every request outstanding longer than this. The
+                // callback only flags the segment; the worker that owns the
+                // qpair aborts it (see AbortNofSegmentIo).
+                spdk_nvme_ctrlr_register_timeout_callback(
+                    info->ctrlr, io_timeout_ms * 1000, io_timeout_ms * 1000,
+                    NofIoTimeoutCallback, nullptr);
+            }
+            LOG(INFO) << "NoF I/O timeout: " << io_timeout_ms << " ms"
+                      << (io_timeout_ms == 0 ? " (disabled)" : "");
+
             connected_ctrlrs[tr.ctrlr_key] = std::move(new_info);
         } else {
             info = it->second.get();
@@ -376,6 +470,12 @@ int SpdkWrapper::SubmitRequest(const nof_seg_handle *seg_handle, void *ptr,
     if (!seg_handle || !ptr || !lba_count || !seg_handle->qpair ||
         !seg_handle->ns) {
         return -1;
+    }
+
+    if (seg_handle->disconnected.load(std::memory_order_relaxed)) {
+        // Same result SPDK would give for a disconnected qpair, without
+        // building a request first.
+        return -ENXIO;
     }
 
     struct spdk_nvme_qpair *qpair = seg_handle->qpair;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -103,17 +103,8 @@ static int CountSpdkNofQueuedTasks(const mooncake::SpdkNofTask* head) {
     return count;
 }
 
-static inline void SpdkNofTaskCompletion(mooncake::SpdkNofTask* task) {
-    if (task->remaining_lba == 0 && task->outstanding_sub_io == 0) {
-        task->state->set_completed(task->failed
-                                       ? mooncake::ErrorCode::TRANSFER_FAIL
-                                       : mooncake::ErrorCode::OK);
-        if (!task->on_chain) {
-            delete task;
-        }
-    }
-}
-
+// SPDK completion callback: adapt the NVMe completion and hand the sub-I/O to
+// the transport-independent accounting in transfer_task.h.
 static void nvmf_io_complete(void* ctx, const struct spdk_nvme_cpl* cpl) {
     if (!ctx) {
         LOG(ERROR) << "nvmf_io_complete ctx is null";
@@ -122,32 +113,61 @@ static void nvmf_io_complete(void* ctx, const struct spdk_nvme_cpl* cpl) {
 
     mooncake::SpdkNofSubTask* sub_task =
         reinterpret_cast<mooncake::SpdkNofSubTask*>(ctx);
-    mooncake::SpdkNofTask* task = sub_task->task;
-    mooncake::SpdkNofQos* nof_qos = task->nof_qos;
-    int op = task->op;
-    if (--(*task->io_count) < 0) {
-        LOG(ERROR) << "total outstanding io < 0";
+    const bool failed = spdk_nvme_cpl_is_error(cpl);
+    if (failed) {
+        if (sub_task->task->nof_qos->state ==
+            mooncake::SpdkNofSegmentState::kDraining) {
+            // Expected while a timed-out qpair is being aborted; the worker
+            // logs one summary for the whole drain.
+            VLOG(1) << "task_complete: I/O aborted "
+                    << spdk_nvme_cpl_get_status_string(&cpl->status);
+        } else {
+            LOG(ERROR) << "task_complete: I/O failed "
+                       << spdk_nvme_cpl_get_status_string(&cpl->status);
+        }
     }
 
-    if (--(task->outstanding_sub_io) < 0) {
-        LOG(ERROR) << "task outstanding io < 0";
+    mooncake::SpdkNofCompleteSubTask(sub_task, failed);
+}
+
+// Act on the stall state of a segment after it has been polled. Runs on the
+// worker thread that owns the segment's qpair, outside any completion
+// callback.
+static void HandleSpdkNofStall(int work_idx, mooncake::nof_seg_handle* seg,
+                               mooncake::SpdkNofQos& nof_qos,
+                               bool io_timed_out) {
+    using mooncake::SpdkNofSegmentState;
+    using mooncake::SpdkNofStallAction;
+    if (!io_timed_out && nof_qos.state == SpdkNofSegmentState::kActive) {
+        return;
     }
 
-    nof_qos->inflight_blocks[op] -= sub_task->submit_lba_count;
-    if (nof_qos->inflight_blocks[op] < 0) {
-        LOG(ERROR) << "task outstanding io < 0";
+    const auto now = std::chrono::steady_clock::now();
+    SpdkNofStallAction action =
+        mooncake::SpdkNofAdvanceStallState(nof_qos, io_timed_out, now);
+    if (action == SpdkNofStallAction::kAbort) {
+        LOG(ERROR) << "work " << work_idx << ", seg " << seg
+                   << " NoF I/O timed out with inflight_read="
+                   << nof_qos.inflight_blocks[mooncake::kSpdkNofOpRead]
+                   << " inflight_write="
+                   << nof_qos.inflight_blocks[mooncake::kSpdkNofOpWrite]
+                   << " blocks, aborting the qpair locally";
+        // Completes every outstanding request through nvmf_io_complete; with
+        // SPDK v23.01 that happens before the call returns, so the segment
+        // normally drains right here.
+        mooncake::SpdkWrapper::GetInstance().AbortNofSegmentIo(seg);
+        action = mooncake::SpdkNofAdvanceStallState(nof_qos, false, now);
     }
-
-    if (spdk_nvme_cpl_is_error(cpl)) {
-        LOG(ERROR) << "task_complete: I/O failed"
-                   << spdk_nvme_cpl_get_status_string(&cpl->status);
-        task->remaining_lba = 0;
-        task->failed = true;
+    if (action == SpdkNofStallAction::kDrained) {
+        const auto drain_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - nof_qos.drain_started)
+                .count();
+        LOG(ERROR) << "work " << work_idx << ", seg " << seg << " drained "
+                   << nof_qos.drained_sub_io << " aborted sub-I/Os in "
+                   << drain_ms
+                   << " ms; the qpair stays disconnected until reconnected";
     }
-
-    SpdkNofTaskCompletion(task);
-
-    sub_task->sub_task_pool->push(sub_task);
 }
 #endif
 namespace mooncake {
@@ -484,6 +504,11 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
         }
 
         for (auto& [seg_handle, nof_qos] : seg_to_qos) {
+            if (nof_qos->state != SpdkNofSegmentState::kActive) {
+                // Being drained after an I/O timeout: nothing goes to this
+                // qpair until every outstanding sub-I/O has been reclaimed.
+                continue;
+            }
             uint32_t block_size =
                 SpdkWrapper::GetInstance().GetBlockSize(seg_handle);
             for (int i = 0; i < kSpdkNofOpNum; ++i) {
@@ -520,6 +545,10 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
                         if (ret != 0) {
                             LOG(ERROR) << "work " << work_idx << ", seg "
                                        << task->seg_handle << " submit io fail";
+                            // SPDK does not invoke the callback for a request
+                            // it rejected at submission, so the slot is free.
+                            sub_task->task = nullptr;
+                            sub_task_pool.push(sub_task);
                             task->failed = true;
                             task->remaining_lba = 0;
                         } else {
@@ -541,13 +570,21 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
         }
 
         if (total_outstanding_io > 0) {
-            int64_t ret = 0;
-            for (auto& it : seg_to_qos) {
-                ret = SpdkWrapper::GetInstance().NvmePollProcessCompletion(
-                    it.first, 0);
+            for (auto& [seg_handle, nof_qos] : seg_to_qos) {
+                if (nof_qos->InflightBlocks() == 0) {
+                    // Nothing of ours is outstanding on this qpair. This
+                    // also keeps a disconnected qpair from being polled.
+                    continue;
+                }
+                bool io_timed_out = false;
+                int64_t ret =
+                    SpdkWrapper::GetInstance().NvmePollProcessCompletion(
+                        seg_handle, 0, &io_timed_out);
                 if (ret < 0) {
                     LOG(ERROR) << "poll completion error: ret " << ret;
                 }
+                HandleSpdkNofStall(work_idx, seg_handle, *nof_qos,
+                                   io_timed_out);
             }
         }
 
@@ -568,6 +605,7 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
                         << CountSpdkNofQueuedTasks(nof_qos->head[0])
                         << " queued_write="
                         << CountSpdkNofQueuedTasks(nof_qos->head[1])
+                        << " state=" << static_cast<int>(nof_qos->state)
                         << " total_outstanding_io=" << total_outstanding_io;
                 }
                 last_debug_snapshot = now;

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -115,6 +115,7 @@ add_store_test(master_service_promotion_test_for_snapshot
                ha/snapshot/master_service_promotion_test_for_snapshot.cpp)
 if(USE_NOF)
   add_store_test(nof_heartbeat_test nof_heartbeat_test.cpp)
+  add_store_test(nof_task_lifecycle_test nof_task_lifecycle_test.cpp)
 endif()
 add_store_test(client_integration_test client_integration_test.cpp)
 add_test(

--- a/mooncake-store/tests/e2e/run_nof_stalled_io_tcp_e2e.sh
+++ b/mooncake-store/tests/e2e/run_nof_stalled_io_tcp_e2e.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# NoF stalled-I/O regression for kvcache-ai/Mooncake#3864.
+#
+# Same local TCP nvmf_tgt setup as run_nof_heartbeat_tcp_e2e.sh, but the target
+# is suspended with SIGSTOP instead of being killed: the TCP connection stays
+# established and the io qpair keeps looking healthy while the target stops
+# answering. Without an I/O timeout the client's put/get blocks forever on the
+# SPDK future. With it, the client must fail within MC_NOF_IO_TIMEOUT_MS plus a
+# margin, the worker must reclaim every outstanding sub-I/O before the caller
+# is told, and the client must keep serving requests afterwards (fail-fast on
+# the disconnected qpair, no crash, no data mismatch).
+#
+# Runs NoF-only (CLIENT_GLOBAL_SEGMENT_SIZE=0) so a memory replica cannot hide
+# a stuck NoF transfer. Needs an SPDK build under extern/spdk, hugepages and
+# passwordless sudo like the heartbeat e2e. The whole run is bounded by
+# RUN_TIMEOUT_SEC through an outer watchdog, so a regression cannot hang CI.
+set -euo pipefail
+
+RUN_TIMEOUT_SEC=${RUN_TIMEOUT_SEC:-300}
+if [[ -z "${NOF_STALL_E2E_CHILD:-}" ]]; then
+  export NOF_STALL_E2E_CHILD=1
+  exec timeout --foreground -k 10 "$RUN_TIMEOUT_SEC" "$BASH" "$0" "$@"
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+BUILD_DIR=${BUILD_DIR:-"$REPO_ROOT/build"}
+LOG_DIR=${LOG_DIR:-/tmp/mooncake_nof_stalled_io_e2e}
+MASTER_RPC=${MASTER_RPC:-127.0.0.1:50051}
+MASTER_HOST=${MASTER_RPC%:*}
+MASTER_PORT=${MASTER_RPC##*:}
+METADATA_HOST=${METADATA_HOST:-127.0.0.1}
+METADATA_PORT=${METADATA_PORT:-8080}
+METADATA_SERVER="http://$METADATA_HOST:$METADATA_PORT/metadata"
+TARGET_HOST=${TARGET_HOST:-127.0.0.1}
+TARGET_PORT=${TARGET_PORT:-4420}
+TARGET_NQN=${TARGET_NQN:-nqn.2016-06.io.spdk:cnode1}
+NOF_SIZE=${NOF_SIZE:-67108864}
+PAYLOAD_SIZE=${PAYLOAD_SIZE:-4096}
+CLIENT_DURATION=${CLIENT_DURATION:-0}
+CLIENT_SLEEP_MS=${CLIENT_SLEEP_MS:-200}
+# The master's heartbeat also stops getting answers; keep its unmount well
+# after the client-side I/O timeout so the failure observed below comes from
+# the timeout and not from the segment disappearing.
+HEARTBEAT_INTERVAL=${HEARTBEAT_INTERVAL:-10}
+HEARTBEAT_TIMEOUT_MS=${HEARTBEAT_TIMEOUT_MS:-500}
+HEARTBEAT_FAILURES=${HEARTBEAT_FAILURES:-3}
+CLIENT_GLOBAL_SEGMENT_SIZE=${CLIENT_GLOBAL_SEGMENT_SIZE:-0}
+CLIENT_LOCAL_BUFFER_SIZE=${CLIENT_LOCAL_BUFFER_SIZE:-33554432}
+CLIENT_MEMORY_REPLICA_NUM=${CLIENT_MEMORY_REPLICA_NUM:-0}
+CLIENT_NOF_REPLICA_NUM=${CLIENT_NOF_REPLICA_NUM:-1}
+PRE_FAULT_SUCCESS_TARGET=${PRE_FAULT_SUCCESS_TARGET:-3}
+IO_TIMEOUT_MS=${IO_TIMEOUT_MS:-3000}
+# Detection happens on the worker's next poll after the deadline and the
+# drain is local, so a few seconds of slack is plenty.
+STALL_SLACK_SEC=${STALL_SLACK_SEC:-10}
+POST_TIMEOUT_OBSERVATION_SEC=${POST_TIMEOUT_OBSERVATION_SEC:-10}
+
+TARGET_PID=""
+MASTER_PID=""
+META_PID=""
+CLIENT_PID=""
+
+cleanup() {
+  [[ -n "$CLIENT_PID" ]] && kill "$CLIENT_PID" >/dev/null 2>&1 || true
+  [[ -n "$MASTER_PID" ]] && kill "$MASTER_PID" >/dev/null 2>&1 || true
+  if [[ -n "$TARGET_PID" ]]; then
+    kill -CONT "$TARGET_PID" >/dev/null 2>&1 || true
+    kill "$TARGET_PID" >/dev/null 2>&1 || true
+  fi
+  [[ -n "$META_PID" ]] && kill "$META_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+count_pattern() {
+  local file=$1
+  local pattern=$2
+  grep -c "$pattern" "$file" 2>/dev/null || true
+}
+
+# Number of put/get result lines of the given kind after line `start`.
+count_results_after() {
+  local file=$1
+  local start=$2
+  local kind=$3  # ok | fail | any
+  awk -v start="$start" -v kind="$kind" '
+    NR > start {
+      if (kind == "ok" && ($0 ~ /put_ok/ || $0 ~ /get_ok/)) count++
+      else if (kind == "fail" && ($0 ~ /put_fail/ || $0 ~ /get_fail/)) count++
+      else if (kind == "any" && ($0 ~ /put_ok/ || $0 ~ /get_ok/ || $0 ~ /put_fail/ || $0 ~ /get_fail/)) count++
+    }
+    END { print count + 0 }
+  ' "$file"
+}
+
+fail() {
+  echo "FAIL: $*"
+  {
+    echo "=== client tail ==="
+    tail -n 80 "$LOG_DIR/client.log"
+    echo "=== master tail ==="
+    tail -n 40 "$LOG_DIR/master.log"
+  } 2>/dev/null || true
+  exit 1
+}
+
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+sudo -n sh -c 'echo 512 > /proc/sys/vm/nr_hugepages'
+sudo -n umount /dev/hugepages >/dev/null 2>&1 || true
+sudo -n mkdir -p /dev/hugepages
+sudo -n mount -t hugetlbfs -o pagesize=2M,mode=1777 none /dev/hugepages
+grep -E 'HugePages_Total|HugePages_Free|Hugepagesize' /proc/meminfo >"$LOG_DIR/hugepages.log"
+
+pkill -f '/nvmf_tgt' >/dev/null 2>&1 || true
+pkill -f 'mooncake_master' >/dev/null 2>&1 || true
+pkill -f 'http_metadata_server.py' >/dev/null 2>&1 || true
+sleep 1
+
+"$REPO_ROOT/extern/spdk/build/bin/nvmf_tgt" -m 0x1 -u --iova-mode=va --wait-for-rpc >"$LOG_DIR/target.log" 2>&1 &
+TARGET_PID=$!
+sleep 3
+
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_start_init >/dev/null
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_wait_init >/dev/null
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" bdev_malloc_create -b Malloc0 64 4096 >/dev/null
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_transport -t TCP >/dev/null || true
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_subsystem "$TARGET_NQN" -a -s SPDK00000000000001 >/dev/null || true
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_ns "$TARGET_NQN" Malloc0 >/dev/null || true
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_listener "$TARGET_NQN" -t tcp -a "$TARGET_HOST" -s "$TARGET_PORT" >/dev/null || true
+
+python3 "$REPO_ROOT/mooncake-wheel/mooncake/http_metadata_server.py" --host "$METADATA_HOST" --port "$METADATA_PORT" >"$LOG_DIR/metadata.log" 2>&1 &
+META_PID=$!
+sleep 2
+
+"$BUILD_DIR/mooncake-store/src/mooncake_master" \
+  --rpc_address="$MASTER_HOST" \
+  --rpc_port="$MASTER_PORT" \
+  --enable_http_metadata_server=false \
+  --logtostderr=true \
+  --nof_heartbeat_interval_sec="$HEARTBEAT_INTERVAL" \
+  --nof_heartbeat_probe_timeout_ms="$HEARTBEAT_TIMEOUT_MS" \
+  --nof_heartbeat_failures_threshold="$HEARTBEAT_FAILURES" >"$LOG_DIR/master.log" 2>&1 &
+MASTER_PID=$!
+sleep 3
+
+PYTHONPATH="$BUILD_DIR/mooncake-integration" MC_NOF_TRTYPE=TCP python3 - <<PY >"$LOG_DIR/register.log" 2>&1
+import store
+ret = store.MooncakeDistributedNoFRegister().real_register(
+    "$TARGET_NQN",
+    1,
+    "$TARGET_HOST",
+    int("$TARGET_PORT"),
+    0,
+    int("$NOF_SIZE"),
+    "$MASTER_RPC",
+)
+print(f"register_ret {ret}", flush=True)
+raise SystemExit(0 if ret == 0 else 1)
+PY
+
+# MC_NOF_DEBUG + GLOG_logtostderr put the worker's nof_qos_state snapshots and
+# the timeout/drain messages into client.log next to the put/get results.
+PYTHONPATH="$BUILD_DIR/mooncake-integration" \
+MC_NOF_IO_TIMEOUT_MS="$IO_TIMEOUT_MS" MC_NOF_DEBUG=1 GLOG_logtostderr=1 \
+python3 "$SCRIPT_DIR/store_client_e2e.py" \
+  --local-hostname "127.0.0.1:50071" \
+  --metadata-server "$METADATA_SERVER" \
+  --master-server "$MASTER_RPC" \
+  --global-segment-size "$CLIENT_GLOBAL_SEGMENT_SIZE" \
+  --local-buffer-size "$CLIENT_LOCAL_BUFFER_SIZE" \
+  --memory-replica-num "$CLIENT_MEMORY_REPLICA_NUM" \
+  --nof-replica-num "$CLIENT_NOF_REPLICA_NUM" \
+  --payload-size "$PAYLOAD_SIZE" \
+  --duration-sec "$CLIENT_DURATION" \
+  --sleep-ms "$CLIENT_SLEEP_MS" \
+  --key-prefix "nof-stalled-io" >"$LOG_DIR/client.log" 2>&1 &
+CLIENT_PID=$!
+
+deadline=$((SECONDS + 30))
+while (( SECONDS < deadline )); do
+  put_ok_count=$(count_pattern "$LOG_DIR/client.log" 'put_ok')
+  get_ok_count=$(count_pattern "$LOG_DIR/client.log" 'get_ok')
+  if (( put_ok_count >= PRE_FAULT_SUCCESS_TARGET && get_ok_count >= PRE_FAULT_SUCCESS_TARGET )); then
+    break
+  fi
+  sleep 1
+done
+
+put_ok_count=$(count_pattern "$LOG_DIR/client.log" 'put_ok')
+get_ok_count=$(count_pattern "$LOG_DIR/client.log" 'get_ok')
+if (( put_ok_count < PRE_FAULT_SUCCESS_TARGET || get_ok_count < PRE_FAULT_SUCCESS_TARGET )); then
+  fail "client did not reach enough initial success: put_ok=$put_ok_count get_ok=$get_ok_count"
+fi
+
+# --- stall: the target stops answering but its connection stays up ---------
+pre_stall_line_count=$(wc -l <"$LOG_DIR/client.log")
+kill -STOP "$TARGET_PID"
+stall_start=$SECONDS
+
+stall_window_sec=$(( IO_TIMEOUT_MS / 1000 + STALL_SLACK_SEC ))
+first_failure_sec=-1
+while (( SECONDS - stall_start < stall_window_sec )); do
+  if (( $(count_results_after "$LOG_DIR/client.log" "$pre_stall_line_count" fail) > 0 )); then
+    first_failure_sec=$((SECONDS - stall_start))
+    break
+  fi
+  sleep 1
+done
+
+if (( first_failure_sec < 0 )); then
+  fail "client I/O still unresolved ${stall_window_sec}s after the target was suspended (MC_NOF_IO_TIMEOUT_MS=$IO_TIMEOUT_MS); this is the #3864 hang"
+fi
+
+timeout_lines=$(count_pattern "$LOG_DIR/client.log" 'NoF I/O timed out')
+drained_lines=$(count_pattern "$LOG_DIR/client.log" 'aborted sub-I/Os')
+if (( timeout_lines <= 0 || drained_lines <= 0 )); then
+  fail "client failed the I/O but the worker did not report a timeout + drain (timed_out=$timeout_lines drained=$drained_lines)"
+fi
+if (( $(count_pattern "$LOG_DIR/client.log" 'outstanding io < 0') > 0 || $(count_pattern "$LOG_DIR/client.log" 'inflight blocks < 0') > 0 )); then
+  fail "sub-I/O accounting went negative during the drain"
+fi
+
+# --- after the timeout: the client must keep going, fail-fast on the dead
+# qpair, and the worker's accounting must be back at zero -------------------
+post_timeout_line_count=$(wc -l <"$LOG_DIR/client.log")
+observation_deadline=$((SECONDS + POST_TIMEOUT_OBSERVATION_SEC))
+post_timeout_results=0
+while (( SECONDS < observation_deadline )); do
+  post_timeout_results=$(count_results_after "$LOG_DIR/client.log" "$post_timeout_line_count" any)
+  (( post_timeout_results >= 2 )) && break
+  sleep 1
+done
+if (( post_timeout_results < 2 )); then
+  fail "client stopped making progress after the first timed-out I/O (results=$post_timeout_results)"
+fi
+if ! kill -0 "$CLIENT_PID" >/dev/null 2>&1; then
+  fail "client process died after the timed-out I/O"
+fi
+if (( $(count_pattern "$LOG_DIR/client.log" 'data_mismatch') > 0 )); then
+  fail "data mismatch observed"
+fi
+
+last_qos_state=$(grep 'nof_qos_state' "$LOG_DIR/client.log" | tail -n 1 || true)
+if [[ -n "$last_qos_state" ]]; then
+  if ! grep -q 'inflight_read=0 inflight_write=0' <<<"$last_qos_state" || \
+     ! grep -q 'state=0' <<<"$last_qos_state" || \
+     ! grep -q 'total_outstanding_io=0' <<<"$last_qos_state"; then
+    fail "worker accounting did not return to baseline: $last_qos_state"
+  fi
+else
+  echo "warning: no nof_qos_state snapshot found in client.log"
+fi
+
+# --- resume the target: nothing may crash on either side --------------------
+kill -CONT "$TARGET_PID"
+sleep 3
+if ! kill -0 "$TARGET_PID" >/dev/null 2>&1; then
+  fail "nvmf_tgt died after being resumed"
+fi
+if ! kill -0 "$CLIENT_PID" >/dev/null 2>&1; then
+  fail "client process died after the target was resumed"
+fi
+post_resume_line_count=$(wc -l <"$LOG_DIR/client.log")
+sleep 5
+post_resume_results=$(count_results_after "$LOG_DIR/client.log" "$post_resume_line_count" any)
+post_resume_successes=$(count_results_after "$LOG_DIR/client.log" "$post_resume_line_count" ok)
+
+kill "$CLIENT_PID" >/dev/null 2>&1 || true
+wait "$CLIENT_PID" >/dev/null 2>&1 || true
+CLIENT_PID=""
+
+{
+  echo "=== hugepages ==="
+  cat "$LOG_DIR/hugepages.log"
+  echo "=== register ==="
+  cat "$LOG_DIR/register.log"
+  echo "=== client ==="
+  cat "$LOG_DIR/client.log"
+  echo "=== master tail ==="
+  tail -n 100 "$LOG_DIR/master.log"
+  echo "=== target tail ==="
+  tail -n 60 "$LOG_DIR/target.log"
+  echo "=== verdict ==="
+  echo "io_timeout_ms=$IO_TIMEOUT_MS"
+  echo "first_failure_sec_after_stall=$first_failure_sec"
+  echo "timeout_lines=$timeout_lines"
+  echo "drained_lines=$drained_lines"
+  echo "post_timeout_results=$post_timeout_results"
+  echo "post_resume_results=$post_resume_results"
+  echo "post_resume_successes=$post_resume_successes"
+  echo "last_qos_state=$last_qos_state"
+  echo "pre_fault_put_ok=$put_ok_count"
+  echo "pre_fault_get_ok=$get_ok_count"
+  echo "client_global_segment_size=$CLIENT_GLOBAL_SEGMENT_SIZE"
+} >"$LOG_DIR/summary.log"
+
+cat "$LOG_DIR/summary.log"

--- a/mooncake-store/tests/nof_task_lifecycle_test.cpp
+++ b/mooncake-store/tests/nof_task_lifecycle_test.cpp
@@ -1,0 +1,295 @@
+// Lifecycle invariants of SPDK NoF tasks and sub-I/Os around a stalled qpair
+// (kvcache-ai/Mooncake#3864). Exercises the transport-independent helpers in
+// transfer_task.h the way SpdkNofWorkerPool::workerThread() and the SPDK
+// completion callback use them, without SPDK or a target:
+//
+//  * the caller of a task is completed exactly once;
+//  * a SpdkNofSubTask slot goes back to the pool only through its completion;
+//  * QoS, per-task and per-worker accounting return to baseline;
+//  * the segment leaves kDraining only once every outstanding sub-I/O has
+//    completed, whether it completed normally or was aborted.
+#include "transfer_task.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <stack>
+#include <vector>
+
+namespace mooncake {
+namespace {
+
+constexpr uint32_t kBlockSize = 4096;
+constexpr int kSlotCount = 16;
+
+// nof_seg_handle is opaque; the helpers only compare the pointer.
+nof_seg_handle* FakeSegment() {
+    static int anchor = 0;
+    return reinterpret_cast<nof_seg_handle*>(&anchor);
+}
+
+class NofTaskLifecycleTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        qos_ = std::make_unique<SpdkNofQos>(kBlockSize);
+        slots_.resize(kSlotCount);
+        for (auto& slot : slots_) {
+            slot.task = nullptr;
+            slot.submit_lba_count = 0;
+            slot.sub_task_pool = &pool_;
+            pool_.push(&slot);
+        }
+    }
+
+    // What the worker does when it takes a task off its queue.
+    SpdkNofTask* Enqueue(int lba_count, int op,
+                         std::shared_ptr<SpdkNofOperationState>* state_out) {
+        auto state = std::make_shared<SpdkNofOperationState>();
+        auto* task = new SpdkNofTask(FakeSegment(), buffer_, /*off=*/0,
+                                     lba_count, op, state);
+        task->io_count = &total_outstanding_io_;
+        task->nof_qos = qos_.get();
+        task->on_chain = true;
+        qos_->PushTask(task);
+        *state_out = std::move(state);
+        return task;
+    }
+
+    // The bookkeeping the submit loop performs for one accepted sub-I/O.
+    SpdkNofSubTask* Submit(SpdkNofTask* task, int lba_count) {
+        EXPECT_FALSE(pool_.empty());
+        SpdkNofSubTask* sub_task = pool_.top();
+        pool_.pop();
+        sub_task->task = task;
+        sub_task->submit_lba_count = lba_count;
+        task->idx++;
+        task->remaining_lba -= lba_count;
+        qos_->inflight_blocks[task->op] += lba_count;
+        task->outstanding_sub_io++;
+        total_outstanding_io_++;
+        return sub_task;
+    }
+
+    // The submit loop pops a task once all of its LBAs have been submitted
+    // (or it was failed) and lets SpdkNofTaskCompletion() decide whether it
+    // is finished. After this the task pointer must not be used.
+    void PopFromChain(SpdkNofTask* task) {
+        ASSERT_EQ(qos_->head[task->op], task);
+        qos_->PopTask(task->op);
+        task->on_chain = false;
+        SpdkNofTaskCompletion(task);
+    }
+
+    SpdkNofStallAction Advance(bool io_timed_out) {
+        return SpdkNofAdvanceStallState(*qos_, io_timed_out,
+                                        std::chrono::steady_clock::now());
+    }
+
+    void ExpectBaseline() {
+        EXPECT_EQ(pool_.size(), static_cast<size_t>(kSlotCount));
+        EXPECT_EQ(qos_->InflightBlocks(), 0);
+        EXPECT_EQ(total_outstanding_io_, 0);
+        EXPECT_TRUE(qos_->Empty());
+        EXPECT_EQ(qos_->state, SpdkNofSegmentState::kActive);
+    }
+
+    alignas(kBlockSize) char buffer_[kBlockSize];
+    std::unique_ptr<SpdkNofQos> qos_;
+    std::vector<SpdkNofSubTask> slots_;
+    std::stack<SpdkNofSubTask*> pool_;
+    int64_t total_outstanding_io_ = 0;
+};
+
+TEST_F(NofTaskLifecycleTest, NormalCompletion) {
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/2, kSpdkNofOpWrite, &state);
+    SpdkNofSubTask* first = Submit(task, 1);
+    SpdkNofSubTask* second = Submit(task, 1);
+    PopFromChain(task);  // fully submitted, still 2 sub-I/Os outstanding
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(pool_.size(), static_cast<size_t>(kSlotCount - 2));
+
+    SpdkNofCompleteSubTask(first, /*failed=*/false);
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(first->task, nullptr);
+
+    SpdkNofCompleteSubTask(second, /*failed=*/false);
+    ASSERT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::OK);
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kNone);
+    ExpectBaseline();
+}
+
+TEST_F(NofTaskLifecycleTest, ErrorOnPartiallySubmittedTaskCompletesCallerOnce) {
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/3, kSpdkNofOpRead, &state);
+    SpdkNofSubTask* sub_task = Submit(task, 1);
+
+    // The callback fails the task while it is still on the chain with LBAs
+    // left to submit: the caller is told now, the task itself must survive
+    // until the submit loop takes it off the chain.
+    SpdkNofCompleteSubTask(sub_task, /*failed=*/true);
+    ASSERT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::TRANSFER_FAIL);
+    EXPECT_TRUE(task->completed);
+    EXPECT_TRUE(task->on_chain);
+    EXPECT_EQ(task->remaining_lba, 0);
+
+    // Second SpdkNofTaskCompletion() from the submit loop: no second
+    // set_completed() (that asserts in debug builds), the task is freed.
+    PopFromChain(task);
+    EXPECT_EQ(state->get_result(), ErrorCode::TRANSFER_FAIL);
+    ExpectBaseline();
+}
+
+TEST_F(NofTaskLifecycleTest, SlotIsReturnedOnlyByCompletion) {
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/1, kSpdkNofOpWrite, &state);
+    SpdkNofSubTask* sub_task = Submit(task, 1);
+    PopFromChain(task);
+
+    // Neither the caller nor the pool may see anything until SPDK is done
+    // with the callback context.
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(pool_.size(), static_cast<size_t>(kSlotCount - 1));
+    EXPECT_EQ(sub_task->task, task);
+
+    SpdkNofCompleteSubTask(sub_task, /*failed=*/false);
+    EXPECT_TRUE(state->is_completed());
+    EXPECT_EQ(pool_.size(), static_cast<size_t>(kSlotCount));
+    EXPECT_EQ(pool_.top(), sub_task);
+    EXPECT_EQ(sub_task->task, nullptr);
+}
+
+TEST_F(NofTaskLifecycleTest, TimeoutAbortsAndDrainsBeforeCallerIsFailed) {
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/4, kSpdkNofOpWrite, &state);
+    SpdkNofSubTask* first = Submit(task, 1);
+    SpdkNofSubTask* second = Submit(task, 1);
+    // 2 LBAs not yet submitted, 2 sub-I/Os outstanding on the stalled qpair.
+
+    ASSERT_EQ(Advance(/*io_timed_out=*/true), SpdkNofStallAction::kAbort);
+    EXPECT_EQ(qos_->state, SpdkNofSegmentState::kDraining);
+    // Nothing has completed yet, so the caller cannot be told anything and
+    // the drain is not over.
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kNone);
+    EXPECT_EQ(qos_->state, SpdkNofSegmentState::kDraining);
+
+    // The local abort completes the outstanding requests as aborted. The
+    // first one fails the task (remaining LBAs are dropped) but the caller
+    // still cannot be told: the second sub-I/O may still be referenced by
+    // SPDK, and with it the caller's buffer.
+    SpdkNofCompleteSubTask(first, /*failed=*/true);
+    EXPECT_EQ(qos_->drained_sub_io, 1);
+    EXPECT_EQ(task->remaining_lba, 0);
+    EXPECT_TRUE(task->failed);
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(qos_->InflightBlocks(), 1);
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kNone);
+
+    SpdkNofCompleteSubTask(second, /*failed=*/true);
+    EXPECT_EQ(qos_->drained_sub_io, 2);
+    ASSERT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::TRANSFER_FAIL);
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kDrained);
+    EXPECT_EQ(qos_->state, SpdkNofSegmentState::kActive);
+
+    PopFromChain(task);
+    ExpectBaseline();
+}
+
+TEST_F(NofTaskLifecycleTest, PartialCompletionAtTimeoutFailsCallerOnce) {
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/3, kSpdkNofOpRead, &state);
+    SpdkNofSubTask* done = Submit(task, 1);
+    SpdkNofSubTask* stuck_a = Submit(task, 1);
+    SpdkNofSubTask* stuck_b = Submit(task, 1);
+    PopFromChain(task);
+    SpdkNofCompleteSubTask(done, /*failed=*/false);
+    EXPECT_FALSE(state->is_completed());
+
+    ASSERT_EQ(Advance(true), SpdkNofStallAction::kAbort);
+    SpdkNofCompleteSubTask(stuck_a, /*failed=*/true);
+    ASSERT_FALSE(state->is_completed());
+    SpdkNofCompleteSubTask(stuck_b, /*failed=*/true);
+    ASSERT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::TRANSFER_FAIL);
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kDrained);
+    ExpectBaseline();
+}
+
+TEST_F(NofTaskLifecycleTest, SeveralTasksTimedOutTogether) {
+    constexpr int kTasks = 3;
+    std::shared_ptr<SpdkNofOperationState> states[kTasks];
+    SpdkNofTask* tasks[kTasks];
+    SpdkNofSubTask* sub_tasks[kTasks];
+    for (int i = 0; i < kTasks; ++i) {
+        tasks[i] = Enqueue(/*lba_count=*/2, kSpdkNofOpWrite, &states[i]);
+    }
+    for (int i = 0; i < kTasks; ++i) {
+        sub_tasks[i] = Submit(tasks[i], 1);  // one chunk each still queued
+    }
+    ASSERT_EQ(Advance(true), SpdkNofStallAction::kAbort);
+    for (int i = 0; i < kTasks; ++i) {
+        SpdkNofCompleteSubTask(sub_tasks[i], /*failed=*/true);
+    }
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kDrained);
+    for (int i = 0; i < kTasks; ++i) {
+        ASSERT_TRUE(states[i]->is_completed());
+        EXPECT_EQ(states[i]->get_result(), ErrorCode::TRANSFER_FAIL);
+        PopFromChain(tasks[i]);
+    }
+    ExpectBaseline();
+}
+
+TEST_F(NofTaskLifecycleTest, RepeatedTimeoutReportWhileDrainingIsIgnored) {
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/1, kSpdkNofOpWrite, &state);
+    SpdkNofSubTask* sub_task = Submit(task, 1);
+    PopFromChain(task);
+
+    ASSERT_EQ(Advance(true), SpdkNofStallAction::kAbort);
+    // e.g. a reset issued by another path, or SPDK reporting the next
+    // request of the same qpair, must not restart the drain.
+    EXPECT_EQ(Advance(true), SpdkNofStallAction::kNone);
+    EXPECT_EQ(qos_->state, SpdkNofSegmentState::kDraining);
+    EXPECT_EQ(qos_->drained_sub_io, 0);
+
+    SpdkNofCompleteSubTask(sub_task, /*failed=*/true);
+    EXPECT_EQ(Advance(true), SpdkNofStallAction::kDrained);
+    ExpectBaseline();
+}
+
+TEST_F(NofTaskLifecycleTest, HealthyIoAfterDrain) {
+    std::shared_ptr<SpdkNofOperationState> stalled_state;
+    SpdkNofTask* stalled =
+        Enqueue(/*lba_count=*/1, kSpdkNofOpRead, &stalled_state);
+    SpdkNofSubTask* stalled_sub = Submit(stalled, 1);
+    PopFromChain(stalled);
+    ASSERT_EQ(Advance(true), SpdkNofStallAction::kAbort);
+    SpdkNofCompleteSubTask(stalled_sub, /*failed=*/true);
+    ASSERT_EQ(Advance(false), SpdkNofStallAction::kDrained);
+    EXPECT_EQ(stalled_state->get_result(), ErrorCode::TRANSFER_FAIL);
+
+    std::shared_ptr<SpdkNofOperationState> state;
+    SpdkNofTask* task = Enqueue(/*lba_count=*/1, kSpdkNofOpRead, &state);
+    SpdkNofSubTask* sub_task = Submit(task, 1);
+    PopFromChain(task);
+    SpdkNofCompleteSubTask(sub_task, /*failed=*/false);
+    EXPECT_EQ(state->get_result(), ErrorCode::OK);
+    EXPECT_EQ(Advance(false), SpdkNofStallAction::kNone);
+    ExpectBaseline();
+}
+
+}  // namespace
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    google::InitGoogleLogging("NofTaskLifecycleTest");
+    FLAGS_logtostderr = true;
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

Addresses #3864.

### 1. Failure mode

SPDK NoF application I/O has no bound. `ApplyCtrlrOptsFromEnv()` forces `keep_alive_timeout_ms = 0`, nothing registers `spdk_nvme_ctrlr_register_timeout_callback()`, and `SpdkNofTaskCompletion()` resolves the future only after every submitted sub-I/O's callback has run. When the target stops answering while its connection stays up (a suspended target process, a wedged storage stack behind it, a lost response), `spdk_nvme_qpair_process_completions()` returns 0 forever, the requests stay on the qpair's outstanding list, and `Client::TransferData()` blocks on `future->get()` indefinitely. This is different from #3863 / #3886: there the qpair *fails* and SPDK aborts everything itself; here the qpair looks healthy.

### 2. Reproducer

`mooncake-store/tests/e2e/run_nof_stalled_io_tcp_e2e.sh` (new) reuses the local TCP `nvmf_tgt` setup of the heartbeat e2e but **suspends the target with `SIGSTOP` instead of killing it**, in NoF-only mode so a memory replica cannot hide the stall. On current `main` the client's put never returns; the script bounds itself with an outer `timeout` and fails with `client I/O still unresolved ... this is the #3864 hang`. With this change it asserts that the I/O fails within `MC_NOF_IO_TIMEOUT_MS` plus slack, that the worker logged the timeout and the drain, that the accounting is back at zero, that the client keeps serving (fail-fast) and survives `SIGCONT`. It needs SPDK, hugepages and passwordless sudo like the heartbeat e2e.

### 3. Why a naive timeout is unsafe

The SPDK callback context is a `SpdkNofSubTask` slot from a worker-local free list, and the data pointer handed to `spdk_nvme_ns_cmd_read/write` is the caller's buffer, released as soon as `future->get()` returns. If a deadline simply failed the future and recycled the slot while the request was still outstanding, a late completion would touch a reused slot and, for reads, DMA into memory the caller has already reused. So a timeout must terminate the SPDK request first, and the caller may only be told once every sub-I/O of its task has come back through the callback.

### 4. Mechanism and state machine

Detection uses SPDK's own per-request timeout (`spdk_nvme_ctrlr_register_timeout_callback`, registered once per controller when it is attached). SPDK stamps each request at transport submission and, from inside `process_completions()` on the polling thread, reports requests older than `MC_NOF_IO_TIMEOUT_MS`. Cost on the healthy path is one tick compare on the head of the qpair's outstanding list per poll; nothing is added to Mooncake's submission path. The callback only flags the segment being polled (a `thread_local` set by `NvmePollProcessCompletion()`); it never tears anything down from inside SPDK's completion context.

Termination is `SpdkWrapper::AbortNofSegmentIo()` = `spdk_nvme_ctrlr_disconnect_io_qpair()`, issued by the worker that owns the qpair, after the poll returns. With the pinned SPDK v23.01.1 (TCP, and RDMA in the default synchronous mode) it completes every outstanding request through its callback with `ABORTED - SQ DELETION` before returning, and fails everything still queued inside SPDK; it needs no cooperation from the target. The NVMe Abort admin command (`spdk_nvme_ctrlr_cmd_abort[_ext]`) was rejected: it has to be answered by the same stalled target and nobody polls the admin queue.

Per segment, in the worker (`SpdkNofSegmentState`, driven by `SpdkNofAdvanceStallState()`):

```
kActive --(SPDK timeout reported on a poll)--> kDraining : AbortNofSegmentIo()
kDraining --(inflight_blocks == 0, i.e. every outstanding sub-I/O completed)--> kActive
```

While draining nothing is submitted to the segment and it keeps being polled. Aborted completions go through the normal callback path, so counters, slots and futures are handled by one code path. After the drain the qpair is left disconnected: further submissions to that segment fail immediately (`-ENXIO`), exactly like today's failed-qpair path, until something reconnects it (see §5).

Invariants:

* **Exactly-once caller completion.** `SpdkNofTask::completed` guards `set_completed()`. This also fixes a pre-existing double completion: an error callback on a partially submitted task completed the caller, and the submit loop completed it again when popping it (an assert in debug builds).
* **No early slot reuse.** A `SpdkNofSubTask` returns to the pool only inside `SpdkNofCompleteSubTask()`. A request rejected at submission now returns its slot too (SPDK does not invoke the callback for it); previously that slot leaked, which after a timeout would leak one slot per fail-fast task.
* **No DMA into reused caller memory.** The future resolves only when `outstanding_sub_io == 0`, and the only way an outstanding sub-I/O ends is its callback, which the local abort forces.
* **Balanced accounting.** `total_outstanding_io`, `SpdkNofQos::inflight_blocks[]`, the free list and task lifetime are all handled by the unchanged completion path; the drain summary logs the number of reclaimed sub-I/Os.
* **Cheap hot path.** One `bool` per poll, one branch per polled segment. Segments with nothing outstanding are no longer polled at all (this also stops the `poll completion error` log spam a disconnected or failed qpair used to produce on every loop iteration).

### 5. Interaction with #3886

#3886 reconnects a qpair that SPDK marks failed (`spdk_nvme_qpair_get_failure_reason() != NONE`), with a controller reset as fallback. A reset aborts outstanding requests through the very same callbacks, so for this state machine it is just another way for `inflight_blocks` to reach zero; the timeout never double-fails or double-releases anything (`RepeatedTimeoutReportWhileDrainingIsIgnored`). This PR deliberately does not add reconnect logic. Two things #3886 should know once both land:

* a qpair disconnected here still reports `SPDK_NVME_QPAIR_FAILURE_NONE`, so its `IsNofSegmentFailed()` should also consult the `nof_seg_handle::disconnected` flag this PR records (and its reconnect should clear it);
* the abort here only ever touches the qpair owned by the calling worker, so it does not have the cross-worker reset hazard #3886 documents.

### 6. Configuration

`MC_NOF_IO_TIMEOUT_MS` (ms, default 30000, `0` disables), read once per process next to the other `MC_NOF_*` knobs and documented in the NVMe-oF deployment guide. The clock starts when SPDK hands the request to the transport, not at queue admission: time spent in Mooncake's own submission queue does not count. Failed transfers surface as `TRANSFER_FAIL` (no new error code).

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

**Test commands:**
```bash
# unit test (USE_NOF builds); also run here standalone with -fsanitize=address,undefined and NDEBUG off
./build/mooncake-store/tests/nof_task_lifecycle_test
# real SPDK e2e (SPDK build under extern/spdk, hugepages, passwordless sudo):
bash mooncake-store/tests/e2e/run_nof_stalled_io_tcp_e2e.sh
# baseline: same script with the timeout disabled reproduces the hang
IO_TIMEOUT_MS=0 STALL_SLACK_SEC=40 bash mooncake-store/tests/e2e/run_nof_stalled_io_tcp_e2e.sh
bash -n mooncake-store/tests/e2e/run_nof_stalled_io_tcp_e2e.sh
./scripts/code_format.sh --changed-lines --check -b upstream/main
pre-commit run --files $(git diff --name-only --diff-filter=ACMR upstream/main...HEAD)
```

**Test results:**
- [x] Unit tests pass — `nof_task_lifecycle_test`, 8 cases (normal completion, error on a partially submitted task, slot returned only by completion, timeout→abort→drain ordering, partial completion at timeout, several tasks timed out together, repeated timeout report while draining, healthy I/O after drain). Passed both as the CMake target linked against the real store library and as a standalone build with `-fsanitize=address,undefined` and `NDEBUG` off (so the `set_completed()` assert is live).
- [x] Integration tests pass — the new e2e was run against a real SPDK v23.01.1 `nvmf_tgt` (TCP, malloc bdev) with this build. Verdict of the passing run: `first_failure_sec_after_stall=4` with `MC_NOF_IO_TIMEOUT_MS=3000`, one `NoF I/O timed out ... aborting the qpair locally` line, one `drained 1 aborted sub-I/Os in 0 ms` line, no negative counters, last `nof_qos_state` at `inflight_read=0 inflight_write=0 state=0 total_outstanding_io=0`, client kept serving (fail-fast `submit io fail` on the disconnected qpair, 5 results within 10 s) and survived `SIGCONT` (all 24 results after the resume were fail-fast failures, as expected without a reconnect), no data mismatch. Baseline with the timeout disabled (pre-patch behaviour) on the same build: `client I/O still unresolved 40s after the target was suspended`, `inflight_write=1` for the whole window — the #3864 hang.
  Caveat on how it was run: the machine has no root and no hugepages, so the run used a local copy of the script that passes `--no-huge --legacy-mem --iova-mode=va` to `nvmf_tgt` and to the initiator through a local-only env hook in `SpdkWrapper::InitializeEnv()`, plus a local-only 4 KiB alignment for the client staging buffer (without hugepages `spdk_zmalloc` honours only the requested 64-byte alignment and NoF rejects the buffer). None of that is in this PR. The committed script's hugepage/sudo path was not executed here.
- [x] Manual testing done — `transfer_task.cpp` and `spdk_wrapper.cpp` compiled against the pinned SPDK v23.01.1 headers with and without `USE_NOF`; every SPDK API used (`spdk_nvme_ctrlr_register_timeout_callback`, `spdk_nvme_ctrlr_disconnect_io_qpair`, `spdk_nvme_qpair_process_completions`) was checked against that version's `lib/nvme` implementation. `bash -n`, the changed-lines format check and all pre-commit hooks pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## Limitations / remaining risks

* Newer SPDK releases (>= 23.05) tear a TCP qpair down asynchronously; the state machine already waits for `inflight_blocks == 0` instead of assuming the abort is synchronous, but that path has not been exercised.
* Requests still queued inside SPDK (`qpair->queued_req`, only when the transport is out of request objects) are not timestamped by SPDK; they are failed by the same local abort once any submitted request times out.
* Timed-out segments are not reconnected here; with only this PR a segment whose target stalls stays fail-fast in that client until the process restarts, which is today's behaviour for any failed qpair. Recovery is #3886's job.
* The timeout must exceed the worst-case I/O latency of the target; a value that is too small turns slow I/O into aborted I/O.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to assist with implementation and test development. The submitter reviewed the final diff and is responsible for the changes.