### PR TITLE
[TENT] Say why the drop and arbitration MLU read different bytes_ahead

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/deadline_mlu.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/deadline_mlu.h
@@ -14,9 +14,22 @@
 //
 // The one definition of a request's predicted deadline feasibility (MLU),
 // shared by the admission queue's drop predictor (RFC #2519 step 3) and the
-// RDMA workers' bandwidth arbitration (RFC #2792). Both must rank the same
-// request the same way from the same bandwidth series, or the admission
-// layer can drop a flow the NIC layer just promoted.
+// RDMA workers' bandwidth arbitration (RFC #2792). Both must apply the same
+// formula to the same bandwidth series, or the admission layer can drop a
+// flow the NIC layer just promoted.
+//
+// The two layers deliberately do NOT read the same `bytes_ahead`. Each counts
+// the bytes it can actually see ahead of the request at its decision point:
+//   * admission decides before the request reaches a worker, so everything
+//     dispatched and not yet completed precedes it (`dispatching_bytes_`,
+//     which includes slices still sitting in worker queues);
+//   * arbitration decides at posting time, when the worker-queue slices are
+//     its own contenders, so only the hardware backlog (`getPostedBytes`)
+//     plus the slots already ordered ahead of it precede a slot.
+// The drop side therefore reads the wider set. That is the intended way
+// round: the drop is the irreversible decision, so it is the conservative
+// one. Weigh the necessity carefully before changing this asymmetry in
+// either direction.
 
 #pragma once
 
@@ -31,10 +44,11 @@ namespace tent {
 // where predicted completion time = (bytes_ahead + length) / bw_bps.
 //
 // The deadline is absolute, so the request must first wait for the bytes
-// already in the pipeline ahead of it (`bytes_ahead`: dispatched but not
-// completed) and then spend its own wire time. Queueing is therefore an
-// additive term over the wire rate -- not folded into a slower bandwidth,
-// which would scale the wait by the request's size.
+// already in the pipeline ahead of it (`bytes_ahead`: whatever the calling
+// layer can see ahead of the request, see the file comment) and then spend
+// its own wire time. Queueing is therefore an additive term over the wire
+// rate -- not folded into a slower bandwidth, which would scale the wait by
+// the request's size.
 //
 // Higher == more urgent. No deadline (deadline_ns == 0) or no usable
 // bandwidth (bw_bps <= 0) yields 0: nothing to predict, so never urgent and


### PR DESCRIPTION
## Description

  Comment-only follow-up promised in the #3780 review. `deadline_mlu.h` said the admission drop predictor and the RDMA arbitration "must rank the same request the same way", but the two layers intentionally pass different `bytes_ahead`: admission passes `dispatching_bytes_` (dispatched and not yet completed, including slices still in worker queues), arbitration passes the posted hardware backlog (`getPostedBytes`) plus the slots already ordered ahead. The header now states that each layer counts the bytes it can actually see at its decision point, that the drop side reading the wider set is the intended conservative direction (it is the irreversible decision), and asks that the necessity be weighed carefully before changing the asymmetry either way. No code change.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] Documentation update

  ## How Has This Been Tested?

  Comment-only change in a header; no behavior affected.

  **Test commands:**
  ```bash
  pre-commit run --files mooncake-transfer-engine/tent/include/tent/runtime/deadline_mlu.h

  Test results:
  - [x] Manual testing done (pre-commit hooks pass; no code changed)
  
  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass

  AI Assistance Disclosure

  - [x] AI tools were used (specify below)