### PR TITLE
[CI/Build] Add Kylin support to dependencies installer

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -72,7 +72,7 @@ detect_os() {
     elif [ -f /etc/redhat-release ]; then
         OS="centos"
     else
-        print_error "Cannot detect OS. Supported OS: Ubuntu, Debian, CentOS, RHEL, Rocky, AlmaLinux, EulerOS, and openEuler."
+        print_error "Cannot detect OS. Supported OS: Ubuntu, Debian, CentOS, RHEL, Rocky, AlmaLinux, EulerOS, openEuler, and Kylin."
     fi
 
     echo -e "${GREEN}Detected OS: $OS ${OS_VERSION:-unknown}${NC}"
@@ -135,7 +135,7 @@ print_section "Updating package lists"
 if [ "$OS" = "ubuntu" ] || [ "$OS" = "debian" ]; then
     apt-get update
     check_success "Failed to update package lists"
-elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "euleros" ] || [ "$OS" = "openeuler" ]; then
+elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "euleros" ] || [ "$OS" = "openeuler" ] || [ "$OS" = "kylin" ]; then
     yum install -y dnf-plugins-core epel-release || true
     yum config-manager --set-enabled powertools || yum config-manager --set-enabled crb || true
     yum clean all
@@ -216,6 +216,60 @@ elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS
                      libbsd-devel"
 
     yum install -y $SYSTEM_PACKAGES
+    check_success "Failed to install system packages"
+
+elif [ "$OS" = "kylin" ]; then
+    SYSTEM_PACKAGES="@development \
+                     cmake \
+                     ninja-build \
+                     git \
+                     wget \
+                     rdma-core-devel \
+                     glog-devel \
+                     gflags-devel \
+                     jsoncpp-devel \
+                     libunwind-devel \
+                     numactl-devel \
+                     python3-devel \
+                     boost-devel \
+                     openssl-devel \
+                     protobuf-devel \
+                     yaml-cpp-devel \
+                     libcurl-devel \
+                     hiredis-devel \
+                     liburing-devel \
+                     jemalloc-devel \
+                     msgpack-devel \
+                     libzstd-devel \
+                     pkgconf-pkg-config \
+                     elfutils-libelf-devel \
+                     patchelf  \
+                     xxhash-devel \
+                     libbsd-devel"
+
+    if [ -z "${KYLIN_EPKL_URL:-}" ]; then
+        KYLIN_NKVERS_OUTPUT=""
+        if command -v nkvers >/dev/null 2>&1; then
+            KYLIN_NKVERS_OUTPUT=$(nkvers 2>/dev/null)
+        fi
+
+        KYLIN_VERSION=${KYLIN_VERSION:-$(printf '%s\n' "$KYLIN_NKVERS_OUTPUT" | sed -nE 's/.*release[[:space:]]+(V[0-9]+).*/\1/p' | head -n 1)}
+        KYLIN_VERSION=${KYLIN_VERSION:-$OS_VERSION}
+        case "$KYLIN_VERSION" in
+            V*) ;;
+            [0-9]*) KYLIN_VERSION="V${KYLIN_VERSION}" ;;
+        esac
+
+        KYLIN_EPKL_RELEASE=${KYLIN_EPKL_RELEASE:-$(printf '%s\n' "$KYLIN_NKVERS_OUTPUT" | sed -nE 's/.*release[[:space:]]+V[0-9]+[[:space:]]+([0-9]{4})\/.*/\1/p' | head -n 1)}
+        if [ -z "$KYLIN_VERSION" ] || [ -z "$KYLIN_EPKL_RELEASE" ]; then
+            print_error "Cannot detect Kylin release. Set KYLIN_EPKL_URL or KYLIN_EPKL_RELEASE explicitly."
+        fi
+
+        KYLIN_EPKL_URL="https://eps-server.openkylin.top/NS/${KYLIN_VERSION}/${KYLIN_EPKL_RELEASE}/EPKL/main/$(uname -m)/"
+    fi
+    dnf --repofrompath="kylin-epkl,$KYLIN_EPKL_URL" \
+        --setopt=kylin-epkl.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kylin \
+        --enablerepo=kylin-epkl install -y $SYSTEM_PACKAGES
     check_success "Failed to install system packages"
 else
     print_error "Unsupported OS: $OS"


### PR DESCRIPTION
## Description

Add Kylin Advanced Server V11 support to `dependencies.sh`.

- adds a dedicated Kylin package update and installation path without modifying the existing Ubuntu/Debian and RHEL-compatible dependency paths;
- obtains the Kylin major version and release version from `nkvers`;
- adds the official EPKL repository only for the current DNF command by using `--repofrompath`, without creating a persistent repository configuration;
- configures the system Kylin GPG key for RPM signature verification.

## Module

- [x] CI/CD

## Type of Change

- [x] New feature

## How Has This Been Tested?



**Test commands:**
```bash
bash -n dependencies.sh
sudo bash dependencies.sh
mkdir build
cd build
cmake ..
make -j
sudo make install
```

**Test results:**
- [x] Manual testing done
- all required system packages were installed or resolved successfully;
- Mooncake configured and built successfully;

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run pre-commit on the files changed in this PR and all hooks pass

## AI Assistance Disclosure

- [x] AI tools were used

OpenAI Codex assisted with refining the Kylin-specific installer logic. The author reviewed the changes and manually validated them on Kylin Advanced Server V11 2503 x86_64.