### PR TITLE
[CI/Build] Upload pre-release wheels to GitHub Releases

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,8 +1,8 @@
 name: Pre-Release
 
-# Build the same core wheel matrix as the stable release workflows, publish the
-# exact artifacts to TestPyPI, then consume them in smoke and T-one tests.
-# No production PyPI or GitHub Release publication happens here.
+# Build the same core wheel matrix as the stable release workflows and attach
+# the artifacts to a GitHub Pre-release. Also publish the exact artifacts to
+# TestPyPI, then consume them in smoke and T-one tests. No production PyPI upload.
 on:
   push:
     tags:
@@ -74,6 +74,32 @@ jobs:
       architecture: ${{ matrix.architecture }}
       artifact-prefix: ${{ matrix.artifact-prefix }}
       version-override: ${{ needs.version-stamp.outputs.package_version }}
+
+  publish-github-release:
+    name: Upload wheels to GitHub Pre-release
+    needs: build
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: pre-release-github-${{ github.ref_name }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - name: Download all pre-release wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: mooncake-wheel/dist-release
+          pattern: mooncake-wheel*pre-release*
+          merge-multiple: true
+
+      - name: Upload wheels to GitHub Pre-release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          prerelease: true
+          make_latest: false
+          files: mooncake-wheel/dist-release/*.whl
+          fail_on_unmatched_files: true
 
   publish-testpypi:
     name: Validate and publish wheels to TestPyPI


### PR DESCRIPTION
## Description

Pushing a pre-release tag such as `v0.3.14-rc1` currently builds wheels and publishes them to TestPyPI, but leaves no downloadable wheels on the tag's GitHub Release page. Attach the existing build artifacts to a GitHub Pre-release after the build matrix succeeds.

- Upload all 24 core wheels: CUDA, CUDA 13, and non-CUDA; x86_64 and ARM64; Python 3.10–3.13.
- Use the original tag, explicitly mark the release as a prerelease, and keep `make_latest: false`.
- Serialize uploads for the same tag and fail if no wheels match the upload path.
- Run GitHub publication independently of TestPyPI publication and its downstream tests. The existing TestPyPI gate, stable-release workflows, and production PyPI publication remain unchanged.

This extends the TestPyPI workflow introduced in #3672. It uses the existing RC/alpha/beta/pre tag triggers and adds GitHub release assets; it does not duplicate that gate. The new upload step uses `softprops/action-gh-release@v3` (Node 24), since actionlint rejects the Node 16 runtime in the older v1 action used by the stable workflows.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
actionlint .github/workflows/pre-release.yaml
python3 -m pytest -q mooncake-wheel/tests/test_testpypi_wheel_gate.py
pre-commit run --files .github/workflows/pre-release.yaml
git diff --check origin/main...HEAD
```

**Test results:**
- [x] Unit tests pass: 6 existing TestPyPI gate tests passed.
- [ ] Integration tests pass: the tag-triggered build and real GitHub asset upload have not been run for this change.
- [x] Manual testing done: actionlint 1.7.12, all applicable pre-commit hooks, and diff whitespace checks passed. Reviewed the artifact naming and the upstream download/release action inputs.

## Checklist

- [ ] I have performed a self-review of my own code (human submitter review pending; Codex reviewed the diff).
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable; YAML-only change).
- [x] I have run pre-commit on the files changed in this PR and all hooks pass.
- [ ] I have updated the documentation (not applicable; the workflow header documents the new publication behavior).
- [ ] I have added tests to prove my changes are effective (no new tests; existing gate tests and workflow lint were run).
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable).

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex inspected the existing release workflows, implemented the additional publication job, reviewed the diff, and ran the local checks. Human submitter review is pending; this PR is a draft in accordance with AGENTS.md's requirement that the human submitter review every changed line and be able to defend the change end-to-end.