### PR TITLE
[TENT] Drain RDMA CQ and dest GPU before tearing down MRs

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/platform/cuda.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/cuda.h
@@ -122,6 +122,8 @@ class CudaPlatform : public Platform {
 
     virtual const std::string type() const { return "cuda"; }
 
+    Status synchronizeDevices(const Topology* topology) override;
+
     Status getStreamFromPool(CUDAStreamHandle& outHandle,
                              int deviceId = CUDAStreamPool::kCurrentDevice);
 

--- a/mooncake-transfer-engine/tent/include/tent/platform/rocm.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/rocm.h
@@ -117,6 +117,8 @@ class RocmPlatform : public Platform {
 
     virtual const std::string type() const { return kAmdGpuLocationType; }
 
+    Status synchronizeDevices(const Topology* topology) override;
+
     Status getStreamFromPool(HIPStreamHandle& outHandle,
                              int deviceId = HIPStreamPool::kCurrentDevice);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/platform.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/platform.h
@@ -49,6 +49,15 @@ class Platform {
         void *start, size_t len, bool skip_prefault = false) = 0;
 
     virtual const std::string type() const = 0;
+
+    // Make GPUDirect / device DMA visible on devices named in `topology`.
+    // GPU platforms flush those devices; CPU and others no-op. Failures are
+    // logged and still return OK so teardown can continue.
+    virtual Status synchronizeDevices(const Topology *topology);
+
+   protected:
+    static std::vector<int> topologyDeviceIndices(const Topology *topology,
+                                                  Topology::MemType mem_type);
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -70,6 +70,8 @@ class RdmaTransport : public Transport {
 
     virtual Status uninstall();
 
+    Status quiesce() override;
+
     virtual Status allocateSubBatch(SubBatchRef& batch, size_t max_size);
 
     virtual Status freeSubBatch(SubBatchRef& batch);

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -57,6 +57,12 @@ class Workers {
 
     Status stop();
 
+    // Stop accepting new submits and wait until every worker's inflight
+    // count hits 0. Workers keep polling CQ so in-flight GPUDirect writes
+    // can complete. timeout_ns bounds the wait so teardown cannot hang.
+    static constexpr uint64_t kDefaultQuiesceTimeoutNs = 10000000000ull;
+    Status quiesce(uint64_t timeout_ns = kDefaultQuiesceTimeoutNs);
+
     Status submit(RdmaSlice* slice);
 
     Status submit(RdmaSliceList& slice_list, int worker_id = -1);
@@ -171,6 +177,7 @@ class Workers {
     std::thread monitor_;
 
     std::atomic<bool> running_;
+    std::atomic<bool> accepting_submits_{true};
 
     struct PostPath {
         int local_device_id;

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -19,6 +19,7 @@
 #include <cuda_runtime.h>
 #include <numa.h>
 #include <glog/logging.h>
+#include <vector>
 
 namespace mooncake {
 namespace tent {
@@ -77,6 +78,57 @@ Status CudaPlatform::copy(void* dst, void* src, size_t length) {
     CHECK_CUDA(
         cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
     CHECK_CUDA(cudaStreamSynchronize(stream.get()));
+    return Status::OK();
+}
+
+Status CudaPlatform::synchronizeDevices(const Topology* topology) {
+    const std::vector<int> devices =
+        topologyDeviceIndices(topology, Topology::MEM_CUDA);
+    if (devices.empty()) return Status::OK();
+
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count <= 0) {
+        if (err != cudaSuccess) {
+            LOG(WARNING) << "CudaPlatform::synchronizeDevices "
+                            "cudaGetDeviceCount failed: "
+                         << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+        }
+        return Status::OK();
+    }
+
+    int saved = 0;
+    const bool have_saved = cudaGetDevice(&saved) == cudaSuccess;
+    if (!have_saved) (void)cudaGetLastError();
+
+    for (int device : devices) {
+        if (device >= device_count) continue;
+        err = cudaSetDevice(device);
+        if (err != cudaSuccess) {
+            LOG(WARNING) << "CudaPlatform::synchronizeDevices cudaSetDevice("
+                         << device << ") failed: " << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+            continue;
+        }
+        err = cudaDeviceSynchronize();
+        if (err != cudaSuccess) {
+            LOG(WARNING)
+                << "CudaPlatform::synchronizeDevices cudaDeviceSynchronize "
+                   "device "
+                << device << " failed: " << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+        }
+    }
+    if (have_saved) {
+        err = cudaSetDevice(saved);
+        if (err != cudaSuccess) {
+            LOG(WARNING)
+                << "CudaPlatform::synchronizeDevices restore cudaSetDevice("
+                << saved << ") failed: " << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+        }
+    }
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/platform/rocm/rocm_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/rocm/rocm_allocator.cpp
@@ -18,6 +18,7 @@
 #include <hip/hip_runtime.h>
 #include <numa.h>
 #include <glog/logging.h>
+#include <vector>
 
 namespace mooncake {
 namespace tent {
@@ -71,6 +72,57 @@ Status RocmPlatform::copy(void* dst, void* src, size_t length) {
     CHECK_STATUS(getStreamFromPool(stream, device_id));
     CHECK_HIP(hipMemcpyAsync(dst, src, length, hipMemcpyDefault, stream.get()));
     CHECK_HIP(hipStreamSynchronize(stream.get()));
+    return Status::OK();
+}
+
+Status RocmPlatform::synchronizeDevices(const Topology* topology) {
+    const std::vector<int> devices =
+        topologyDeviceIndices(topology, Topology::MEM_ROCM);
+    if (devices.empty()) return Status::OK();
+
+    int device_count = 0;
+    hipError_t err = hipGetDeviceCount(&device_count);
+    if (err != hipSuccess || device_count <= 0) {
+        if (err != hipSuccess) {
+            LOG(WARNING) << "RocmPlatform::synchronizeDevices "
+                            "hipGetDeviceCount failed: "
+                         << hipGetErrorString(err);
+            (void)hipGetLastError();
+        }
+        return Status::OK();
+    }
+
+    int saved = 0;
+    const bool have_saved = hipGetDevice(&saved) == hipSuccess;
+    if (!have_saved) (void)hipGetLastError();
+
+    for (int device : devices) {
+        if (device >= device_count) continue;
+        err = hipSetDevice(device);
+        if (err != hipSuccess) {
+            LOG(WARNING) << "RocmPlatform::synchronizeDevices hipSetDevice("
+                         << device << ") failed: " << hipGetErrorString(err);
+            (void)hipGetLastError();
+            continue;
+        }
+        err = hipDeviceSynchronize();
+        if (err != hipSuccess) {
+            LOG(WARNING)
+                << "RocmPlatform::synchronizeDevices hipDeviceSynchronize "
+                   "device "
+                << device << " failed: " << hipGetErrorString(err);
+            (void)hipGetLastError();
+        }
+    }
+    if (have_saved) {
+        err = hipSetDevice(saved);
+        if (err != hipSuccess) {
+            LOG(WARNING)
+                << "RocmPlatform::synchronizeDevices restore hipSetDevice("
+                << saved << ") failed: " << hipGetErrorString(err);
+            (void)hipGetLastError();
+        }
+    }
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/platform.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/platform.cpp
@@ -14,6 +14,10 @@
 
 #include "tent/runtime/platform.h"
 
+#include <mutex>
+#include <unordered_set>
+#include <vector>
+
 #ifdef USE_CUDA
 #include "tent/platform/cuda.h"
 #elif defined(USE_HIP)
@@ -50,6 +54,30 @@ Platform& Platform::getLoader(std::shared_ptr<Config> conf) {
 #endif
     });
     return *g_instance;
+}
+
+Status Platform::synchronizeDevices(const Topology* topology) {
+    (void)topology;
+    return Status::OK();
+}
+
+std::vector<int> Platform::topologyDeviceIndices(const Topology* topology,
+                                                 Topology::MemType mem_type) {
+    std::vector<int> devices;
+    if (!topology) return devices;
+
+    std::unordered_set<int> seen;
+    const size_t mem_count = topology->getMemCount();
+    for (size_t i = 0; i < mem_count; ++i) {
+        const auto* mem =
+            topology->getMemEntry(static_cast<Topology::MemID>(i));
+        if (!mem || mem->type != mem_type) continue;
+        LocationParser parser(mem->name);
+        const int device = parser.index();
+        if (device < 0 || !seen.insert(device).second) continue;
+        devices.push_back(device);
+    }
+    return devices;
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -20,6 +20,10 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
@@ -53,6 +57,8 @@ namespace tent {
 
 namespace {
 
+constexpr uint64_t kDefaultRdmaQuiesceTimeoutNs = 10000000000ull;
+
 uint16_t getRdmaBindDefaultPort(const Config& config) {
     constexpr const char* kKey = "rpc_server_port";
     if (!config.contains(kKey)) return 0;
@@ -79,6 +85,75 @@ uint16_t getRdmaBindDefaultPort(const Config& config) {
     }
 
     return 0;
+}
+
+// Dest-GPU visibility for GPUDirect writes is not implied by a successful
+// local CQ. Synchronize only CUDA devices named in this engine's topology so
+// teardown does not create primary contexts on unused GPUs.
+Status synchronizeDestCudaDevices(const Topology* topology) {
+#ifdef USE_CUDA
+    if (!topology) return Status::OK();
+
+    const size_t mem_count = topology->getMemCount();
+    bool any_cuda = false;
+    for (size_t i = 0; i < mem_count; ++i) {
+        const auto* mem =
+            topology->getMemEntry(static_cast<Topology::MemID>(i));
+        if (mem && mem->type == Topology::MEM_CUDA) {
+            any_cuda = true;
+            break;
+        }
+    }
+    if (!any_cuda) return Status::OK();
+
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count <= 0) {
+        if (err != cudaSuccess) {
+            LOG(WARNING) << "RDMA quiesce cudaGetDeviceCount failed: "
+                         << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+        }
+        return Status::OK();
+    }
+
+    int saved = 0;
+    const bool have_saved = cudaGetDevice(&saved) == cudaSuccess;
+    if (!have_saved) (void)cudaGetLastError();
+
+    for (size_t i = 0; i < mem_count; ++i) {
+        const auto* mem =
+            topology->getMemEntry(static_cast<Topology::MemID>(i));
+        if (!mem || mem->type != Topology::MEM_CUDA) continue;
+        LocationParser parser(mem->name);
+        const int device = parser.index();
+        if (device < 0 || device >= device_count) continue;
+        err = cudaSetDevice(device);
+        if (err != cudaSuccess) {
+            LOG(WARNING) << "RDMA quiesce cudaSetDevice(" << device
+                         << ") failed: " << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+            continue;
+        }
+        err = cudaDeviceSynchronize();
+        if (err != cudaSuccess) {
+            LOG(WARNING) << "RDMA quiesce cudaDeviceSynchronize device "
+                         << device << " failed: " << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+        }
+    }
+    if (have_saved) {
+        err = cudaSetDevice(saved);
+        if (err != cudaSuccess) {
+            LOG(WARNING) << "RDMA quiesce restore cudaSetDevice(" << saved
+                         << ") failed: " << cudaGetErrorString(err);
+            (void)cudaGetLastError();
+        }
+    }
+#else
+    (void)topology;
+#endif
+    return Status::OK();
 }
 
 }  // namespace
@@ -377,12 +452,36 @@ Status RdmaTransport::install(std::string& local_segment_name,
     return Status::OK();
 }
 
+Status RdmaTransport::quiesce() {
+    uint64_t timeout_ns = kDefaultRdmaQuiesceTimeoutNs;
+    if (conf_) {
+        timeout_ns = conf_->get("transports/rdma/max_timeout_ns", timeout_ns);
+    }
+    Status drain = Status::OK();
+    if (workers_) {
+        drain = workers_->quiesce(timeout_ns);
+        if (!drain.ok()) {
+            LOG(ERROR) << "RDMA workers quiesce failed: " << drain.ToString();
+        }
+    }
+    const Status sync = synchronizeDestCudaDevices(local_topology_.get());
+    if (!sync.ok()) {
+        LOG(WARNING) << "RDMA dest-GPU sync during quiesce failed: "
+                     << sync.ToString();
+    }
+    return drain;
+}
+
 Status RdmaTransport::uninstall() {
     // ControlService may still receive BootstrapRdma RPCs while uninstall is
     // running. Unregister and drain the callback before destroying workers,
     // contexts, and other state used by onSetupRdmaConnections(). Keep this
     // outside installed_ so partially-installed transports are covered too.
     if (metadata_) metadata_->setBootstrapRdmaCallback(nullptr);
+
+    // Drain CQ and dest-GPU visibility while MRs and QPs are still alive.
+    // Idempotent when deconstruct() already called quiesce().
+    (void)quiesce();
 
     if (installed_) {
         // Stop notification worker thread

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -20,17 +20,12 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
-#ifdef USE_CUDA
-#include <cuda_runtime.h>
-#endif
-
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
 #include <cstdlib>
 #include <future>
 #include <limits>
-#include <set>
 #include <sstream>
 
 #include "tent/common/status.h"
@@ -39,6 +34,7 @@
 #include "tent/transport/rdma/endpoint_store.h"
 #include "tent/transport/rdma/workers.h"
 #include "tent/common/utils/string_builder.h"
+#include "tent/runtime/platform.h"
 #include "tent/runtime/topology.h"
 #include "tent/common/utils/random.h"
 #include "tent/thirdparty/nlohmann/json.h"
@@ -85,75 +81,6 @@ uint16_t getRdmaBindDefaultPort(const Config& config) {
     }
 
     return 0;
-}
-
-// Dest-GPU visibility for GPUDirect writes is not implied by a successful
-// local CQ. Synchronize only CUDA devices named in this engine's topology so
-// teardown does not create primary contexts on unused GPUs.
-Status synchronizeDestCudaDevices(const Topology* topology) {
-#ifdef USE_CUDA
-    if (!topology) return Status::OK();
-
-    const size_t mem_count = topology->getMemCount();
-    bool any_cuda = false;
-    for (size_t i = 0; i < mem_count; ++i) {
-        const auto* mem =
-            topology->getMemEntry(static_cast<Topology::MemID>(i));
-        if (mem && mem->type == Topology::MEM_CUDA) {
-            any_cuda = true;
-            break;
-        }
-    }
-    if (!any_cuda) return Status::OK();
-
-    int device_count = 0;
-    cudaError_t err = cudaGetDeviceCount(&device_count);
-    if (err != cudaSuccess || device_count <= 0) {
-        if (err != cudaSuccess) {
-            LOG(WARNING) << "RDMA quiesce cudaGetDeviceCount failed: "
-                         << cudaGetErrorString(err);
-            (void)cudaGetLastError();
-        }
-        return Status::OK();
-    }
-
-    int saved = 0;
-    const bool have_saved = cudaGetDevice(&saved) == cudaSuccess;
-    if (!have_saved) (void)cudaGetLastError();
-
-    for (size_t i = 0; i < mem_count; ++i) {
-        const auto* mem =
-            topology->getMemEntry(static_cast<Topology::MemID>(i));
-        if (!mem || mem->type != Topology::MEM_CUDA) continue;
-        LocationParser parser(mem->name);
-        const int device = parser.index();
-        if (device < 0 || device >= device_count) continue;
-        err = cudaSetDevice(device);
-        if (err != cudaSuccess) {
-            LOG(WARNING) << "RDMA quiesce cudaSetDevice(" << device
-                         << ") failed: " << cudaGetErrorString(err);
-            (void)cudaGetLastError();
-            continue;
-        }
-        err = cudaDeviceSynchronize();
-        if (err != cudaSuccess) {
-            LOG(WARNING) << "RDMA quiesce cudaDeviceSynchronize device "
-                         << device << " failed: " << cudaGetErrorString(err);
-            (void)cudaGetLastError();
-        }
-    }
-    if (have_saved) {
-        err = cudaSetDevice(saved);
-        if (err != cudaSuccess) {
-            LOG(WARNING) << "RDMA quiesce restore cudaSetDevice(" << saved
-                         << ") failed: " << cudaGetErrorString(err);
-            (void)cudaGetLastError();
-        }
-    }
-#else
-    (void)topology;
-#endif
-    return Status::OK();
 }
 
 }  // namespace
@@ -464,7 +391,8 @@ Status RdmaTransport::quiesce() {
             LOG(ERROR) << "RDMA workers quiesce failed: " << drain.ToString();
         }
     }
-    const Status sync = synchronizeDestCudaDevices(local_topology_.get());
+    const Status sync =
+        Platform::getLoader().synchronizeDevices(local_topology_.get());
     if (!sync.ok()) {
         LOG(WARNING) << "RDMA dest-GPU sync during quiesce failed: "
                      << sync.ToString();

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -21,8 +21,11 @@
 #include <algorithm>
 #include <cassert>
 #include <cerrno>
+#include <chrono>
 #include <fstream>
 #include <sstream>
+#include <string>
+#include <thread>
 
 #include "tent/transport/rdma/bw_arbitration.h"
 #include "tent/transport/rdma/endpoint_store.h"
@@ -61,6 +64,7 @@ Workers::Workers(RdmaTransport* transport)
     : transport_(transport),
       num_workers_(0),
       running_(false),
+      accepting_submits_(true),
       worker_context_(nullptr) {
     device_selector_ = std::make_unique<DeviceSelector>();
     device_selector_->loadTopology(transport_->local_topology_);
@@ -240,6 +244,7 @@ Workers::~Workers() {
 Status Workers::start() {
     const static uint64_t kDefaultMaxTimeoutNs = 10000000000ull;
     if (!running_) {
+        accepting_submits_.store(true, std::memory_order_release);
         running_ = true;
         monitor_ = std::thread([this] { monitorThread(); });
         num_workers_ = transport_->params_->workers.num_workers;
@@ -256,6 +261,7 @@ Status Workers::start() {
 
 Status Workers::stop() {
     if (!running_) return Status::OK();
+    accepting_submits_.store(false, std::memory_order_release);
     running_ = false;
     for (size_t id = 0; id < num_workers_; ++id) {
         auto& worker = worker_context_[id];
@@ -271,7 +277,45 @@ Status Workers::stop() {
     return Status::OK();
 }
 
+Status Workers::quiesce(uint64_t timeout_ns) {
+    accepting_submits_.store(false, std::memory_order_release);
+    if (!running_.load(std::memory_order_acquire) || !worker_context_ ||
+        num_workers_ == 0) {
+        return Status::OK();
+    }
+
+    for (size_t id = 0; id < num_workers_; ++id) {
+        auto& worker = worker_context_[id];
+        std::lock_guard<std::mutex> lock(worker.mutex);
+        if (worker.in_suspend) worker.cv.notify_all();
+    }
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::nanoseconds(timeout_ns);
+    while (true) {
+        int64_t inflight = 0;
+        for (size_t id = 0; id < num_workers_; ++id) {
+            inflight += worker_context_[id].inflight_slices.load(
+                std::memory_order_acquire);
+        }
+        if (inflight == 0) return Status::OK();
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return Status::InternalError("RDMA quiesce timed out with " +
+                                         std::to_string(inflight) +
+                                         " inflight slices" LOC_MARK);
+        }
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+}
+
 Status Workers::submit(RdmaSliceList& slice_list, int worker_id) {
+    if (!accepting_submits_.load(std::memory_order_acquire)) {
+        return Status::InternalError("RDMA transport is quiescing" LOC_MARK);
+    }
+    if (!running_.load(std::memory_order_acquire) || !worker_context_ ||
+        num_workers_ == 0) {
+        return Status::InternalError("RDMA workers are not running" LOC_MARK);
+    }
     if (worker_id < 0 || worker_id >= (int)num_workers_) {
         // If caller didn't specify the worker, find the least loaded one
         long min_inflight = INT64_MAX;

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -88,6 +88,14 @@ class RdmaTransportTestPeer {
         return transport.context_set_;
     }
 
+    static void setNumWorkers(RdmaTransport& transport, int num_workers) {
+        transport.params_->workers.num_workers = num_workers;
+    }
+
+    static void addInflight(Workers& workers, size_t worker_id, int64_t delta) {
+        workers.worker_context_[worker_id].inflight_slices.fetch_add(delta);
+    }
+
     using NotifyAction = RdmaTransport::NotifyCompletionAction;
 
     static NotifyAction classifyNotifyCompletion(ibv_wc_status status,
@@ -927,6 +935,57 @@ TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {
     const int status = child_guard.finish();
     ASSERT_TRUE(WIFEXITED(status));
     EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+TEST(RdmaQuiesceTest, TransportQuiesceWithoutInstallIsOk) {
+    RdmaTransport transport;
+    EXPECT_TRUE(transport.quiesce().ok());
+    EXPECT_TRUE(transport.quiesce().ok());
+}
+
+TEST(RdmaQuiesceTest, WorkersQuiesceWithoutStartRejectsSubmit) {
+    auto topology = std::make_shared<Topology>();
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+
+    EXPECT_TRUE(workers->quiesce().ok());
+    EXPECT_TRUE(workers->quiesce().ok());
+
+    RdmaSliceList slice_list;
+    EXPECT_TRUE(workers->submit(slice_list).IsInternalError());
+}
+
+TEST(RdmaQuiesceTest, IdleWorkersDrainAndRejectSubmit) {
+    auto topology = std::make_shared<Topology>();
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    RdmaTransportTestPeer::setNumWorkers(transport, 1);
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+    ASSERT_TRUE(workers->start().ok());
+
+    EXPECT_TRUE(workers->quiesce().ok());
+    RdmaSliceList slice_list;
+    EXPECT_TRUE(workers->submit(slice_list).IsInternalError());
+    EXPECT_TRUE(workers->quiesce().ok());
+    ASSERT_TRUE(workers->stop().ok());
+}
+
+TEST(RdmaQuiesceTest, DrainTimeoutLeavesInflight) {
+    auto topology = std::make_shared<Topology>();
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    RdmaTransportTestPeer::setNumWorkers(transport, 1);
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+    ASSERT_TRUE(workers->start().ok());
+    RdmaTransportTestPeer::addInflight(*workers, 0, 1);
+
+    const auto started = std::chrono::steady_clock::now();
+    EXPECT_TRUE(workers->quiesce(50'000'000ull).IsInternalError());
+    EXPECT_LT(std::chrono::steady_clock::now() - started,
+              std::chrono::milliseconds(500));
+
+    ASSERT_TRUE(workers->stop().ok());
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -31,6 +31,7 @@
 #include "tent/common/config.h"
 #include "tent/common/types.h"
 #include "tent/transfer_engine.h"
+#include "tent/runtime/platform.h"
 #include "tent/runtime/topology.h"
 #include "tent/transport/rdma/context.h"
 #include "tent/transport/rdma/params.h"
@@ -941,6 +942,20 @@ TEST(RdmaQuiesceTest, TransportQuiesceWithoutInstallIsOk) {
     RdmaTransport transport;
     EXPECT_TRUE(transport.quiesce().ok());
     EXPECT_TRUE(transport.quiesce().ok());
+}
+
+TEST(RdmaQuiesceTest, TransportQuiesceSyncsTopologyDevicesViaPlatform) {
+    auto topology = std::make_shared<Topology>();
+    Topology::MemEntry memory;
+    memory.name = "cuda:0";
+    memory.type = Topology::MEM_CUDA;
+    memory.numa_node = 0;
+    topology->mem_list_.push_back(std::move(memory));
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    EXPECT_TRUE(transport.quiesce().ok());
+    EXPECT_TRUE(Platform::getLoader().synchronizeDevices(topology.get()).ok());
 }
 
 TEST(RdmaQuiesceTest, WorkersQuiesceWithoutStartRejectsSubmit) {


### PR DESCRIPTION
## Description

Teardown currently calls `Transport::quiesce()` (a no-op on TENT RDMA) and
then destroys workers / unregisters MRs while GPUDirect WRITEs may still be
in flight. Dest GPU visibility is also not implied by a successful local CQ.

Override RDMA `quiesce()` so it:
1. stops accepting new submits
2. waits for per-worker `inflight_slices` to hit zero (CQ drain, bounded by
   `transports/rdma/max_timeout_ns`, default 10s)
3. `Platform::synchronizeDevices()` on devices named in this engine's topology
   (CUDA/HIP on GPU platforms; no-op elsewhere)

`uninstall()` calls the same path while MRs and QPs are still alive. Submit
after quiesce returns `InternalError`. Does not change `mergeRequests` or
RailMonitor.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake -G Ninja -S . -B build-tent \
  -DUSE_TENT=ON -DUSE_CUDA=ON -DUSE_HTTP=ON \
  -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF
cmake --build build-tent --target tent_rdma_transport_test
./build-tent/mooncake-transfer-engine/tent/tests/tent_rdma_transport_test \
  --gtest_filter='RdmaQuiesceTest.*'
./build-tent/mooncake-transfer-engine/tent/tests/tent_rdma_transport_test
```

**Test results:**
- [x] Unit tests pass (`RdmaQuiesceTest` 5/5; `tent_rdma_transport_test` 31/31)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: local H20 + mlx5_bond_* WriteThenRead included in the 31

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (pre-commit C/C++ hook)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Cursor (Grok 4.6): implemented the RDMA quiesce path, moved dest-GPU sync onto
`Platform`, added unit tests, built and ran tent RDMA tests, drafted this PR.
Human submitter reviewed the diff.

Made with [Cursor](https://cursor.com)