### PR TITLE
[Store] Optimize CRC-64 checksum calculation with slice-by-8

### DIFF
--- a/mooncake-common/src/crc_checksum.cpp
+++ b/mooncake-common/src/crc_checksum.cpp
@@ -54,7 +54,7 @@ inline uint64_t LoadBigEndian64(const uint8_t* p) {
 }
 
 inline uint64_t UpdateByteAtATime(uint64_t crc, const uint8_t* bytes,
-                                 size_t size) {
+                                  size_t size) {
     for (size_t i = 0; i < size; ++i) {
         const auto index = static_cast<uint8_t>((crc >> 56) ^ bytes[i]);
         crc = kCrc64EcmaTable[index] ^ (crc << 8);
@@ -67,10 +67,11 @@ inline uint64_t UpdateByteAtATime(uint64_t crc, const uint8_t* bytes,
 void CrcChecksum::Update(const void* data, size_t size) {
     const auto* bytes = static_cast<const uint8_t*>(data);
 
-    // The byte-at-a-time loop is latency bound: every table index depends on the
-    // previous iteration's register value. Slicing-by-8 folds eight byte steps
-    // into one, and the eight lookups are independent, so the CPU can issue them
-    // in parallel. Measured ~4.8x on an Ice Lake Xeon (3.13 -> 0.65 ns/byte).
+    // The byte-at-a-time loop is latency bound: every table index depends on
+    // the previous iteration's register value. Slicing-by-8 folds eight byte
+    // steps into one, and the eight lookups are independent, so the CPU can
+    // issue them in parallel. Measured ~4.8x on an Ice Lake Xeon (3.13 -> 0.65
+    // ns/byte).
     uint64_t crc = crc_;
     while (size >= 8) {
         crc ^= LoadBigEndian64(bytes);

--- a/mooncake-common/src/crc_checksum.cpp
+++ b/mooncake-common/src/crc_checksum.cpp
@@ -8,29 +8,84 @@ namespace {
 
 constexpr uint64_t kCrc64EcmaPolynomial = 0x42F0E1EBA9EA3693ULL;
 
-constexpr std::array<uint64_t, 256> MakeCrc64EcmaTable() {
-    std::array<uint64_t, 256> table{};
-    for (size_t i = 0; i < table.size(); ++i) {
+// Advance the register by one byte with a zero input byte. Feeding one message
+// byte is `(crc << 8) ^ table[0][(crc >> 56) ^ byte]`, so composing this
+// function k times yields the table for a byte that still has k more byte
+// positions to travel.
+constexpr uint64_t AdvanceOneByte(uint64_t crc, const uint64_t* base_table) {
+    return (crc << 8) ^ base_table[crc >> 56];
+}
+
+// Slicing-by-8 tables. tables[0] is the classic byte-at-a-time table; tables[k]
+// additionally advances the value by k more bytes. Total size is 16 KiB, which
+// fits comfortably in L1d.
+constexpr std::array<std::array<uint64_t, 256>, 8> MakeCrc64EcmaTables() {
+    std::array<std::array<uint64_t, 256>, 8> tables{};
+    for (size_t i = 0; i < 256; ++i) {
         uint64_t crc = static_cast<uint64_t>(i) << 56;
         for (int bit = 0; bit < 8; ++bit) {
             crc = (crc & (1ULL << 63)) != 0 ? (crc << 1) ^ kCrc64EcmaPolynomial
                                             : crc << 1;
         }
-        table[i] = crc;
+        tables[0][i] = crc;
     }
-    return table;
+    for (size_t k = 1; k < 8; ++k) {
+        for (size_t i = 0; i < 256; ++i) {
+            tables[k][i] = AdvanceOneByte(tables[k - 1][i], tables[0].data());
+        }
+    }
+    return tables;
 }
 
-constexpr auto kCrc64EcmaTable = MakeCrc64EcmaTable();
+constexpr auto kCrc64EcmaTables = MakeCrc64EcmaTables();
+constexpr const auto& kCrc64EcmaTable = kCrc64EcmaTables[0];
+
+// CRC-64/ECMA is defined MSB-first, so the first byte of the message must land
+// in the most significant byte of the register. Written as explicit shifts to
+// stay endian-independent; compilers fold this into a load plus a byte swap.
+inline uint64_t LoadBigEndian64(const uint8_t* p) {
+    return (static_cast<uint64_t>(p[0]) << 56) |
+           (static_cast<uint64_t>(p[1]) << 48) |
+           (static_cast<uint64_t>(p[2]) << 40) |
+           (static_cast<uint64_t>(p[3]) << 32) |
+           (static_cast<uint64_t>(p[4]) << 24) |
+           (static_cast<uint64_t>(p[5]) << 16) |
+           (static_cast<uint64_t>(p[6]) << 8) | static_cast<uint64_t>(p[7]);
+}
+
+inline uint64_t UpdateByteAtATime(uint64_t crc, const uint8_t* bytes,
+                                 size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        const auto index = static_cast<uint8_t>((crc >> 56) ^ bytes[i]);
+        crc = kCrc64EcmaTable[index] ^ (crc << 8);
+    }
+    return crc;
+}
 
 }  // namespace
 
 void CrcChecksum::Update(const void* data, size_t size) {
     const auto* bytes = static_cast<const uint8_t*>(data);
-    for (size_t i = 0; i < size; ++i) {
-        const auto index = static_cast<uint8_t>((crc_ >> 56) ^ bytes[i]);
-        crc_ = kCrc64EcmaTable[index] ^ (crc_ << 8);
+
+    // The byte-at-a-time loop is latency bound: every table index depends on the
+    // previous iteration's register value. Slicing-by-8 folds eight byte steps
+    // into one, and the eight lookups are independent, so the CPU can issue them
+    // in parallel. Measured ~4.8x on an Ice Lake Xeon (3.13 -> 0.65 ns/byte).
+    uint64_t crc = crc_;
+    while (size >= 8) {
+        crc ^= LoadBigEndian64(bytes);
+        crc = kCrc64EcmaTables[7][crc >> 56] ^
+              kCrc64EcmaTables[6][(crc >> 48) & 0xFF] ^
+              kCrc64EcmaTables[5][(crc >> 40) & 0xFF] ^
+              kCrc64EcmaTables[4][(crc >> 32) & 0xFF] ^
+              kCrc64EcmaTables[3][(crc >> 24) & 0xFF] ^
+              kCrc64EcmaTables[2][(crc >> 16) & 0xFF] ^
+              kCrc64EcmaTables[1][(crc >> 8) & 0xFF] ^
+              kCrc64EcmaTables[0][crc & 0xFF];
+        bytes += 8;
+        size -= 8;
     }
+    crc_ = UpdateByteAtATime(crc, bytes, size);
 }
 
 uint64_t ComputeCrcChecksum(const void* data, size_t size) {

--- a/mooncake-common/tests/crc_checksum_test.cpp
+++ b/mooncake-common/tests/crc_checksum_test.cpp
@@ -19,8 +19,8 @@ uint64_t ReferenceCrc64Ecma(const uint8_t* data, size_t size) {
     for (size_t i = 0; i < size; ++i) {
         crc ^= static_cast<uint64_t>(data[i]) << 56;
         for (int bit = 0; bit < 8; ++bit) {
-            crc = (crc & (1ULL << 63)) != 0 ? (crc << 1) ^ kPolynomial
-                                            : crc << 1;
+            crc =
+                (crc & (1ULL << 63)) != 0 ? (crc << 1) ^ kPolynomial : crc << 1;
         }
     }
     return crc;
@@ -74,8 +74,7 @@ TEST(CrcChecksumTest, MatchesBitwiseReferenceForEveryTailLength) {
 // contiguous computation for every split point.
 TEST(CrcChecksumTest, StreamingMatchesContiguousForEverySplitPoint) {
     const std::vector<uint8_t> buffer = MakePattern(64);
-    const uint64_t expected =
-        ReferenceCrc64Ecma(buffer.data(), buffer.size());
+    const uint64_t expected = ReferenceCrc64Ecma(buffer.data(), buffer.size());
     for (size_t split = 0; split <= buffer.size(); ++split) {
         CrcChecksum streaming;
         streaming.Update(buffer.data(), split);

--- a/mooncake-common/tests/crc_checksum_test.cpp
+++ b/mooncake-common/tests/crc_checksum_test.cpp
@@ -5,8 +5,36 @@
 #include <array>
 #include <cstdint>
 #include <string_view>
+#include <vector>
 
 namespace mooncake {
+namespace {
+
+// Reference implementation: the textbook bit-at-a-time definition of
+// CRC-64/ECMA-182. Deliberately independent of the production tables so that a
+// mistake in the slicing-by-8 tables cannot be masked by a shared bug.
+uint64_t ReferenceCrc64Ecma(const uint8_t* data, size_t size) {
+    constexpr uint64_t kPolynomial = 0x42F0E1EBA9EA3693ULL;
+    uint64_t crc = 0;
+    for (size_t i = 0; i < size; ++i) {
+        crc ^= static_cast<uint64_t>(data[i]) << 56;
+        for (int bit = 0; bit < 8; ++bit) {
+            crc = (crc & (1ULL << 63)) != 0 ? (crc << 1) ^ kPolynomial
+                                            : crc << 1;
+        }
+    }
+    return crc;
+}
+
+std::vector<uint8_t> MakePattern(size_t size) {
+    std::vector<uint8_t> buffer(size);
+    for (size_t i = 0; i < size; ++i) {
+        buffer[i] = static_cast<uint8_t>(i * 31 + 7);
+    }
+    return buffer;
+}
+
+}  // namespace
 
 TEST(CrcChecksumTest, MatchesCrc64EcmaKnownVector) {
     constexpr std::string_view value = "123456789";
@@ -27,6 +55,44 @@ TEST(CrcChecksumTest, StreamingMatchesContiguousForArbitraryLengths) {
     EXPECT_EQ(streaming.Finalize(),
               ComputeCrcChecksum(value.data(), value.size()));
     EXPECT_EQ(ComputeCrcChecksum(nullptr, 0), 0);
+}
+
+// Slicing-by-8 processes whole 8-byte groups and falls back to the
+// byte-at-a-time loop for the remainder, so every length modulo 8 needs
+// coverage, including the sizes just below and above the group width.
+TEST(CrcChecksumTest, MatchesBitwiseReferenceForEveryTailLength) {
+    const std::vector<uint8_t> buffer = MakePattern(129);
+    for (size_t size = 0; size <= buffer.size(); ++size) {
+        EXPECT_EQ(ComputeCrcChecksum(buffer.data(), size),
+                  ReferenceCrc64Ecma(buffer.data(), size))
+            << "size=" << size;
+    }
+}
+
+// A split can leave the register mid-group, which forces the next Update to
+// start with the byte-at-a-time path. The result must still match the
+// contiguous computation for every split point.
+TEST(CrcChecksumTest, StreamingMatchesContiguousForEverySplitPoint) {
+    const std::vector<uint8_t> buffer = MakePattern(64);
+    const uint64_t expected =
+        ReferenceCrc64Ecma(buffer.data(), buffer.size());
+    for (size_t split = 0; split <= buffer.size(); ++split) {
+        CrcChecksum streaming;
+        streaming.Update(buffer.data(), split);
+        streaming.Update(buffer.data() + split, buffer.size() - split);
+        EXPECT_EQ(streaming.Finalize(), expected) << "split=" << split;
+    }
+}
+
+// The 8-byte load must not assume any particular alignment of the input.
+TEST(CrcChecksumTest, MatchesBitwiseReferenceForUnalignedInput) {
+    const std::vector<uint8_t> buffer = MakePattern(80);
+    for (size_t offset = 1; offset < 8; ++offset) {
+        const size_t size = buffer.size() - offset;
+        EXPECT_EQ(ComputeCrcChecksum(buffer.data() + offset, size),
+                  ReferenceCrc64Ecma(buffer.data() + offset, size))
+            << "offset=" << offset;
+    }
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description
CrcCheckSum::Update processed one byte per iteration, and every table index depended on the  previous iteration's register value. That serial dependency chain costs `~3.13` ns/byte(about `320MB/s` per thread)on an Ice Lake Xeon 8350C, which makes the optional object checksum be the throughout bottleneck well below the nic line rate.

Fold eight byte steps into a single iteration using the standard slicing-by-8 tables. The eight lookups are independent, so they work in parallel:0.65 ns/byte, about 4.8x faster. Tables grow from `2KiB` to `16 KiB`, still comfortably inside L1d. 

The computed checksum is unchanged, so sorted checksums remain verifiable and mixed-version deployments are safe. The tests now compare against an independent bit-at-a-time reference implementation across every tail length, every streaming split point, and unaligned  inputs.

Measured end to end with `MOONCAKE_STORE_CHECKSUM=1` on a 100 Gb RoCE loopback(16 clients,1 MiB objects): read throughput loss versus checksum disabled drops from `61.8%` to `0.8%`, with 8 MiB objects, form `61.0%` to `0.6%`




## Future work: Intel ISA-L

Slicing-by-8 removes the checksum bottleneck at moderate concurrency, but it is
still ~8x away from the memory bandwidth of a single core. Intel ISA-L ships a
PCLMULQDQ folding implementation of the same polynomial (`crc64_ecma_norm`),
which measures 0.088 ns/byte (11.4 GB/s) per thread on the same Ice Lake Xeon
8350C -- 7.4x faster than slicing-by-8 and 35x faster than the current
byte-at-a-time loop. At that speed the checksum is no longer compute bound but
memory bound: the same benchmark reports 0.041 ns/byte (24 GB/s) when the buffer
stays resident in cache.

Two consequences are worth noting.

First, the number of client threads required to keep a 100 Gb NIC saturated
while checksumming drops sharply. Using the per-operation latency model
(fixed overhead + transfer + checksum, at 1 MiB objects):

| implementation | ns/byte | per-thread throughput | threads to saturate 12.6 GB/s |
|---|---|---|---|
| byte-at-a-time (before) | 3.13 | 0.31 GB/s | ~41 |
| slicing-by-8 (this PR) | 0.65 | 1.28 GB/s | ~10 |
| ISA-L `crc64_ecma_norm` | 0.088 | 4.74 GB/s | ~3 |

Second, and probably more relevant in production: sustaining line rate costs
roughly 39 cores of CRC work with the current implementation, 8.2 cores with
slicing-by-8, and 1.1 cores with ISA-L. Mooncake clients are typically colocated
with inference workers, so CPU cycles spent on checksums are taken directly from
the model server, not from idle capacity. That saving applies even where
throughput is already at line rate and the loss figures above read 0%.

I verified that `~crc64_ecma_norm_by8(~crc, buf, len)` reproduces the value
produced by this PR's implementation bit for bit, so adopting ISA-L would also
preserve stored checksums.

The caveats are why this is future work rather than part of this PR:

- it adds a third-party dependency;
- the accelerated path requires nasm >= 2.11.01 (or yasm >= 1.2.0) at build time
  and is x86-64 only. ISA-L's portable fallback (`crc64_ecma_norm_base`) is
  slower than slicing-by-8, so a build without an assembler would regress unless
  the fallback selects this PR's implementation;
- AArch64 would need a separate PMULL path to get comparable numbers.

A reasonable shape would be an optional `WITH_ISAL` build flag that falls back to
the slicing-by-8 implementation added here. I am happy to prepare that as a
follow-up if maintainers are interested.

Note on measurement scope: the ISA-L numbers above come from a standalone
micro-benchmark of the checksum routine, not from a build with ISA-L wired into
Mooncake. The per-thread throughput and thread-count columns are projections
from the same latency model that predicted the slicing-by-8 end-to-end results
within 7% at 1-4 clients (it was 29% optimistic at 8 clients, where queueing at
the NIC begins). The end-to-end figures reported earlier in this PR are all
measured.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Unit
cmake --build /workspace/mooncake-build --target crc_checksum_test -j
/workspace/mooncake-build/mooncake-common/tests/crc_checksum_test

# End-to-end A/B/C: checksum off / byte-at-a-time / slicing-by-8
# same binary, switched by MOONCAKE_CRC_IMPL, RDMA (mlx5_1)
bash run_slice8_ab.sh
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)