### PR TITLE
[TransferEngine] Add POSIX SHM transport for same-host DRAM copies

### DIFF
--- a/docs/source/api-reference/cpp/transfer-engine.md
+++ b/docs/source/api-reference/cpp/transfer-engine.md
@@ -199,6 +199,15 @@ Unregisters the region.
 - `update_metadata`: Whether to publish the unregistration to the metadata service.
 - Return value: If successful, returns 0; otherwise, returns a negative value.
 
+#### TransferEngine::allocateSharedMemory
+
+```cpp
+void* allocateSharedMemory(size_t length);
+int freeSharedMemory(void* addr);
+```
+
+Allocates a POSIX shared-memory region that `ShmTransport` can export to same-host peers. Ordinary `malloc` cannot be advertised this way. Requires `ShmTransport` (`MC_FORCE_SHM=1` or `installTransport("shm")`). Call `registerLocalMemory` on the returned pointer before remote access; a sub-range inside that allocation, or a length larger than the allocation, returns an error. Classic Transfer Engine only; TENT returns `nullptr` / `ERR_NOT_IMPLEMENTED`. Combining SHM with RDMA/TCP on one engine requires `-DENABLE_MULTI_PROTOCOL=ON`. Without that flag, `installTransport("shm")` logs a WARNING if it replaces an existing rdma/tcp segment protocol. Objects are created mode `0600` (same UID) with names `/mooncake_<pid>_xxxxxxxx`. `freeSharedMemory` only accepts pointers returned by `allocateSharedMemory`; a `malloc` pointer is rejected without unregistering other transports. Crash leftovers in `/dev/shm` are not reaped automatically. Peers detect an unlinked object on the next transfer, drop the orphaned mmap, and refetch metadata once; if realloc changes the virtual address, the initiator must use the new `BufferDesc.addr`.
+
 #### TransferEngine::registerLocalMemoryBatch
 
 ```cpp
@@ -399,7 +408,7 @@ Transport* installTransport(const std::string& proto, void** args);
 
 Installs a transport backend explicitly.
 
-- `proto`: Transport protocol name, such as `rdma`, `tcp`, or `nvmeof`.
+- `proto`: Transport protocol name, such as `rdma`, `tcp`, `nvmeof`, or `shm`.
 - `args`: Transport-specific arguments.
 > Note: In TENT, `installTransport` is not exposed (removed from the public API, including compatibility surfaces). Transport selection is internal to TENT.
 

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -11,7 +11,7 @@ Mooncake Transfer Engine is a high-performance, zero-copy data transfer library 
 
 As shown in the diagram, each specific client corresponds to a `TransferEngine`, which not only includes a RAM Segment but also integrates management for high-speed transfers across multiple threads and network cards. The RAM Segment, in principle, corresponds to the entire virtual address space of this `TransferEngine`, but in reality, only parts of it (known as a `Buffer`) are registered for (GPUDirect) RDMA Read/Write. Each Buffer can have separate permissions (corresponding to RDMA `rkey`, etc.) and network card affinity (e.g., preferred NICs for different types of memory).
 
-Mooncake Transfer Engine provides interfaces through the `TransferEngine` class (located in `mooncake-transfer-engine/include/transfer_engine.h`), where the specific data transfer functions for different backends are implemented by the `Transport` class, currently supporting `TcpTransport`, `RdmaTransport`, `EfaTransport`, `NVMeoFTransport`, `NvlinkTransport`, `IntraNodeNvlinkTransport`, and `HipTransport`.
+Mooncake Transfer Engine provides interfaces through the `TransferEngine` class (located in `mooncake-transfer-engine/include/transfer_engine.h`), where the specific data transfer functions for different backends are implemented by the `Transport` class, currently supporting `TcpTransport`, `RdmaTransport`, `EfaTransport`, `NVMeoFTransport`, `NvlinkTransport`, `IntraNodeNvlinkTransport`, `HipTransport`, and `ShmTransport`.
 
 (segment)=
 ### Segment
@@ -41,6 +41,7 @@ With the help of Transfer Engine, Mooncake Store can achieve local DRAM/VRAM rea
 | NVMe-of          | ✓    | ✓    |
 
 - Local memcpy: If the target Segment is actually in the local DRAM/VRAM, direct data copy interfaces such as memcpy, cudaMemcpy are used.
+- SHM: Same-host DRAM transfers of POSIX shm-backed buffers (`MC_FORCE_SHM=1`). With `-DENABLE_MULTI_PROTOCOL=ON` this installs SHM alongside RDMA/TCP; without it, SHM is the only transport. Objects are `0600` (same UID). Same hostname does not imply a shared `/dev/shm`. In-flight copies pin the cached mmap so prune/cap cannot unmap it.
 - TCP: Supports data transfer between local DRAM and remote DRAM.
 - RDMA: Supports data transfer between local DRAM/VRAM and remote DRAM. It supports multi-network card pooling and retry functions in implementation.
 - HIP: Supports intra-node data transfers between GPU VRAM and GPU VRAM, as well as between GPU VRAM and CPU DRAM, using IPC handles or Shareable handles for ROCm.
@@ -159,7 +160,7 @@ The following video shows a normal run as described above, with the Target on th
 ![transfer-engine-running](../../image/transfer-engine-running.gif)
 
 ## Transfer Engine C/C++ API
-Transfer Engine provides interfaces through the `TransferEngine` class (located in `mooncake-transfer-engine/include/transfer_engine.h`), where the specific data transfer functions for different backends are implemented by the `Transport` class, currently supporting `TcpTransport`, `RdmaTransport`, `EfaTransport` (for AWS EFA), `NVMeoFTransport`, `NvlinkTransport` (for NVIDIA GPUs), `IntraNodeNvlinkTransport` (for NVIDIA GPUs), and `HipTransport` (for AMD GPUs).
+Transfer Engine provides interfaces through the `TransferEngine` class (located in `mooncake-transfer-engine/include/transfer_engine.h`), where the specific data transfer functions for different backends are implemented by the `Transport` class, currently supporting `TcpTransport`, `RdmaTransport`, `EfaTransport` (for AWS EFA), `NVMeoFTransport`, `NvlinkTransport` (for NVIDIA GPUs), `IntraNodeNvlinkTransport` (for NVIDIA GPUs), `HipTransport` (for AMD GPUs), and `ShmTransport` (POSIX shm for same-host DRAM).
 
 For a complete C++ API reference, see [Transfer Engine C++ API Reference](../../api-reference/cpp/transfer-engine.md).
 
@@ -507,7 +508,8 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_MUSA_IPC_OPEN_DEVICE` (`musa` transport only) Select the device context used to open imported IPC memory. The default `current` preserves the caller's context; `metadata` is an opt-in that uses the runtime-visible logical ordinal advertised by the remote buffer. With `metadata`, every peer must map each logical ordinal to the same physical GPU. `MTHREADS_VISIBLE_DEVICES` is a container-toolkit setting and is not used by Mooncake to infer this mapping.
 - `MC_MUSA_COPY_API` (`musa` transport only) Select `auto` (default), `transfer_batch`, or `default`. On MUSA SDK 5.2 or newer, `auto` uses `muMemoryTransferBatchAsync` when every copy in a batch meets `MC_MUSA_TRANSFER_BATCH_MIN_BYTES`; `default` uses per-slice CUDA-compatible copies.
 - `MC_MUSA_TRANSFER_BATCH_MIN_BYTES` (`musa` transport only) Minimum copy size selected by `MC_MUSA_COPY_API=auto`. The default is 1048576 (1 MiB).
-- `MC_FORCE_TCP` Force to use TCP as the active transport regardless whether RDMA devices are installed.
+- `MC_FORCE_TCP` Force to use TCP as the active transport regardless whether RDMA devices are installed. Takes precedence over `MC_FORCE_SHM`.
+- `MC_FORCE_SHM` Opt in to POSIX SHM for same-host DRAM copies of buffers allocated with `allocateSharedMemory`. Default off. With `-DENABLE_MULTI_PROTOCOL=ON`, SHM is installed alongside RDMA/TCP (`rdma,shm` / `tcp,shm`). Without multi-protocol, SHM is the only transport (skip RDMA/TCP auto-install), like `MC_FORCE_TCP`. `MC_FORCE_TCP` is handled first in `init` and returns before SHM install. Alternative: `installTransport("shm")`, which logs a WARNING if it overwrites a non-empty rdma/tcp protocol. Objects are created `0600` (same UID). A peer `free`+`allocate` that reuses the same virtual address is remapped after the POSIX name disappears; a new address still needs a fresh `BufferDesc` (see `MC_TE_METADATA_REFRESH_INTERVAL_SECONDS`).
 - `MC_MIN_RPC_PORT` Specifies the minimum port number for RPC service. The default value is 15000.
 - `MC_MAX_RPC_PORT` Specifies the maximum port number for RPC service. The default value is 17000.
 - `MC_PATH_ROUNDROBIN` Use round-robin mode in the RDMA path selection. This may be beneficial for transferring large bulks.

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -16,6 +16,7 @@ Mooncake Transfer Engine supports multiple communication protocols for data tran
 | **hip** | AMD ROCm/HIP | AMD GPU communication | ⚠️ Advanced |
 | **barex** | RDMA-capable NIC | Bare-metal RDMA extension | ⚠️ Advanced |
 | **cxl** | CXL-capable hardware | Memory pooling and sharing | ⚠️ Advanced |
+| **shm** | None (POSIX shm, same host) | Same-host DRAM copies without NIC loopback | ⚠️ Advanced |
 | **ascend** | Huawei Ascend NPU | Ascend NPU communication | ⚠️ Advanced |
 | **tpu** | Google TPU (PJRT) | TPU KV-cache transfer via host-DRAM staging | 🧪 Experimental (TENT) |
 | **mpcomm** | RDMA-capable NIC(s) | Multi-NIC memory pooling with NIC/QP load balancing | ⚠️ Advanced (TENT) |
@@ -307,6 +308,30 @@ export MC_INTRANODE_NVLINK=true
 
 **Requirements:**
 - CXL-capable hardware
+
+### SHM Transport (shm)
+
+**Description:** Same-host DRAM copies over POSIX shared memory. Classic Transfer Engine maps the peer's named shm object, relocates the peer virtual address into the local mapping, and `memcpy`s. This is a first-class transport like HIP, not a replacement for `CxlTransport` (DAX offset addressing).
+
+**Use When:**
+- Two processes on the same machine exchange DRAM buffers
+- You want to avoid RDMA/TCP loopback for that path
+
+**Requirements:**
+- Linux POSIX shm (`/dev/shm`)
+- Buffers allocated with `TransferEngine::allocateSharedMemory` (ordinary `malloc` cannot be exported)
+- Runtime opt-in: `MC_FORCE_SHM=1`, or `installTransport("shm")`. With `-DENABLE_MULTI_PROTOCOL=ON` this adds SHM next to RDMA/TCP (`rdma,shm` / `tcp,shm`); without it, SHM is the only transport.
+- Same-host SHM **and** cross-host RDMA/TCP in one engine: build with `-DENABLE_MULTI_PROTOCOL=ON` (segment protocol becomes `rdma,shm` or `tcp,shm`)
+
+**Limitations:**
+- Same host only. Without `ENABLE_MULTI_PROTOCOL`, `MC_FORCE_SHM=1` (or `installTransport("shm")` after another transport) sets `segment.protocol` to `shm` and replaces RDMA/TCP routing; `installTransport("shm")` logs a WARNING when it overwrites a non-empty protocol. Coexistence needs `-DENABLE_MULTI_PROTOCOL=ON`.
+- `registerLocalMemory` must use the pointer from `allocateSharedMemory` (a shorter prefix is allowed). A sub-range or overflowing range returns an error instead of silently skipping. Ordinary `malloc` is still skipped so TCP/RDMA can register it.
+- Same-UID only: objects are created `0600` with POSIX names `/mooncake_<pid>_xxxxxxxx`. Creator and consumer must share a user; a hostname match does not imply a shared `/dev/shm` (for example Kubernetes `hostNetwork` pods).
+- Crash or `SIGKILL` can leave objects in `/dev/shm` until reboot; there is no automatic reaper.
+- After `freeSharedMemory` + `allocateSharedMemory`, a peer that still has a cached mapping probes the POSIX name before memcpy. An unlinked object is dropped and the segment descriptor is refetched once; a changed virtual address still requires the initiator to read the new `BufferDesc.addr` (relocate cannot guess a new offset). Background refresh remains optional via `MC_TE_METADATA_REFRESH_INTERVAL_SECONDS`.
+- Relocate caches at most 32 mmap'd peer objects per target. An in-flight copy pins its mapping so prune/cap cannot `munmap` it until memcpy returns; the cache may briefly exceed 32 while pins are held.
+- Default off because the path is not NUMA-aware
+- Mooncake Store segments are not shm-backed until a follow-up allocator change
 
 ### Ascend Transport (ascend)
 

--- a/docs/source/performance/mooncake/tebench.md
+++ b/docs/source/performance/mooncake/tebench.md
@@ -368,6 +368,9 @@ gpu_id + thread_id
   is explicitly enabled or disabled by tebench — the engine reads the
   transport enable list from the `MC_TENT_CONF` config file (see Section
   5.8 for multi-transport scenarios).
+  Classic `--backend=classic --xport_type=shm` also uses this flag: DRAM
+  buffers come from POSIX shm and are `mbind`'d onto the same NUMA node as
+  `numa_alloc_onnode` before registering `cpu:<node>`.
 * `--tent_intent_type` : attach a standard transfer intent to every request,
   such as `foreground_get`, `background_prefetch`, or `checkpoint`. This is
   useful for validating intent-specific transport and QoS policy selection.

--- a/mooncake-transfer-engine/benchmark/te_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/te_backend.cpp
@@ -125,6 +125,54 @@ static void* allocateMemoryPool(size_t size, int buffer_id,
     return numa_alloc_onnode(size, buffer_id);
 }
 
+static int parseIndex(const std::string& loc) {
+    auto pos = loc.find(':');
+    if (pos == std::string::npos || pos + 1 >= loc.size()) {
+        throw std::invalid_argument("Invalid loc format: " + loc);
+    }
+    return std::stoi(loc.substr(pos + 1));
+}
+
+// POSIX shm mmap does not place pages. Bind the mapping before first touch
+// so DRAM buffers land on the same node as numa_alloc_onnode(size, node).
+static void bindShmBufferToNode(void* addr, size_t size, int node) {
+    if (!addr || size == 0) return;
+    if (numa_available() < 0) {
+        LOG(WARNING)
+            << "tebench: NUMA unavailable; shm buffer not bound to cpu:"
+            << node;
+        return;
+    }
+    if (node < 0 || node >= numa_num_configured_nodes()) {
+        LOG(WARNING) << "tebench: invalid NUMA node " << node;
+        return;
+    }
+    numa_tonode_memory(addr, size, node);
+    const long page_size = sysconf(_SC_PAGESIZE);
+    auto* p = static_cast<char*>(addr);
+    if (page_size > 0) {
+        for (size_t off = 0; off < size; off += static_cast<size_t>(page_size))
+            p[off] = 0;
+    }
+    p[size - 1] = 0;
+}
+
+static std::string cpuLocationFromPages(void* addr, int expected_node) {
+    const auto expected = "cpu:" + std::to_string(expected_node);
+    const auto entries = getMemoryLocation(addr, 1, true);
+    if (entries.empty() || entries[0].location.rfind("cpu:", 0) != 0) {
+        LOG(WARNING) << "tebench: could not resolve NUMA node for shm buffer, "
+                        "registering as "
+                     << expected;
+        return expected;
+    }
+    if (parseIndex(entries[0].location) != expected_node) {
+        LOG(WARNING) << "tebench: shm buffer intended for " << expected
+                     << " is on " << entries[0].location;
+    }
+    return entries[0].location;
+}
+
 static void freeMemoryPool(void* addr, size_t size) {
 #if defined(USE_CUDA) && defined(USE_MNNVL)
     CUmemGenericAllocationHandle handle;
@@ -153,16 +201,36 @@ static void freeMemoryPool(void* addr, size_t size) {
 
 int TEBenchRunner::allocateBuffers() {
     auto total_buffer_size = XferBenchConfig::total_buffer_size;
+    const bool use_shm = engine_->getTransport("shm") != nullptr;
     if (XferBenchConfig::seg_type == "DRAM") {
         int num_buffers = numa_num_configured_nodes();
         pinned_buffer_list_.resize(num_buffers, nullptr);
+        shm_backed_.assign(num_buffers, 0);
         for (int i = 0; i < num_buffers; ++i) {
-            auto location = "cpu:" + std::to_string(i);
-            pinned_buffer_list_[i] =
-                allocateMemoryPool(total_buffer_size, i, false);
+            std::string location = "cpu:" + std::to_string(i);
+            if (use_shm) {
+                pinned_buffer_list_[i] =
+                    engine_->allocateSharedMemory(total_buffer_size);
+                shm_backed_[i] = 1;
+                if (pinned_buffer_list_[i]) {
+                    bindShmBufferToNode(pinned_buffer_list_[i],
+                                        total_buffer_size, i);
+                    location = cpuLocationFromPages(pinned_buffer_list_[i], i);
+                }
+            } else {
+                pinned_buffer_list_[i] =
+                    allocateMemoryPool(total_buffer_size, i, false);
+            }
             if (!pinned_buffer_list_[i]) return -1;
-            engine_->registerLocalMemory(pinned_buffer_list_[i],
-                                         total_buffer_size, location);
+            if (engine_->registerLocalMemory(pinned_buffer_list_[i],
+                                             total_buffer_size, location)) {
+                LOG(ERROR) << "Failed to register DRAM buffer " << i;
+                return -1;
+            }
+        }
+        if (use_shm) {
+            LOG(INFO) << "tebench: DRAM buffers allocated from POSIX shm "
+                         "and bound to NUMA nodes";
         }
 #if defined(USE_CUDA) || defined(USE_SUNRISE)
     } else if (XferBenchConfig::seg_type == "VRAM") {
@@ -197,10 +265,15 @@ int TEBenchRunner::freeBuffers() {
     auto total_buffer_size = XferBenchConfig::total_buffer_size;
     for (size_t i = 0; i < pinned_buffer_list_.size(); ++i) {
         if (!pinned_buffer_list_[i]) continue;
-        engine_->unregisterLocalMemory(pinned_buffer_list_[i]);
-        freeMemoryPool(pinned_buffer_list_[i], total_buffer_size);
+        if (i < shm_backed_.size() && shm_backed_[i]) {
+            engine_->freeSharedMemory(pinned_buffer_list_[i]);
+        } else {
+            engine_->unregisterLocalMemory(pinned_buffer_list_[i]);
+            freeMemoryPool(pinned_buffer_list_[i], total_buffer_size);
+        }
     }
     pinned_buffer_list_.clear();
+    shm_backed_.clear();
     return 0;
 }
 
@@ -208,8 +281,9 @@ TEBenchRunner::TEBenchRunner() {
     signal(SIGINT, signalHandlerV0);
     signal(SIGTERM, signalHandlerV0);
     // Disable auto-discovery when an explicit non-RDMA xport is requested
-    // (e.g. flagcx) so we can installTransport() ourselves below.
-    bool auto_disc = XferBenchConfig::xport_type != "flagcx";
+    // (e.g. flagcx, shm) so we can installTransport() ourselves below.
+    bool auto_disc = XferBenchConfig::xport_type != "flagcx" &&
+                     XferBenchConfig::xport_type != "shm";
     engine_ = std::make_unique<mooncake::TransferEngine>(auto_disc);
     auto conn_str = XferBenchConfig::metadata_type == "p2p"
                         ? "P2PHANDSHAKE"
@@ -232,6 +306,13 @@ TEBenchRunner::TEBenchRunner() {
         auto* xp = engine_->installTransport("flagcx", nullptr);
         LOG_ASSERT(xp) << "installTransport(flagcx) failed";
         LOG(INFO) << "tebench: FlagCX transport installed";
+    }
+    if (XferBenchConfig::xport_type == "shm") {
+        if (!engine_->getTransport("shm")) {
+            auto* shm = engine_->installTransport("shm", nullptr);
+            LOG_ASSERT(shm) << "installTransport(shm) failed";
+        }
+        LOG(INFO) << "tebench: SHM transport installed";
     }
     init_ok_ = (allocateBuffers() == 0);
     if (!init_ok_) {
@@ -311,14 +392,6 @@ int TEBenchRunner::stopInitiator() {
         thread.join();
     }
     return 0;
-}
-
-static int parseIndex(const std::string& loc) {
-    auto pos = loc.find(':');
-    if (pos == std::string::npos || pos + 1 >= loc.size()) {
-        throw std::invalid_argument("Invalid loc format: " + loc);
-    }
-    return std::stoi(loc.substr(pos + 1));
 }
 
 void TEBenchRunner::pinThread(int thread_id) {

--- a/mooncake-transfer-engine/benchmark/te_backend.h
+++ b/mooncake-transfer-engine/benchmark/te_backend.h
@@ -116,6 +116,7 @@ class TEBenchRunner : public BenchRunner {
    private:
     std::unique_ptr<mooncake::TransferEngine> engine_;
     std::vector<void*> pinned_buffer_list_;
+    std::vector<char> shm_backed_;
     std::vector<SegmentID> target_handles_;
     std::vector<std::shared_ptr<TransferMetadata::SegmentDesc>> target_infos_;
 

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -77,6 +77,27 @@ static inline std::string getHostname() {
     return hostname;
 }
 
+// True when the variable is set to anything other than 0/false/no/off.
+// Used by MC_FORCE_SHM.
+inline bool envFlagEnabled(const char *name) {
+    const char *value = std::getenv(name);
+    if (!value || !*value) return false;
+    auto eqIgnoreCase = [](const char *a, const char *b) {
+        for (; *a && *b; ++a, ++b) {
+            unsigned char ca = static_cast<unsigned char>(*a);
+            unsigned char cb = static_cast<unsigned char>(*b);
+            if (ca >= 'A' && ca <= 'Z')
+                ca = static_cast<unsigned char>(ca - 'A' + 'a');
+            if (cb >= 'A' && cb <= 'Z')
+                cb = static_cast<unsigned char>(cb - 'A' + 'a');
+            if (ca != cb) return false;
+        }
+        return *a == *b;
+    };
+    return !eqIgnoreCase(value, "0") && !eqIgnoreCase(value, "false") &&
+           !eqIgnoreCase(value, "no") && !eqIgnoreCase(value, "off");
+}
+
 // libnuma fills the cache numa_node_to_cpus() reads lazily and without locking,
 // so concurrent first callers each allocate it and all but one are orphaned --
 // a leak LeakSanitizer fails the build on. Worker pools bind every thread at

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -21,9 +21,11 @@
 
 namespace mooncake {
 class TransferEngineImplTestPeer;
+class MultiTransportTestPeer;
 
 class MultiTransport {
     friend class TransferEngineImplTestPeer;
+    friend class MultiTransportTestPeer;
 
    public:
     using BatchID = Transport::BatchID;
@@ -73,10 +75,11 @@ class MultiTransport {
     Transport *getTransport(const std::string &proto);
 
     /**
-     * @brief Check if TCP is the only installed transport.
+     * @brief Check if TCP is the only installed host transport.
      *
-     * When only TCP transport is available (no RDMA, NVLink, etc.),
-     * local memcpy is preferred over TCP loopback for same-host transfers.
+     * When only TCP is available (no RDMA, NVLink, etc.), local memcpy is
+     * preferred over TCP loopback for same-host transfers. POSIX SHM is
+     * intra-node only and does not change this classification.
      */
     bool isTcpOnly() const;
 

--- a/mooncake-transfer-engine/include/multi_transport_locality.h
+++ b/mooncake-transfer-engine/include/multi_transport_locality.h
@@ -65,14 +65,19 @@ inline bool hostEquals(const std::string& a, const std::string& b) {
     return true;
 }
 
-// GPU IPC transports (HIP and MUSA) only work between processes on the same
-// physical host. A cross-host target must fall back to RDMA/TCP. Two engines
-// co-located on one host share the host portion of their segment name (they
-// differ only in port).
-inline bool isGpuIpcReachableTarget(const std::string& target_segment_name,
-                                    const std::string& local_server_name) {
+// Same-host IPC transports (HIP/MUSA GPU IPC and POSIX SHM) only work between
+// processes on the same physical host. A cross-host target must fall back to
+// RDMA/TCP. Two engines co-located on one host share the host portion of their
+// segment name (they differ only in port).
+inline bool isLocalIpcReachableTarget(const std::string& target_segment_name,
+                                      const std::string& local_server_name) {
     return hostEquals(segmentHost(target_segment_name),
                       segmentHost(local_server_name));
+}
+
+inline bool isGpuIpcReachableTarget(const std::string& target_segment_name,
+                                    const std::string& local_server_name) {
+    return isLocalIpcReachableTarget(target_segment_name, local_server_name);
 }
 
 // Compatibility name retained for existing callers/tests.

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -129,6 +129,14 @@ class TransferEngine {
                             bool remote_accessible = true,
                             bool update_metadata = true);
 
+    // Allocate POSIX shm that ShmTransport can export to same-host peers.
+    // Requires ShmTransport (MC_FORCE_SHM=1 or installTransport("shm")).
+    // Caller must registerLocalMemory before remote access. Returns nullptr
+    // on failure.
+    void* allocateSharedMemory(size_t length);
+
+    int freeSharedMemory(void* addr);
+
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
 
     Status submitTransfer(BatchID batch_id,
@@ -247,10 +255,11 @@ class TransferEngine {
 #endif
 
     /**
-     * @brief Check if TCP is the only installed transport.
+     * @brief Check if TCP is the only installed host transport.
      *
-     * When only TCP transport is available (no RDMA, NVLink, etc.),
-     * local memcpy is preferred over TCP loopback for same-host transfers.
+     * When only TCP is available (no RDMA, NVLink, etc.), local memcpy is
+     * preferred over TCP loopback for same-host transfers. POSIX SHM is
+     * intra-node only and does not change this classification.
      */
     bool isTcpOnly() const;
 

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -420,6 +420,10 @@ class TransferEngineImpl {
 
     void* getBaseAddr() { return multi_transports_->getBaseAddr(); }
 
+    void* allocateSharedMemory(size_t length);
+
+    int freeSharedMemory(void* addr);
+
     void setWhitelistFilters(std::vector<std::string>&& filters) {
         filter_ = std::move(filters);
     }

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -69,10 +69,10 @@ class TransferMetadata {
 #else
         using mr_key_t = uint32_t;
 #endif
-        std::vector<mr_key_t> lkey;         // for rdma/efa
-        std::vector<mr_key_t> rkey;         // for rdma/efa
-        std::string shm_name;               // for nvlink and hip
-        uint64_t offset;                    // for cxl
+        std::vector<mr_key_t> lkey;  // for rdma/efa
+        std::vector<mr_key_t> rkey;  // for rdma/efa
+        std::string shm_name;  // nvlink/hip IPC blob, or POSIX shm object name
+        uint64_t offset;       // for cxl
         std::vector<std::string> tseg;      // for ub/urma
         std::vector<uint32_t> l_seg_index;  // for ub/urma
 

--- a/mooncake-transfer-engine/include/transport/shm_transport/shm_transport.h
+++ b/mooncake-transfer-engine/include/transport/shm_transport/shm_transport.h
@@ -1,0 +1,170 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SHM_TRANSPORT_H_
+#define SHM_TRANSPORT_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "common.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+
+class ShmTransportTestPeer;
+
+// POSIX shm_open requires a name that begins with '/'. The object itself is
+// still "mooncake_*" so routing can distinguish it from GPU IPC blobs.
+inline constexpr char kPosixShmNamePrefix[] = "/mooncake_";
+
+inline bool isPosixShmName(const std::string& name) {
+    std::string_view key = name;
+    if (!key.empty() && key.front() == '/') key.remove_prefix(1);
+    constexpr std::string_view bare = "mooncake_";
+    return key.size() > bare.size() && key.substr(0, bare.size()) == bare;
+}
+
+class ShmTransport : public Transport {
+   public:
+    ShmTransport();
+
+    ~ShmTransport() override;
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest>& entries) override;
+
+    Status submitTransferTask(
+        const std::vector<TransferTask*>& task_list) override;
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                             TransferStatus& status) override;
+
+    void* allocateSharedMemory(size_t length);
+
+    int freeSharedMemory(void* addr);
+
+    bool getShmName(void* addr, std::string* name) const;
+
+   private:
+    struct OpenedShmEntry {
+        void* shm_addr = nullptr;
+        uint64_t length = 0;
+        std::string shm_name;
+        std::atomic<uint32_t> pin_count{0};
+        std::atomic<bool> stale{false};
+    };
+
+   public:
+    // Holds a relocate-cache mmap until memcpy finishes so prune/cap cannot
+    // munmap it out from under an in-flight copy.
+    class MappingPin {
+       public:
+        MappingPin() = default;
+        MappingPin(MappingPin&& other) noexcept;
+        MappingPin& operator=(MappingPin&& other) noexcept;
+        ~MappingPin();
+        MappingPin(const MappingPin&) = delete;
+        MappingPin& operator=(const MappingPin&) = delete;
+        void reset();
+        explicit operator bool() const { return static_cast<bool>(entry_); }
+
+       private:
+        friend class ShmTransport;
+        MappingPin(ShmTransport* transport,
+                   std::shared_ptr<OpenedShmEntry> entry);
+        ShmTransport* transport_ = nullptr;
+        std::shared_ptr<OpenedShmEntry> entry_;
+    };
+
+   private:
+    int install(std::string& local_server_name,
+                std::shared_ptr<TransferMetadata> meta,
+                std::shared_ptr<Topology> topo) override;
+
+    int registerLocalMemory(void* addr, size_t length,
+                            const std::string& location, bool remote_accessible,
+                            bool update_metadata) override;
+
+    int unregisterLocalMemory(void* addr, bool update_metadata) override;
+
+    int registerLocalMemoryBatch(
+        const std::vector<Transport::BufferEntry>& buffer_list,
+        const std::string& location) override;
+
+    int unregisterLocalMemoryBatch(
+        const std::vector<void*>& addr_list) override;
+
+    const char* getName() const override { return "shm"; }
+
+    friend class ShmTransportTestPeer;
+
+    struct AllocatedShmEntry {
+        std::string name;
+        size_t length = 0;
+    };
+
+    using RelocateMap =
+        std::unordered_map<uint64_t, std::shared_ptr<OpenedShmEntry>>;
+    using PendingUnmap = std::vector<std::pair<void*, uint64_t>>;
+
+    void* createSharedMemory(const std::string& path, size_t size,
+                             int* error = nullptr);
+
+    Status relocateSharedMemoryAddress(uint64_t& dest_addr, uint64_t length,
+                                       uint64_t target_id,
+                                       MappingPin* pin = nullptr);
+
+    static bool tryResolve(const RelocateMap& relocate_map, uint64_t& dest_addr,
+                           uint64_t length, const std::string& shm_name,
+                           std::shared_ptr<OpenedShmEntry>* out_entry);
+
+    static void queueUnmap(OpenedShmEntry& entry, PendingUnmap* pending);
+    static void unpinLocked(OpenedShmEntry& entry, PendingUnmap* pending);
+    static void flushUnmaps(PendingUnmap& pending);
+    void pruneAndCapLocked(RelocateMap& mappings,
+                           const TransferMetadata::SegmentDesc& desc,
+                           uint64_t keep_addr, PendingUnmap* pending);
+    void pruneIfNeeded(SegmentID target_id,
+                       const TransferMetadata::SegmentDesc& desc,
+                       uint64_t keep_addr);
+    void adoptPin(std::shared_ptr<OpenedShmEntry> entry, MappingPin* pin);
+
+    Status copySlice(TransferTask& task, const TransferRequest& request,
+                     uint64_t dest_addr);
+
+    void failSlice(TransferTask& task, const TransferRequest& request);
+
+    RWSpinlock relocate_lock_;
+    std::unordered_map<SegmentID, RelocateMap> relocate_map_;
+
+    mutable std::mutex shm_path_mutex_;
+    std::unordered_map<void*, AllocatedShmEntry> shm_path_map_;
+
+    static constexpr int kShmCreateMaxRetries = 8;
+    static constexpr size_t kMaxMappingsPerTarget = 32;
+};
+
+}  // namespace mooncake
+
+#endif  // SHM_TRANSPORT_H_

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -89,6 +89,11 @@ target_link_libraries(
          asio_shared
          yalantinglibs::yalantinglibs
   PRIVATE transport transfer_metadata_plugin)
+if(UNIX AND NOT APPLE)
+  # shm_open/shm_unlink live in librt on glibc; OBJECT-library PRIVATE deps do
+  # not propagate through $<TARGET_OBJECTS:shm_transport>.
+  target_link_libraries(transfer_engine PRIVATE rt)
+endif()
 if(BUILD_SHARED_LIBS)
   install(TARGETS transfer_engine DESTINATION lib)
 endif()

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -62,6 +62,7 @@
 #ifdef USE_CXL
 #include "transport/cxl_transport/cxl_transport.h"
 #endif
+#include "transport/shm_transport/shm_transport.h"
 #ifdef USE_UBSHMEM
 #include "transport/ascend_transport/ubshmem_transport/ubshmem_transport.h"
 #endif
@@ -503,6 +504,9 @@ Transport* MultiTransport::installTransport(const std::string& proto,
         transport = new CxlTransport();
     }
 #endif
+    else if (std::string(proto) == "shm") {
+        transport = new ShmTransport();
+    }
 #ifdef USE_UBSHMEM
     else if (std::string(proto) == "ubshmem") {
         transport = new UBShmemTransport();
@@ -585,6 +589,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         return Status::InvalidArgument("Invalid target segment ID " +
                                        std::to_string(entry.target_id));
     }
+
     auto proto = target_segment_desc->protocol;
 #ifdef ENABLE_MULTI_PROTOCOL
     // Multi-protocol segment (e.g. "rdma,hip"): a single batch may target
@@ -602,6 +607,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
             if (p == "hip") return std::getenv("MC_DISABLE_HIP") ? 0 : 4;
             if (p == "maca") return std::getenv("MC_DISABLE_MACA") ? 0 : 4;
             if (p == "musa") return std::getenv("MC_DISABLE_MUSA") ? 0 : 4;
+            if (p == "shm") return 4;
             if (p == "cxl") return 3;
             if (p == "rdma") return 2;
             if (p == "tcp") return 1;
@@ -613,7 +619,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         // This makes the intra-node fast path (hip) and the cross-node path
         // (rdma) work automatically from a single multi-protocol segment,
         // without requiring the operator to set MC_DISABLE_HIP.
-        const bool gpu_ipc_reachable = isGpuIpcReachableTarget(
+        const bool local_ipc_reachable = isLocalIpcReachableTarget(
             target_segment_desc->name, local_server_name_);
         std::string chosen;
         int chosen_priority = -1;
@@ -626,8 +632,9 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
                     : buffer.addr;
             if (entry.target_offset >= start &&
                 entry.target_offset < start + buffer.length) {
-                if ((buffer.protocol == "hip" || buffer.protocol == "musa") &&
-                    !gpu_ipc_reachable) {
+                if ((buffer.protocol == "hip" || buffer.protocol == "musa" ||
+                     buffer.protocol == "shm") &&
+                    !local_ipc_reachable) {
                     continue;
                 }
                 int priority = protocol_priority(buffer.protocol);
@@ -654,7 +661,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         if (globalConfig().trace) {
             LOG(INFO) << "MultiTransport::selectTransport route: target_id="
                       << entry.target_id << " segment_protocol=\"" << proto
-                      << "\" gpu_ipc_reachable=" << gpu_ipc_reachable
+                      << "\" local_ipc_reachable=" << local_ipc_reachable
                       << " chosen=" << chosen;
         }
         transport = transport_map_[chosen].get();
@@ -701,12 +708,13 @@ Status MultiTransport::mp_selectTransport(const TransferRequest& entry,
         if (!item.empty()) protos.push_back(item);
     }
 
-    // hip GPU IPC cannot reach a remote host; downgrade an explicit hip
-    // preference to a cross-host-capable transport for a cross-host target
+    // hip GPU IPC and POSIX SHM cannot reach a remote host; downgrade an
+    // explicit intra-node preference to a cross-host-capable transport
     // (mirrors the locality gate in selectTransport). Prefer rdma, then tcp.
-    if ((preferred_proto == "hip" || preferred_proto == "musa") &&
-        !isGpuIpcReachableTarget(target_segment_desc->name,
-                                 local_server_name_)) {
+    if ((preferred_proto == "hip" || preferred_proto == "musa" ||
+         preferred_proto == "shm") &&
+        !isLocalIpcReachableTarget(target_segment_desc->name,
+                                   local_server_name_)) {
         std::string fallback;
         for (const char* candidate : {"rdma", "tcp"}) {
             if (std::find(protos.begin(), protos.end(), candidate) !=
@@ -761,7 +769,11 @@ Transport* MultiTransport::getTransport(const std::string& proto) {
 }
 
 bool MultiTransport::isTcpOnly() const {
-    return transport_map_.size() == 1 && transport_map_.count("tcp") == 1;
+    // SHM is intra-node DRAM IPC, not a cross-host fabric. Ignore it so a
+    // tcp+shm engine still auto-enables Store same-process memcpy.
+    size_t n = transport_map_.size();
+    if (transport_map_.count("shm")) --n;
+    return n == 1 && transport_map_.count("tcp") == 1;
 }
 
 std::vector<Transport*> MultiTransport::listTransports() {

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -165,6 +165,14 @@ int TransferEngine::unregisterLocalMemory(void* addr, bool update_metadata) {
     return impl_->unregisterLocalMemory(addr, update_metadata);
 }
 
+void* TransferEngine::allocateSharedMemory(size_t length) {
+    return impl_->allocateSharedMemory(length);
+}
+
+int TransferEngine::freeSharedMemory(void* addr) {
+    return impl_->freeSharedMemory(addr);
+}
+
 Status TransferEngine::submitTransfer(
     BatchID batch_id, const std::vector<TransferRequest>& entries) {
     return impl_->submitTransfer(batch_id, entries);
@@ -586,6 +594,20 @@ int TransferEngine::unregisterLocalMemory(void* addr, bool update_metadata) {
         return (int)status.code();
     } else
         return impl_->unregisterLocalMemory(addr, update_metadata);
+}
+
+void* TransferEngine::allocateSharedMemory(size_t length) {
+    if (use_tent_) {
+        LOG(WARNING) << "allocateSharedMemory is classic TE only; use TENT "
+                        "allocateLocalMemory with SHM enabled";
+        return nullptr;
+    }
+    return impl_->allocateSharedMemory(length);
+}
+
+int TransferEngine::freeSharedMemory(void* addr) {
+    if (use_tent_) return ERR_NOT_IMPLEMENTED;
+    return impl_->freeSharedMemory(addr);
 }
 
 int TransferEngine::registerLocalMemoryBatch(

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -28,8 +28,10 @@
 #endif
 
 #include "transfer_metadata_plugin.h"
+#include "common.h"
 #include "transport/transport.h"
 #include "transport/rdma_twosided/rdma_twosided_transport.h"
+#include "transport/shm_transport/shm_transport.h"
 #ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
 #endif
@@ -41,6 +43,34 @@ bool overlapWithRegion(uintptr_t addr, uint64_t length, void* region_addr,
                        uint64_t region_length) {
     return overlap(reinterpret_cast<void*>(addr), length, region_addr,
                    region_length);
+}
+
+Transport* tryInstallShmTransport(MultiTransport* multi_transports,
+                                  std::shared_ptr<Topology> topology) {
+    if (!multi_transports) return nullptr;
+    if (Transport* existing = multi_transports->getTransport("shm")) {
+        return existing;
+    }
+    return multi_transports->installTransport("shm", topology);
+}
+
+int maybeInstallShmTransport(MultiTransport* multi_transports,
+                             std::shared_ptr<Topology> topology) {
+#ifdef ENABLE_MULTI_PROTOCOL
+    if (!multi_transports || !envFlagEnabled("MC_FORCE_SHM")) return 0;
+    Transport* shm = tryInstallShmTransport(multi_transports, topology);
+    if (!shm) {
+        LOG(WARNING) << "MC_FORCE_SHM is set but failed to install SHM "
+                        "transport; continuing without it";
+        return 0;
+    }
+    LOG(INFO) << "SHM transport installed for same-host DRAM copies";
+    return 0;
+#else
+    (void)multi_transports;
+    (void)topology;
+    return 0;
+#endif
 }
 }  // namespace
 
@@ -223,6 +253,25 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
         return -1;
 #endif
     }
+
+    // MC_FORCE_SHM:
+    // - Without ENABLE_MULTI_PROTOCOL: SHM-only (skip RDMA/TCP), like
+    //   MC_FORCE_TCP.
+    // - With ENABLE_MULTI_PROTOCOL: fall through so auto-discover still
+    //   installs RDMA/TCP, then maybeInstallShmTransport appends SHM.
+#ifndef ENABLE_MULTI_PROTOCOL
+    if (envFlagEnabled("MC_FORCE_SHM")) {
+        Transport* shm_transport =
+            tryInstallShmTransport(multi_transports_.get(), local_topology_);
+        if (!shm_transport) {
+            LOG(ERROR)
+                << "MC_FORCE_SHM is set but failed to install SHM transport";
+            return -1;
+        }
+        LOG(INFO) << "MC_FORCE_SHM is set, using SHM transport only";
+        return 0;
+    }
+#endif
 
 #if defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT)
     Transport* ascend_transport =
@@ -457,6 +506,7 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
     }
 #endif
 
+    maybeInstallShmTransport(multi_transports_.get(), local_topology_);
     return 0;
 }
 
@@ -511,6 +561,33 @@ Transport* TransferEngineImpl::installTransport(const std::string& proto,
 
 int TransferEngineImpl::uninstallTransport(const std::string& proto) {
     return 0;
+}
+
+void* TransferEngineImpl::allocateSharedMemory(size_t length) {
+    auto* shm =
+        dynamic_cast<ShmTransport*>(multi_transports_->getTransport("shm"));
+    if (!shm) {
+        LOG(ERROR) << "allocateSharedMemory requires ShmTransport "
+                      "(set MC_FORCE_SHM=1 or installTransport(\"shm\"))";
+        return nullptr;
+    }
+    return shm->allocateSharedMemory(length);
+}
+
+int TransferEngineImpl::freeSharedMemory(void* addr) {
+    if (!addr) return ERR_INVALID_ARGUMENT;
+    auto* shm =
+        dynamic_cast<ShmTransport*>(multi_transports_->getTransport("shm"));
+    if (!shm) return ERR_INVALID_ARGUMENT;
+    std::string shm_name;
+    if (!shm->getShmName(addr, &shm_name)) return ERR_INVALID_ARGUMENT;
+    int uret = unregisterLocalMemory(addr, true);
+    if (uret && uret != ERR_ADDRESS_NOT_REGISTERED) {
+        LOG(WARNING) << "unregisterLocalMemory failed before freeSharedMemory, "
+                        "ret="
+                     << uret;
+    }
+    return shm->freeSharedMemory(addr);
 }
 
 #if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)) && \

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -364,8 +364,15 @@ static int encodeMultiProtocolSegmentDesc(
             Json::Value lkeyJSON(Json::arrayValue);
             for (auto &entry : buffer.lkey) lkeyJSON.append(entry);
             bufferJSON["lkey"] = lkeyJSON;
+            if (!buffer.shm_name.empty())
+                bufferJSON["shm_name"] = buffer.shm_name;
         } else if (buffer.protocol == "tcp") {
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+            if (!buffer.shm_name.empty())
+                bufferJSON["shm_name"] = buffer.shm_name;
+        } else if (buffer.protocol == "shm") {
+            bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+            bufferJSON["shm_name"] = buffer.shm_name;
         } else if (buffer.protocol == "hip" || buffer.protocol == "maca" ||
                    buffer.protocol == "musa") {
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
@@ -399,7 +406,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
         is_multi_protocol = true;
         for (const auto &proto : protocols) {
             if (proto != "cxl" && proto != "tcp" && proto != "rdma" &&
-                proto != "hip" && proto != "maca" && proto != "musa") {
+                proto != "hip" && proto != "maca" && proto != "musa" &&
+                proto != "shm") {
                 is_multi_protocol = false;
                 break;
             }
@@ -407,8 +415,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
         if (!is_multi_protocol) {
             LOG(ERROR) << "Unsupported multi-protocol combination: "
                        << desc.protocol
-                       << ". Only cxl, tcp, rdma, hip, maca and musa may be "
-                          "combined.";
+                       << ". Only cxl, tcp, rdma, hip, maca, musa and shm may "
+                          "be combined.";
             return ERR_INVALID_ARGUMENT;
         }
     }
@@ -456,6 +464,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             Json::Value lkeyJSON(Json::arrayValue);
             for (auto &entry : buffer.lkey) lkeyJSON.append(entry);
             bufferJSON["lkey"] = lkeyJSON;
+            if (!buffer.shm_name.empty())
+                bufferJSON["shm_name"] = buffer.shm_name;
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -491,6 +501,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             bufferJSON["name"] = buffer.name;
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
             bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
+            if (!buffer.shm_name.empty())
+                bufferJSON["shm_name"] = buffer.shm_name;
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -555,7 +567,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
                segmentJSON["protocol"] == "maca" ||
                segmentJSON["protocol"] == "musa" ||
                segmentJSON["protocol"] == "ubshmem" ||
-               segmentJSON["protocol"] == "sunrise_link") {
+               segmentJSON["protocol"] == "sunrise_link" ||
+               segmentJSON["protocol"] == "shm") {
         Json::Value buffersJSON(Json::arrayValue);
         for (const auto &buffer : desc.buffers) {
             Json::Value bufferJSON;
@@ -728,6 +741,10 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
                     << buffer.lkey.size() << ", " << desc->devices.size();
                 return nullptr;
             }
+            if (bufferJSON.isMember("shm_name") &&
+                bufferJSON["shm_name"].isString()) {
+                buffer.shm_name = bufferJSON["shm_name"].asString();
+            }
             desc->buffers.push_back(buffer);
         } else if (buffer_protocol == "tcp") {
             TransferMetadata::BufferDesc buffer;
@@ -736,6 +753,28 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
             buffer.length = bufferJSON["length"].asUInt64();
             buffer.protocol = buffer_protocol;
             if (buffer.name.empty() || !buffer.addr || !buffer.length) {
+                LOG(WARNING)
+                    << "Corrupted segment descriptor, name " << segment_name
+                    << " buffer_protocol " << buffer_protocol;
+                return nullptr;
+            }
+            if (bufferJSON.isMember("shm_name") &&
+                bufferJSON["shm_name"].isString()) {
+                buffer.shm_name = bufferJSON["shm_name"].asString();
+            }
+            desc->buffers.push_back(buffer);
+        } else if (buffer_protocol == "shm") {
+            TransferMetadata::BufferDesc buffer;
+            buffer.name = bufferJSON["name"].asString();
+            buffer.addr = bufferJSON["addr"].asUInt64();
+            buffer.length = bufferJSON["length"].asUInt64();
+            buffer.protocol = buffer_protocol;
+            if (bufferJSON.isMember("shm_name") &&
+                bufferJSON["shm_name"].isString()) {
+                buffer.shm_name = bufferJSON["shm_name"].asString();
+            }
+            if (buffer.name.empty() || !buffer.addr || !buffer.length ||
+                buffer.shm_name.empty()) {
                 LOG(WARNING)
                     << "Corrupted segment descriptor, name " << segment_name
                     << " buffer_protocol " << buffer_protocol;
@@ -780,7 +819,8 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
             for (const auto &protocolStr : segmentJSON["protocol"]) {
                 std::string proto = protocolStr.asString();
                 if (proto != "cxl" && proto != "tcp" && proto != "rdma" &&
-                    proto != "hip" && proto != "maca" && proto != "musa") {
+                    proto != "hip" && proto != "maca" && proto != "musa" &&
+                    proto != "shm") {
                     is_multi_protocol = false;
                     break;
                 }
@@ -789,7 +829,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                 LOG(ERROR)
                     << "Unsupported multi-protocol combination in segment: "
                     << segment_name
-                    << ". Only cxl, tcp, rdma, hip, maca and musa may be "
+                    << ". Only cxl, tcp, rdma, hip, maca, musa and shm may be "
                        "combined.";
                 return nullptr;
             }
@@ -872,6 +912,10 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                     << desc->devices.size();
                 return nullptr;
             }
+            if (bufferJSON.isMember("shm_name") &&
+                bufferJSON["shm_name"].isString()) {
+                buffer.shm_name = bufferJSON["shm_name"].asString();
+            }
             desc->buffers.push_back(buffer);
         }
 
@@ -928,6 +972,10 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                              << segment_name << " protocol " << desc->protocol;
                 return nullptr;
             }
+            if (bufferJSON.isMember("shm_name") &&
+                bufferJSON["shm_name"].isString()) {
+                buffer.shm_name = bufferJSON["shm_name"].asString();
+            }
             desc->buffers.push_back(buffer);
         }
         desc->rdma_server_name = segmentJSON["rdma_server_name"].asString();
@@ -951,7 +999,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     } else if (desc->protocol == "nvlink" || desc->protocol == "nvlink_intra" ||
                desc->protocol == "hip" || desc->protocol == "maca" ||
                desc->protocol == "musa" || desc->protocol == "ubshmem" ||
-               desc->protocol == "sunrise_link") {
+               desc->protocol == "sunrise_link" || desc->protocol == "shm") {
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
             buffer.name = bufferJSON["name"].asString();

--- a/mooncake-transfer-engine/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/CMakeLists.txt
@@ -41,6 +41,9 @@ if(USE_CXL)
   target_sources(transport PUBLIC $<TARGET_OBJECTS:cxl_transport>)
 endif()
 
+add_subdirectory(shm_transport)
+target_sources(transport PUBLIC $<TARGET_OBJECTS:shm_transport>)
+
 if(USE_ASCEND_DIRECT)
   add_subdirectory(ascend_transport)
 elseif(USE_ASCEND)

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "cuda_alike.h"
+#include "common.h"
 
 namespace mooncake {
 namespace device {

--- a/mooncake-transfer-engine/src/transport/shm_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/shm_transport/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB SHM_SOURCES "*.cpp")
+
+add_library(shm_transport OBJECT ${SHM_SOURCES})
+target_link_libraries(shm_transport PRIVATE glog::glog)
+if(UNIX AND NOT APPLE)
+  target_link_libraries(shm_transport PRIVATE rt)
+endif()

--- a/mooncake-transfer-engine/src/transport/shm_transport/shm_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/shm_transport/shm_transport.cpp
@@ -1,0 +1,837 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/shm_transport/shm_transport.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <glog/logging.h>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include "error.h"
+
+namespace mooncake {
+namespace {
+
+std::string randomShmName() {
+    std::string result = std::string(kPosixShmNamePrefix) +
+                         std::to_string(static_cast<long>(getpid())) + "_";
+    for (int i = 0; i < 8; ++i) result += 'a' + SimpleRandom::Get().next(26);
+    return result;
+}
+
+bool rangeContains(uint64_t start, uint64_t span, uint64_t addr,
+                   uint64_t length) {
+    if (addr < start) return false;
+    const uint64_t offset = addr - start;
+    return offset <= span && span - offset >= length;
+}
+
+bool posixShmObjectExists(const std::string& shm_name) {
+    int fd = shm_open(shm_name.c_str(), O_RDWR, 0);
+    if (fd < 0) return false;
+    close(fd);
+    return true;
+}
+
+uint64_t rangeEnd(uint64_t start, uint64_t span) {
+    if (span == 0) return start;
+    if (start > std::numeric_limits<uint64_t>::max() - span) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return start + span;
+}
+
+bool rangesOverlap(uint64_t a, uint64_t a_len, uint64_t b, uint64_t b_len) {
+    return a < rangeEnd(b, b_len) && b < rangeEnd(a, a_len);
+}
+
+bool protocolListContains(const std::string& protocol,
+                          const std::string& token) {
+    std::stringstream ss(protocol);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        if (item == token) return true;
+    }
+    return false;
+}
+
+Status mapPosixShm(const std::string& shm_name, uint64_t length, void** out) {
+    int shm_fd = shm_open(shm_name.c_str(), O_RDWR, 0600);
+    if (shm_fd < 0) {
+        return Status::Memory(std::string("Failed to open shared memory ") +
+                              shm_name);
+    }
+    struct stat st;
+    if (fstat(shm_fd, &st) != 0) {
+        close(shm_fd);
+        return Status::Memory(std::string("Failed to fstat shared memory ") +
+                              shm_name);
+    }
+    if (st.st_size < 0 || static_cast<uint64_t>(st.st_size) < length) {
+        close(shm_fd);
+        return Status::Memory(
+            std::string("Shared memory file shorter than registered "
+                        "buffer length: ") +
+            shm_name);
+    }
+    void* mapped =
+        mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+    close(shm_fd);
+    if (mapped == MAP_FAILED) {
+        return Status::Memory("Failed to map shared memory");
+    }
+    *out = mapped;
+    return Status::OK();
+}
+
+size_t posixBufferCount(const TransferMetadata::SegmentDesc& desc) {
+    size_t count = 0;
+    for (const auto& entry : desc.buffers) {
+        if (isPosixShmName(entry.shm_name)) ++count;
+    }
+    return count;
+}
+
+bool posixBufferAddrListed(const TransferMetadata::SegmentDesc& desc,
+                           uint64_t addr) {
+    for (const auto& entry : desc.buffers) {
+        if (isPosixShmName(entry.shm_name) && entry.addr == addr) return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+ShmTransport::ShmTransport() = default;
+
+ShmTransport::~ShmTransport() {
+    PendingUnmap pending;
+    {
+        RWSpinlock::WriteGuard guard(relocate_lock_);
+        for (auto& relocate_map : relocate_map_) {
+            for (auto& entry : relocate_map.second) {
+                if (!entry.second || !entry.second->shm_addr ||
+                    !entry.second->length) {
+                    continue;
+                }
+                pending.emplace_back(entry.second->shm_addr,
+                                     entry.second->length);
+                entry.second->shm_addr = nullptr;
+                entry.second->length = 0;
+            }
+        }
+        relocate_map_.clear();
+    }
+    flushUnmaps(pending);
+    {
+        std::lock_guard<std::mutex> lock(shm_path_mutex_);
+        for (auto& entry : shm_path_map_) {
+            if (entry.first && entry.second.length) {
+                munmap(entry.first, entry.second.length);
+            }
+            if (!entry.second.name.empty()) {
+                shm_unlink(entry.second.name.c_str());
+            }
+        }
+        shm_path_map_.clear();
+    }
+    if (metadata_ && !local_server_name_.empty()) {
+        metadata_->removeSegmentDesc(local_server_name_);
+    }
+}
+
+int ShmTransport::install(std::string& local_server_name,
+                          std::shared_ptr<TransferMetadata> meta,
+                          std::shared_ptr<Topology> topo) {
+    (void)topo;
+    metadata_ = meta;
+    local_server_name_ = local_server_name;
+
+    auto old_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    if (!desc) return ERR_MEMORY;
+    if (old_desc) *desc = *old_desc;
+
+    desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    if (desc->protocol.empty()) {
+        desc->protocol = "shm";
+    } else if (!protocolListContains(desc->protocol, "shm")) {
+        desc->protocol += ",shm";
+    }
+#else
+    if (!desc->protocol.empty() && desc->protocol != "shm") {
+        LOG(WARNING) << "ShmTransport::install replaces segment protocol '"
+                     << desc->protocol
+                     << "' with 'shm'. Rebuild with "
+                        "-DENABLE_MULTI_PROTOCOL=ON to keep RDMA/TCP "
+                        "alongside SHM";
+    }
+    desc->protocol = "shm";
+#endif
+
+    metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
+                               std::move(desc));
+    return 0;
+}
+
+void* ShmTransport::createSharedMemory(const std::string& path, size_t size,
+                                       int* error) {
+    auto fail = [&](int err) -> void* {
+        if (error) *error = err;
+        return nullptr;
+    };
+
+    // O_EXCL prevents silently opening and truncating an existing object.
+    int shm_fd = shm_open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (shm_fd == -1) {
+        const int err = errno;
+        if (err != EEXIST) {
+            PLOG(ERROR) << "Failed to open shared memory file " << path;
+        }
+        return fail(err);
+    }
+
+    if (ftruncate(shm_fd, static_cast<off_t>(size)) == -1) {
+        const int err = errno;
+        PLOG(ERROR) << "Failed to truncate shared memory file " << path;
+        close(shm_fd);
+        shm_unlink(path.c_str());
+        return fail(err);
+    }
+
+    void* mapped_addr =
+        mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+    if (mapped_addr == MAP_FAILED) {
+        const int err = errno;
+        PLOG(ERROR) << "Failed to map shared memory file " << path;
+        close(shm_fd);
+        shm_unlink(path.c_str());
+        return fail(err);
+    }
+
+    close(shm_fd);
+    std::lock_guard<std::mutex> lock(shm_path_mutex_);
+    shm_path_map_[mapped_addr] = AllocatedShmEntry{path, size};
+    if (error) *error = 0;
+    return mapped_addr;
+}
+
+void* ShmTransport::allocateSharedMemory(size_t length) {
+    if (length == 0) {
+        LOG(ERROR) << "ShmTransport does not support zero-length allocation";
+        return nullptr;
+    }
+    for (int attempt = 0; attempt < kShmCreateMaxRetries; ++attempt) {
+        const std::string name = randomShmName();
+        int error = 0;
+        void* addr = createSharedMemory(name, length, &error);
+        if (addr) return addr;
+        if (error != EEXIST) break;
+    }
+    LOG(ERROR) << "Failed to allocate shared memory of size " << length;
+    return nullptr;
+}
+
+int ShmTransport::freeSharedMemory(void* addr) {
+    std::lock_guard<std::mutex> lock(shm_path_mutex_);
+    auto it = shm_path_map_.find(addr);
+    if (it == shm_path_map_.end()) {
+        return ERR_INVALID_ARGUMENT;
+    }
+    munmap(addr, it->second.length);
+    shm_unlink(it->second.name.c_str());
+    shm_path_map_.erase(it);
+    return 0;
+}
+
+bool ShmTransport::getShmName(void* addr, std::string* name) const {
+    if (!name) return false;
+    std::lock_guard<std::mutex> lock(shm_path_mutex_);
+    auto it = shm_path_map_.find(addr);
+    if (it == shm_path_map_.end()) return false;
+    *name = it->second.name;
+    return true;
+}
+
+int ShmTransport::registerLocalMemory(void* addr, size_t length,
+                                      const std::string& location,
+                                      bool remote_accessible,
+                                      bool update_metadata) {
+    (void)remote_accessible;
+    std::string shm_name;
+    size_t alloc_length = 0;
+    bool exact_base = false;
+    bool inside_or_overlapping = false;
+    {
+        std::lock_guard<std::mutex> lock(shm_path_mutex_);
+        auto it = shm_path_map_.find(addr);
+        if (it != shm_path_map_.end()) {
+            exact_base = true;
+            shm_name = it->second.name;
+            alloc_length = it->second.length;
+        } else {
+            const uint64_t range_addr = reinterpret_cast<uint64_t>(addr);
+            for (const auto& entry : shm_path_map_) {
+                const uint64_t base = reinterpret_cast<uint64_t>(entry.first);
+                if (rangeContains(base, entry.second.length, range_addr,
+                                  length) ||
+                    rangesOverlap(range_addr, length, base,
+                                  entry.second.length)) {
+                    inside_or_overlapping = true;
+                    break;
+                }
+            }
+        }
+    }
+    if (inside_or_overlapping) {
+        LOG(ERROR) << "registerLocalMemory must use the pointer returned by "
+                      "allocateSharedMemory, not a sub-range inside it: addr="
+                   << addr << " length=" << length;
+        return ERR_INVALID_ARGUMENT;
+    }
+    if (!exact_base) return 0;
+    if (length > alloc_length) {
+        LOG(ERROR) << "registerLocalMemory length " << length
+                   << " exceeds POSIX shm allocation " << alloc_length << " at "
+                   << addr;
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    TransferMetadata::BufferDesc desc;
+    desc.addr = reinterpret_cast<uint64_t>(addr);
+    desc.length = length;
+    desc.name = location.empty() ? local_server_name_ : location;
+    desc.shm_name = shm_name;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc.protocol = "shm";
+#endif
+    return metadata_->addLocalMemoryBuffer(desc, update_metadata);
+}
+
+int ShmTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
+    std::string shm_name;
+    if (!getShmName(addr, &shm_name)) return 0;
+    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+}
+
+int ShmTransport::registerLocalMemoryBatch(
+    const std::vector<Transport::BufferEntry>& buffer_list,
+    const std::string& location) {
+    bool exported = false;
+    for (const auto& buffer : buffer_list) {
+        std::string name;
+        const bool owned = getShmName(buffer.addr, &name);
+        int ret = registerLocalMemory(buffer.addr, buffer.length, location,
+                                      true, false);
+        if (ret) return ret;
+        if (owned) exported = true;
+    }
+    if (!exported) return 0;
+    return metadata_->updateLocalSegmentDesc();
+}
+
+int ShmTransport::unregisterLocalMemoryBatch(
+    const std::vector<void*>& addr_list) {
+    int first_error = 0;
+    bool owned_any = false;
+    for (auto* addr : addr_list) {
+        std::string name;
+        if (getShmName(addr, &name)) owned_any = true;
+        int ret = unregisterLocalMemory(addr, false);
+        if (ret && !first_error) first_error = ret;
+    }
+    if (!owned_any) return first_error;
+    int metadata_ret = metadata_->updateLocalSegmentDesc();
+    return first_error ? first_error : metadata_ret;
+}
+
+bool ShmTransport::tryResolve(const RelocateMap& relocate_map,
+                              uint64_t& dest_addr, uint64_t length,
+                              const std::string& shm_name,
+                              std::shared_ptr<OpenedShmEntry>* out_entry) {
+    for (const auto& entry : relocate_map) {
+        if (!entry.second ||
+            entry.second->stale.load(std::memory_order_acquire))
+            continue;
+        if (entry.second->shm_name != shm_name) continue;
+        if (!entry.second->shm_addr) continue;
+        if (rangeContains(entry.first, entry.second->length, dest_addr,
+                          length)) {
+            dest_addr = dest_addr - entry.first +
+                        reinterpret_cast<uint64_t>(entry.second->shm_addr);
+            if (out_entry) *out_entry = entry.second;
+            return true;
+        }
+    }
+    return false;
+}
+
+void ShmTransport::queueUnmap(OpenedShmEntry& entry, PendingUnmap* pending) {
+    if (entry.pin_count.load(std::memory_order_acquire) > 0) {
+        entry.stale.store(true, std::memory_order_release);
+        return;
+    }
+    if (!pending) return;
+    if (entry.shm_addr && entry.length) {
+        pending->emplace_back(entry.shm_addr, entry.length);
+    }
+    entry.shm_addr = nullptr;
+    entry.length = 0;
+    entry.stale.store(true, std::memory_order_release);
+}
+
+void ShmTransport::unpinLocked(OpenedShmEntry& entry, PendingUnmap* pending) {
+    const uint32_t prev =
+        entry.pin_count.fetch_sub(1, std::memory_order_acq_rel);
+    if (prev == 1 && entry.stale.load(std::memory_order_acquire) &&
+        entry.shm_addr && entry.length) {
+        if (pending) pending->emplace_back(entry.shm_addr, entry.length);
+        entry.shm_addr = nullptr;
+        entry.length = 0;
+    }
+}
+
+void ShmTransport::flushUnmaps(PendingUnmap& pending) {
+    for (auto& entry : pending) {
+        if (entry.first && entry.second) munmap(entry.first, entry.second);
+    }
+    pending.clear();
+}
+
+void ShmTransport::pruneAndCapLocked(RelocateMap& mappings,
+                                     const TransferMetadata::SegmentDesc& desc,
+                                     uint64_t keep_addr,
+                                     PendingUnmap* pending) {
+    for (auto it = mappings.begin(); it != mappings.end();) {
+        if (it->first != keep_addr &&
+            (!it->second || !posixBufferAddrListed(desc, it->first))) {
+            if (it->second) queueUnmap(*it->second, pending);
+            it = mappings.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    while (mappings.size() > kMaxMappingsPerTarget) {
+        auto victim = mappings.end();
+        for (auto it = mappings.begin(); it != mappings.end(); ++it) {
+            if (it->first == keep_addr || !it->second) continue;
+            if (it->second->pin_count.load(std::memory_order_acquire) == 0) {
+                victim = it;
+                break;
+            }
+        }
+        if (victim == mappings.end()) {
+            for (auto it = mappings.begin(); it != mappings.end(); ++it) {
+                if (it->first == keep_addr) continue;
+                victim = it;
+                break;
+            }
+        }
+        if (victim == mappings.end()) break;
+        if (victim->second) queueUnmap(*victim->second, pending);
+        mappings.erase(victim);
+    }
+}
+
+void ShmTransport::pruneIfNeeded(SegmentID target_id,
+                                 const TransferMetadata::SegmentDesc& desc,
+                                 uint64_t keep_addr) {
+    const size_t live = posixBufferCount(desc);
+    bool need = false;
+    {
+        RWSpinlock::ReadGuard guard(relocate_lock_);
+        auto target = relocate_map_.find(target_id);
+        if (target == relocate_map_.end()) return;
+        need = target->second.size() > live ||
+               target->second.size() > kMaxMappingsPerTarget;
+    }
+    if (!need) return;
+    PendingUnmap pending;
+    {
+        RWSpinlock::WriteGuard guard(relocate_lock_);
+        auto target = relocate_map_.find(target_id);
+        if (target != relocate_map_.end()) {
+            pruneAndCapLocked(target->second, desc, keep_addr, &pending);
+        }
+    }
+    flushUnmaps(pending);
+}
+
+ShmTransport::MappingPin::MappingPin(ShmTransport* transport,
+                                     std::shared_ptr<OpenedShmEntry> entry)
+    : transport_(transport), entry_(std::move(entry)) {}
+
+ShmTransport::MappingPin::MappingPin(MappingPin&& other) noexcept
+    : transport_(other.transport_), entry_(std::move(other.entry_)) {
+    other.transport_ = nullptr;
+}
+
+ShmTransport::MappingPin& ShmTransport::MappingPin::operator=(
+    MappingPin&& other) noexcept {
+    if (this != &other) {
+        reset();
+        transport_ = other.transport_;
+        entry_ = std::move(other.entry_);
+        other.transport_ = nullptr;
+    }
+    return *this;
+}
+
+ShmTransport::MappingPin::~MappingPin() { reset(); }
+
+void ShmTransport::MappingPin::reset() {
+    if (!transport_ || !entry_) {
+        transport_ = nullptr;
+        entry_.reset();
+        return;
+    }
+    PendingUnmap pending;
+    {
+        RWSpinlock::WriteGuard guard(transport_->relocate_lock_);
+        unpinLocked(*entry_, &pending);
+    }
+    flushUnmaps(pending);
+    transport_ = nullptr;
+    entry_.reset();
+}
+
+void ShmTransport::adoptPin(std::shared_ptr<OpenedShmEntry> entry,
+                            MappingPin* pin) {
+    if (!pin || !entry) return;
+    *pin = MappingPin(this, std::move(entry));
+}
+
+Status ShmTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,
+                                                 uint64_t length,
+                                                 uint64_t target_id,
+                                                 MappingPin* pin) {
+    if (pin) pin->reset();
+    if (!metadata_) {
+        return Status::InvalidArgument("SHM transport is not installed");
+    }
+    const uint64_t requested_addr = dest_addr;
+    auto attempt = [&](bool force_update) -> Status {
+        dest_addr = requested_addr;
+        auto desc = metadata_->getSegmentDescByID(target_id, force_update);
+        if (!desc) {
+            return Status::AddressNotRegistered("Invalid target segment ID");
+        }
+
+        const BufferDesc* buffer = nullptr;
+        for (const auto& entry : desc->buffers) {
+            if (!isPosixShmName(entry.shm_name)) continue;
+            if (rangeContains(entry.addr, entry.length, dest_addr, length)) {
+                buffer = &entry;
+                break;
+            }
+        }
+        if (!buffer) {
+            return Status::AddressNotRegistered(
+                "Requested address is not in a POSIX shm buffer");
+        }
+
+        std::shared_ptr<OpenedShmEntry> hit;
+        {
+            RWSpinlock::ReadGuard guard(relocate_lock_);
+            auto target = relocate_map_.find(target_id);
+            uint64_t candidate = requested_addr;
+            if (target == relocate_map_.end() ||
+                !tryResolve(target->second, candidate, length, buffer->shm_name,
+                            &hit) ||
+                !hit) {
+                hit.reset();
+            }
+        }
+        if (hit && pin) {
+            bool pinned = false;
+            {
+                RWSpinlock::WriteGuard guard(relocate_lock_);
+                if (!hit->stale.load(std::memory_order_acquire) &&
+                    hit->shm_addr) {
+                    hit->pin_count.fetch_add(1, std::memory_order_acq_rel);
+                    pinned = true;
+                }
+            }
+            if (!pinned) hit.reset();
+        }
+        if (hit) {
+            // Cached mmap stays valid after shm_unlink. Probe the name so a
+            // peer free+realloc cannot silently write into the orphaned object.
+            if (posixShmObjectExists(buffer->shm_name)) {
+                dest_addr = requested_addr - buffer->addr +
+                            reinterpret_cast<uint64_t>(hit->shm_addr);
+                adoptPin(hit, pin);
+                pruneIfNeeded(target_id, *desc, buffer->addr);
+                return Status::OK();
+            }
+            if (pin) {
+                PendingUnmap drop;
+                {
+                    RWSpinlock::WriteGuard guard(relocate_lock_);
+                    unpinLocked(*hit, &drop);
+                }
+                flushUnmaps(drop);
+            }
+        }
+
+        PendingUnmap pending;
+        std::shared_ptr<OpenedShmEntry> reused;
+        {
+            RWSpinlock::WriteGuard guard(relocate_lock_);
+            RelocateMap& mappings = relocate_map_[target_id];
+            pruneAndCapLocked(mappings, *desc, buffer->addr, &pending);
+            auto mapping = mappings.find(buffer->addr);
+            if (mapping != mappings.end() && mapping->second &&
+                mapping->second->shm_name == buffer->shm_name &&
+                mapping->second->shm_addr) {
+                reused = mapping->second;
+                if (pin)
+                    reused->pin_count.fetch_add(1, std::memory_order_acq_rel);
+            } else if (mapping != mappings.end()) {
+                if (mapping->second) queueUnmap(*mapping->second, &pending);
+                mappings.erase(mapping);
+            }
+        }
+        flushUnmaps(pending);
+
+        if (reused && posixShmObjectExists(buffer->shm_name)) {
+            dest_addr = requested_addr - buffer->addr +
+                        reinterpret_cast<uint64_t>(reused->shm_addr);
+            adoptPin(reused, pin);
+            return Status::OK();
+        }
+        if (reused) {
+            {
+                RWSpinlock::WriteGuard guard(relocate_lock_);
+                if (pin) unpinLocked(*reused, &pending);
+                auto target = relocate_map_.find(target_id);
+                if (target != relocate_map_.end()) {
+                    auto mapping = target->second.find(buffer->addr);
+                    if (mapping != target->second.end() && mapping->second &&
+                        mapping->second->shm_name == buffer->shm_name) {
+                        queueUnmap(*mapping->second, &pending);
+                        target->second.erase(mapping);
+                    }
+                }
+            }
+            flushUnmaps(pending);
+        }
+
+        void* shm_addr = nullptr;
+        Status mapped =
+            mapPosixShm(buffer->shm_name, buffer->length, &shm_addr);
+        if (!mapped.ok()) return mapped;
+        LOG(INFO) << "Original shared memory: " << (void*)buffer->addr << "--"
+                  << (void*)(buffer->addr + buffer->length);
+        LOG(INFO) << "Remapped shared memory: " << shm_addr << "--"
+                  << (void*)((uintptr_t)shm_addr + buffer->length);
+
+        std::shared_ptr<OpenedShmEntry> installed;
+        {
+            RWSpinlock::WriteGuard guard(relocate_lock_);
+            RelocateMap& mappings = relocate_map_[target_id];
+            auto mapping = mappings.find(buffer->addr);
+            if (mapping != mappings.end() && mapping->second &&
+                mapping->second->shm_name == buffer->shm_name &&
+                mapping->second->shm_addr) {
+                pending.emplace_back(shm_addr, buffer->length);
+                shm_addr = mapping->second->shm_addr;
+                installed = mapping->second;
+            } else {
+                if (mapping != mappings.end()) {
+                    if (mapping->second) queueUnmap(*mapping->second, &pending);
+                    mappings.erase(mapping);
+                }
+                installed = std::make_shared<OpenedShmEntry>();
+                installed->shm_addr = shm_addr;
+                installed->length = buffer->length;
+                installed->shm_name = buffer->shm_name;
+                mappings[buffer->addr] = installed;
+            }
+            if (pin && installed)
+                installed->pin_count.fetch_add(1, std::memory_order_acq_rel);
+            pruneAndCapLocked(mappings, *desc, buffer->addr, &pending);
+        }
+        flushUnmaps(pending);
+
+        dest_addr = requested_addr - buffer->addr +
+                    reinterpret_cast<uint64_t>(shm_addr);
+        adoptPin(installed, pin);
+        return Status::OK();
+    };
+
+    Status status = attempt(false);
+    if (status.ok() || !status.IsMemory()) return status;
+    if (pin) pin->reset();
+    // The cached segment desc still named an object that is gone (peer
+    // free/realloc). Refetch once so the same virtual address can remap.
+    return attempt(true);
+}
+
+Status ShmTransport::copySlice(TransferTask& task,
+                               const TransferRequest& request,
+                               uint64_t dest_addr) {
+    task.total_bytes = request.length;
+    Slice* slice = getSliceCache().allocate();
+    slice->source_addr = (char*)request.source;
+    slice->local.dest_addr = (char*)dest_addr;
+    slice->length = request.length;
+    slice->opcode = request.opcode;
+    slice->task = &task;
+    slice->target_id = request.target_id;
+    slice->status = Slice::PENDING;
+    task.slice_list.push_back(slice);
+    __sync_fetch_and_add(&task.slice_count, 1);
+
+    if (!slice->source_addr || !slice->local.dest_addr) {
+        slice->markFailed();
+        return Status::InvalidArgument("SHM copy with null pointer");
+    }
+
+    void* src = (request.opcode == TransferRequest::READ)
+                    ? (void*)slice->local.dest_addr
+                    : slice->source_addr;
+    void* dst = (request.opcode == TransferRequest::READ)
+                    ? slice->source_addr
+                    : (void*)slice->local.dest_addr;
+    std::memcpy(dst, src, slice->length);
+    slice->markSuccess();
+    return Status::OK();
+}
+
+void ShmTransport::failSlice(TransferTask& task,
+                             const TransferRequest& request) {
+    Slice* slice = getSliceCache().allocate();
+    slice->source_addr = (char*)request.source;
+    slice->local.dest_addr = nullptr;
+    slice->length = request.length;
+    slice->opcode = request.opcode;
+    slice->task = &task;
+    slice->target_id = request.target_id;
+    slice->status = Slice::PENDING;
+    task.slice_list.push_back(slice);
+    __sync_fetch_and_add(&task.slice_count, 1);
+    slice->markFailed();
+}
+
+Status ShmTransport::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest>& entries) {
+    auto& batch_desc = *((BatchDesc*)(batch_id));
+    if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
+        return Status::InvalidArgument(
+            "ShmTransport: Exceed the limitation of capacity");
+    }
+
+    std::vector<uint64_t> dest_addrs;
+    dest_addrs.reserve(entries.size());
+    std::vector<MappingPin> pins(entries.size());
+    for (size_t i = 0; i < entries.size(); ++i) {
+        const auto& request = entries[i];
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            Status status = relocateSharedMemoryAddress(
+                dest_addr, request.length, request.target_id, &pins[i]);
+            if (!status.ok()) return status;
+        }
+        dest_addrs.push_back(dest_addr);
+    }
+
+    size_t task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(task_id + entries.size());
+    for (size_t i = 0; i < entries.size(); ++i) {
+        TransferTask& task = batch_desc.task_list[task_id++];
+        task.batch_id = batch_id;
+        Status status = copySlice(task, entries[i], dest_addrs[i]);
+        if (!status.ok()) return status;
+    }
+    return Status::OK();
+}
+
+Status ShmTransport::submitTransferTask(
+    const std::vector<TransferTask*>& task_list) {
+    std::vector<uint64_t> dest_addrs;
+    dest_addrs.reserve(task_list.size());
+    std::vector<MappingPin> pins(task_list.size());
+    Status first_error = Status::OK();
+    for (size_t i = 0; i < task_list.size(); ++i) {
+        auto* task = task_list[i];
+        assert(task);
+        assert(task->request);
+        const auto& request = *task->request;
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            Status status = relocateSharedMemoryAddress(
+                dest_addr, request.length, request.target_id, &pins[i]);
+            if (!status.ok()) {
+                if (first_error.ok()) first_error = status;
+                dest_addrs.push_back(0);
+                continue;
+            }
+        }
+        dest_addrs.push_back(dest_addr);
+    }
+
+    if (!first_error.ok()) {
+        for (auto* task : task_list) failSlice(*task, *task->request);
+        return first_error;
+    }
+
+    for (size_t i = 0; i < task_list.size(); ++i) {
+        Status status =
+            copySlice(*task_list[i], *task_list[i]->request, dest_addrs[i]);
+        if (!status.ok()) return status;
+    }
+    return Status::OK();
+}
+
+Status ShmTransport::getTransferStatus(BatchID batch_id, size_t task_id,
+                                       TransferStatus& status) {
+    auto& batch_desc = *((BatchDesc*)(batch_id));
+    const size_t task_count = batch_desc.task_list.size();
+    if (task_id >= task_count) {
+        return Status::InvalidArgument(
+            "ShmTransport::getTransferStatus invalid argument, batch id: " +
+            std::to_string(batch_id));
+    }
+    auto& task = batch_desc.task_list[task_id];
+    status.transferred_bytes = task.transferred_bytes;
+    uint64_t success_slice_count = task.success_slice_count;
+    uint64_t failed_slice_count = task.failed_slice_count;
+    if (success_slice_count + failed_slice_count == task.slice_count) {
+        if (failed_slice_count) {
+            status.s = TransferStatusEnum::FAILED;
+        } else {
+            status.s = TransferStatusEnum::COMPLETED;
+        }
+        task.is_finished = true;
+    } else {
+        status.s = TransferStatusEnum::WAITING;
+    }
+    return Status::OK();
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -140,6 +140,18 @@ if(USE_CXL)
   add_test(NAME cxl_transport_test COMMAND cxl_transport_test)
 endif()
 
+add_executable(shm_transport_test ${WORKSPACE}/shm_transport_test.cpp)
+target_link_libraries(shm_transport_test PUBLIC transfer_engine gtest
+                                                gtest_main)
+add_test(NAME shm_transport_test COMMAND shm_transport_test)
+
+if(USE_TCP)
+  add_executable(shm_transport_e2e_test ${WORKSPACE}/shm_transport_e2e_test.cpp)
+  target_link_libraries(shm_transport_e2e_test PUBLIC transfer_engine gtest
+                                                      gtest_main)
+  add_test(NAME shm_transport_e2e_test COMMAND shm_transport_e2e_test)
+endif()
+
 if(USE_NVMEOF)
   add_executable(nvmeof_status_test ${WORKSPACE}/nvmeof_status_test.cpp)
   target_link_libraries(nvmeof_status_test PUBLIC transfer_engine gtest

--- a/mooncake-transfer-engine/tests/shm_transport_e2e_test.cpp
+++ b/mooncake-transfer-engine/tests/shm_transport_e2e_test.cpp
@@ -1,0 +1,606 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include "common.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/shm_transport/shm_transport.h"
+
+namespace mooncake {
+
+class ShmTransportTestPeer {
+   public:
+    static size_t mappingCount(ShmTransport& transport,
+                               Transport::SegmentID target_id) {
+        RWSpinlock::ReadGuard guard(transport.relocate_lock_);
+        auto it = transport.relocate_map_.find(target_id);
+        return it == transport.relocate_map_.end() ? 0 : it->second.size();
+    }
+};
+
+namespace {
+
+std::string UniqueServerName(uint16_t extra) {
+    return "127.0.0.1:" +
+           std::to_string(21000 + static_cast<int>(getpid() % 1000) + extra);
+}
+
+class ScopedEnv {
+   public:
+    ScopedEnv(const char* name, const char* value) : name_(name) {
+        const char* old = std::getenv(name);
+        if (old) {
+            had_old_ = true;
+            old_ = old;
+        }
+        if (value)
+            setenv(name_.c_str(), value, 1);
+        else
+            unsetenv(name_.c_str());
+    }
+
+    ~ScopedEnv() {
+        if (had_old_)
+            setenv(name_.c_str(), old_.c_str(), 1);
+        else
+            unsetenv(name_.c_str());
+    }
+
+   private:
+    std::string name_;
+    std::string old_;
+    bool had_old_{false};
+};
+
+bool WaitStatus(TransferEngine& engine, BatchID batch_id,
+                TransferStatusEnum expected) {
+    TransferStatus status;
+    for (int i = 0; i < 1000; ++i) {
+        Status s = engine.getTransferStatus(batch_id, 0, status);
+        if (!s.ok()) return false;
+        if (status.s == expected) return true;
+        if (status.s == TransferStatusEnum::FAILED &&
+            expected != TransferStatusEnum::FAILED)
+            return false;
+        usleep(1000);
+    }
+    return false;
+}
+
+bool WaitCompleted(TransferEngine& engine, BatchID batch_id) {
+    return WaitStatus(engine, batch_id, TransferStatusEnum::COMPLETED);
+}
+
+std::unique_ptr<TransferEngine> MakeEngine(const std::string& server_name,
+                                           bool install_shm = true) {
+    auto engine = std::make_unique<TransferEngine>(false);
+    auto host_port = parseHostNameWithPort(server_name);
+    int rc = engine->init(P2PHANDSHAKE, server_name, host_port.first.c_str(),
+                          host_port.second);
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(engine->installTransport("tcp", nullptr), nullptr);
+    if (install_shm) {
+        EXPECT_NE(engine->installTransport("shm", nullptr), nullptr);
+        EXPECT_TRUE(engine->isTcpOnly());
+    } else {
+        EXPECT_EQ(engine->getTransport("shm"), nullptr);
+    }
+    return engine;
+}
+
+void ExpectShmWriteAndRead(TransferEngine& owner, TransferEngine& peer,
+                           void* remote, uint64_t remote_base, size_t length) {
+    std::vector<uint8_t> payload(length);
+    std::vector<uint8_t> readback(length, 0);
+    for (size_t i = 0; i < length; ++i) payload[i] = static_cast<uint8_t>(i);
+    ASSERT_EQ(peer.registerLocalMemory(payload.data(), length, "cpu:0"), 0);
+
+    auto segment_id = peer.openSegment(owner.getLocalIpAndPort());
+    {
+        auto batch = peer.allocateBatchID(1);
+        TransferRequest write;
+        write.opcode = TransferRequest::WRITE;
+        write.source = payload.data();
+        write.target_id = segment_id;
+        write.target_offset = remote_base;
+        write.length = length;
+        ASSERT_TRUE(peer.submitTransfer(batch, {write}).ok());
+        ASSERT_TRUE(WaitCompleted(peer, batch));
+        ASSERT_TRUE(peer.freeBatchID(batch).ok());
+    }
+
+    auto* shm = dynamic_cast<ShmTransport*>(peer.getTransport("shm"));
+    ASSERT_NE(shm, nullptr);
+    EXPECT_GE(ShmTransportTestPeer::mappingCount(*shm, segment_id), 1u);
+    EXPECT_EQ(std::memcmp(remote, payload.data(), length), 0);
+
+    ASSERT_EQ(peer.registerLocalMemory(readback.data(), length, "cpu:0"), 0);
+    {
+        auto batch = peer.allocateBatchID(1);
+        TransferRequest read;
+        read.opcode = TransferRequest::READ;
+        read.source = readback.data();
+        read.target_id = segment_id;
+        read.target_offset = remote_base;
+        read.length = length;
+        ASSERT_TRUE(peer.submitTransfer(batch, {read}).ok());
+        ASSERT_TRUE(WaitCompleted(peer, batch));
+        ASSERT_TRUE(peer.freeBatchID(batch).ok());
+    }
+    EXPECT_EQ(readback, payload);
+}
+
+const TransferMetadata::BufferDesc* FindPosixShmBuffer(
+    const TransferMetadata::SegmentDesc& desc) {
+    for (const auto& buffer : desc.buffers) {
+        if (isPosixShmName(buffer.shm_name)) return &buffer;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+TEST(ShmTransportE2E, WriteAndReadBetweenEngines) {
+    const size_t length = 2 * 1024 * 1024;
+    auto engine_a = MakeEngine(UniqueServerName(0));
+    auto engine_b = MakeEngine(UniqueServerName(1));
+    ASSERT_TRUE(engine_a);
+    ASSERT_TRUE(engine_b);
+
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+
+    auto desc = engine_a->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(desc);
+    ASSERT_FALSE(desc->buffers.empty());
+    EXPECT_NE(desc->protocol.find("shm"), std::string::npos);
+#ifdef ENABLE_MULTI_PROTOCOL
+    EXPECT_NE(desc->protocol.find("tcp"), std::string::npos);
+    auto* shm_buffer = FindPosixShmBuffer(*desc);
+    ASSERT_NE(shm_buffer, nullptr);
+    EXPECT_EQ(shm_buffer->protocol, "shm");
+#else
+    EXPECT_EQ(desc->protocol, "shm");
+#endif
+
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    ASSERT_FALSE(remote_desc->buffers.empty());
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    uint64_t remote_base = remote_shm->addr;
+    EXPECT_NE(remote_desc->protocol.find("shm"), std::string::npos);
+
+    ASSERT_NO_FATAL_FAILURE(ExpectShmWriteAndRead(*engine_a, *engine_b, remote,
+                                                  remote_base, length));
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+
+TEST(ShmTransportE2E, WriteAndRead4K) {
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(6));
+    auto engine_b = MakeEngine(UniqueServerName(7));
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    uint64_t remote_base = remote_shm->addr;
+    ASSERT_NO_FATAL_FAILURE(ExpectShmWriteAndRead(*engine_a, *engine_b, remote,
+                                                  remote_base, length));
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+
+TEST(ShmTransportE2E, WriteAndReadCrossPage) {
+    const size_t length = static_cast<size_t>(sysconf(_SC_PAGESIZE)) + 64;
+    auto engine_a = MakeEngine(UniqueServerName(8));
+    auto engine_b = MakeEngine(UniqueServerName(9));
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    uint64_t remote_base = remote_shm->addr;
+    ASSERT_NO_FATAL_FAILURE(ExpectShmWriteAndRead(*engine_a, *engine_b, remote,
+                                                  remote_base, length));
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+
+TEST(ShmTransportE2E, RegisterSubRangeFails) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t length = page_size * 2;
+    auto engine_a = MakeEngine(UniqueServerName(24));
+    auto engine_b = MakeEngine(UniqueServerName(25));
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    auto* mid = static_cast<char*>(remote) + page_size;
+    EXPECT_EQ(engine_a->registerLocalMemory(mid, page_size, "cpu:0"),
+              ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(engine_a->registerLocalMemory(remote, length + 1, "cpu:0"),
+              ERR_INVALID_ARGUMENT);
+
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, page_size, "cpu:0"), 0);
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    EXPECT_EQ(remote_shm->length, page_size);
+    ASSERT_NO_FATAL_FAILURE(ExpectShmWriteAndRead(*engine_a, *engine_b, remote,
+                                                  remote_shm->addr, page_size));
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+
+TEST(ShmTransportE2E, TransferFailsAfterFreeSharedMemory) {
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(10));
+    auto engine_b = MakeEngine(UniqueServerName(11));
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    uint64_t remote_base = remote_shm->addr;
+
+    std::vector<uint8_t> payload(length, 0x5a);
+    ASSERT_EQ(engine_b->registerLocalMemory(payload.data(), length, "cpu:0"),
+              0);
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+
+    auto batch = engine_b->allocateBatchID(1);
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.source = payload.data();
+    write.target_id = segment_id;
+    write.target_offset = remote_base;
+    write.length = length;
+    EXPECT_FALSE(engine_b->submitTransfer(batch, {write}).ok());
+    auto* shm = dynamic_cast<ShmTransport*>(engine_b->getTransport("shm"));
+    ASSERT_NE(shm, nullptr);
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(*shm, segment_id), 0u);
+    ASSERT_TRUE(WaitStatus(*engine_b, batch, TransferStatusEnum::FAILED));
+    ASSERT_TRUE(engine_b->freeBatchID(batch).ok());
+}
+
+TEST(ShmTransportE2E, FreeSharedMemoryDoesNotUnregisterMalloc) {
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(20));
+    auto engine_b = MakeEngine(UniqueServerName(21));
+    std::vector<uint8_t> remote(length, 0);
+    std::vector<uint8_t> payload(length, 0x9a);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote.data(), length, "cpu:0"), 0);
+    ASSERT_EQ(engine_b->registerLocalMemory(payload.data(), length, "cpu:0"),
+              0);
+    EXPECT_EQ(engine_a->freeSharedMemory(remote.data()), ERR_INVALID_ARGUMENT);
+
+    // Local metadata still has the malloc buffer; freeSharedMemory must not
+    // unregister transports it does not own.
+    auto local_desc =
+        engine_a->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    ASSERT_FALSE(local_desc->buffers.empty());
+    EXPECT_EQ(local_desc->buffers[0].addr,
+              reinterpret_cast<uint64_t>(remote.data()));
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    ASSERT_FALSE(remote_desc->buffers.empty());
+    auto batch = engine_b->allocateBatchID(1);
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.source = payload.data();
+    write.target_id = segment_id;
+    write.target_offset = remote_desc->buffers[0].addr;
+    write.length = length;
+    ASSERT_TRUE(engine_b->submitTransfer(batch, {write}).ok());
+    ASSERT_TRUE(WaitCompleted(*engine_b, batch));
+    ASSERT_TRUE(engine_b->freeBatchID(batch).ok());
+    EXPECT_EQ(remote, payload);
+#else
+    // installTransport("shm") replaced protocol with "shm", so decode skips
+    // malloc buffers (empty shm_name). Do not index buffers[0].
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    EXPECT_EQ(FindPosixShmBuffer(*remote_desc), nullptr);
+    EXPECT_TRUE(remote_desc->buffers.empty());
+#endif
+}
+
+TEST(ShmTransportE2E, TransferAfterFreeAndReallocateSharedMemory) {
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(22));
+    auto engine_b = MakeEngine(UniqueServerName(23));
+    std::vector<uint8_t> first_payload(length, 0xa1);
+    std::vector<uint8_t> second_payload(length, 0xb2);
+    ASSERT_EQ(
+        engine_b->registerLocalMemory(first_payload.data(), length, "cpu:0"),
+        0);
+    ASSERT_EQ(
+        engine_b->registerLocalMemory(second_payload.data(), length, "cpu:0"),
+        0);
+
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    uint64_t remote_base = remote_shm->addr;
+
+    auto submit_write = [&](std::vector<uint8_t>& payload) -> bool {
+        auto batch = engine_b->allocateBatchID(1);
+        TransferRequest write;
+        write.opcode = TransferRequest::WRITE;
+        write.source = payload.data();
+        write.target_id = segment_id;
+        write.target_offset = remote_base;
+        write.length = length;
+        if (!engine_b->submitTransfer(batch, {write}).ok()) {
+            (void)engine_b->freeBatchID(batch);
+            return false;
+        }
+        if (!WaitCompleted(*engine_b, batch)) {
+            (void)engine_b->freeBatchID(batch);
+            return false;
+        }
+        if (!engine_b->freeBatchID(batch).ok()) return false;
+        return std::memcmp(remote, payload.data(), length) == 0;
+    };
+    EXPECT_TRUE(submit_write(first_payload));
+
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+    remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+
+    // Do not call syncSegmentCache: relocate must notice the unlinked object,
+    // drop the orphaned mmap, and refetch the peer descriptor.
+    if (!submit_write(second_payload)) {
+        remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+        ASSERT_TRUE(remote_desc);
+        remote_shm = FindPosixShmBuffer(*remote_desc);
+        ASSERT_NE(remote_shm, nullptr);
+        remote_base = remote_shm->addr;
+        ASSERT_TRUE(submit_write(second_payload));
+    }
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+
+TEST(ShmTransportE2E, UnsetMcForceShmDoesNotInstallShm) {
+    ScopedEnv disable_force("MC_FORCE_SHM", nullptr);
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(12), /*install_shm=*/false);
+    auto engine_b = MakeEngine(UniqueServerName(13), /*install_shm=*/false);
+    ASSERT_EQ(engine_a->getTransport("shm"), nullptr);
+    ASSERT_EQ(engine_b->getTransport("shm"), nullptr);
+    EXPECT_EQ(engine_a->allocateSharedMemory(length), nullptr);
+
+    std::vector<uint8_t> remote(length, 0);
+    std::vector<uint8_t> payload(length, 0x3c);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote.data(), length, "cpu:0"), 0);
+    ASSERT_EQ(engine_b->registerLocalMemory(payload.data(), length, "cpu:0"),
+              0);
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    EXPECT_FALSE(isPosixShmName(remote_desc->buffers[0].shm_name));
+
+    auto batch = engine_b->allocateBatchID(1);
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.source = payload.data();
+    write.target_id = segment_id;
+    write.target_offset = remote_desc->buffers[0].addr;
+    write.length = length;
+    ASSERT_TRUE(engine_b->submitTransfer(batch, {write}).ok());
+    ASSERT_TRUE(WaitCompleted(*engine_b, batch));
+    ASSERT_TRUE(engine_b->freeBatchID(batch).ok());
+    EXPECT_EQ(remote, payload);
+}
+
+#ifndef ENABLE_MULTI_PROTOCOL
+TEST(ShmTransportE2E, McForceShmInstallsShmOnly) {
+    ScopedEnv force_shm("MC_FORCE_SHM", "1");
+    const std::string server_name = UniqueServerName(16);
+    auto engine = std::make_unique<TransferEngine>(true);
+    auto host_port = parseHostNameWithPort(server_name);
+    ASSERT_EQ(engine->init(P2PHANDSHAKE, server_name, host_port.first.c_str(),
+                           host_port.second),
+              0);
+    EXPECT_NE(engine->getTransport("shm"), nullptr);
+    EXPECT_EQ(engine->getTransport("tcp"), nullptr);
+    EXPECT_EQ(engine->getTransport("rdma"), nullptr);
+    auto desc = engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(desc);
+    EXPECT_EQ(desc->protocol, "shm");
+    void* buf = engine->allocateSharedMemory(4096);
+    ASSERT_NE(buf, nullptr);
+    EXPECT_EQ(engine->freeSharedMemory(buf), 0);
+}
+#endif
+
+#ifdef ENABLE_MULTI_PROTOCOL
+TEST(ShmTransportE2E, McForceShmCoexistsWithHostTransport) {
+    ScopedEnv force_shm("MC_FORCE_SHM", "1");
+    const std::string server_name = UniqueServerName(18);
+    auto engine = std::make_unique<TransferEngine>(true);
+    auto host_port = parseHostNameWithPort(server_name);
+    ASSERT_EQ(engine->init(P2PHANDSHAKE, server_name, host_port.first.c_str(),
+                           host_port.second),
+              0);
+    EXPECT_NE(engine->getTransport("shm"), nullptr);
+    EXPECT_TRUE(engine->getTransport("tcp") != nullptr ||
+                engine->getTransport("rdma") != nullptr);
+    auto desc = engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(desc);
+    EXPECT_NE(desc->protocol.find("shm"), std::string::npos);
+    EXPECT_NE(desc->protocol.find(','), std::string::npos);
+}
+
+TEST(ShmTransportE2E, MallocBufferUsesTcp) {
+    const size_t length = 4096;
+    const std::string name_a = UniqueServerName(2);
+    const std::string name_b = UniqueServerName(3);
+    std::vector<uint8_t> remote(length, 0);
+    std::vector<uint8_t> payload(length, 0x7e);
+
+    auto engine_a = MakeEngine(name_a);
+    auto engine_b = MakeEngine(name_b);
+
+    ASSERT_EQ(engine_a->registerLocalMemory(remote.data(), length, "cpu:0"), 0);
+    ASSERT_EQ(engine_b->registerLocalMemory(payload.data(), length, "cpu:0"),
+              0);
+
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    uint64_t remote_base = remote_desc->buffers[0].addr;
+    EXPECT_EQ(FindPosixShmBuffer(*remote_desc), nullptr);
+
+    auto batch = engine_b->allocateBatchID(1);
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.source = payload.data();
+    write.target_id = segment_id;
+    write.target_offset = remote_base;
+    write.length = length;
+    ASSERT_TRUE(engine_b->submitTransfer(batch, {write}).ok());
+    ASSERT_TRUE(WaitCompleted(*engine_b, batch));
+    ASSERT_TRUE(engine_b->freeBatchID(batch).ok());
+
+    auto* shm = dynamic_cast<ShmTransport*>(engine_b->getTransport("shm"));
+    ASSERT_NE(shm, nullptr);
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(*shm, segment_id), 0u);
+    EXPECT_EQ(remote, payload);
+}
+
+TEST(ShmTransportE2E, SubmitTransferPrefersShmOnSameHost) {
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(4));
+    auto engine_b = MakeEngine(UniqueServerName(5));
+    std::vector<uint8_t> payload(length, 0xa5);
+
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+    auto local_desc =
+        engine_a->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    EXPECT_NE(local_desc->protocol.find("tcp"), std::string::npos);
+    EXPECT_NE(local_desc->protocol.find("shm"), std::string::npos);
+    auto* shm_buffer = FindPosixShmBuffer(*local_desc);
+    ASSERT_NE(shm_buffer, nullptr);
+    EXPECT_EQ(shm_buffer->protocol, "shm");
+    ASSERT_EQ(engine_b->registerLocalMemory(payload.data(), length, "cpu:0"),
+              0);
+
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+    uint64_t remote_base = remote_shm->addr;
+
+    auto batch = engine_b->allocateBatchID(1);
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.source = payload.data();
+    write.target_id = segment_id;
+    write.target_offset = remote_base;
+    write.length = length;
+    ASSERT_TRUE(engine_b->submitTransfer(batch, {write}).ok());
+    ASSERT_TRUE(WaitCompleted(*engine_b, batch));
+    ASSERT_TRUE(engine_b->freeBatchID(batch).ok());
+
+    auto* shm = dynamic_cast<ShmTransport*>(engine_b->getTransport("shm"));
+    ASSERT_NE(shm, nullptr);
+    EXPECT_GE(ShmTransportTestPeer::mappingCount(*shm, segment_id), 1u);
+    EXPECT_EQ(std::memcmp(remote, payload.data(), length), 0);
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+
+TEST(ShmTransportE2E, MpSubmitTransferHonorsTcpPreference) {
+    const size_t length = 4096;
+    auto engine_a = MakeEngine(UniqueServerName(14));
+    auto engine_b = MakeEngine(UniqueServerName(15));
+    std::vector<uint8_t> payload(length, 0x3d);
+
+    void* remote = engine_a->allocateSharedMemory(length);
+    ASSERT_NE(remote, nullptr);
+    std::memset(remote, 0, length);
+    ASSERT_EQ(engine_a->registerLocalMemory(remote, length, "cpu:0"), 0);
+    ASSERT_EQ(engine_b->registerLocalMemory(payload.data(), length, "cpu:0"),
+              0);
+
+    auto segment_id = engine_b->openSegment(engine_a->getLocalIpAndPort());
+    auto remote_desc = engine_b->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_TRUE(remote_desc);
+    auto* remote_shm = FindPosixShmBuffer(*remote_desc);
+    ASSERT_NE(remote_shm, nullptr);
+
+    auto batch = engine_b->allocateBatchID(1);
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.source = payload.data();
+    write.target_id = segment_id;
+    write.target_offset = remote_shm->addr;
+    write.length = length;
+    std::string proto = "tcp";
+    ASSERT_TRUE(engine_b->mp_submitTransfer(batch, {write}, proto).ok());
+    ASSERT_TRUE(WaitCompleted(*engine_b, batch));
+    ASSERT_TRUE(engine_b->freeBatchID(batch).ok());
+
+    auto* shm = dynamic_cast<ShmTransport*>(engine_b->getTransport("shm"));
+    ASSERT_NE(shm, nullptr);
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(*shm, segment_id), 0u);
+    EXPECT_EQ(std::memcmp(remote, payload.data(), length), 0);
+    ASSERT_EQ(engine_a->freeSharedMemory(remote), 0);
+}
+#endif
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/shm_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/shm_transport_test.cpp
@@ -1,0 +1,884 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "common.h"
+#include "multi_transport.h"
+#include "transfer_metadata.h"
+#include "transport/shm_transport/shm_transport.h"
+
+namespace mooncake {
+
+class MultiTransportTestPeer {
+   public:
+    static Status selectTransport(MultiTransport& multi,
+                                  const Transport::TransferRequest& entry,
+                                  Transport*& transport) {
+        return multi.selectTransport(entry, transport);
+    }
+};
+
+class ShmTransportTestPeer {
+   public:
+    static int install(ShmTransport& transport, std::string& local_server_name,
+                       std::shared_ptr<TransferMetadata> metadata) {
+        std::shared_ptr<Topology> topo;
+        return transport.install(local_server_name, metadata, topo);
+    }
+
+    static Status relocate(ShmTransport& transport, uint64_t& address,
+                           uint64_t length, Transport::SegmentID target_id) {
+        return transport.relocateSharedMemoryAddress(address, length,
+                                                     target_id);
+    }
+
+    static Status relocatePinned(
+        ShmTransport& transport, uint64_t& address, uint64_t length,
+        Transport::SegmentID target_id,
+        std::unique_ptr<ShmTransport::MappingPin>& pin) {
+        pin = std::make_unique<ShmTransport::MappingPin>();
+        return transport.relocateSharedMemoryAddress(address, length, target_id,
+                                                     pin.get());
+    }
+
+    static uint32_t pinCount(ShmTransport& transport,
+                             Transport::SegmentID target_id, uint64_t addr) {
+        RWSpinlock::ReadGuard guard(transport.relocate_lock_);
+        auto it = transport.relocate_map_.find(target_id);
+        if (it == transport.relocate_map_.end()) return 0;
+        auto mapping = it->second.find(addr);
+        if (mapping == it->second.end() || !mapping->second) return 0;
+        return mapping->second->pin_count.load();
+    }
+
+    static size_t mappingCount(ShmTransport& transport,
+                               Transport::SegmentID target_id) {
+        RWSpinlock::ReadGuard guard(transport.relocate_lock_);
+        auto it = transport.relocate_map_.find(target_id);
+        return it == transport.relocate_map_.end() ? 0 : it->second.size();
+    }
+
+    static size_t maxMappingsPerTarget() {
+        return ShmTransport::kMaxMappingsPerTarget;
+    }
+
+    static void* createSharedMemory(ShmTransport& transport,
+                                    const std::string& path, size_t size,
+                                    int* error = nullptr) {
+        return transport.createSharedMemory(path, size, error);
+    }
+
+    static int registerLocalMemory(ShmTransport& transport, void* addr,
+                                   size_t length,
+                                   const std::string& location = "cpu:0") {
+        return transport.registerLocalMemory(addr, length, location, true,
+                                             true);
+    }
+
+    static int registerLocalMemoryBatch(
+        ShmTransport& transport,
+        const std::vector<Transport::BufferEntry>& buffer_list,
+        const std::string& location = "cpu:0") {
+        return transport.registerLocalMemoryBatch(buffer_list, location);
+    }
+};
+
+namespace {
+
+constexpr Transport::SegmentID kPeerSegmentId = 1;
+constexpr uint64_t kRemoteAddress = 0x10000000;
+
+class ScopedShmFile {
+   public:
+    explicit ScopedShmFile(size_t length, const std::string& tag = "test")
+        : name_(std::string(kPosixShmNamePrefix) + tag + "_" +
+                std::to_string(getpid()) + "_" +
+                std::to_string(reinterpret_cast<uintptr_t>(this))),
+          length_(length) {
+        shm_unlink(name_.c_str());
+        fd_ = shm_open(name_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+        EXPECT_GE(fd_, 0);
+        if (fd_ >= 0) {
+            EXPECT_EQ(ftruncate(fd_, static_cast<off_t>(length_)), 0);
+            addr_ = mmap(nullptr, length_, PROT_READ | PROT_WRITE, MAP_SHARED,
+                         fd_, 0);
+            EXPECT_NE(addr_, MAP_FAILED);
+        }
+    }
+
+    ~ScopedShmFile() {
+        if (addr_ && addr_ != MAP_FAILED) munmap(addr_, length_);
+        if (fd_ >= 0) close(fd_);
+        shm_unlink(name_.c_str());
+    }
+
+    const std::string& name() const { return name_; }
+    void* addr() const { return addr_; }
+
+   private:
+    std::string name_;
+    size_t length_;
+    int fd_{-1};
+    void* addr_{nullptr};
+};
+
+void addPeerBuffers(
+    TransferMetadata& metadata,
+    const std::vector<std::pair<std::string, uint64_t>>& buffers,
+    size_t length) {
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    desc->name = "127.0.0.1:19001";
+    desc->protocol = "tcp";
+    for (const auto& buffer_info : buffers) {
+        TransferMetadata::BufferDesc buffer;
+        buffer.name = "cpu:0";
+        buffer.addr = buffer_info.second;
+        buffer.length = length;
+        buffer.shm_name = buffer_info.first;
+        desc->buffers.push_back(buffer);
+    }
+    metadata.addLocalSegment(kPeerSegmentId, desc->name, std::move(desc));
+}
+
+void addPeerSegment(TransferMetadata& metadata, const std::string& shm_name,
+                    uint64_t remote_addr, size_t length) {
+    addPeerBuffers(metadata, {{shm_name, remote_addr}}, length);
+}
+
+}  // namespace
+
+TEST(ShmNameTest, PrefixDetectsPosixNames) {
+    EXPECT_TRUE(isPosixShmName("/mooncake_1234_abcdefgh"));
+    EXPECT_TRUE(isPosixShmName("mooncake_1234_abcdefgh"));
+    EXPECT_FALSE(isPosixShmName(""));
+    EXPECT_FALSE(isPosixShmName("/mooncake_"));
+    EXPECT_FALSE(isPosixShmName("mooncake_"));
+    EXPECT_FALSE(isPosixShmName("cuda-ipc-handle"));
+}
+
+TEST(ShmTransportTest, SharesRelocationAcrossThreads) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile shm_file(page_size);
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, shm_file.name(), kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    constexpr size_t kThreadCount = 8;
+    std::vector<uint64_t> relocated(kThreadCount, kRemoteAddress);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        threads.emplace_back([&transport, &relocated, i, page_size]() {
+            auto status = ShmTransportTestPeer::relocate(
+                transport, relocated[i], page_size, kPeerSegmentId);
+            EXPECT_TRUE(status.ok()) << status.ToString();
+        });
+    }
+    for (auto& thread : threads) thread.join();
+
+    for (uint64_t address : relocated) EXPECT_EQ(address, relocated.front());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+
+    auto* mapped = reinterpret_cast<char*>(relocated.front());
+    mapped[0] = 0x5a;
+    EXPECT_EQ(static_cast<unsigned char*>(shm_file.addr())[0], 0x5a);
+}
+
+TEST(ShmTransportTest, ConsumerDoesNotCreateMissingFile) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const std::string shm_name = std::string(kPosixShmNamePrefix) + "missing_" +
+                                 std::to_string(getpid());
+    shm_unlink(shm_name.c_str());
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, shm_name, kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t address = kRemoteAddress;
+    auto status = ShmTransportTestPeer::relocate(transport, address, page_size,
+                                                 kPeerSegmentId);
+    EXPECT_FALSE(status.ok());
+
+    std::string_view key = shm_name;
+    if (!key.empty() && key.front() == '/') key.remove_prefix(1);
+    std::string path = std::string("/dev/shm/") + std::string(key);
+    EXPECT_EQ(access(path.c_str(), F_OK), -1);
+    EXPECT_EQ(errno, ENOENT);
+}
+
+TEST(ShmTransportTest, RejectsBackingFileShorterThanBuffer) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const std::string shm_name =
+        std::string(kPosixShmNamePrefix) + "short_" + std::to_string(getpid());
+    shm_unlink(shm_name.c_str());
+    int fd = shm_open(shm_name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    ASSERT_GE(fd, 0);
+    ASSERT_EQ(ftruncate(fd, static_cast<off_t>(page_size / 2)), 0);
+    close(fd);
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, shm_name, kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t address = kRemoteAddress;
+    auto status = ShmTransportTestPeer::relocate(transport, address, page_size,
+                                                 kPeerSegmentId);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 0);
+
+    shm_unlink(shm_name.c_str());
+}
+
+TEST(ShmTransportTest, CreateSharedMemoryDoesNotTruncateExisting) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile shm_file(page_size);
+    std::memset(shm_file.addr(), 0x3c, page_size);
+
+    ShmTransport transport;
+    int error = 0;
+    void* mapped = ShmTransportTestPeer::createSharedMemory(
+        transport, shm_file.name(), page_size, &error);
+    EXPECT_EQ(mapped, nullptr);
+    EXPECT_EQ(error, EEXIST);
+    EXPECT_EQ(static_cast<unsigned char*>(shm_file.addr())[0], 0x3c);
+}
+
+TEST(ShmTransportTest, RelocateMissKeepsExistingMappings) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile shm_file(page_size);
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, shm_file.name(), kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t address = kRemoteAddress;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, address, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+
+    uint64_t missing = kRemoteAddress + page_size * 4;
+    auto status = ShmTransportTestPeer::relocate(transport, missing, page_size,
+                                                 kPeerSegmentId);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+}
+
+TEST(ShmTransportTest, RelocateInvalidatesStaleShmName) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile first(page_size, "first");
+    ScopedShmFile second(page_size, "second");
+    std::memset(first.addr(), 0x11, page_size);
+    std::memset(second.addr(), 0x22, page_size);
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, first.name(), kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t address = kRemoteAddress;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, address, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+    std::memset(reinterpret_cast<void*>(address), 0xaa, page_size);
+    EXPECT_EQ(static_cast<unsigned char*>(first.addr())[0], 0xaa);
+    EXPECT_EQ(static_cast<unsigned char*>(second.addr())[0], 0x22);
+
+    addPeerSegment(*metadata, second.name(), kRemoteAddress, page_size);
+    address = kRemoteAddress;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, address, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+    std::memset(reinterpret_cast<void*>(address), 0xbb, page_size);
+    EXPECT_EQ(static_cast<unsigned char*>(first.addr())[0], 0xaa);
+    EXPECT_EQ(static_cast<unsigned char*>(second.addr())[0], 0xbb);
+}
+
+TEST(ShmTransportTest, RelocateUnlinkedObjectDropsMapping) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile shm_file(page_size);
+    std::memset(shm_file.addr(), 0x11, page_size);
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, shm_file.name(), kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t address = kRemoteAddress;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, address, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+    std::memset(reinterpret_cast<void*>(address), 0xaa, page_size);
+    EXPECT_EQ(static_cast<unsigned char*>(shm_file.addr())[0], 0xaa);
+
+    ASSERT_EQ(shm_unlink(shm_file.name().c_str()), 0);
+    address = kRemoteAddress;
+    auto status = ShmTransportTestPeer::relocate(transport, address, page_size,
+                                                 kPeerSegmentId);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 0);
+    EXPECT_EQ(static_cast<unsigned char*>(shm_file.addr())[0], 0xaa);
+}
+
+TEST(ShmTransportTest, RelocatePrunesAddrsNotInDescriptor) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile first(page_size, "keep");
+    ScopedShmFile second(page_size, "drop");
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerBuffers(*metadata,
+                   {{first.name(), kRemoteAddress},
+                    {second.name(), kRemoteAddress + page_size}},
+                   page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t first_addr = kRemoteAddress;
+    uint64_t second_addr = kRemoteAddress + page_size;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, first_addr, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, second_addr,
+                                               page_size, kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 2);
+
+    addPeerBuffers(*metadata, {{first.name(), kRemoteAddress}}, page_size);
+    first_addr = kRemoteAddress;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, first_addr, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+}
+
+TEST(ShmTransportTest, RelocateCapsMappingsPerTarget) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t cap = ShmTransportTestPeer::maxMappingsPerTarget();
+    std::vector<std::unique_ptr<ScopedShmFile>> files;
+    std::vector<std::pair<std::string, uint64_t>> buffers;
+    files.reserve(cap + 1);
+    buffers.reserve(cap + 1);
+    for (size_t i = 0; i < cap + 1; ++i) {
+        files.push_back(std::make_unique<ScopedShmFile>(
+            page_size, "cap" + std::to_string(i)));
+        buffers.emplace_back(files.back()->name(),
+                             kRemoteAddress + i * page_size);
+    }
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerBuffers(*metadata, buffers, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    for (const auto& buffer : buffers) {
+        uint64_t address = buffer.second;
+        ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, address,
+                                                   page_size, kPeerSegmentId)
+                        .ok());
+    }
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId),
+              cap);
+}
+
+TEST(ShmTransportTest, RelocatePinSurvivesCap) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t cap = ShmTransportTestPeer::maxMappingsPerTarget();
+    std::vector<std::unique_ptr<ScopedShmFile>> files;
+    std::vector<std::pair<std::string, uint64_t>> buffers;
+    files.reserve(cap + 1);
+    buffers.reserve(cap + 1);
+    for (size_t i = 0; i < cap + 1; ++i) {
+        files.push_back(std::make_unique<ScopedShmFile>(
+            page_size, "pin-cap" + std::to_string(i)));
+        buffers.emplace_back(files.back()->name(),
+                             kRemoteAddress + i * page_size);
+    }
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerBuffers(*metadata, buffers, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t pinned_addr = buffers.front().second;
+    std::unique_ptr<ShmTransport::MappingPin> pin;
+    ASSERT_TRUE(ShmTransportTestPeer::relocatePinned(
+                    transport, pinned_addr, page_size, kPeerSegmentId, pin)
+                    .ok());
+    ASSERT_TRUE(pin && *pin);
+    EXPECT_EQ(ShmTransportTestPeer::pinCount(transport, kPeerSegmentId,
+                                             buffers.front().second),
+              1u);
+
+    for (size_t i = 1; i < buffers.size(); ++i) {
+        uint64_t address = buffers[i].second;
+        ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, address,
+                                                   page_size, kPeerSegmentId)
+                        .ok());
+    }
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId),
+              cap);
+    EXPECT_EQ(ShmTransportTestPeer::pinCount(transport, kPeerSegmentId,
+                                             buffers.front().second),
+              1u);
+
+    std::memset(reinterpret_cast<void*>(pinned_addr), 0xab, page_size);
+    EXPECT_EQ(static_cast<unsigned char*>(files.front()->addr())[0], 0xab);
+
+    pin.reset();
+    EXPECT_EQ(ShmTransportTestPeer::pinCount(transport, kPeerSegmentId,
+                                             buffers.front().second),
+              0u);
+}
+
+TEST(ShmTransportTest, RelocatePinSurvivesPrune) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile first(page_size, "keep");
+    ScopedShmFile second(page_size, "drop");
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerBuffers(*metadata,
+                   {{first.name(), kRemoteAddress},
+                    {second.name(), kRemoteAddress + page_size}},
+                   page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t first_addr = kRemoteAddress;
+    uint64_t second_addr = kRemoteAddress + page_size;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, first_addr, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    std::unique_ptr<ShmTransport::MappingPin> pin;
+    ASSERT_TRUE(ShmTransportTestPeer::relocatePinned(
+                    transport, second_addr, page_size, kPeerSegmentId, pin)
+                    .ok());
+    ASSERT_TRUE(pin && *pin);
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 2);
+
+    addPeerBuffers(*metadata, {{first.name(), kRemoteAddress}}, page_size);
+    first_addr = kRemoteAddress;
+    ASSERT_TRUE(ShmTransportTestPeer::relocate(transport, first_addr, page_size,
+                                               kPeerSegmentId)
+                    .ok());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, kPeerSegmentId), 1);
+
+    std::memset(reinterpret_cast<void*>(second_addr), 0xcd, page_size);
+    EXPECT_EQ(static_cast<unsigned char*>(second.addr())[0], 0xcd);
+
+    pin.reset();
+    std::memset(reinterpret_cast<void*>(first_addr), 0xef, page_size);
+    EXPECT_EQ(static_cast<unsigned char*>(first.addr())[0], 0xef);
+}
+
+TEST(ShmTransportTest, RelocateCopySurvivesConcurrentCap) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t cap = ShmTransportTestPeer::maxMappingsPerTarget();
+    std::vector<std::unique_ptr<ScopedShmFile>> files;
+    std::vector<std::pair<std::string, uint64_t>> buffers;
+    files.reserve(cap + 1);
+    buffers.reserve(cap + 1);
+    for (size_t i = 0; i < cap + 1; ++i) {
+        files.push_back(std::make_unique<ScopedShmFile>(
+            page_size, "race" + std::to_string(i)));
+        buffers.emplace_back(files.back()->name(),
+                             kRemoteAddress + i * page_size);
+    }
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerBuffers(*metadata, buffers, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    uint64_t pinned_addr = buffers.front().second;
+    std::unique_ptr<ShmTransport::MappingPin> pin;
+    ASSERT_TRUE(ShmTransportTestPeer::relocatePinned(
+                    transport, pinned_addr, page_size, kPeerSegmentId, pin)
+                    .ok());
+    ASSERT_TRUE(pin && *pin);
+
+    std::atomic<bool> stop{false};
+    std::thread copier([&]() {
+        std::vector<char> src(page_size, 0x5a);
+        while (!stop.load()) {
+            std::memcpy(reinterpret_cast<void*>(pinned_addr), src.data(),
+                        page_size);
+        }
+    });
+    for (int round = 0; round < 4; ++round) {
+        for (const auto& buffer : buffers) {
+            uint64_t address = buffer.second;
+            auto status = ShmTransportTestPeer::relocate(
+                transport, address, page_size, kPeerSegmentId);
+            EXPECT_TRUE(status.ok()) << status.ToString();
+        }
+    }
+    stop.store(true);
+    copier.join();
+    pin.reset();
+    EXPECT_EQ(static_cast<unsigned char*>(files.front()->addr())[0], 0x5a);
+}
+
+TEST(ShmTransportTest, SubmitIsAllOrNothingWhenRelocateFailsMidBatch) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    ScopedShmFile shm_file(page_size);
+    std::memset(shm_file.addr(), 0x11, page_size);
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    addPeerSegment(*metadata, shm_file.name(), kRemoteAddress, page_size);
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    std::vector<char> src(page_size, 0x22);
+    Transport::TransferRequest ok;
+    ok.opcode = Transport::TransferRequest::WRITE;
+    ok.source = src.data();
+    ok.target_id = kPeerSegmentId;
+    ok.target_offset = kRemoteAddress;
+    ok.length = page_size;
+
+    Transport::TransferRequest bad = ok;
+    bad.target_offset = kRemoteAddress + page_size * 8;
+
+    auto batch = transport.allocateBatchID(2);
+    ASSERT_NE(batch, static_cast<Transport::BatchID>(ERR_MEMORY));
+    auto status = transport.submitTransfer(batch, {ok, bad});
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(static_cast<unsigned char*>(shm_file.addr())[0], 0x11);
+    ASSERT_TRUE(transport.freeBatchID(batch).ok());
+}
+
+TEST(ShmTransportTest, LocalSegmentCopiesWithoutShmOpen) {
+    const size_t length = 4096;
+    std::vector<char> src(length, 0x44);
+    std::vector<char> dst(length, 0);
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    Transport::TransferRequest req;
+    req.opcode = Transport::TransferRequest::WRITE;
+    req.source = src.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(dst.data());
+    req.length = length;
+
+    auto batch = transport.allocateBatchID(1);
+    ASSERT_TRUE(transport.submitTransfer(batch, {req}).ok());
+    Transport::TransferStatus st;
+    ASSERT_TRUE(transport.getTransferStatus(batch, 0, st).ok());
+    EXPECT_EQ(st.s, Transport::TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(dst, src);
+    ASSERT_TRUE(transport.freeBatchID(batch).ok());
+}
+
+TEST(ShmTransportTest, RegisterRejectsSubRangeAndOverflow) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    void* base = transport.allocateSharedMemory(page_size * 2);
+    ASSERT_NE(base, nullptr);
+    auto* mid = static_cast<char*>(base) + page_size;
+    EXPECT_EQ(
+        ShmTransportTestPeer::registerLocalMemory(transport, mid, page_size),
+        ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(ShmTransportTestPeer::registerLocalMemory(transport, base,
+                                                        page_size * 2 + 1),
+              ERR_INVALID_ARGUMENT);
+
+    std::vector<char> heap(page_size);
+    EXPECT_EQ(ShmTransportTestPeer::registerLocalMemory(transport, heap.data(),
+                                                        page_size),
+              0);
+
+    ASSERT_EQ(
+        ShmTransportTestPeer::registerLocalMemory(transport, base, page_size),
+        0);
+    auto desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(desc);
+    ASSERT_EQ(desc->buffers.size(), 1u);
+    EXPECT_EQ(desc->buffers[0].addr, reinterpret_cast<uint64_t>(base));
+    EXPECT_EQ(desc->buffers[0].length, page_size);
+    EXPECT_TRUE(isPosixShmName(desc->buffers[0].shm_name));
+
+    ASSERT_EQ(transport.freeSharedMemory(base), 0);
+}
+
+TEST(ShmTransportTest, RegisterBatchSkipsMallocAndExportsShm) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+
+    std::vector<char> heap(page_size);
+    Transport::BufferEntry heap_entry{heap.data(), page_size};
+    EXPECT_EQ(
+        ShmTransportTestPeer::registerLocalMemoryBatch(transport, {heap_entry}),
+        0);
+    auto desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(desc);
+    for (const auto& buffer : desc->buffers) {
+        EXPECT_FALSE(isPosixShmName(buffer.shm_name));
+    }
+
+    void* base = transport.allocateSharedMemory(page_size);
+    ASSERT_NE(base, nullptr);
+    std::string shm_name;
+    ASSERT_TRUE(transport.getShmName(base, &shm_name));
+    ASSERT_FALSE(shm_name.empty());
+    EXPECT_EQ(shm_name.front(), '/');
+    EXPECT_TRUE(isPosixShmName(shm_name));
+
+    Transport::BufferEntry shm_entry{base, page_size};
+    EXPECT_EQ(ShmTransportTestPeer::registerLocalMemoryBatch(
+                  transport, {heap_entry, shm_entry}),
+              0);
+    desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(desc);
+    int posix_buffers = 0;
+    for (const auto& buffer : desc->buffers) {
+        if (isPosixShmName(buffer.shm_name)) ++posix_buffers;
+    }
+    EXPECT_EQ(posix_buffers, 1);
+    ASSERT_EQ(transport.freeSharedMemory(base), 0);
+}
+
+#ifndef ENABLE_MULTI_PROTOCOL
+TEST(ShmTransportTest, InstallReplacesNonShmProtocol) {
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    desc->name = "127.0.0.1:19000";
+    desc->protocol = "tcp";
+    metadata->addLocalSegment(LOCAL_SEGMENT_ID, desc->name, std::move(desc));
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+    auto installed = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(installed);
+    EXPECT_EQ(installed->protocol, "shm");
+}
+#endif
+
+#ifdef ENABLE_MULTI_PROTOCOL
+TEST(ShmTransportTest, InstallDoesNotTreatUbshmemAsShm) {
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    desc->name = "127.0.0.1:19000";
+    desc->protocol = "ubshmem";
+    metadata->addLocalSegment(LOCAL_SEGMENT_ID, desc->name, std::move(desc));
+
+    ShmTransport transport;
+    std::string local = "127.0.0.1:19000";
+    ASSERT_EQ(ShmTransportTestPeer::install(transport, local, metadata), 0);
+    auto installed = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(installed);
+    EXPECT_EQ(installed->protocol, "ubshmem,shm");
+}
+#endif
+
+class ShmRoutingTest : public ::testing::Test {
+   protected:
+    static constexpr uint64_t kRemoteAddr = 0x10000000;
+
+    void SetUp() override {
+        metadata_ = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+        local_name_ = "127.0.0.1:19000";
+        multi_ = std::make_unique<MultiTransport>(metadata_, local_name_);
+        ASSERT_NE(multi_->installTransport("shm", nullptr), nullptr);
+        shm_ = multi_->getTransport("shm");
+        ASSERT_NE(shm_, nullptr);
+    }
+
+    void AddBuffer(TransferMetadata::SegmentDesc& desc,
+                   const std::string& shm_name,
+                   const std::string& buffer_protocol) {
+        TransferMetadata::BufferDesc buffer;
+        buffer.name = "cpu:0";
+        buffer.addr = kRemoteAddr;
+        buffer.length = 4096;
+        buffer.shm_name = shm_name;
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer.protocol = buffer_protocol;
+#else
+        (void)buffer_protocol;
+#endif
+        desc.buffers.push_back(buffer);
+    }
+
+    Transport::SegmentID AddPeer(const std::string& segment_name,
+                                 const std::string& shm_name,
+                                 const std::string& protocol = "shm",
+                                 const std::string& buffer_protocol = "") {
+        auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+        desc->name = segment_name;
+        desc->protocol = protocol;
+        AddBuffer(*desc, shm_name,
+                  buffer_protocol.empty() ? protocol : buffer_protocol);
+        const Transport::SegmentID id = next_segment_id_++;
+        metadata_->addLocalSegment(id, segment_name, std::move(desc));
+        return id;
+    }
+
+    Transport::TransferRequest MakeWrite(Transport::SegmentID id) const {
+        Transport::TransferRequest request;
+        request.opcode = Transport::TransferRequest::WRITE;
+        request.source = nullptr;
+        request.target_id = id;
+        request.target_offset = kRemoteAddr;
+        request.length = 64;
+        return request;
+    }
+
+    std::shared_ptr<TransferMetadata> metadata_;
+    std::string local_name_;
+    std::unique_ptr<MultiTransport> multi_;
+    Transport* shm_{nullptr};
+    Transport::SegmentID next_segment_id_{10};
+};
+
+TEST_F(ShmRoutingTest, SameHostSelectsShm) {
+    auto id = AddPeer("127.0.0.1:19001", "mooncake_1_abcdefgh");
+    auto request = MakeWrite(id);
+    Transport* transport = nullptr;
+    auto status =
+        MultiTransportTestPeer::selectTransport(*multi_, request, transport);
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(transport, shm_);
+}
+
+#ifndef ENABLE_MULTI_PROTOCOL
+TEST_F(ShmRoutingTest, CrossHostStillSelectsShmWithoutMultiProtocol) {
+    auto id = AddPeer("10.0.0.2:19001", "mooncake_1_abcdefgh");
+    auto request = MakeWrite(id);
+    Transport* transport = nullptr;
+    auto status =
+        MultiTransportTestPeer::selectTransport(*multi_, request, transport);
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(transport, shm_);
+}
+#endif
+
+#ifdef ENABLE_MULTI_PROTOCOL
+TEST_F(ShmRoutingTest, SameHostShmBeatsTcp) {
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    desc->name = "127.0.0.1:19001";
+    desc->protocol = "tcp,shm";
+    AddBuffer(*desc, "", "tcp");
+    AddBuffer(*desc, "mooncake_1_abcdefgh", "shm");
+    const auto id = next_segment_id_++;
+    metadata_->addLocalSegment(id, desc->name, std::move(desc));
+
+    auto request = MakeWrite(id);
+    Transport* transport = nullptr;
+    auto status =
+        MultiTransportTestPeer::selectTransport(*multi_, request, transport);
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(transport, shm_);
+}
+
+TEST_F(ShmRoutingTest, CrossHostSkipsShm) {
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    desc->name = "10.0.0.2:19001";
+    desc->protocol = "tcp,shm";
+    AddBuffer(*desc, "", "tcp");
+    AddBuffer(*desc, "mooncake_1_abcdefgh", "shm");
+    const auto id = next_segment_id_++;
+    metadata_->addLocalSegment(id, desc->name, std::move(desc));
+
+    auto request = MakeWrite(id);
+    Transport* transport = nullptr;
+    auto status =
+        MultiTransportTestPeer::selectTransport(*multi_, request, transport);
+    EXPECT_TRUE(status.IsNotSupportedTransport()) << status.ToString();
+    EXPECT_NE(transport, shm_);
+}
+
+TEST_F(ShmRoutingTest, TcpOnlyBufferDoesNotSelectShm) {
+    auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    desc->name = "127.0.0.1:19001";
+    desc->protocol = "tcp,shm";
+    AddBuffer(*desc, "", "tcp");
+    const auto id = next_segment_id_++;
+    metadata_->addLocalSegment(id, desc->name, std::move(desc));
+
+    auto request = MakeWrite(id);
+    Transport* transport = nullptr;
+    auto status =
+        MultiTransportTestPeer::selectTransport(*multi_, request, transport);
+    EXPECT_TRUE(status.IsNotSupportedTransport()) << status.ToString();
+    EXPECT_NE(transport, shm_);
+}
+
+TEST_F(ShmRoutingTest, HipBufferDoesNotSelectShm) {
+    auto id =
+        AddPeer("127.0.0.1:19001", "mooncake_1_abcdefgh", "tcp,hip", "hip");
+    auto request = MakeWrite(id);
+    Transport* transport = nullptr;
+    auto status =
+        MultiTransportTestPeer::selectTransport(*multi_, request, transport);
+    EXPECT_TRUE(status.IsNotSupportedTransport()) << status.ToString();
+    EXPECT_NE(transport, shm_);
+}
+#endif
+
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Add an opt-in POSIX SHM transport to classic Transfer Engine so same-host, different-process DRAM copies can `memcpy` instead of looping through RDMA/TCP.

Modeled on TENT `ShmTransport` and installed as a first-class protocol like HIP (not an overlay on rdma/tcp buffers, and not an extension of `CxlTransport`). RFC: https://github.com/kvcache-ai/Mooncake/issues/3912

- New `ShmTransport`: named POSIX shm, peer-VA relocate, synchronous `memcpy`
- `TransferEngine::allocateSharedMemory` / `freeSharedMemory` (ordinary `malloc` cannot be exported)
- Runtime opt-in: `MC_FORCE_SHM=1` (or `installTransport("shm")`)
  - With `-DENABLE_MULTI_PROTOCOL=ON`: SHM is added next to RDMA/TCP (`rdma,shm` / `tcp,shm`)
  - Without MP: SHM-only, like `MC_FORCE_TCP`
- tebench: `--xport_type=shm`

Store allocator changes are follow-up (PR-B).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
ctest --test-dir build-shm -R 'shm_transport|multi_transport_locality' --output-on-failure

# classic tebench, same host, 1 thread, batch=1, 2s, 256 MiB DRAM, no consistency mix
./tebench --backend=classic --xport_type=shm --seg_type=DRAM --metadata_type=p2p \
  --total_buffer_size=268435456 --start_block_size=4096 --max_block_size=16777216 \
  --start_batch_size=1 --max_batch_size=1 --start_num_threads=1 --max_num_threads=1 \
  --duration=2 --op_type=write   # then --op_type=read
```

**Test results:**
- [x] Unit tests pass (`shm_transport_test`, `shm_transport_e2e_test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Local classic tebench, same host, `--xport_type=shm`, 1 thread / batch=1 / 2s / 256 MiB DRAM. Logs show `Remapped shared memory`. `--check_consistency` is a WRITE+READ+verify mix and is not used for bandwidth.

| BlkSize | Write BW (GB/s) | Write Avg Lat (us) | Read BW (GB/s) | Read Avg Lat (us) |
|---:|---:|---:|---:|---:|
| 4 KiB | 2.78 | 1.5 | 2.95 | 1.4 |
| 8 KiB | 5.41 | 1.5 | 5.47 | 1.5 |
| 16 KiB | 9.23 | 1.8 | 9.57 | 1.7 |
| 32 KiB | 15.54 | 2.1 | 15.65 | 2.1 |
| 64 KiB | 24.31 | 2.7 | 25.10 | 2.6 |
| 128 KiB | 34.35 | 3.8 | 34.90 | 3.8 |
| 256 KiB | 40.95 | 6.4 | 39.21 | 6.7 |
| 512 KiB | 39.70 | 13.2 | 39.57 | 13.3 |
| 1 MiB | 43.04 | 24.4 | 43.17 | 24.3 |
| 2 MiB | 45.60 | 46.0 | 45.56 | 46.0 |
| 4 MiB | 46.90 | 89.4 | 46.84 | 89.5 |
| 8 MiB | 44.15 | 190.0 | 43.77 | 191.6 |
| 16 MiB | 30.64 | 547.5 | 30.00 | 559.3 |

Peak ~47 GB/s at 4 MiB for both write and read. Same-VM TCP loopback on this host was ~1.15 GB/s at 1 MiB.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok 4.6 helped implement classic TE `ShmTransport`, metadata/routing, tests, docs, and this PR. The human submitter is responsible for reviewing and defending every changed line.

Made with [Cursor](https://cursor.com)