### PR TITLE
[Fix] TENT gid lid refresh

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -43,6 +43,18 @@ class RdmaEndPoint;
 class EndpointStore;
 class RdmaTransport;
 
+struct RdmaAddressSnapshot {
+    uint16_t lid = 0;
+    std::string gid;
+    int gid_index = -1;
+};
+
+enum class RdmaAddressRefreshResult {
+    UNCHANGED = 0,
+    CHANGED = 1,
+    FAILED = 2,
+};
+
 class RdmaContext {
     friend class RdmaCQ;
     friend class RdmaEndPoint;
@@ -101,11 +113,22 @@ class RdmaContext {
     const std::string name() const { return device_name_; }
 
    public:
-    uint16_t lid() const { return lid_; }
+    // Take lid/gid/index under one lock so a bootstrap never mixes values from
+    // two address generations while the monitor thread refreshes the port.
+    RdmaAddressSnapshot address() const;
 
-    std::string gid() const;
+    uint16_t lid() const { return address().lid; }
 
-    int gidIndex() const { return gid_index_; }
+    std::string gid() const { return address().gid; }
+
+    int gidIndex() const { return address().gid_index; }
+
+    // Re-query the port's LID and GID. Auto-GID mode repeats the initial
+    // selection; an explicit gid_index keeps that index and refreshes its
+    // value. The new address is published before it becomes visible locally.
+    RdmaAddressRefreshResult refreshAddress(
+        RdmaAddressSnapshot *previous = nullptr,
+        RdmaAddressSnapshot *current = nullptr);
 
     ibv_context *nativeContext() const { return native_context_; }
 
@@ -193,6 +216,11 @@ class RdmaContext {
     size_t num_comp_channel_ = 0;
     std::vector<ibv_comp_channel *> comp_channel_;
 
+    // The monitor thread may refresh these while bootstrap handlers read
+    // them. address_mutex_ keeps each lid/gid/index snapshot self-consistent;
+    // address_refresh_mutex_ serializes hardware reprobes and publication.
+    mutable std::mutex address_mutex_;
+    std::mutex address_refresh_mutex_;
     uint16_t lid_ = 0;
     // Set by openDevice() and refreshed by refreshPortAttributes() on the
     // monitor thread. Today every runtime reader is that same thread;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -187,11 +187,12 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
    private:
     int setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
-                    std::vector<uint32_t> peer_qp_num_list,
+                    std::vector<uint32_t> peer_qp_num_list, int local_gid_index,
                     std::string* reply_msg = nullptr);
 
     int setupOneQP(int qp_index, const std::string& peer_gid, uint16_t peer_lid,
-                   uint32_t peer_qp_num, std::string* reply_msg = nullptr);
+                   uint32_t peer_qp_num, int local_gid_index,
+                   std::string* reply_msg = nullptr);
 
     // Returns the pool segment owning qp_index, or nullptr when no pools are
     // configured (the default single-pool case). Read-only after construct().
@@ -225,6 +226,9 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     RdmaContext* context_;
     EndPointParams* params_;
     std::string endpoint_name_;
+    // Immutable address generation used to create this endpoint's QPs and
+    // bootstrap descriptors. A context refresh evicts the whole endpoint.
+    RdmaAddressSnapshot local_address_;
 
     std::vector<ibv_qp*> qp_list_;
     // Per-pool QP layout, resolved once in construct() from params_->qp_pools.

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -122,6 +122,11 @@ class RdmaTransport : public Transport {
    public:
     Status setupLocalSegment();
 
+    // Update one RNIC's published address after a GID/LID change. The local
+    // descriptor is rolled back if registry synchronization fails.
+    Status refreshLocalDeviceDesc(const std::string& device_name, uint16_t lid,
+                                  const std::string& gid);
+
     std::shared_ptr<Config> config() const { return conf_; }
 
    private:

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -189,10 +189,14 @@ class Workers {
     void applyContextEvent(int dev_id, RdmaContext& context,
                            const ibv_async_event& event);
 
-    // Everything a recovered port needs: resume the context, re-seed its
-    // bandwidth and make it selectable again. Shared by the
-    // IBV_EVENT_PORT_ACTIVE path and by resumePausedContexts().
-    void activateContext(int dev_id, RdmaContext& context);
+    // Re-query and publish one context's GID/LID.
+    RdmaAddressRefreshResult refreshAddress(RdmaContext& context);
+
+    // Everything a recovered port needs: refresh its address, resume the
+    // context, re-seed its bandwidth and make it selectable again. Shared by
+    // the IBV_EVENT_PORT_ACTIVE path and by resumePausedContexts(). Returns
+    // false when the address cannot be refreshed, keeping the context paused.
+    bool activateContext(int dev_id, RdmaContext& context);
 
     // Re-read the link speed after a port event and re-seed the selector if
     // it changed; a link that returns at the same speed keeps what it

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -512,14 +512,17 @@ void RdmaContext::evictEndpoints() {
 }
 
 int RdmaContext::resume() {
-    DeviceStatus expected = DEVICE_PAUSED;
-    status_.compare_exchange_strong(expected, DEVICE_ENABLED);
-    if (expected != DEVICE_PAUSED) return -1;
-    // Port recovered: evict all cached endpoints so stale QPs (which may
-    // have entered IBV_QPS_ERR while the link was down) are torn down and
-    // rebuilt on the next getOrInsert() call.
+    if (status_.load(std::memory_order_acquire) != DEVICE_PAUSED) return -1;
+    // Keep the context paused while old QPs are retired. Publishing ENABLED
+    // first lets a concurrent bootstrap reuse an EP_READY endpoint from the
+    // previous address generation.
     evictEndpoints();
-    return 0;
+    DeviceStatus expected = DEVICE_PAUSED;
+    return status_.compare_exchange_strong(expected, DEVICE_ENABLED,
+                                           std::memory_order_release,
+                                           std::memory_order_relaxed)
+               ? 0
+               : -1;
 }
 
 RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
@@ -659,15 +662,89 @@ int RdmaContext::unregisterMemReg(MemReg id) {
     return 0;
 }
 
-std::string RdmaContext::gid() const {
-    std::string gid_str;
-    char buf[16] = {0};
-    const static size_t kGidLength = 16;
-    for (size_t i = 0; i < kGidLength; ++i) {
-        sprintf(buf, "%02x", gid_.raw[i]);
-        gid_str += i == 0 ? buf : std::string(":") + buf;
+RdmaAddressSnapshot RdmaContext::address() const {
+    std::lock_guard<std::mutex> guard(address_mutex_);
+    return {lid_, gidBytesToString(gid_.raw), gid_index_};
+}
+
+RdmaAddressRefreshResult RdmaContext::refreshAddress(
+    RdmaAddressSnapshot* previous, RdmaAddressSnapshot* current) {
+    std::lock_guard<std::mutex> refresh_guard(address_refresh_mutex_);
+    const auto old_address = address();
+    if (previous) *previous = old_address;
+    if (!native_context_ || !params_) return RdmaAddressRefreshResult::FAILED;
+
+    ibv_port_attr port_attr{};
+    const uint8_t port = params_->device.port;
+    if (verbs_.ibv_query_port_default(native_context_, port, &port_attr)) {
+        PLOG(WARNING) << "Failed to refresh RDMA address on " << device_name_
+                      << "/" << static_cast<int>(port);
+        return RdmaAddressRefreshResult::FAILED;
     }
-    return gid_str;
+    if (port_attr.state != IBV_PORT_ACTIVE) {
+        LOG(WARNING) << "Cannot refresh RDMA address on " << device_name_ << "/"
+                     << static_cast<int>(port) << " while port state is "
+                     << port_attr.state;
+        return RdmaAddressRefreshResult::FAILED;
+    }
+
+    int next_gid_index = params_->device.gid_index;
+    if (next_gid_index < 0) {
+        if (getBestGidIndex(device_name_, native_context_, port_attr, port,
+                            next_gid_index) == GidNetworkState::GID_NOT_FOUND) {
+            LOG(WARNING) << "No suitable GID found while refreshing "
+                         << device_name_ << "/" << static_cast<int>(port);
+            return RdmaAddressRefreshResult::FAILED;
+        }
+    }
+    if (next_gid_index < 0 || next_gid_index >= port_attr.gid_tbl_len) {
+        LOG(WARNING) << "Refreshed GID index " << next_gid_index
+                     << " is out of range [0, " << port_attr.gid_tbl_len
+                     << ") for " << device_name_;
+        return RdmaAddressRefreshResult::FAILED;
+    }
+
+    ibv_gid next_gid{};
+    if (verbs_.ibv_query_gid(native_context_, port, next_gid_index,
+                             &next_gid)) {
+        PLOG(WARNING) << "Failed to refresh GID " << next_gid_index << " on "
+                      << device_name_ << "/" << static_cast<int>(port);
+        return RdmaAddressRefreshResult::FAILED;
+    }
+    if (isNullGid(&next_gid)) {
+        LOG(WARNING) << "Refreshed GID " << next_gid_index << " on "
+                     << device_name_ << "/" << static_cast<int>(port)
+                     << " is empty";
+        return RdmaAddressRefreshResult::FAILED;
+    }
+
+    RdmaAddressSnapshot next_address{
+        port_attr.lid, gidBytesToString(next_gid.raw), next_gid_index};
+    if (current) *current = next_address;
+    const bool changed = next_address.lid != old_address.lid ||
+                         next_address.gid != old_address.gid ||
+                         next_address.gid_index != old_address.gid_index;
+
+    // Publish even when the address is unchanged: a context whose port was
+    // down during setupLocalSegment() was omitted and must be inserted when
+    // it recovers.
+    auto status = transport_.refreshLocalDeviceDesc(
+        device_name_, next_address.lid, next_address.gid);
+    if (!status.ok()) {
+        LOG(ERROR) << "Failed to publish refreshed RDMA address for "
+                   << device_name_ << ": " << status.ToString();
+        return RdmaAddressRefreshResult::FAILED;
+    }
+
+    if (!changed) return RdmaAddressRefreshResult::UNCHANGED;
+
+    {
+        std::lock_guard<std::mutex> guard(address_mutex_);
+        lid_ = next_address.lid;
+        gid_ = next_gid;
+        gid_index_ = next_address.gid_index;
+    }
+    return RdmaAddressRefreshResult::CHANGED;
 }
 
 RdmaCQ* RdmaContext::cq(int index) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -503,8 +503,14 @@ void RdmaContext::cleanupResources() {
 
 int RdmaContext::pause() {
     DeviceStatus expected = DEVICE_ENABLED;
-    status_.compare_exchange_strong(expected, DEVICE_PAUSED);
-    return (expected == DEVICE_PAUSED) ? 0 : -1;
+    if (status_.compare_exchange_strong(expected, DEVICE_PAUSED,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire)) {
+        return 0;
+    }
+    // Pausing is idempotent. Other states (UNINIT/DISABLED) must not proceed
+    // into hardware reprobe or metadata publication.
+    return expected == DEVICE_PAUSED ? 0 : -1;
 }
 
 void RdmaContext::evictEndpoints() {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -56,12 +56,10 @@ static inline const std::string statusToString(
 }
 
 // Forward declaration for notification QP setup
-static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
-                                   const std::string& peer_gid_str,
-                                   uint16_t peer_lid, uint32_t peer_qp_num,
-                                   uint16_t pkey_index,
-                                   uint8_t service_level = 0,
-                                   uint8_t traffic_class = 0);
+static int setupNotifyQpConnection(
+    ibv_qp* qp, RdmaContext* ctx, int local_gid_index,
+    const std::string& peer_gid_str, uint16_t peer_lid, uint32_t peer_qp_num,
+    uint16_t pkey_index, uint8_t service_level = 0, uint8_t traffic_class = 0);
 
 // A peer that reused the same nic path after restarting retires the stale
 // endpoint on the first bootstrap and expects a retry. Older peers also
@@ -98,6 +96,7 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
     context_ = context;
     params_ = params;
     endpoint_name_ = endpoint_name;
+    local_address_ = context_->address();
     inflight_slices_.store(0, std::memory_order_relaxed);
 
     // Resolve the per-pool QP layout (see computeQpPoolSegments). Empty
@@ -406,6 +405,7 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
     auto& transport = context_->transport_;
     std::vector<uint32_t> qp_num;
     BootstrapDesc local_desc, peer_desc;
+    const auto& local_address = local_address_;
     bool same_nic = false;
     bool is_self = false;
 
@@ -433,8 +433,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         qp_num = qpNum();
         local_desc.qp_num = qp_num;
         local_desc.notify_qp_num = notifyQpNum();
-        local_desc.local_lid = context_->lid();
-        local_desc.local_gid = context_->gid();
+        local_desc.local_lid = local_address.lid;
+        local_desc.local_gid = local_address.gid;
 
         same_nic = (local_desc.local_nic_path == local_desc.peer_nic_path);
         is_self =
@@ -448,8 +448,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
     std::string peer_gid;
     uint16_t peer_lid = 0;
     if (same_nic) {
-        peer_gid = context_->gid();
-        peer_lid = context_->lid();
+        peer_gid = local_address.gid;
+        peer_lid = local_address.lid;
     } else if (is_self) {
         // Same server, different NIC: call handler directly, bypass RPC
         int rc = transport.onSetupRdmaConnections(local_desc, peer_desc);
@@ -550,7 +550,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         assert(qp_num.size());
         peer_server_name_ = peer_server_name;
         peer_nic_name_ = peer_nic_name;
-        int rc = setupAllQPs(peer_gid, peer_lid, qp_num);
+        int rc =
+            setupAllQPs(peer_gid, peer_lid, qp_num, local_address.gid_index);
         if (rc) {
             beginDestroyNoLock();
             return mooncake::tent::Status::InternalError(
@@ -561,8 +562,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         // Setup notification QP connection if peer supports it
         if (peer_desc.notify_qp_num != 0 && notify_qp_) {
             rc = setupNotifyQpConnection(
-                notify_qp_, context_, peer_gid, peer_lid,
-                peer_desc.notify_qp_num, params_->pkey_index,
+                notify_qp_, context_, local_address.gid_index, peer_gid,
+                peer_lid, peer_desc.notify_qp_num, params_->pkey_index,
                 params_->service_level, params_->traffic_class);
             if (rc) {
                 LOG(WARNING)
@@ -605,8 +606,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
                 MakeNicPath(transport.rdma_server_name_, context_->name());
             local_desc.peer_nic_path = peer_desc.local_nic_path;
             local_desc.qp_num = qpNum();
-            local_desc.local_lid = context_->lid();
-            local_desc.local_gid = context_->gid();
+            local_desc.local_lid = local_address_.lid;
+            local_desc.local_gid = local_address_.gid;
             local_desc.notify_qp_num = notifyQpNum();
             return mooncake::tent::Status::OK();
         }
@@ -641,8 +642,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
         MakeNicPath(transport.rdma_server_name_, context_->name());
     local_desc.peer_nic_path = peer_nic_path;
     local_desc.qp_num = qpNum();
-    local_desc.local_lid = context_->lid();
-    local_desc.local_gid = context_->gid();
+    local_desc.local_lid = local_address_.lid;
+    local_desc.local_gid = local_address_.gid;
     local_desc.notify_qp_num = notifyQpNum();  // Pass notification QP number
     if (peer_desc.local_gid.empty()) {
         return mooncake::tent::Status::InvalidArgument(
@@ -650,8 +651,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     }
     peer_server_name_ = peer_server_name;
     peer_nic_name_ = peer_nic_name;
-    int rc =
-        setupAllQPs(peer_desc.local_gid, peer_desc.local_lid, peer_desc.qp_num);
+    int rc = setupAllQPs(peer_desc.local_gid, peer_desc.local_lid,
+                         peer_desc.qp_num, local_address_.gid_index);
     if (rc) {
         beginDestroyNoLock();
         return mooncake::tent::Status::InternalError(
@@ -662,8 +663,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     // Setup notification QP connection if peer supports it
     if (peer_desc.notify_qp_num != 0 && notify_qp_) {
         rc = setupNotifyQpConnection(
-            notify_qp_, context_, peer_desc.local_gid, peer_desc.local_lid,
-            peer_desc.notify_qp_num, params_->pkey_index,
+            notify_qp_, context_, local_address_.gid_index, peer_desc.local_gid,
+            peer_desc.local_lid, peer_desc.notify_qp_num, params_->pkey_index,
             params_->service_level, params_->traffic_class);
         if (rc) {
             notify_connected_ = false;
@@ -713,7 +714,7 @@ const QpPoolSegment* RdmaEndPoint::poolForQp(int qp_index) const {
 
 int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
                               std::vector<uint32_t> peer_qp_num_list,
-                              std::string* reply_msg) {
+                              int local_gid_index, std::string* reply_msg) {
     if (status_.load(std::memory_order_relaxed) == EP_READY) {
         return -1;
     }
@@ -729,8 +730,9 @@ int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
     }
 
     for (int qp_index = 0; qp_index < (int)qp_list_.size(); ++qp_index) {
-        int ret = setupOneQP(qp_index, peer_gid, peer_lid,
-                             peer_qp_num_list[qp_index], reply_msg);
+        int ret =
+            setupOneQP(qp_index, peer_gid, peer_lid, peer_qp_num_list[qp_index],
+                       local_gid_index, reply_msg);
         if (ret) {
             return ret;
         }
@@ -925,7 +927,7 @@ void RdmaEndPoint::cancelQuota(int qp_index, int num_entries) {
 
 int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
                              uint16_t peer_lid, uint32_t peer_qp_num,
-                             std::string* reply_msg) {
+                             int local_gid_index, std::string* reply_msg) {
     assert(qp_index >= 0 && qp_index < (int)qp_list_.size());
     auto& qp = qp_list_[qp_index];
 
@@ -978,7 +980,7 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
     }
 
     attr.ah_attr.grh.dgid = peer_gid_raw;
-    attr.ah_attr.grh.sgid_index = context().gidIndex();
+    attr.ah_attr.grh.sgid_index = local_gid_index;
     attr.ah_attr.grh.hop_limit = params_->hop_limit;
     attr.ah_attr.grh.flow_label = params_->flow_label;
     attr.ah_attr.grh.traffic_class = qp_traffic_class;
@@ -1105,6 +1107,7 @@ void RdmaEndPoint::repostAllNotifyRecvs() {
 }
 
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
+                                   int local_gid_index,
                                    const std::string& peer_gid_str,
                                    uint16_t peer_lid, uint32_t peer_qp_num,
                                    uint16_t pkey_index, uint8_t service_level,
@@ -1157,7 +1160,7 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
     qp_attr.ah_attr.port_num = ctx->portNum();
     memcpy(&qp_attr.ah_attr.grh.dgid, &peer_gid, 16);
     qp_attr.ah_attr.grh.flow_label = 0;
-    qp_attr.ah_attr.grh.sgid_index = ctx->gidIndex();
+    qp_attr.ah_attr.grh.sgid_index = local_gid_index;
     qp_attr.ah_attr.grh.hop_limit = 255;
     qp_attr.ah_attr.grh.traffic_class = traffic_class;
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -20,6 +20,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
@@ -633,6 +634,67 @@ Status RdmaTransport::removeMemoryBuffer(BufferDesc& desc) {
     return local_buffer_manager_.removeBuffer(desc);
 }
 
+Status RdmaTransport::refreshLocalDeviceDesc(const std::string& device_name,
+                                             uint16_t lid,
+                                             const std::string& gid) {
+    if (!metadata_)
+        return Status::InvalidArgument(
+            "RDMA metadata is not initialized" LOC_MARK);
+
+    auto& manager = metadata_->segmentManager();
+    bool existed = false;
+    uint16_t previous_lid = 0;
+    std::string previous_gid;
+    CHECK_STATUS(manager.updateLocal([&](SegmentDesc& segment) -> Status {
+        if (segment.type != SegmentType::Memory)
+            return Status::InvalidArgument(
+                "Local segment is not a memory segment" LOC_MARK);
+        auto* device = segment.findDevice(device_name);
+        if (!device) {
+            auto& detail = std::get<MemorySegmentDesc>(segment.detail);
+            DeviceDesc added;
+            added.name = device_name;
+            added.lid = lid;
+            added.gid = gid;
+            detail.devices.push_back(std::move(added));
+            return Status::OK();
+        }
+        existed = true;
+        previous_lid = device->lid;
+        previous_gid = device->gid;
+        device->lid = lid;
+        device->gid = gid;
+        return Status::OK();
+    }));
+
+    auto status = manager.synchronizeLocal();
+    if (status.ok()) return status;
+
+    auto rollback = manager.updateLocal([&](SegmentDesc& segment) -> Status {
+        if (segment.type != SegmentType::Memory)
+            return Status::InvalidArgument(
+                "Local segment is not a memory segment" LOC_MARK);
+        auto& devices = std::get<MemorySegmentDesc>(segment.detail).devices;
+        auto it = std::find_if(devices.begin(), devices.end(),
+                               [&](const DeviceDesc& device) {
+                                   return device.name == device_name;
+                               });
+        if (it == devices.end()) return Status::OK();
+        if (!existed) {
+            devices.erase(it);
+        } else {
+            it->lid = previous_lid;
+            it->gid = previous_gid;
+        }
+        return Status::OK();
+    });
+    if (!rollback.ok()) {
+        LOG(ERROR) << "Failed to roll back RDMA address metadata for "
+                   << device_name << ": " << rollback.ToString();
+    }
+    return status;
+}
+
 Status RdmaTransport::setupLocalSegment() {
     auto& manager = metadata_->segmentManager();
     CHECK_STATUS(manager.updateLocal([&](SegmentDesc& segment) -> Status {
@@ -646,8 +708,9 @@ Status RdmaTransport::setupLocalSegment() {
             if (context->status() != RdmaContext::DEVICE_ENABLED) continue;
             DeviceDesc device_desc;
             device_desc.name = context->name();
-            device_desc.lid = context->lid();
-            device_desc.gid = context->gid();
+            const auto address = context->address();
+            device_desc.lid = address.lid;
+            device_desc.gid = address.gid;
             detail.devices.push_back(device_desc);
         }
         return Status::OK();
@@ -668,10 +731,9 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     auto index = context_name_lookup_[local_nic_name];
     auto context = context_set_[index];
     auto ctx_status = context->status();
-    if (ctx_status != RdmaContext::DEVICE_ENABLED &&
-        ctx_status != RdmaContext::DEVICE_PAUSED) {
+    if (ctx_status != RdmaContext::DEVICE_ENABLED) {
         std::stringstream ss;
-        ss << "Device is down: " << peer_desc.local_nic_path;
+        ss << "Device is not ready: " << peer_desc.local_nic_path;
         LOG(ERROR) << ss.str();
         local_desc.reply_msg = ss.str();
         return -1;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -1300,7 +1300,15 @@ RdmaAddressRefreshResult Workers::refreshAddress(RdmaContext& context) {
 bool Workers::activateContext(int dev_id, RdmaContext& context) {
     // Stop new work from selecting this NIC while its address generation is
     // being replaced. Incoming bootstrap also rejects paused contexts.
-    context.pause();
+    if (context.pause() != 0 ||
+        context.status() != RdmaContext::DEVICE_PAUSED) {
+        if (device_selector_)
+            device_selector_->setDeviceAvailable(dev_id, false);
+        LOG(WARNING) << "Action: " << context.name()
+                     << " cannot refresh RDMA address from context state "
+                     << context.status();
+        return false;
+    }
     if (device_selector_) device_selector_->setDeviceAvailable(dev_id, false);
 
     auto result = refreshAddress(context);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -1202,9 +1202,25 @@ void Workers::applyContextEvent(int dev_id, RdmaContext& context,
                 // flows.
                 device_selector_->setDeviceAvailable(dev_id, false);
                 LOG(WARNING) << "Action: " << context.name() << " down";
-            } else {
-                activateContext(dev_id, context);
+            } else if (activateContext(dev_id, context)) {
                 LOG(WARNING) << "Action: " << context.name() << " up";
+            }
+            break;
+        }
+        case IBV_EVENT_GID_CHANGE:
+        case IBV_EVENT_LID_CHANGE: {
+            if (event.element.port_num != context.portNum()) {
+                LOG(INFO) << context.name() << ": ignoring "
+                          << ibv_event_type_str(event.event_type)
+                          << " for port " << event.element.port_num
+                          << " (this context uses port "
+                          << static_cast<int>(context.portNum()) << ")";
+                break;
+            }
+            if (activateContext(dev_id, context)) {
+                LOG(WARNING)
+                    << "Action: " << context.name() << " refreshed after "
+                    << ibv_event_type_str(event.event_type);
             }
             break;
         }
@@ -1222,12 +1238,44 @@ void Workers::applyContextEvent(int dev_id, RdmaContext& context,
     }
 }
 
-void Workers::activateContext(int dev_id, RdmaContext& context) {
-    context.resume();
+RdmaAddressRefreshResult Workers::refreshAddress(RdmaContext& context) {
+    RdmaAddressSnapshot previous;
+    RdmaAddressSnapshot current;
+    auto result = context.refreshAddress(&previous, &current);
+    if (result == RdmaAddressRefreshResult::CHANGED) {
+        LOG(WARNING) << "Refreshed RDMA address for " << context.name()
+                     << ": LID " << previous.lid << " -> " << current.lid
+                     << ", GID[" << previous.gid_index << "] " << previous.gid
+                     << " -> GID[" << current.gid_index << "] " << current.gid;
+    } else if (result == RdmaAddressRefreshResult::UNCHANGED) {
+        VLOG(1) << "RDMA address for " << context.name() << " is unchanged";
+    }
+    return result;
+}
+
+bool Workers::activateContext(int dev_id, RdmaContext& context) {
+    // Stop new work from selecting this NIC while its address generation is
+    // being replaced. Incoming bootstrap also rejects paused contexts.
+    context.pause();
+    if (device_selector_) device_selector_->setDeviceAvailable(dev_id, false);
+
+    auto result = refreshAddress(context);
+    if (result == RdmaAddressRefreshResult::FAILED) {
+        LOG(WARNING) << "Action: " << context.name()
+                     << " remains down because its RDMA address could not be "
+                        "refreshed";
+        return false;
+    }
+
+    // resume() evicts every endpoint built with the previous address before
+    // the NIC becomes selectable again. This is deliberately conservative for
+    // a spurious change event whose queried value is unchanged.
+    if (context.resume() != 0) return false;
     // The link may have renegotiated while down: re-seed before the device
     // becomes selectable so no worker scores it on the old rate.
     refreshLinkSpeed(dev_id, context);
     if (device_selector_) device_selector_->setDeviceAvailable(dev_id, true);
+    return true;
 }
 
 void Workers::refreshLinkSpeed(int dev_id, RdmaContext& context) {

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -1026,6 +1026,28 @@ TEST_F(RdmaAddressRefreshEventTest, AddressEventForAnotherPortIsIgnored) {
 }
 
 TEST_F(RdmaAddressRefreshEventTest,
+       NonPausableContextSkipsAddressAndMetadataRefresh) {
+    ibv_gid old_gid{};
+    old_gid.raw[15] = kOldGidByte;
+    RdmaContextTestPeer::seedAddress(*context_, kDeviceName, kOldLid,
+                                     fake_port.expected_gid_index, old_gid,
+                                     RdmaContext::DEVICE_DISABLED);
+    const auto before = context_->address();
+
+    fire(IBV_EVENT_GID_CHANGE);
+
+    EXPECT_EQ(fake_port.query_gid_calls, 0);
+    EXPECT_EQ(context_->status(), RdmaContext::DEVICE_DISABLED);
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+    const auto after = context_->address();
+    EXPECT_EQ(after.lid, before.lid);
+    EXPECT_EQ(after.gid, before.gid);
+    const auto published = publishedDevice();
+    EXPECT_EQ(published.lid, before.lid);
+    EXPECT_EQ(published.gid, before.gid);
+}
+
+TEST_F(RdmaAddressRefreshEventTest,
        AddressChangeWhilePortDownKeepsNicUnavailable) {
     fake_port.state = IBV_PORT_DOWN;
     const auto before = context_->address();
@@ -2197,6 +2219,36 @@ TEST_F(RdmaContextEventTest, RecoveryPollLeavesInertContextsAlone) {
     RdmaTransportTestPeer::resumePausedContexts(*workers_);
 
     EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+}
+
+TEST(RdmaContextPauseTest, TransitionAndAlreadyPausedAreSuccessful) {
+    RdmaTransport transport;
+    RdmaContext context(transport);
+    ibv_gid gid{};
+    gid.raw[15] = 1;
+    RdmaContextTestPeer::seedAddress(context, "fake-rnic", /*lid=*/1,
+                                     /*gid_index=*/0, gid,
+                                     RdmaContext::DEVICE_ENABLED);
+
+    EXPECT_EQ(context.pause(), 0);
+    EXPECT_EQ(context.status(), RdmaContext::DEVICE_PAUSED);
+    EXPECT_EQ(context.pause(), 0);  // idempotent
+    EXPECT_EQ(context.status(), RdmaContext::DEVICE_PAUSED);
+}
+
+TEST(RdmaContextPauseTest, RejectsUninitializedAndDisabledStates) {
+    RdmaTransport transport;
+    RdmaContext context(transport);
+    EXPECT_EQ(context.pause(), -1);
+    EXPECT_EQ(context.status(), RdmaContext::DEVICE_UNINIT);
+
+    ibv_gid gid{};
+    gid.raw[15] = 1;
+    RdmaContextTestPeer::seedAddress(context, "fake-rnic", /*lid=*/1,
+                                     /*gid_index=*/0, gid,
+                                     RdmaContext::DEVICE_DISABLED);
+    EXPECT_EQ(context.pause(), -1);
+    EXPECT_EQ(context.status(), RdmaContext::DEVICE_DISABLED);
 }
 
 TEST(RdmaContextPortStateTest, QueryOnInertContextIsRejected) {

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -56,6 +56,16 @@ class RdmaTransportTestPeer {
         transport.conf_ = std::make_shared<Config>();
     }
 
+    static void bindMetadata(RdmaTransport& transport,
+                             std::shared_ptr<ControlService> metadata) {
+        transport.metadata_ = std::move(metadata);
+    }
+
+    static void bindContexts(RdmaTransport& transport,
+                             RdmaContextSet contexts) {
+        transport.context_set_ = std::move(contexts);
+    }
+
     // Runs the monitorThread() 1 Hz reclaim tick without starting any worker
     // threads.
     static void reclaimEndpoints(RdmaTransport& transport) {
@@ -208,6 +218,18 @@ class RdmaContextTestPeer {
         context.endpoint_store_.reset();
     }
 
+    static void seedAddress(RdmaContext& context,
+                            const std::string& device_name, uint16_t lid,
+                            int gid_index, const ibv_gid& gid,
+                            RdmaContext::DeviceStatus status) {
+        std::lock_guard<std::mutex> guard(context.address_mutex_);
+        context.device_name_ = device_name;
+        context.lid_ = lid;
+        context.gid_index_ = gid_index;
+        context.gid_ = gid;
+        context.status_ = status;
+    }
+
     static void unbindDevice(RdmaContext& context) {
         context.native_context_ = nullptr;
     }
@@ -219,6 +241,10 @@ class RdmaContextTestPeer {
 // it and puts the slice on the queue pair the way submitSlices would.
 class RdmaEndPointTestPeer {
    public:
+    static RdmaAddressSnapshot localAddress(const RdmaEndPoint& endpoint) {
+        return endpoint.local_address_;
+    }
+
     static void pretendPosted(const std::shared_ptr<RdmaEndPoint>& endpoint,
                               int qp_index, RdmaSlice* slice) {
         ASSERT_TRUE(endpoint->reserveQuota(qp_index, 1));
@@ -589,13 +615,18 @@ class RdmaContextEventTest : public ::testing::Test {
     DeviceSelector* selector_ = nullptr;
 };
 
-TEST_F(RdmaContextEventTest, PortErrAndPortActiveFlipAvailability) {
+TEST_F(RdmaContextEventTest,
+       PortActiveKeepsDeviceUnavailableWhenAddressRefreshFails) {
     fire(IBV_EVENT_PORT_ERR, ourPort());
     EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
     EXPECT_LT(selector_->getAggregateEwmaBandwidth(), 0.0);
+
+    // This fixture deliberately has no usable verbs context. PORT_ACTIVE must
+    // not re-admit a NIC whose current address cannot be queried. The success
+    // path is covered by RdmaAddressRefreshEventTest below.
     fire(IBV_EVENT_PORT_ACTIVE, ourPort());
-    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
-    EXPECT_GT(selector_->getAggregateEwmaBandwidth(), 0.0);
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+    EXPECT_LT(selector_->getAggregateEwmaBandwidth(), 0.0);
 }
 
 TEST_F(RdmaContextEventTest, EventsForAnotherPortAreIgnored) {
@@ -642,7 +673,14 @@ struct FakePortVerbs {
     ibv_context native{};      // placeholder handle, never dereferenced
     uint8_t active_speed = 0;  // what ibv_query_port reports
     uint8_t active_width = 0;
+    ibv_port_state state = IBV_PORT_ACTIVE;
+    uint16_t lid = 0;
+    int gid_table_len = 8;
     int query_port_rc = 0;
+    ibv_gid gid{};
+    int expected_gid_index = 3;
+    int query_gid_rc = 0;
+    int query_gid_calls = 0;
     uint64_t speed_100mbps = 0;  // what ibv_query_port_speed reports
     int query_speed_rc = 0;
     int query_speed_calls = 0;
@@ -653,9 +691,24 @@ int fakeQueryPort(ibv_context* context, uint8_t, ibv_port_attr* attr) {
     if (context != &fake_port.native) return EINVAL;
     if (fake_port.query_port_rc) return fake_port.query_port_rc;
     *attr = {};
-    attr->state = IBV_PORT_ACTIVE;
+    attr->state = fake_port.state;
     attr->active_speed = fake_port.active_speed;
     attr->active_width = fake_port.active_width;
+    attr->lid = fake_port.lid;
+    attr->gid_tbl_len = fake_port.gid_table_len;
+    return 0;
+}
+
+int fakeQueryGid(ibv_context* context, uint8_t, int gid_index, ibv_gid* gid) {
+    ++fake_port.query_gid_calls;
+    if (context != &fake_port.native ||
+        gid_index != fake_port.expected_gid_index)
+        return EINVAL;
+    if (fake_port.query_gid_rc) {
+        errno = fake_port.query_gid_rc;
+        return fake_port.query_gid_rc;
+    }
+    *gid = fake_port.gid;
     return 0;
 }
 
@@ -679,9 +732,10 @@ class RdmaContextFakeVerbsTest : public ::testing::Test {
         context_ = std::make_unique<RdmaContext>(transport_);
         auto& verbs = RdmaContextTestPeer::verbs(*context_);
         verbs.ibv_query_port_default = fakeQueryPort;
+        verbs.ibv_query_gid = fakeQueryGid;
         verbs.ibv_query_port_speed = fakeQueryPortSpeed;
-        RdmaContextTestPeer::bindDevice(*context_, &fake_port.native,
-                                        std::make_shared<RdmaParams>());
+        params_ = std::make_shared<RdmaParams>();
+        RdmaContextTestPeer::bindDevice(*context_, &fake_port.native, params_);
     }
 
     void TearDown() override {
@@ -692,6 +746,7 @@ class RdmaContextFakeVerbsTest : public ::testing::Test {
 
     RdmaTransport transport_;
     std::unique_ptr<RdmaContext> context_;
+    std::shared_ptr<RdmaParams> params_;
 };
 
 TEST_F(RdmaContextFakeVerbsTest, EffectiveSpeedPreferredWhenVerbReportsIt) {
@@ -780,11 +835,22 @@ TEST(RdmaContextEventChainTest, PortActiveReseedsOnlyWhenTheSpeedChanged) {
     fake_port = FakePortVerbs{};
     fake_port.active_speed = 128;
     fake_port.active_width = 2;  // 400G
+    fake_port.lid = 1;
+    fake_port.gid.raw[15] = 1;
     auto& verbs = RdmaContextTestPeer::verbs(context);
     verbs.ibv_query_port_default = fakeQueryPort;
+    verbs.ibv_query_gid = fakeQueryGid;
     verbs.ibv_query_port_speed = fakeQueryPortSpeed;
-    RdmaContextTestPeer::bindDevice(context, &fake_port.native,
-                                    std::make_shared<RdmaParams>());
+    auto params = std::make_shared<RdmaParams>();
+    params->device.gid_index = fake_port.expected_gid_index;
+    RdmaContextTestPeer::bindDevice(context, &fake_port.native, params);
+    RdmaContextTestPeer::seedAddress(context, "mc-absent-rnic-1", fake_port.lid,
+                                     fake_port.expected_gid_index,
+                                     fake_port.gid,
+                                     RdmaContext::DEVICE_ENABLED);
+    auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+    RdmaTransportTestPeer::bindMetadata(transport, metadata);
+    ASSERT_TRUE(transport.setupLocalSegment().ok());
 
     // Pretend init seeded it at 400G and it learned ~45 GB/s since.
     ASSERT_EQ(context.refreshPortAttributes(), 0);
@@ -812,6 +878,213 @@ TEST(RdmaContextEventChainTest, PortActiveReseedsOnlyWhenTheSpeedChanged) {
     EXPECT_TRUE(selector->isDeviceAvailable(kDev));
 
     RdmaContextTestPeer::unbindDevice(context);
+}
+
+// The complete address-refresh chain: a GID_CHANGE event re-queries both
+// address components, publishes them into the local segment descriptor, and
+// leaves the device available. All verbs are fakes, so no RNIC is required.
+class RdmaAddressRefreshEventTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        fake_port = FakePortVerbs{};
+        fake_port.active_speed = 128;
+        fake_port.active_width = 2;
+        fake_port.lid = kNewLid;
+        fake_port.gid.raw[15] = kNewGidByte;
+
+        topology_ = std::make_shared<Topology>();
+        ASSERT_TRUE(topology_
+                        ->parse(R"({"nics":[
+                            {"name":"mc-fake-rnic","type":0,"numa_node":0}]})")
+                        .ok());
+        RdmaTransportTestPeer::bindTopology(transport_, topology_);
+
+        metadata_ = std::make_shared<ControlService>("p2p", "", nullptr);
+        RdmaTransportTestPeer::bindMetadata(transport_, metadata_);
+
+        context_ = std::make_shared<RdmaContext>(transport_);
+        params_ = std::make_shared<RdmaParams>();
+        params_->device.port = kPort;
+        params_->device.gid_index = fake_port.expected_gid_index;
+        auto& verbs = RdmaContextTestPeer::verbs(*context_);
+        verbs.ibv_query_port_default = fakeQueryPort;
+        verbs.ibv_query_gid = fakeQueryGid;
+        verbs.ibv_query_port_speed = fakeQueryPortSpeed;
+        RdmaContextTestPeer::bindDevice(*context_, &fake_port.native, params_);
+
+        ibv_gid old_gid{};
+        old_gid.raw[15] = kOldGidByte;
+        RdmaContextTestPeer::seedAddress(*context_, kDeviceName, kOldLid,
+                                         fake_port.expected_gid_index, old_gid,
+                                         RdmaContext::DEVICE_ENABLED);
+        RdmaTransportTestPeer::bindContexts(transport_, {context_});
+
+        ASSERT_TRUE(
+            metadata_->segmentManager()
+                .updateLocal([&](SegmentDesc& segment) -> Status {
+                    segment.name = "local";
+                    segment.type = SegmentType::Memory;
+                    auto& devices =
+                        std::get<MemorySegmentDesc>(segment.detail).devices;
+                    DeviceDesc device;
+                    device.name = kDeviceName;
+                    device.lid = kOldLid;
+                    device.gid = context_->gid();
+                    devices.push_back(std::move(device));
+                    return Status::OK();
+                })
+                .ok());
+
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        ASSERT_NE(selector_, nullptr);
+        ASSERT_TRUE(selector_->isDeviceAvailable(kDev));
+    }
+
+    void TearDown() override {
+        workers_.reset();
+        RdmaTransportTestPeer::bindContexts(transport_, {});
+        RdmaContextTestPeer::unbindDevice(*context_);
+        context_.reset();
+    }
+
+    void fire(ibv_event_type type, int port = kPort) {
+        ibv_async_event event{};
+        event.event_type = type;
+        event.element.port_num = port;
+        RdmaTransportTestPeer::applyContextEvent(*workers_, kDev, *context_,
+                                                 event);
+    }
+
+    DeviceDesc publishedDevice() const {
+        auto local = metadata_->segmentManager().getLocal();
+        auto* device = local ? local->findDevice(kDeviceName) : nullptr;
+        return device ? *device : DeviceDesc{};
+    }
+
+    static constexpr int kDev = 0;
+    static constexpr uint8_t kPort = 1;
+    static constexpr uint16_t kOldLid = 7;
+    static constexpr uint16_t kNewLid = 9;
+    static constexpr uint8_t kOldGidByte = 0x11;
+    static constexpr uint8_t kNewGidByte = 0x22;
+    static constexpr const char* kDeviceName = "mc-fake-rnic";
+
+    RdmaTransport transport_;
+    std::shared_ptr<Topology> topology_;
+    std::shared_ptr<ControlService> metadata_;
+    std::shared_ptr<RdmaContext> context_;
+    std::shared_ptr<RdmaParams> params_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+};
+
+TEST_F(RdmaAddressRefreshEventTest, GidChangeRefreshesPublishedAddress) {
+    fire(IBV_EVENT_GID_CHANGE);
+
+    const auto address = context_->address();
+    EXPECT_EQ(address.lid, kNewLid);
+    EXPECT_EQ(address.gid_index, fake_port.expected_gid_index);
+    EXPECT_EQ(address.gid, "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:22");
+    const auto published = publishedDevice();
+    ASSERT_EQ(published.name, kDeviceName);
+    EXPECT_EQ(published.lid, address.lid);
+    EXPECT_EQ(published.gid, address.gid);
+    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+}
+
+TEST_F(RdmaAddressRefreshEventTest, LidChangeRefreshesPublishedAddress) {
+    fake_port.gid.raw[15] = kOldGidByte;
+    fire(IBV_EVENT_LID_CHANGE);
+
+    const auto address = context_->address();
+    EXPECT_EQ(address.lid, kNewLid);
+    EXPECT_EQ(address.gid, "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:11");
+    const auto published = publishedDevice();
+    ASSERT_EQ(published.name, kDeviceName);
+    EXPECT_EQ(published.lid, kNewLid);
+}
+
+TEST_F(RdmaAddressRefreshEventTest, AddressEventForAnotherPortIsIgnored) {
+    const auto before = context_->address();
+
+    fire(IBV_EVENT_GID_CHANGE, kPort + 1);
+
+    const auto after = context_->address();
+    EXPECT_EQ(after.lid, before.lid);
+    EXPECT_EQ(after.gid, before.gid);
+    EXPECT_EQ(fake_port.query_gid_calls, 0);
+}
+
+TEST_F(RdmaAddressRefreshEventTest,
+       AddressChangeWhilePortDownKeepsNicUnavailable) {
+    fake_port.state = IBV_PORT_DOWN;
+    const auto before = context_->address();
+
+    fire(IBV_EVENT_GID_CHANGE);
+
+    const auto after = context_->address();
+    EXPECT_EQ(after.lid, before.lid);
+    EXPECT_EQ(after.gid, before.gid);
+    EXPECT_EQ(fake_port.query_gid_calls, 0);
+    EXPECT_EQ(context_->status(), RdmaContext::DEVICE_PAUSED);
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+}
+
+TEST_F(RdmaAddressRefreshEventTest, RefreshFailureKeepsOldAddressAndPausesNic) {
+    fake_port.query_gid_rc = EIO;
+    const auto before = context_->address();
+
+    fire(IBV_EVENT_GID_CHANGE);
+
+    const auto after = context_->address();
+    EXPECT_EQ(after.lid, before.lid);
+    EXPECT_EQ(after.gid, before.gid);
+    EXPECT_EQ(context_->status(), RdmaContext::DEVICE_PAUSED);
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+    const auto published = publishedDevice();
+    ASSERT_EQ(published.name, kDeviceName);
+    EXPECT_EQ(published.lid, before.lid);
+    EXPECT_EQ(published.gid, before.gid);
+}
+
+TEST_F(RdmaAddressRefreshEventTest, PortActivePublishesInitiallyMissingNic) {
+    // The port was down during setupLocalSegment(), so this NIC was omitted.
+    // Its hardware address did not change while down; publication is still
+    // required before it can be made selectable.
+    fake_port.lid = kOldLid;
+    fake_port.gid = {};
+    fake_port.gid.raw[15] = kOldGidByte;
+    ASSERT_TRUE(
+        metadata_->segmentManager()
+            .updateLocal([&](SegmentDesc& segment) -> Status {
+                std::get<MemorySegmentDesc>(segment.detail).devices.clear();
+                return Status::OK();
+            })
+            .ok());
+    context_->pause();
+    ASSERT_TRUE(selector_->setDeviceAvailable(kDev, false).ok());
+
+    fire(IBV_EVENT_PORT_ACTIVE);
+
+    EXPECT_EQ(context_->status(), RdmaContext::DEVICE_ENABLED);
+    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+    const auto published = publishedDevice();
+    ASSERT_EQ(published.name, kDeviceName);
+    EXPECT_EQ(published.lid, kOldLid);
+    EXPECT_EQ(published.gid, context_->address().gid);
+}
+
+TEST_F(RdmaAddressRefreshEventTest, PortActiveRefreshesBeforeReenable) {
+    context_->pause();
+    ASSERT_TRUE(selector_->setDeviceAvailable(kDev, false).ok());
+
+    fire(IBV_EVENT_PORT_ACTIVE);
+
+    EXPECT_EQ(context_->status(), RdmaContext::DEVICE_ENABLED);
+    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+    EXPECT_EQ(context_->address().lid, kNewLid);
+    EXPECT_EQ(publishedDevice().gid, context_->address().gid);
 }
 
 // A slice that hits the software timeout turns terminal here, not on the CQ,
@@ -1563,6 +1836,11 @@ class RdmaWorkersSharedQpTest : public ::testing::Test {
         ASSERT_EQ(notify_cq_.construct(context_.get(), 4096, 0), 0);
         RdmaContextTestPeer::bindResources(*context_, &fake.pd, {&cq_},
                                            &notify_cq_);
+        ibv_gid local_gid{};
+        local_gid.raw[15] = 0x11;
+        RdmaContextTestPeer::seedAddress(*context_, "mc-absent-rnic-1",
+                                         /*lid=*/7, /*gid_index=*/3, local_gid,
+                                         RdmaContext::DEVICE_ENABLED);
 
         endpoint_ = std::make_shared<RdmaEndPoint>();
         ASSERT_EQ(
@@ -1653,6 +1931,25 @@ class RdmaWorkersSharedQpTest : public ::testing::Test {
 };
 
 RdmaWorkersSharedQpTest::FakeState RdmaWorkersSharedQpTest::fake;
+
+TEST_F(RdmaWorkersSharedQpTest, EndpointPinsConstructionAddressGeneration) {
+    const auto endpoint_address =
+        RdmaEndPointTestPeer::localAddress(*endpoint_);
+    ASSERT_EQ(endpoint_address.lid, 7);
+    ASSERT_EQ(endpoint_address.gid_index, 3);
+
+    ibv_gid next_gid{};
+    next_gid.raw[15] = 0x22;
+    RdmaContextTestPeer::seedAddress(*context_, "mc-absent-rnic-1", /*lid=*/9,
+                                     /*gid_index=*/4, next_gid,
+                                     RdmaContext::DEVICE_ENABLED);
+
+    const auto pinned = RdmaEndPointTestPeer::localAddress(*endpoint_);
+    EXPECT_EQ(pinned.lid, endpoint_address.lid);
+    EXPECT_EQ(pinned.gid, endpoint_address.gid);
+    EXPECT_EQ(pinned.gid_index, endpoint_address.gid_index);
+    EXPECT_NE(context_->address().gid, pinned.gid);
+}
 
 TEST_F(RdmaWorkersSharedQpTest, TimeoutSweepGivesTheOtherLaneItsSliceBack) {
     // Lane 1 posted first, so lane 0's timeout sweeps it off the queue pair
@@ -1932,6 +2229,9 @@ TEST(RdmaPausedContextRecoveryTest, PollActivatesPausedContextWithLivePort) {
     RdmaContext& context = *contexts[0];
     if (context.status() != RdmaContext::DEVICE_ENABLED)
         GTEST_SKIP() << device_name << " has no usable active port";
+    auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+    RdmaTransportTestPeer::bindMetadata(transport, metadata);
+    ASSERT_TRUE(transport.setupLocalSegment().ok());
 
     auto workers = RdmaTransportTestPeer::makeWorkers(transport);
     auto* selector = workers->getDeviceSelector();


### PR DESCRIPTION
## Description

Related to #3523, Defect D only. 

TENT currently reads an RNIC's LID, GID, and GID index once in RdmaContext::openDevice() and reuses those cached values for later bootstrap replies and QP address-handle setup. If the address changes after a link flap or network reconfiguration, peers can receive stale Segment metadata or bootstrap data and build QPs against an obsolete address, causing RTR failures, transfer timeouts, or reconnect loops.


This PR adds runtime RDMA address refresh and makes recovery fail closed:

1. Handle IBV_EVENT_GID_CHANGE, IBV_EVENT_LID_CHANGE, and IBV_EVENT_PORT_ACTIVE by temporarily pausing the context and removing the NIC from DeviceSelector.
2. Require the hardware port to be fully IBV_PORT_ACTIVE, then re-query its LID, GID, and GID index. Auto-GID mode repeats the initial selection policy; an explicitly configured GID index remains fixed while its value is refreshed.
3. Update the local Segment metadata before exposing the new address locally. If the NIC was omitted during startup because its port was down, recovery upserts it even when the address value itself did not change.
4. Keep the NIC paused if querying or metadata publication fails, preserving the previous local address. The local metadata update is rolled back when registry synchronization reports failure.
5. Retire all endpoints built with the previous address before changing the context back to DEVICE_ENABLED and making it selectable again.

The refresh sequence is:


GID_CHANGE / LID_CHANGE / PORT_ACTIVE
  -> pause context and remove NIC from DeviceSelector
  -> verify port is ACTIVE
  -> query current LID, GID, and gid_index
  -> publish/upsert the address in Segment metadata
  -> retire endpoints using the old address
  -> set context ENABLED and re-enable NIC selection

**Address-generation consistency**
A refresh can race with bootstrap and endpoint setup, so reading LID, GID, and GID index independently is unsafe. This PR introduces RdmaAddressSnapshot and protects address reads with a mutex, ensuring each snapshot contains values from one generation.

Each RdmaEndPoint captures one immutable local address snapshot when it is constructed. Bootstrap descriptors, data QP setup, and notification QP setup all use that same snapshot and GID index. A context refresh evicts the complete endpoint before the NIC becomes selectable again, preventing a new address from being paired with QPs created from the previous generation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The focused coverage verifies:

GID change refreshes both the context and published Segment metadata.
LID change refreshes both the context and published Segment metadata.
Address-change events for another port are ignored.
A GID/LID event while the port is still down does not re-enable the NIC.
A query failure preserves the old address and keeps the NIC paused.
A NIC omitted from startup metadata is inserted on recovery even when its address is unchanged.
PORT_ACTIVE refreshes and publishes the address before re-enabling the NIC.
An endpoint keeps the address generation captured at construction time.
The existing real-RNIC recovery test passes on mlx5/CX8 hardware.

**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)