### PR TITLE
[CI/Build] Simplify CI orchestration and share smoke services

### DIFF
--- a/.github/workflows/_build-efa-wheel.yaml
+++ b/.github/workflows/_build-efa-wheel.yaml
@@ -11,9 +11,6 @@ on:
         # cuda | cuda13 | non-cuda
         type: string
         required: true
-      use-cuda:
-        type: boolean
-        required: true
       python-versions:
         # JSON array consumed by the called workflow's Python matrix.
         type: string
@@ -25,13 +22,6 @@ on:
       cmake-args:
         type: string
         required: true
-      variant-flag:
-        # build_wheel.sh package variant, e.g. EFA_BUILD.
-        type: string
-        required: true
-      cuda-version:
-        type: string
-        default: '12.8.1'
       torch-cuda-arch-list:
         type: string
         default: ''
@@ -52,9 +42,10 @@ jobs:
       BUILD_PROFILE: ${{ inputs.build-profile }}
       CMAKE_ARGS: ${{ inputs.cmake-args }}
       EFA_VARIANT: ${{ inputs.variant }}
-      USE_CUDA: ${{ inputs.use-cuda }}
-      VARIANT_FLAG: ${{ inputs.variant-flag }}
-      CUDA_VERSION: ${{ inputs.cuda-version }}
+      USE_CUDA: ${{ inputs.variant != 'non-cuda' }}
+      VARIANT_FLAG: ${{ fromJSON('{"cuda":"EFA_BUILD","cuda13":"EFA_CU13_BUILD","non-cuda":"EFA_NON_CUDA_BUILD"}')[inputs.variant] }}
+      CUDA_VERSION: ${{ inputs.variant == 'cuda13' && '13.0.2' || '12.8.1' }}
+      TORCH_CUDA_ARCH_LIST: ${{ inputs.torch-cuda-arch-list }}
 
     steps:
       - name: Validate build inputs
@@ -64,17 +55,10 @@ jobs:
             *) echo "::error::Unknown EFA build profile: $BUILD_PROFILE"; exit 1 ;;
           esac
 
-          case "$EFA_VARIANT:$USE_CUDA:$VARIANT_FLAG" in
-            cuda:true:EFA_BUILD|cuda13:true:EFA_CU13_BUILD|non-cuda:false:EFA_NON_CUDA_BUILD) ;;
-            *) echo "::error::Inconsistent EFA variant inputs"; exit 1 ;;
+          case "$EFA_VARIANT" in
+            cuda|cuda13|non-cuda) ;;
+            *) echo "::error::Unknown EFA variant: $EFA_VARIANT"; exit 1 ;;
           esac
-        shell: bash
-
-      - name: Configure CUDA architecture list
-        if: ${{ inputs.torch-cuda-arch-list != '' }}
-        env:
-          ARCH_LIST: ${{ inputs.torch-cuda-arch-list }}
-        run: echo "TORCH_CUDA_ARCH_LIST=$ARCH_LIST" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Checkout source
@@ -91,10 +75,10 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Install CUDA Toolkit
-        if: ${{ inputs.use-cuda }}
+        if: ${{ inputs.variant != 'non-cuda' }}
         uses: Jimver/cuda-toolkit@v0.2.29
         with:
-          cuda: ${{ inputs.cuda-version }}
+          cuda: ${{ env.CUDA_VERSION }}
           method: 'network'
           sub-packages: '["nvcc", "nvrtc-dev"]'
           non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
@@ -201,7 +185,7 @@ jobs:
         shell: bash
 
       - name: Verify CUDA runtime dependency
-        if: ${{ inputs.use-cuda }}
+        if: ${{ inputs.variant != 'non-cuda' }}
         run: |
           WHL=$(ls mooncake-wheel/dist-py${{ steps.python-tag.outputs.python_version_tag }}/*.whl | head -1)
           inspect_dir=$(mktemp -d)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -28,14 +28,7 @@ jobs:
   # Ubuntu jobs remain consumer tests, not an alternate wheel build environment.
   build-wheel:
     needs: [spell-check, clang-format, check-paths]
-    if: &run-ci-for-source-changes >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         contains(github.event.pull_request.labels.*.name, 'run-ci'))))
+    if: &run-ci-for-source-changes needs.check-paths.outputs.src == 'true'
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       python-versions: '["3.10", "3.12"]'
@@ -44,20 +37,15 @@ jobs:
 
   test-wheel-ubuntu:
     needs: [build-wheel]
-    if: >-
-      needs.build-wheel.result == 'success' &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         contains(github.event.pull_request.labels.*.name, 'run-ci'))))
     strategy:
       matrix:
         include:
           - ubuntu-version: ubuntu-22.04
             python-version: '3.12'
+            artifact: mooncake-wheel-ci-py312
           - ubuntu-version: ubuntu-24.04
             python-version: '3.10'
+            artifact: mooncake-wheel-ci-py310
     runs-on: ${{ matrix.ubuntu-version }}
     steps:
     - uses: actions/checkout@v4
@@ -69,16 +57,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Generate Python version tag
-      id: generate_tag_test
-      run: |
-        echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Download wheel artifact
       uses: actions/download-artifact@v4
       with:
-        name: mooncake-wheel-ci-py${{ steps.generate_tag_test.outputs.python_version_tag }}
+        name: ${{ matrix.artifact }}
         path: mooncake-wheel/dist
 
     - name: Verify wheel file exists
@@ -131,186 +113,15 @@ jobs:
         sudo sysctl -w \
           "net.ipv4.ip_local_reserved_ports=${reserved_ports:+$reserved_ports,}50052"
 
-        mkdir -p /tmp/mooncake_storage
-        mooncake_master \
-          --default_kv_lease_ttl=500 \
-          --eviction_high_watermark_ratio=0.95 \
-          --cluster_id=ci_store_api_smoke \
-          --port 50051 \
-          --enable_http_metadata_server=true \
-          >"$RUNNER_TEMP/mooncake-master.log" 2>&1 &
-        master_pid=$!
-        rpc_server_pid=""
-
-        cleanup() {
-          if [ -n "$rpc_server_pid" ]; then
-            kill "$rpc_server_pid" 2>/dev/null || true
-            wait "$rpc_server_pid" 2>/dev/null || true
-          fi
-          kill "$master_pid" 2>/dev/null || true
-          wait "$master_pid" 2>/dev/null || true
-        }
-        trap cleanup EXIT
-
-        master_ready=false
-        for _ in {1..50}; do
-          if ! kill -0 "$master_pid" 2>/dev/null; then
-            cat "$RUNNER_TEMP/mooncake-master.log"
-            echo "::error::mooncake_master exited before becoming ready"
-            exit 1
-          fi
-          if ss -H -ltn 'sport = :50051' | grep -q . && \
-             ss -H -ltn 'sport = :8080' | grep -q .; then
-            master_ready=true
-            break
-          fi
-          sleep 0.1
-        done
-        if [ "$master_ready" != true ]; then
-          cat "$RUNNER_TEMP/mooncake-master.log"
-          echo "::error::mooncake_master did not become ready within 5 seconds"
-          exit 1
-        fi
-
-        python scripts/test_upsert_api.py
-        python -m unittest mooncake-wheel.tests.test_weight_snapshot_api
-        python scripts/test_async_store.py
-        python scripts/test_copy_move_api.py
-        python -m unittest mooncake-wheel.tests.test_safetensor_functions
-        python scripts/test_drain_http_api.py --timeout-sec 90
-
-        python -u mooncake-transfer-engine/tests/rpc_communicator_test.py \
-          server --url 127.0.0.1:9004 --data-size 1 \
-          >"$RUNNER_TEMP/rpc-server.log" 2>&1 &
-        rpc_server_pid=$!
-        rpc_ready=false
-        for _ in {1..50}; do
-          if ! kill -0 "$rpc_server_pid" 2>/dev/null; then
-            cat "$RUNNER_TEMP/rpc-server.log"
-            echo "::error::RPC communicator server exited before becoming ready"
-            exit 1
-          fi
-          if ss -H -ltn 'sport = :9004' | grep -q .; then
-            rpc_ready=true
-            break
-          fi
-          sleep 0.1
-        done
-        if [ "$rpc_ready" != true ]; then
-          cat "$RUNNER_TEMP/rpc-server.log"
-          echo "::error::RPC communicator server did not become ready within 5 seconds"
-          exit 1
-        fi
-
-        client_rc=0
-        timeout 10 python -u \
-          mooncake-transfer-engine/tests/rpc_communicator_test.py \
-          client --url 127.0.0.1:9004 --threads 2 --data-size 1 \
-          >"$RUNNER_TEMP/rpc-client.log" 2>&1 || \
-          client_rc=$?
-        cat "$RUNNER_TEMP/rpc-client.log"
-        if [ "$client_rc" -ne 0 ] && [ "$client_rc" -ne 124 ]; then
-          echo "::error::RPC communicator client failed with exit code $client_rc"
-          exit "$client_rc"
-        fi
-        if ! grep -q '^bandwidth:' "$RUNNER_TEMP/rpc-client.log"; then
-          cat "$RUNNER_TEMP/rpc-server.log"
-          echo "::error::RPC communicator did not complete a successful transfer"
-          exit 1
-        fi
+        ./scripts/ci/run_store_api_smoke.sh
+        ./scripts/ci/run_rpc_smoke.sh
       shell: bash
 
     - name: Run SSD offload and promotion end-to-end tests
       if: matrix.ubuntu-version == 'ubuntu-22.04' && matrix.python-version == '3.12'
       run: |
         source test_env/bin/activate
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
-
-        metadata_pid=""
-        master_pid=""
-        cleanup() {
-          status=$?
-          trap - EXIT
-          if [ -n "$master_pid" ]; then
-            kill "$master_pid" 2>/dev/null || true
-            wait "$master_pid" 2>/dev/null || true
-          fi
-          if [ -n "$metadata_pid" ]; then
-            kill "$metadata_pid" 2>/dev/null || true
-            wait "$metadata_pid" 2>/dev/null || true
-          fi
-          if [ "$status" -ne 0 ]; then
-            cat "$RUNNER_TEMP/mooncake-ssd-master.log" 2>/dev/null || true
-            cat "$RUNNER_TEMP/mooncake-promotion-master.log" 2>/dev/null || true
-            cat "$RUNNER_TEMP/mooncake-metadata.log" 2>/dev/null || true
-          fi
-          rm -rf /tmp/mooncake_ci_ssd_offload \
-            /tmp/mooncake_ci_promotion
-          exit "$status"
-        }
-        trap cleanup EXIT
-
-        wait_for_port() {
-          local pid=$1
-          local port=$2
-          local label=$3
-          for _ in {1..50}; do
-            if ! kill -0 "$pid" 2>/dev/null; then
-              echo "::error::$label exited before listening on port $port"
-              return 1
-            fi
-            if ss -H -ltn "sport = :$port" | grep -q .; then
-              return 0
-            fi
-            sleep 0.1
-          done
-          echo "::error::$label did not listen on port $port within 5 seconds"
-          return 1
-        }
-
-        stop_master() {
-          kill "$master_pid" 2>/dev/null || true
-          wait "$master_pid" 2>/dev/null || true
-          master_pid=""
-        }
-
-        mooncake_http_metadata_server --port 8080 \
-          >"$RUNNER_TEMP/mooncake-metadata.log" 2>&1 &
-        metadata_pid=$!
-        wait_for_port "$metadata_pid" 8080 "metadata server"
-
-        mkdir -p /tmp/mooncake_ci_ssd_offload
-        mooncake_master \
-          --default_kv_lease_ttl=500 \
-          --root_fs_dir=/tmp/mooncake_ci_ssd_offload \
-          >"$RUNNER_TEMP/mooncake-ssd-master.log" 2>&1 &
-        master_pid=$!
-        wait_for_port "$master_pid" 50051 "SSD offload master"
-        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
-          DEFAULT_KV_LEASE_TTL=500 \
-          python mooncake-wheel/tests/test_ssd_offload_in_evict.py
-        stop_master
-
-        mkdir -p /tmp/mooncake_ci_promotion
-        mooncake_master \
-          --default_kv_lease_ttl=500 \
-          --root_fs_dir=/tmp/mooncake_ci_promotion \
-          --enable_offload=true \
-          --offload_on_evict=true \
-          --promotion_on_hit=true \
-          --promotion_admission_threshold=1 \
-          --promotion_max_per_heartbeat=16 \
-          >"$RUNNER_TEMP/mooncake-promotion-master.log" 2>&1 &
-        master_pid=$!
-        wait_for_port "$master_pid" 50051 "promotion master"
-        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
-          DEFAULT_KV_LEASE_TTL=500 \
-          MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/tmp/mooncake_ci_promotion \
-          MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=2 \
-          MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
-          MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
-          python mooncake-wheel/tests/test_promotion_on_hit.py
-        stop_master
+        ./scripts/ci/run_ssd_offload_smoke.sh
       shell: bash
 
   unit-tests:
@@ -537,12 +348,6 @@ jobs:
 
   spell-check:
     name: Spell Check with Typos
-    if: &run-ci >-
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         contains(github.event.pull_request.labels.*.name, 'run-ci'))))
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Actions Repository
@@ -554,7 +359,6 @@ jobs:
 
   reshard-type-check:
     name: Check reshard manifest types
-    if: *run-ci
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -572,9 +376,8 @@ jobs:
         bash scripts/check_reshard_types.sh
       shell: bash
 
-  release-gate-tests:
-    name: Test TestPyPI release gate
-    if: *run-ci
+  ci-script-tests:
+    name: Test CI scripts
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -593,9 +396,11 @@ jobs:
         python -m pytest -q mooncake-wheel/tests/test_testpypi_wheel_gate.py
       shell: bash
 
+    - name: Test CI service and smoke scripts
+      run: python -m unittest discover -s scripts/ci/tests -v
+
   clang-format:
     name: Check code format
-    if: *run-ci
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Actions Repository
@@ -640,7 +445,6 @@ jobs:
 
   python-lint:
     name: Check Python with Ruff
-    if: *run-ci
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -687,56 +491,38 @@ jobs:
 
   docs-check:
     name: Check Sphinx docs build
-    if: *run-ci
+    needs: check-paths
+    if: needs.check-paths.outputs.docs == 'true'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 2
         persist-credentials: false
 
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          docs:
-            - 'docs/**'
-            - 'docs/requirements-docs.txt'
-
     - name: Set up Python
-      if: steps.filter.outputs.docs == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
     - name: Install documentation dependencies
-      if: steps.filter.outputs.docs == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -r docs/requirements-docs.txt
 
     - name: Build docs with strict mode
-      if: steps.filter.outputs.docs == 'true'
-      run: |
-        cd docs
-        make html SPHINXOPTS=-W
-      shell: bash
-
+      working-directory: docs
+      run: make html SPHINXOPTS=-W
 
   check-paths:
-    if: *run-ci
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
-      should-run-downstream: ${{ steps.dispatch-override.outputs.src || steps.filter.outputs.src }}
-      should-run-tent: ${{ steps.dispatch-override.outputs.tent || steps.filter.outputs.tent }}
+      src: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.src }}
+      tent: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.tent }}
+      docs: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.docs }}
     steps:
-      # workflow_dispatch has no PR/push diff context — skip paths-filter and default to true
-      - name: Default to true for workflow_dispatch
-        id: dispatch-override
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "src=true" >> $GITHUB_OUTPUT
-          echo "tent=true" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
         with:
@@ -746,10 +532,14 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         id: filter
         with:
+          # PRs use their base branch; pushes compare against the previous push
+          # on this ref, including release branches.
+          base: ${{ github.event_name == 'push' && github.ref || '' }}
           filters: |
             src:
               - 'mooncake-*/**'
               - 'extern/**'
+              - 'cmake/**'
               - 'CMakeLists.txt'
               - 'dependencies.sh'
               - 'scripts/**'
@@ -758,8 +548,15 @@ jobs:
             tent:
               - 'mooncake-transfer-engine/**'
               - 'mooncake-common/**'
+              - 'extern/**'
+              - 'cmake/**'
               - 'CMakeLists.txt'
               - 'dependencies.sh'
+              - 'scripts/ci/run_transfer_engine_rust_smoke.sh'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
+            docs:
+              - 'docs/**'
               - '.github/workflows/ci.yml'
 
   build-wheel-cu13:
@@ -780,27 +577,13 @@ jobs:
 
   build-wheel-rocm:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         contains(github.event.pull_request.labels.*.name, 'run-ci'))))
+    if: needs.check-paths.outputs.src == 'true'
     uses: ./.github/workflows/ci_rocm.yml
     secrets: inherit
 
   tent-ci:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-tent == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         contains(github.event.pull_request.labels.*.name, 'run-ci'))))
+    if: needs.check-paths.outputs.tent == 'true'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -960,12 +743,13 @@ jobs:
     name: CI Gate
     if: always()
     needs:
+      - check-paths
       - spell-check
       - clang-format
       - python-lint
       - docs-check
       - reshard-type-check
-      - release-gate-tests
+      - ci-script-tests
       - build-wheel
       - unit-tests
       - build-flags
@@ -976,17 +760,46 @@ jobs:
       - tent-ci
     runs-on: ubuntu-latest
     steps:
-      - name: Check required job results
-        run: |
-          failing=$(echo "$NEEDS_JSON" | jq -r '
-            to_entries[] |
-            select(.value.result != "success" and .value.result != "skipped") |
-            "\(.key): \(.value.result)"')
-          if [ -n "$failing" ]; then
-            echo "::error::The following jobs failed or were cancelled:"
-            echo "$failing"
-            exit 1
-          fi
-          echo "All checks passed or were acceptably skipped."
+      # Each path-gated group must succeed when selected and be skipped otherwise.
+      # A failed selector must never turn skipped builds into a successful gate.
+      - name: Check unconditional jobs
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          PASSED: >-
+            ${{ needs.check-paths.result == 'success' &&
+                needs.spell-check.result == 'success' &&
+                needs.clang-format.result == 'success' &&
+                needs.python-lint.result == 'success' &&
+                needs.reshard-type-check.result == 'success' &&
+                needs.ci-script-tests.result == 'success' }}
+        run: |
+          echo "$NEEDS_JSON"
+          test "$PASSED" = true
+
+      - name: Check source jobs
+        env:
+          EXPECTED: ${{ needs.check-paths.outputs.src == 'true' && 'success' || 'skipped' }}
+          RESULTS: >-
+            ${{ needs.build-wheel.result }}
+            ${{ needs.unit-tests.result }}
+            ${{ needs.build-flags.result }}
+            ${{ needs.test-wheel-ubuntu.result }}
+            ${{ needs.build-wheel-cu13.result }}
+            ${{ needs.build-wheel-efa.result }}
+            ${{ needs.build-wheel-rocm.result }}
+        run: |
+          for result in $RESULTS; do
+            test "$result" = "$EXPECTED" || exit 1
+          done
+
+      - name: Check TENT jobs
+        env:
+          EXPECTED: ${{ needs.check-paths.outputs.tent == 'true' && 'success' || 'skipped' }}
+          RESULT: ${{ needs.tent-ci.result }}
+        run: test "$RESULT" = "$EXPECTED"
+
+      - name: Check documentation job
+        env:
+          EXPECTED: ${{ needs.check-paths.outputs.docs == 'true' && 'success' || 'skipped' }}
+          RESULT: ${{ needs.docs-check.result }}
+        run: test "$RESULT" = "$EXPECTED"

--- a/.github/workflows/ci_efa.yml
+++ b/.github/workflows/ci_efa.yml
@@ -11,31 +11,19 @@ jobs:
       matrix:
         include:
           - variant: cuda
-            use_cuda: "ON"
-            build_env: "EFA_BUILD"
-            cuda-version: "12.8.1"
             python-version: "3.12"
           - variant: cuda13
-            use_cuda: "ON"
-            build_env: "EFA_CU13_BUILD"
-            cuda-version: "13.0.2"
             python-version: "3.12"
           - variant: non-cuda
-            use_cuda: "OFF"
-            build_env: "EFA_NON_CUDA_BUILD"
-            cuda-version: "12.8.1"
             python-version: "3.10"
     uses: ./.github/workflows/_build-efa-wheel.yaml
     with:
       variant: ${{ matrix.variant }}
-      use-cuda: ${{ matrix.use_cuda == 'ON' }}
       python-versions: ${{ format('["{0}"]', matrix.python-version) }}
       build-profile: ci
       cmake-args: >-
         -DUSE_ETCD=ON -DUSE_HTTP=ON -DWITH_STORE=ON -DWITH_METRICS=ON
         -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
         -DENABLE_DEBUG_SYMBOLS=OFF
-      variant-flag: ${{ matrix.build_env }}
-      cuda-version: ${{ matrix.cuda-version }}
       torch-cuda-arch-list: '8.0;9.0'
       artifact-prefix: mooncake-wheel-efa-${{ matrix.variant }}-ubuntu

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -407,62 +407,7 @@ jobs:
           python scripts/test_drain_http_api.py --timeout-sec 90
 
       - name: Run RPC Communicator Bandwidth Test
-        run: |
-          rpc_server_pid=""
-          cleanup() {
-            status=$?
-            trap - EXIT
-            if [ -n "$rpc_server_pid" ]; then
-              kill "$rpc_server_pid" 2>/dev/null || true
-              wait "$rpc_server_pid" 2>/dev/null || true
-            fi
-            if [ "$status" -ne 0 ]; then
-              cat "$RUNNER_TEMP/rpc-server.log" 2>/dev/null || true
-            fi
-            exit "$status"
-          }
-          trap cleanup EXIT
-
-          python -u mooncake-transfer-engine/tests/rpc_communicator_test.py \
-            server --url 127.0.0.1:9004 --data-size 1 \
-            >"$RUNNER_TEMP/rpc-server.log" 2>&1 &
-          rpc_server_pid=$!
-
-          rpc_ready=false
-          for _ in {1..50}; do
-            if ! kill -0 "$rpc_server_pid" 2>/dev/null; then
-              cat "$RUNNER_TEMP/rpc-server.log"
-              echo "::error::RPC communicator server exited before becoming ready"
-              exit 1
-            fi
-            if ss -H -ltn 'sport = :9004' | grep -q .; then
-              rpc_ready=true
-              break
-            fi
-            sleep 0.1
-          done
-          if [ "$rpc_ready" != true ]; then
-            cat "$RUNNER_TEMP/rpc-server.log"
-            echo "::error::RPC communicator server did not become ready within 5 seconds"
-            exit 1
-          fi
-
-          client_rc=0
-          timeout 10 python -u \
-            mooncake-transfer-engine/tests/rpc_communicator_test.py \
-            client --url 127.0.0.1:9004 --threads 2 --data-size 1 \
-            >"$RUNNER_TEMP/rpc-client.log" 2>&1 || \
-            client_rc=$?
-          cat "$RUNNER_TEMP/rpc-client.log"
-          if [ "$client_rc" -ne 0 ] && [ "$client_rc" -ne 124 ]; then
-            echo "::error::RPC communicator client failed with exit code $client_rc"
-            exit "$client_rc"
-          fi
-          if ! grep -q '^bandwidth:' "$RUNNER_TEMP/rpc-client.log"; then
-            cat "$RUNNER_TEMP/rpc-server.log"
-            echo "::error::RPC communicator did not complete a successful transfer"
-            exit 1
-          fi
+        run: ./scripts/ci/run_rpc_smoke.sh
         shell: bash
 
   nightly-coverage:

--- a/.github/workflows/release-efa-cuda13.yaml
+++ b/.github/workflows/release-efa-cuda13.yaml
@@ -14,13 +14,10 @@ jobs:
     uses: ./.github/workflows/_build-efa-wheel.yaml
     with:
       variant: cuda13
-      use-cuda: true
-      cuda-version: '13.0.2'
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       build-profile: release
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_ETCD=ON -DWITH_EP=OFF -DSTORE_USE_ETCD=ON
-      variant-flag: EFA_CU13_BUILD
       artifact-prefix: mooncake-wheel-efa-cuda13
 
   publish-release:

--- a/.github/workflows/release-efa-non-cuda.yaml
+++ b/.github/workflows/release-efa-non-cuda.yaml
@@ -14,12 +14,10 @@ jobs:
     uses: ./.github/workflows/_build-efa-wheel.yaml
     with:
       variant: non-cuda
-      use-cuda: false
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       build-profile: release
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_ETCD=ON -DWITH_EP=OFF -DSTORE_USE_ETCD=ON
-      variant-flag: EFA_NON_CUDA_BUILD
       artifact-prefix: mooncake-wheel-efa-non-cuda
 
   publish-release:

--- a/.github/workflows/release-efa.yaml
+++ b/.github/workflows/release-efa.yaml
@@ -14,13 +14,10 @@ jobs:
     uses: ./.github/workflows/_build-efa-wheel.yaml
     with:
       variant: cuda
-      use-cuda: true
-      cuda-version: '12.8.1'
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       build-profile: release
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_ETCD=ON -DWITH_EP=OFF -DSTORE_USE_ETCD=ON
-      variant-flag: EFA_BUILD
       artifact-prefix: mooncake-wheel-efa
 
   publish-release:

--- a/scripts/ci/run_rpc_smoke.sh
+++ b/scripts/ci/run_rpc_smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+: "${RUNNER_TEMP:=${TMPDIR:-/tmp}}"
+source scripts/ci/services.sh
+
+trap 'ci_cleanup_services "$?"' EXIT
+
+ci_start_service rpc "$RUNNER_TEMP/rpc-server.log" \
+  python -u mooncake-transfer-engine/tests/rpc_communicator_test.py \
+  server --url 127.0.0.1:9004 --data-size 1
+ci_wait_service rpc 9004
+
+client_rc=0
+timeout 10 python -u \
+  mooncake-transfer-engine/tests/rpc_communicator_test.py \
+  client --url 127.0.0.1:9004 --threads 2 --data-size 1 \
+  >"$RUNNER_TEMP/rpc-client.log" 2>&1 || \
+  client_rc=$?
+cat "$RUNNER_TEMP/rpc-client.log"
+if [ "$client_rc" -ne 0 ] && [ "$client_rc" -ne 124 ]; then
+  echo "::error::RPC communicator client failed with exit code $client_rc"
+  exit "$client_rc"
+fi
+if ! grep -q '^bandwidth:' "$RUNNER_TEMP/rpc-client.log"; then
+  echo "::error::RPC communicator did not complete a successful transfer"
+  exit 1
+fi

--- a/scripts/ci/run_ssd_offload_smoke.sh
+++ b/scripts/ci/run_ssd_offload_smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+: "${RUNNER_TEMP:=${TMPDIR:-/tmp}}"
+source scripts/ci/services.sh
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
+
+cleanup() {
+  local status=$?
+  ci_cleanup_services "$status" || true
+  rm -rf /tmp/mooncake_ci_ssd_offload /tmp/mooncake_ci_promotion
+  exit "$status"
+}
+trap cleanup EXIT
+
+ci_start_service metadata "$RUNNER_TEMP/mooncake-metadata.log" \
+  mooncake_http_metadata_server --port 8080
+ci_wait_service metadata 8080
+
+mkdir -p /tmp/mooncake_ci_ssd_offload
+ci_start_service ssd "$RUNNER_TEMP/mooncake-ssd-master.log" mooncake_master \
+  --default_kv_lease_ttl=500 \
+  --root_fs_dir=/tmp/mooncake_ci_ssd_offload
+ci_wait_service ssd 50051
+MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
+  DEFAULT_KV_LEASE_TTL=500 \
+  python mooncake-wheel/tests/test_ssd_offload_in_evict.py
+ci_stop_service ssd
+
+mkdir -p /tmp/mooncake_ci_promotion
+ci_start_service promotion "$RUNNER_TEMP/mooncake-promotion-master.log" mooncake_master \
+  --default_kv_lease_ttl=500 \
+  --root_fs_dir=/tmp/mooncake_ci_promotion \
+  --enable_offload=true \
+  --offload_on_evict=true \
+  --promotion_on_hit=true \
+  --promotion_admission_threshold=1 \
+  --promotion_max_per_heartbeat=16
+ci_wait_service promotion 50051
+MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
+  DEFAULT_KV_LEASE_TTL=500 \
+  MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/tmp/mooncake_ci_promotion \
+  MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=2 \
+  MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
+  MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
+  python mooncake-wheel/tests/test_promotion_on_hit.py
+ci_stop_service promotion

--- a/scripts/ci/run_store_api_smoke.sh
+++ b/scripts/ci/run_store_api_smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+: "${RUNNER_TEMP:=${TMPDIR:-/tmp}}"
+source scripts/ci/services.sh
+
+trap 'ci_cleanup_services "$?"' EXIT
+
+mkdir -p /tmp/mooncake_storage
+ci_start_service master "$RUNNER_TEMP/mooncake-master.log" mooncake_master \
+  --default_kv_lease_ttl=500 \
+  --eviction_high_watermark_ratio=0.95 \
+  --cluster_id=ci_store_api_smoke \
+  --port 50051 \
+  --enable_http_metadata_server=true
+ci_wait_service master 50051 8080
+
+python scripts/test_upsert_api.py
+python -m unittest mooncake-wheel.tests.test_weight_snapshot_api
+python scripts/test_async_store.py
+python scripts/test_copy_move_api.py
+python -m unittest mooncake-wheel.tests.test_safetensor_functions
+python scripts/test_drain_http_api.py --timeout-sec 90

--- a/scripts/ci/run_store_go_integration.sh
+++ b/scripts/ci/run_store_go_integration.sh
@@ -2,6 +2,11 @@
 
 set -e -o pipefail
 
+# shellcheck source=scripts/ci/services.sh
+source "$(dirname "${BASH_SOURCE[0]}")/services.sh"
+: "${RUNNER_TEMP:=${TMPDIR:-/tmp}}"
+trap 'ci_cleanup_services "$?"' EXIT
+
 : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
 : "${MOONCAKE_STORE_CLUSTER_ID:?MOONCAKE_STORE_CLUSTER_ID must be set}"
 
@@ -14,12 +19,12 @@ case "${MOONCAKE_STORE_GO_SANITIZED:-0}" in
         ;;
 esac
 
-"$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
+ci_start_service master "$RUNNER_TEMP/mooncake-master.log" \
+    "$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
     --eviction_high_watermark_ratio=0.95 \
     --cluster_id="$MOONCAKE_STORE_CLUSTER_ID" \
-    --port 50051 &
-master_pid=$!
-sleep 3
+    --port 50051
+ci_wait_service master 50051
 
 cd "$GITHUB_WORKSPACE/mooncake-store/go"
 export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-common:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:${LD_LIBRARY_PATH:-}"
@@ -79,5 +84,3 @@ if $sanitized; then
     test_env=(ASAN_OPTIONS=detect_leaks=0:verify_asan_link_order=0 "${test_env[@]}")
 fi
 env "${test_env[@]}" go test -v ./tests/...
-
-kill "$master_pid" 2>/dev/null || true

--- a/scripts/ci/run_store_rust_smoke.sh
+++ b/scripts/ci/run_store_rust_smoke.sh
@@ -2,6 +2,11 @@
 
 set -e -o pipefail
 
+# shellcheck source=scripts/ci/services.sh
+source "$(dirname "${BASH_SOURCE[0]}")/services.sh"
+: "${RUNNER_TEMP:=${TMPDIR:-/tmp}}"
+trap 'ci_cleanup_services "$?"' EXIT
+
 : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
 : "${MOONCAKE_STORE_CLUSTER_ID:?MOONCAKE_STORE_CLUSTER_ID must be set}"
 
@@ -16,12 +21,12 @@ case "${MOONCAKE_STORE_RUST_LINK_ASAN:-0}" in
         ;;
 esac
 
-"$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
+ci_start_service master "$RUNNER_TEMP/mooncake-master.log" \
+    "$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
     --eviction_high_watermark_ratio=0.95 \
     --cluster_id="$MOONCAKE_STORE_CLUSTER_ID" \
-    --port 50051 &
-master_pid=$!
-sleep 3
+    --port 50051
+ci_wait_service master 50051
 
 cd "$GITHUB_WORKSPACE/mooncake-store/rust"
 export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:${LD_LIBRARY_PATH:-}"
@@ -40,5 +45,3 @@ MC_RUST_BENCH_ITERATIONS=4 \
     MC_RUST_BENCH_VALUE_SIZE=4096 \
     MC_RUST_BENCH_WARMUP=1 \
     cargo run --release --example store_benchmark
-
-kill "$master_pid" 2>/dev/null || true

--- a/scripts/ci/services.sh
+++ b/scripts/ci/services.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Source from a suite and install `trap 'ci_cleanup_services "$?"' EXIT`.
+# Commands must stay in the foreground so their PID remains owned by the suite.
+declare -A CI_SERVICE_PIDS=()
+declare -A CI_SERVICE_LOGS=()
+declare -a CI_SERVICE_ORDER=()
+
+ci_start_service() {
+  local name=$1 log=$2
+  shift 2
+  "$@" >"$log" 2>&1 &
+  CI_SERVICE_PIDS[$name]=$!
+  CI_SERVICE_LOGS[$name]=$log
+  CI_SERVICE_ORDER+=("$name")
+}
+
+ci_wait_service() {
+  local name=$1 port ready _
+  shift
+  local pid=${CI_SERVICE_PIDS[$name]}
+  for _ in {1..50}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "::error::$name exited before becoming ready"
+      return 1
+    fi
+    ready=true
+    for port in "$@"; do
+      if ! ss -H -ltn "sport = :$port" | grep -q .; then
+        ready=false
+        break
+      fi
+    done
+    if "$ready"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "::error::$name did not listen on ports $* within 5 seconds"
+  return 1
+}
+
+ci_stop_service() {
+  local name=$1
+  local pid=${CI_SERVICE_PIDS[$name]:-}
+  if [ -n "$pid" ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    unset 'CI_SERVICE_PIDS[$name]'
+  fi
+}
+
+ci_cleanup_services() {
+  local status=$1 name index
+  # Stop dependents before services started earlier (e.g. the metadata server).
+  for ((index=${#CI_SERVICE_ORDER[@]}-1; index>=0; index--)); do
+    ci_stop_service "${CI_SERVICE_ORDER[$index]}"
+  done
+  if [ "$status" -ne 0 ]; then
+    for name in "${CI_SERVICE_ORDER[@]}"; do
+      echo "=== $name ==="
+      cat "${CI_SERVICE_LOGS[$name]}" 2>/dev/null || true
+    done
+  fi
+  return "$status"
+}

--- a/scripts/ci/tests/test_rpc_smoke.py
+++ b/scripts/ci/tests/test_rpc_smoke.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "run_rpc_smoke.sh"
+
+
+class RpcSmokeTest(unittest.TestCase):
+    def test_transfer_result_and_server_cleanup(self):
+        # The bandwidth client runs continuously. A timeout is only acceptable
+        # after it has reported an actual transfer; other failures must propagate.
+        for client_status, bandwidth, expected_status in [
+            (0, True, 0),
+            (124, True, 0),
+            (2, True, 2),
+            (124, False, 1),
+            (0, False, 1),
+        ]:
+            with self.subTest(client_status=client_status, bandwidth=bandwidth):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    ready = root / "ready"
+                    os.mkfifo(ready)
+                    commands = {
+                        "python": """#!/usr/bin/python3
+import os
+import signal
+from pathlib import Path
+root = Path(os.environ['RUNNER_TEMP'])
+(root / 'server.pid').write_text(str(os.getpid()))
+with (root / 'ready').open('w') as pipe:
+    pipe.write('listening\\n')
+signal.pause()
+""",
+                        # Coordinate readiness through a pipe rather than timing
+                        # the background process or binding a real network port.
+                        "ss": '#!/bin/sh\ncat "$RUNNER_TEMP/ready"\n',
+                        "timeout": """#!/bin/sh
+if [ "$REPORT_BANDWIDTH" = true ]; then
+    echo 'bandwidth: 1 GB/s'
+fi
+exit "$CLIENT_STATUS"
+""",
+                    }
+                    for name, content in commands.items():
+                        command = root / name
+                        command.write_text(content)
+                        command.chmod(0o755)
+
+                    result = subprocess.run(
+                        ["bash", str(SCRIPT)],
+                        env={
+                            **os.environ,
+                            "PATH": f"{root}:{os.environ['PATH']}",
+                            "RUNNER_TEMP": directory,
+                            "CLIENT_STATUS": str(client_status),
+                            "REPORT_BANDWIDTH": str(bandwidth).lower(),
+                        },
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    pid = int((root / "server.pid").read_text())
+                    try:
+                        with self.assertRaises(ProcessLookupError):
+                            os.kill(pid, 0)
+                    finally:
+                        # Do not leave a server behind if cleanup regresses.
+                        try:
+                            os.kill(pid, 9)
+                        except ProcessLookupError:
+                            pass
+                    self.assertEqual(
+                        result.returncode,
+                        expected_status,
+                        result.stdout + result.stderr,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_services.py
+++ b/scripts/ci/tests/test_services.py
@@ -1,0 +1,107 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SERVICES = Path(__file__).resolve().parents[1] / "services.sh"
+
+
+class ServicesTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        os.mkfifo(self.root / "ready")
+        os.mkfifo(self.root / "hold")
+
+    def run_suite(self, body):
+        return subprocess.run(
+            ["bash", "-e", "-o", "pipefail", "-c", body],
+            env={**os.environ, "SERVICES": str(SERVICES), "SUITE_TMP": str(self.root)},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_failure_preserves_status_logs_and_cleans_all_services(self):
+        result = self.run_suite(
+            """
+source "$SERVICES"
+trap 'ci_cleanup_services "$?"' EXIT
+for name in metadata master; do
+  ci_start_service "$name" "$SUITE_TMP/$name.log" bash -c '
+    echo "startup: $1"
+    echo ready > "$2/ready"
+    exec cat "$2/hold"
+  ' _ "$name" "$SUITE_TMP"
+  echo "${CI_SERVICE_PIDS[$name]}" >> "$SUITE_TMP/pids"
+  read -r ready < "$SUITE_TMP/ready"
+done
+exit 23
+"""
+        )
+        self.assertEqual(result.returncode, 23, result.stderr)
+        self.assertIn("startup: metadata", result.stdout)
+        self.assertIn("startup: master", result.stdout)
+        for pid in (self.root / "pids").read_text().splitlines():
+            with self.assertRaises(ProcessLookupError):
+                os.kill(int(pid), 0)
+
+    def test_wait_requires_every_port_and_stop_is_idempotent(self):
+        result = self.run_suite(
+            """
+source "$SERVICES"
+trap 'ci_cleanup_services "$?"' EXIT
+ci_start_service master "$SUITE_TMP/master.log" cat "$SUITE_TMP/hold"
+ss() {
+  echo "$*" >> "$SUITE_TMP/probes"
+  if [[ "$*" == *50051 ]]; then
+    echo listening
+  elif [ -f "$SUITE_TMP/retried" ]; then
+    echo listening
+  fi
+}
+sleep() { touch "$SUITE_TMP/retried"; }
+ci_wait_service master 50051 8080
+ci_stop_service master
+ci_stop_service master
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        probes = (self.root / "probes").read_text()
+        self.assertEqual(probes.count(":8080"), 2)
+        self.assertEqual(probes.count(":50051"), 2)
+
+    def test_startup_exit_is_reported_with_server_log(self):
+        result = self.run_suite(
+            """
+source "$SERVICES"
+trap 'ci_cleanup_services "$?"' EXIT
+ci_start_service master "$SUITE_TMP/master.log" bash -c 'echo startup-failed; exit 7'
+wait "${CI_SERVICE_PIDS[master]}" || true
+ci_wait_service master 50051
+"""
+        )
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn("exited before becoming ready", result.stdout)
+        self.assertIn("startup-failed", result.stdout)
+
+    def test_readiness_timeout_fails_without_wall_clock_delay(self):
+        result = self.run_suite(
+            """
+source "$SERVICES"
+trap 'ci_cleanup_services "$?"' EXIT
+ci_start_service master "$SUITE_TMP/master.log" cat "$SUITE_TMP/hold"
+ss() { return 0; }
+sleep() { :; }
+ci_wait_service master 50051
+"""
+        )
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn("did not listen", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Simplify CI orchestration and share service lifecycle code across smoke suites. A failed path selector previously skipped the builds but could still leave `CI Gate` green; the gate now requires selector success and checks each group against its expected success/skipped result.

- Remove obsolete event/label conditions, centralize source/TENT/docs path selection, include shared CMake inputs, and cancel superseded pushes per ref.
- Derive EFA CUDA settings and package flags from the selected variant instead of repeating correlated inputs in every caller.
- Extract Store API, SSD/promotion, and RPC suite entry points. PR and nightly reuse the RPC suite; five suites share foreground-service startup, multi-port readiness, reverse-order teardown, and failure logs while preserving exit status. Rust/Go suites now clean up their master on test failure.
- Exercise lifecycle failure boundaries and RPC timeout/transfer semantics with deterministic local tests, and run them in the `Test CI scripts` job.

Related to #3556. #3338 adds the ROCm hardware E2E tier and #3600 adds TENT coverage to T-one; this PR changes portable CI orchestration and does not include those E2E additions. #3875 changes SSD test retry behavior; this PR only reorganizes how that existing suite is launched.

## Module

- [x] CI/CD

## Type of Change

- [x] Bug fix
- [x] Refactor

## How Has This Been Tested?

**Test commands:**
```bash
python3 -m unittest discover -s scripts/ci/tests -v
actionlint -shellcheck='' <changed workflow files>
shellcheck -x scripts/ci/services.sh <changed suite scripts>
pre-commit run --files <all changed files>
git diff --check
```

**Test results:**
- [x] Unit tests pass: five tests, including five RPC result subcases.
- [ ] Integration tests pass: full wheel builds, Store integration, and hardware suites require CI and were not run locally.
- [x] Manual validation: 215 local gate scenarios evaluated the YAML conditions and executed the gate shell steps, covering legitimate skips, failed selectors, failures, cancellations, and unexpected skips.

Actionlint and pre-commit passed. ShellCheck passed for the shared helper and smoke entry points; the Go integration script retains the same two pre-existing diagnostics (SC2054 and SC2155), with no new diagnostics. Prepared on current `main` at `78566d45`.

## Checklist

- [ ] I have performed a human self-review of every changed line
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable; no C/C++ changes)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable; no product API change)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (targeted CI maintenance and extraction; related roadmap: #3556)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

OpenAI Codex inspected the workflows, implemented the refactor and regression tests, and ran local validation. The human submitter is responsible for reviewing and defending every changed line; no human-review attestation is made here.