### PR TITLE
[Bugfix] Preserve calling thread CPU affinity across SPDK env init

### DIFF
--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <glog/logging.h>
 
 #include <atomic>
@@ -5,6 +7,8 @@
 #include <chrono>
 #include <cstring>
 #include <cstdlib>
+#include <pthread.h>
+#include <sched.h>
 #include <thread>
 #include "spdk/spdk_wrapper.h"
 
@@ -118,11 +122,36 @@ bool SpdkWrapper::InitializeEnv() {
         return true;
     }
 
+    // rte_eal_init registers the calling thread as DPDK's main lcore and may
+    // restrict its CPU affinity to the configured EAL cores (default
+    // core_mask "0x1"). Linux threads inherit the creator's affinity mask, so
+    // without restoring it, every thread sglang spawns after Mooncake's setup
+    // would be pinned to a single core and KV read/write throughput would drop
+    // sharply. Save the original affinity and restore it around spdk_env_init
+    // to stop that propagation. DPDK's main-lcore identity is a thread-local
+    // registration, not the kernel affinity, so later SPDK calls are
+    // unaffected by the restore.
+    cpu_set_t orig_cpuset;
+    CPU_ZERO(&orig_cpuset);
+    bool affinity_saved =
+        pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t),
+                               &orig_cpuset) == 0;
+
     struct spdk_env_opts opts;
     spdk_env_opts_init(&opts);
     opts.name = "mooncake";
 
     int rc = spdk_env_init(&opts);
+
+    // Best-effort restore of the caller's original affinity.
+    if (affinity_saved) {
+        if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t),
+                                   &orig_cpuset) != 0) {
+            LOG(WARNING) << "Failed to restore calling thread CPU affinity "
+                            "after SPDK env init";
+        }
+    }
+
     if (rc != 0) {
         fprintf(stderr, "SPDK init failed: %d\n", rc);
         return false;

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -7,8 +7,10 @@
 #include <chrono>
 #include <cstring>
 #include <cstdlib>
+#if defined(__linux__)
 #include <pthread.h>
 #include <sched.h>
+#endif
 #include <thread>
 #include "spdk/spdk_wrapper.h"
 
@@ -125,17 +127,20 @@ bool SpdkWrapper::InitializeEnv() {
     // rte_eal_init registers the calling thread as DPDK's main lcore and may
     // restrict its CPU affinity to the configured EAL cores (default
     // core_mask "0x1"). Linux threads inherit the creator's affinity mask, so
-    // without restoring it, every thread sglang spawns after Mooncake's setup
-    // would be pinned to a single core and KV read/write throughput would drop
-    // sharply. Save the original affinity and restore it around spdk_env_init
-    // to stop that propagation. DPDK's main-lcore identity is a thread-local
-    // registration, not the kernel affinity, so later SPDK calls are
-    // unaffected by the restore.
+    // without restoring it, every thread the host app spawns after Mooncake's
+    // setup would be pinned to a single core and KV read/write throughput
+    // would drop sharply. Save the original affinity and restore it around
+    // spdk_env_init to stop that propagation. DPDK's main-lcore identity is a
+    // thread registration, not the kernel affinity, so later SPDK calls are
+    // unaffected by the restore. pthread affinity APIs are glibc-specific, so
+    // this is gated to Linux; other platforms see the previous behavior.
+#if defined(__linux__)
     cpu_set_t orig_cpuset;
     CPU_ZERO(&orig_cpuset);
     bool affinity_saved =
         pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t),
                                &orig_cpuset) == 0;
+#endif
 
     struct spdk_env_opts opts;
     spdk_env_opts_init(&opts);
@@ -144,6 +149,7 @@ bool SpdkWrapper::InitializeEnv() {
     int rc = spdk_env_init(&opts);
 
     // Best-effort restore of the caller's original affinity.
+#if defined(__linux__)
     if (affinity_saved) {
         if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t),
                                    &orig_cpuset) != 0) {
@@ -151,6 +157,7 @@ bool SpdkWrapper::InitializeEnv() {
                             "after SPDK env init";
         }
     }
+#endif
 
     if (rc != 0) {
         fprintf(stderr, "SPDK init failed: %d\n", rc);


### PR DESCRIPTION
fix https://github.com/kvcache-ai/Mooncake/issues/3905 when integrating Mooncake NOF with SGLang, as shown in https://github.com/kvcache-ai/Mooncake/pull/3717
rte_eal_init registers the calling thread as DPDK's main lcore and restricts its CPU affinity to the EAL core mask (default "0x1"). Linux threads inherit the creator's affinity mask, so without a restore every thread spawned after setup (e.g. sglang's prefetch/backup workers) would be pinned to a single core, sharply degrading KV read/write throughput. Save and restore the caller's affinity around spdk_env_init.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)