### PR TITLE
[Bugfix][Store] Bind hugepage store segments onto agent-mode engines

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -105,6 +105,30 @@ bool RestoreAgentModeDeviceZero() {
 }
 #endif
 
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+void *AllocateAscendStoreSegment(size_t segment_size,
+                                 const std::string &protocol, bool use_hugepage,
+                                 bool defer_hugetlb, size_t *mapped_size) {
+    size_t actual_size = 0;
+    AscendHostAllocFn host_alloc = nullptr;
+    size_t host_align = 0;
+    size_t alloc_size = segment_size;
+    if (use_hugepage) {
+        host_align = get_hugepage_size_from_env();
+        alloc_size = align_up(segment_size, host_align);
+        host_alloc =
+            static_cast<AscendHostAllocFn>(allocate_buffer_mmap_memory);
+    }
+    void *ptr = ascend_allocate_memory_best_effort(alloc_size, protocol,
+                                                   &actual_size, host_alloc,
+                                                   host_align, defer_hugetlb);
+    if (ptr != nullptr) {
+        *mapped_size = actual_size;
+    }
+    return ptr;
+}
+#endif
+
 std::shared_ptr<RegisteredPinnedRegion> TryPinStoreSegment(
     void *ptr, size_t size, const std::string &protocol,
     const char *segment_owner) {
@@ -991,22 +1015,18 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 ptr = allocate_buffer_numa_segments(mapped_size, seg_numa_nodes,
                                                     page_sz);
                 seg_location = buildSegmentsLocation(page_sz, seg_numa_nodes);
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+            } else if (protocol == "ascend" || protocol == "ubshmem") {
+                ptr = AllocateAscendStoreSegment(
+                    segment_size, this->protocol, should_use_hugepage,
+                    parallel_hugetlb_population, &mapped_size);
+#endif
             } else if (should_use_hugepage) {
                 mapped_size =
                     align_up(segment_size, get_hugepage_size_from_env());
                 ptr = allocate_buffer_mmap_memory(mapped_size,
                                                   get_hugepage_size_from_env(),
                                                   parallel_hugetlb_population);
-#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
-            } else if ((protocol == "ascend" || protocol == "ubshmem") &&
-                       globalConfig().ascend_use_fabric_mem) {
-                size_t actual_size = 0;
-                ptr = ascend_allocate_memory_best_effort(
-                    segment_size, this->protocol, &actual_size);
-                if (ptr) {
-                    mapped_size = actual_size;
-                }
-#endif
             } else {
                 ptr = allocate_buffer_allocator_memory(segment_size,
                                                        this->protocol);
@@ -1022,7 +1042,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             LOG(INFO) << "Mounting segment: " << mount_size << " bytes, "
                       << current_glbseg_size << " of " << total_glbseg_size;
 
-            if (this->protocol == "ascend" || this->protocol == "ubshmem") {
+            if ((this->protocol == "ascend" || this->protocol == "ubshmem") &&
+                !should_use_hugepage) {
                 ascend_segment_ptrs_.emplace_back(
                     ptr, AscendSegmentDeleter{this->protocol});
             } else if (this->protocol == "sunrise_link") {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -764,8 +764,6 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     bool enable_client_http_server, int client_http_port) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
-    const bool should_use_hugepage =
-        use_hugepage_ && this->protocol != "ubshmem";
 #ifdef USE_ASCEND_DIRECT
     if (protocol == "ascend" && globalConfig().ascend_agent_mode) {
         auto ascend_setup = setup_ascend_internal(local_buffer_size);
@@ -872,6 +870,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 #ifdef USE_NOF
     use_spdk_dma_for_client_buffer = true;
 #endif
+    const bool should_use_hugepage = use_hugepage_ &&
+                                     this->protocol != "ubshmem" &&
+                                     !globalConfig().ascend_use_fabric_mem;
     client_buffer_allocator_ = ClientBufferAllocator::create(
         local_buffer_size, this->protocol, should_use_hugepage,
         use_spdk_dma_for_client_buffer);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -103,9 +103,7 @@ bool RestoreAgentModeDeviceZero() {
     }
     return true;
 }
-#endif
 
-#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
 void *AllocateAscendStoreSegment(size_t segment_size,
                                  const std::string &protocol, bool use_hugepage,
                                  bool defer_hugetlb, size_t *mapped_size) {
@@ -113,7 +111,7 @@ void *AllocateAscendStoreSegment(size_t segment_size,
     AscendHostAllocFn host_alloc = nullptr;
     size_t host_align = 0;
     size_t alloc_size = segment_size;
-    if (use_hugepage) {
+    if (use_hugepage && !globalConfig().ascend_use_fabric_mem) {
         host_align = get_hugepage_size_from_env();
         alloc_size = align_up(segment_size, host_align);
         host_alloc =
@@ -894,11 +892,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 #ifdef USE_NOF
     use_spdk_dma_for_client_buffer = true;
 #endif
-    const bool should_use_hugepage = use_hugepage_ &&
-                                     this->protocol != "ubshmem" &&
-                                     !globalConfig().ascend_use_fabric_mem;
     client_buffer_allocator_ = ClientBufferAllocator::create(
-        local_buffer_size, this->protocol, should_use_hugepage,
+        local_buffer_size, this->protocol,
+        use_hugepage_ && !globalConfig().ascend_use_fabric_mem,
         use_spdk_dma_for_client_buffer);
     if (local_buffer_size > 0 && protocol != "cxl") {
         LOG(INFO) << "Registering local memory: " << local_buffer_size
@@ -989,7 +985,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
 
         const bool parallel_hugetlb_population =
-            protocol == "rdma" && should_use_hugepage;
+            protocol == "rdma" && use_hugepage_;
 
         while (global_segment_size > 0) {
             size_t segment_size =
@@ -1007,7 +1003,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 
             if (!seg_numa_nodes.empty()) {
                 // NUMA-segmented allocation: contiguous VMA, per-region binding
-                size_t page_sz = should_use_hugepage
+                size_t page_sz = use_hugepage_
                                      ? get_hugepage_size_from_env()
                                      : static_cast<size_t>(getpagesize());
                 mapped_size =
@@ -1015,13 +1011,13 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 ptr = allocate_buffer_numa_segments(mapped_size, seg_numa_nodes,
                                                     page_sz);
                 seg_location = buildSegmentsLocation(page_sz, seg_numa_nodes);
-#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+#ifdef USE_ASCEND_DIRECT
             } else if (protocol == "ascend" || protocol == "ubshmem") {
                 ptr = AllocateAscendStoreSegment(
-                    segment_size, this->protocol, should_use_hugepage,
+                    segment_size, this->protocol, use_hugepage_,
                     parallel_hugetlb_population, &mapped_size);
 #endif
-            } else if (should_use_hugepage) {
+            } else if (use_hugepage_) {
                 mapped_size =
                     align_up(segment_size, get_hugepage_size_from_env());
                 ptr = allocate_buffer_mmap_memory(mapped_size,
@@ -1042,10 +1038,14 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             LOG(INFO) << "Mounting segment: " << mount_size << " bytes, "
                       << current_glbseg_size << " of " << total_glbseg_size;
 
-            if ((this->protocol == "ascend" || this->protocol == "ubshmem") &&
-                !should_use_hugepage) {
-                ascend_segment_ptrs_.emplace_back(
-                    ptr, AscendSegmentDeleter{this->protocol});
+            if (this->protocol == "ascend" || this->protocol == "ubshmem") {
+                if (use_hugepage_ && !globalConfig().ascend_use_fabric_mem) {
+                    hugepage_segment_ptrs_.emplace_back(
+                        ptr, HugepageSegmentDeleter{mapped_size});
+                } else {
+                    ascend_segment_ptrs_.emplace_back(
+                        ptr, AscendSegmentDeleter{this->protocol});
+                }
             } else if (this->protocol == "sunrise_link") {
 #if defined(USE_SUNRISE)
                 sunrise_segment_ptrs_.emplace_back(ptr,
@@ -1058,7 +1058,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             } else if (this->protocol == "ub") {
                 ub_segment_ptrs_.emplace_back(ptr,
                                               UbSegmentDeleter{mapped_size});
-            } else if (!seg_numa_nodes.empty() || should_use_hugepage) {
+            } else if (!seg_numa_nodes.empty() || use_hugepage_) {
                 // NUMA-segmented or hugepage: track as mmap allocation for
                 // munmap cleanup
                 hugepage_segment_ptrs_.emplace_back(

--- a/mooncake-transfer-engine/include/ascend_allocator.h
+++ b/mooncake-transfer-engine/include/ascend_allocator.h
@@ -16,10 +16,12 @@ using AscendHostAllocFn = void* (*)(size_t, size_t, bool);
 // Fabric-mem: try 100%/90%/.../50% of target (1G-aligned); host_alloc is
 // ignored. Otherwise: exact-size via host_alloc, or aclrtMallocHost if
 // host_alloc is null. Sets *actual_size on success.
-void* ascend_allocate_memory_best_effort(
-    size_t target_size, const std::string& protocol, size_t* actual_size,
-    AscendHostAllocFn host_alloc = nullptr, size_t host_alignment = 0,
-    bool defer_hugetlb_population = false);
+void* ascend_allocate_memory_best_effort(size_t target_size,
+                                         const std::string& protocol,
+                                         size_t* actual_size,
+                                         AscendHostAllocFn host_alloc = nullptr,
+                                         size_t host_alignment = 0,
+                                         bool defer_hugetlb_population = false);
 
 void ascend_free_memory(const std::string& protocol, void* ptr);
 

--- a/mooncake-transfer-engine/include/ascend_allocator.h
+++ b/mooncake-transfer-engine/include/ascend_allocator.h
@@ -9,12 +9,17 @@
 namespace mooncake {
 void* ascend_allocate_memory(size_t total_size, const std::string& protocol);
 
-// Fabric-mem best-effort: try 100%/90%/.../50% of target (1G-aligned).
-// Sets *actual_size on success; returns nullptr if 50% also fails.
-// Non-fabric paths fall back to exact-size ascend_allocate_memory.
-void* ascend_allocate_memory_best_effort(size_t target_size,
-                                         const std::string& protocol,
-                                         size_t* actual_size);
+// Matches store allocate_buffer_mmap_memory(size, alignment, defer_populate).
+using AscendHostAllocFn = void* (*)(size_t, size_t, bool);
+
+// Allocate on the current agent-mode device (round-robin).
+// Fabric-mem: try 100%/90%/.../50% of target (1G-aligned); host_alloc is
+// ignored. Otherwise: exact-size via host_alloc, or aclrtMallocHost if
+// host_alloc is null. Sets *actual_size on success.
+void* ascend_allocate_memory_best_effort(
+    size_t target_size, const std::string& protocol, size_t* actual_size,
+    AscendHostAllocFn host_alloc = nullptr, size_t host_alignment = 0,
+    bool defer_hugetlb_population = false);
 
 void ascend_free_memory(const std::string& protocol, void* ptr);
 

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
@@ -226,6 +226,59 @@ void *AllocateStoreMemoryImpl(size_t total_size, const std::string &protocol) {
     }
     return buffer;
 }
+
+void *AllocateExactOnBoundDevice(size_t total_size, const std::string &protocol,
+                                 size_t *actual_size,
+                                 AscendHostAllocFn host_alloc,
+                                 size_t host_alignment,
+                                 bool defer_hugetlb_population) {
+    void *ptr = host_alloc != nullptr
+                    ? host_alloc(total_size, host_alignment,
+                                 defer_hugetlb_population)
+                    : AllocateStoreMemoryImpl(total_size, protocol);
+    if (ptr == nullptr) {
+        return nullptr;
+    }
+    *actual_size = total_size;
+    CommitAgentDeviceSlot();
+    return ptr;
+}
+
+#ifdef ASCEND_SUPPORT_FABRIC_MEM
+void *AllocateFabricBestEffort(size_t target_size, size_t *actual_size) {
+    // Try 100%, 90%, ... down to 50% of configured size (1G-aligned).
+    // Skip candidates that fall below the unaligned 50% floor after round-down
+    // (e.g. 2.1 GiB target → 50% is 1.05 GiB → 1 GiB must not be accepted).
+    // Probe attempts are quiet; only the final failure logs ERROR.
+    const size_t min_size =
+        target_size * static_cast<size_t>(kBestEffortMinPercent) / 100;
+    size_t last_tried = 0;
+    for (int pct = kBestEffortStartPercent; pct >= kBestEffortMinPercent;
+         pct -= kBestEffortPercentStep) {
+        size_t sz =
+            (pct == kBestEffortStartPercent)
+                ? align_down_1g(target_size)
+                : align_down_1g(target_size * static_cast<size_t>(pct) / 100);
+        if (sz == 0 || sz < min_size || sz == last_tried) {
+            continue;
+        }
+        last_tried = sz;
+        void *ptr = allocate_fabric_exact(sz, /*quiet=*/true);
+        if (ptr != nullptr) {
+            *actual_size = sz;
+            CommitAgentDeviceSlot();
+            if (sz < target_size) {
+                LOG(WARNING) << "Fabric mem best-effort: target=" << target_size
+                             << ", actual=" << sz << " (" << pct << "%)";
+            }
+            return ptr;
+        }
+    }
+    LOG(ERROR) << "Fabric mem best-effort failed: cannot allocate at least "
+               << kBestEffortMinPercent << "% of target=" << target_size;
+    return nullptr;
+}
+#endif
 }  // namespace
 
 void *ascend_allocate_vmm_memory_direct(size_t total_size) {
@@ -264,62 +317,30 @@ void *ascend_allocate_memory(size_t total_size, const std::string &protocol) {
 
 void *ascend_allocate_memory_best_effort(size_t target_size,
                                          const std::string &protocol,
-                                         size_t *actual_size) {
+                                         size_t *actual_size,
+                                         AscendHostAllocFn host_alloc,
+                                         size_t host_alignment,
+                                         bool defer_hugetlb_population) {
     if (actual_size == nullptr) {
         LOG(ERROR) << "ascend_allocate_memory_best_effort: actual_size is null";
         return nullptr;
     }
     *actual_size = 0;
-
     if (!BindNextAgentDevice()) {
         return nullptr;
     }
-
     if (!globalConfig().ascend_use_fabric_mem) {
-        void *ptr = AllocateStoreMemoryImpl(target_size, protocol);
-        if (ptr) {
-            *actual_size = target_size;
-            CommitAgentDeviceSlot();
-        }
-        return ptr;
+        return AllocateExactOnBoundDevice(target_size, protocol, actual_size,
+                                          host_alloc, host_alignment,
+                                          defer_hugetlb_population);
     }
-
+    (void)protocol;
+    (void)host_alloc;
+    (void)host_alignment;
+    (void)defer_hugetlb_population;
 #ifdef ASCEND_SUPPORT_FABRIC_MEM
-    (void)protocol;
-    // Try 100%, 90%, ... down to 50% of configured size (1G-aligned).
-    // Skip candidates that fall below the unaligned 50% floor after round-down
-    // (e.g. 2.1 GiB target → 50% is 1.05 GiB → 1 GiB must not be accepted).
-    // Probe attempts are quiet; only the final failure logs ERROR.
-    const size_t min_size =
-        target_size * static_cast<size_t>(kBestEffortMinPercent) / 100;
-    size_t last_tried = 0;
-    for (int pct = kBestEffortStartPercent; pct >= kBestEffortMinPercent;
-         pct -= kBestEffortPercentStep) {
-        size_t sz =
-            (pct == kBestEffortStartPercent)
-                ? align_down_1g(target_size)
-                : align_down_1g(target_size * static_cast<size_t>(pct) / 100);
-        if (sz == 0 || sz < min_size || sz == last_tried) {
-            continue;
-        }
-        last_tried = sz;
-        void *ptr = allocate_fabric_exact(sz, /*quiet=*/true);
-        if (ptr != nullptr) {
-            *actual_size = sz;
-            CommitAgentDeviceSlot();
-            if (sz < target_size) {
-                LOG(WARNING) << "Fabric mem best-effort: target=" << target_size
-                             << ", actual=" << sz << " (" << pct << "%)";
-            }
-            return ptr;
-        }
-    }
-
-    LOG(ERROR) << "Fabric mem best-effort failed: cannot allocate at least "
-               << kBestEffortMinPercent << "% of target=" << target_size;
-    return nullptr;
+    return AllocateFabricBestEffort(target_size, actual_size);
 #else
-    (void)protocol;
     LOG(ERROR) << "Fabric mem mode is not supported, please upgrade Ascend "
                   "HDK and CANN.";
     return nullptr;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
@@ -232,10 +232,10 @@ void *AllocateExactOnBoundDevice(size_t total_size, const std::string &protocol,
                                  AscendHostAllocFn host_alloc,
                                  size_t host_alignment,
                                  bool defer_hugetlb_population) {
-    void *ptr = host_alloc != nullptr
-                    ? host_alloc(total_size, host_alignment,
-                                 defer_hugetlb_population)
-                    : AllocateStoreMemoryImpl(total_size, protocol);
+    void *ptr =
+        host_alloc != nullptr
+            ? host_alloc(total_size, host_alignment, defer_hugetlb_population)
+            : AllocateStoreMemoryImpl(total_size, protocol);
     if (ptr == nullptr) {
         return nullptr;
     }

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -2292,9 +2292,23 @@ int32_t CurrentAclDevice() {
     return device_id;
 }
 
+int g_host_alloc_calls = 0;
+
+void* CountingHostAlloc(size_t size, size_t alignment, bool defer) {
+    (void)alignment;
+    (void)defer;
+    ++g_host_alloc_calls;
+    void* ptr = nullptr;
+    EXPECT_EQ(aclrtMallocHost(&ptr, size), ACL_ERROR_NONE);
+    return ptr;
+}
+
+void* NullHostAlloc(size_t, size_t, bool) { return nullptr; }
+
 struct AgentAllocEnv {
     explicit AgentAllocEnv(int device_count) {
         mock_acl::reset();
+        g_host_alloc_calls = 0;
         globalConfig().ascend_agent_mode = true;
         globalConfig().ascend_use_fabric_mem = false;
         mock_acl::set_device_count(device_count);
@@ -2338,6 +2352,72 @@ TEST(AgentModeAllocTest, ConsecutiveStoreAllocsRotateDevices) {
     ASSERT_NE(wrap, nullptr);
     EXPECT_EQ(CurrentAclDevice(), first);
     ascend_free_memory("ascend", wrap);
+}
+
+TEST(AgentModeAllocTest, HostAllocRotatesDevices) {
+    constexpr int kDeviceCount = 4;
+    constexpr size_t kAllocSize = 4096;
+    AgentAllocEnv env(kDeviceCount);
+
+    int first = -1;
+    for (int i = 0; i < kDeviceCount; ++i) {
+        size_t actual = 0;
+        void* ptr = ascend_allocate_memory_best_effort(
+            kAllocSize, "ascend", &actual, CountingHostAlloc, kAllocSize,
+            false);
+        ASSERT_NE(ptr, nullptr);
+        EXPECT_EQ(actual, kAllocSize);
+        if (i == 0) {
+            first = CurrentAclDevice();
+            ASSERT_GE(first, 0);
+            ASSERT_LT(first, kDeviceCount);
+        } else {
+            EXPECT_EQ(CurrentAclDevice(), (first + i) % kDeviceCount);
+        }
+        ascend_free_memory("ascend", ptr);
+    }
+    EXPECT_EQ(g_host_alloc_calls, kDeviceCount);
+}
+
+TEST(AgentModeAllocTest, FabricMemIgnoresHostAlloc) {
+    constexpr int kDeviceCount = 4;
+    constexpr size_t kGiB = 1024ULL * 1024 * 1024;
+    AgentAllocEnv env(kDeviceCount);
+    globalConfig().ascend_use_fabric_mem = true;
+    mock_acl::set_malloc_physical_max_success(0);
+
+    size_t actual = 0;
+    void* ptr = ascend_allocate_memory_best_effort(
+        kGiB, "ascend", &actual, CountingHostAlloc, kGiB, false);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(g_host_alloc_calls, 0) << "fabric_mem must not call host_alloc";
+    EXPECT_GT(actual, 0);
+    ascend_free_memory("ascend", ptr);
+}
+
+TEST(AgentModeAllocTest, FailedHostAllocDoesNotConsumeSlot) {
+    constexpr int kDeviceCount = 4;
+    constexpr size_t kAllocSize = 4096;
+    AgentAllocEnv env(kDeviceCount);
+
+    size_t actual = 0;
+    void* marker =
+        ascend_allocate_memory_best_effort(kAllocSize, "ascend", &actual);
+    ASSERT_NE(marker, nullptr);
+    const int d0 = CurrentAclDevice();
+    ascend_free_memory("ascend", marker);
+
+    actual = 0;
+    void* failed = ascend_allocate_memory_best_effort(
+        kAllocSize, "ascend", &actual, NullHostAlloc, kAllocSize, false);
+    EXPECT_EQ(failed, nullptr);
+    EXPECT_EQ(actual, 0);
+
+    actual = 0;
+    void* ok = ascend_allocate_memory_best_effort(kAllocSize, "ascend", &actual);
+    ASSERT_NE(ok, nullptr);
+    EXPECT_EQ(CurrentAclDevice(), (d0 + 1) % kDeviceCount);
+    ascend_free_memory("ascend", ok);
 }
 
 TEST(AgentModeAllocTest, DirectVmmDoesNotRotateSequencer) {

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -2414,7 +2414,8 @@ TEST(AgentModeAllocTest, FailedHostAllocDoesNotConsumeSlot) {
     EXPECT_EQ(actual, 0);
 
     actual = 0;
-    void* ok = ascend_allocate_memory_best_effort(kAllocSize, "ascend", &actual);
+    void* ok =
+        ascend_allocate_memory_best_effort(kAllocSize, "ascend", &actual);
     ASSERT_NE(ok, nullptr);
     EXPECT_EQ(CurrentAclDevice(), (d0 + 1) % kDeviceCount);
     ascend_free_memory("ascend", ok);


### PR DESCRIPTION
## Description

Standalone (`ascend_agent_mode`) splits the store pool across NPUs by binding each chunk to the current ACL device before `MountSegment` / `RegisterMem`. With `MC_STORE_USE_HUGEPAGE`, allocation went through mmap first and skipped that bind, so every chunk registered on engine 0.

This PR:

- Runs the Ascend/ubshmem allocator **before** the generic hugepage branch
- Passes `allocate_buffer_mmap_memory` into `ascend_allocate_memory_best_effort` as `host_alloc`, so hugepage chunks use the same `BindNextAgentDevice` round-robin and register on that engine
- Leaves fabric-mem on the existing VMM percentile path (`host_alloc` is ignored); hugepage mmap is not used together with fabric-mem
- Frees hugepage mmap with `HugepageSegmentDeleter` (`munmap`), not `aclrtFreeHost`

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
source /Users/pkgs/Ascend/cann/bin/setenv.bash
cd /Users/youxiao/codes/Mooncake-hugepage-n-engines/build
cmake -DUSE_ASCEND_DIRECT=ON ..
make mooncake_store transfer_engine ascend_transport
make ascend_direct_transport_test
./mooncake-transfer-engine/tests/ascend_direct_transport_test
```

**Test results:**
- [x] Unit tests pass (`ascend_direct_transport_test`: 84 tests PASSED)
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

Covered in UT: host_alloc device rotation, fabric ignoring host_alloc, failed host_alloc does not consume a device slot.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Production LOC is under the RFC threshold. clang-format-20 applied via `./scripts/code_format.sh`. Treat CI pre-commit as authoritative.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok 4.6 assisted with implementation, unit tests, and this PR. Every changed line was reviewed by the submitter.