### PR TITLE
[Store] Fail-stop supervisor on OpLog writer terminal failure

### DIFF
--- a/mooncake-store/include/ha/oplog/ordered_oplog_writer.h
+++ b/mooncake-store/include/ha/oplog/ordered_oplog_writer.h
@@ -83,6 +83,7 @@ class OrderedOpLogWriter {
     bool IsAccepting() const;
     ErrorCode LastError() const;
     std::optional<OrderedOpLogWriterTerminalState> GetTerminalState() const;
+    void SetTerminalCallback(TerminalCallback callback);
     void Start();
     virtual void Stop();
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -204,6 +204,8 @@ class MasterService {
     ErrorCode SetBatchOpLogBackendForTesting(
         std::shared_ptr<HaKvBackend> backend);
     void SetBatchOpLogWriterFactoryForTesting(BatchOpLogWriterFactory factory);
+    void SetBatchOpLogTerminalCallback(
+        OrderedOpLogWriter::TerminalCallback callback);
 
     /**
      * @brief Test-only wrapper around BatchEvict / NoFBatchEvict so that

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -206,6 +206,7 @@ class MasterService {
     void SetBatchOpLogWriterFactoryForTesting(BatchOpLogWriterFactory factory);
     void SetBatchOpLogTerminalCallback(
         OrderedOpLogWriter::TerminalCallback callback);
+    void StopBatchOpLogWriter();
 
     /**
      * @brief Test-only wrapper around BatchEvict / NoFBatchEvict so that

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -21,6 +21,8 @@ namespace mooncake {
 class HttpMetadataServer;
 class WrappedMasterService {
    public:
+    void SetBatchOpLogTerminalCallback(
+        OrderedOpLogWriter::TerminalCallback callback);
     // Constructor with optional metadata-cleanup-on-timeout configuration.
     // - http_metadata_server: in-process pointer used when the HTTP metadata
     //   server is co-located in the master process (nullptr = not co-located).

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -23,6 +23,7 @@ class WrappedMasterService {
    public:
     void SetBatchOpLogTerminalCallback(
         OrderedOpLogWriter::TerminalCallback callback);
+    void StopBatchOpLogWriter();
     // Constructor with optional metadata-cleanup-on-timeout configuration.
     // - http_metadata_server: in-process pointer used when the HTTP metadata
     //   server is co-located in the master process (nullptr = not co-located).

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -5,6 +5,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string_view>
 #include <thread>
@@ -424,10 +425,12 @@ int RunSupervisorLoop(const HABackendSpec& spec,
         auto wrapped_master_service = std::make_shared<WrappedMasterService>(
             wrapped_config, config.http_metadata_server,
             config.http_metadata_remote_url);
-        std::atomic<bool> writer_terminal{false};
+        auto writer_terminal = std::make_shared<std::atomic<bool>>(false);
+        auto serving_gate = std::make_shared<std::mutex>();
         wrapped_master_service->SetBatchOpLogTerminalCallback(
             [&](const OrderedOpLogWriterTerminalState& state) {
-                if (writer_terminal.exchange(true)) return;
+                std::lock_guard<std::mutex> lock(*serving_gate);
+                if (writer_terminal->exchange(true)) return;
                 LOG(ERROR) << "Batch OpLog writer terminal: "
                            << toString(state.error);
                 admin_server.SetServiceAvailable(false);
@@ -536,15 +539,20 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             return -1;
         }
 
-        if (!serve_shutdown_requested.load(std::memory_order_acquire)) {
-            ActivateServingState(admin_server, wrapped_master_service,
-                                 label_reconciler);
+        {
+            std::lock_guard<std::mutex> lock(*serving_gate);
+            if (!serve_shutdown_requested.load(std::memory_order_acquire) &&
+                !writer_terminal->load(std::memory_order_acquire)) {
+                ActivateServingState(admin_server, wrapped_master_service,
+                                     label_reconciler);
+            }
         }
 
         auto server_err = std::move(ec).get();
         LOG(ERROR) << "Master service stopped: " << server_err;
 
         StopLeadershipMonitor(leadership_monitor_handle);
+        wrapped_master_service->StopBatchOpLogWriter();
         DeactivateServingState(admin_server, label_reconciler);
         auto err = leader_coordinator.ReleaseLeadership(*leadership_session);
         LOG(INFO) << "Release leadership: " << toString(err);

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -424,6 +424,18 @@ int RunSupervisorLoop(const HABackendSpec& spec,
         auto wrapped_master_service = std::make_shared<WrappedMasterService>(
             wrapped_config, config.http_metadata_server,
             config.http_metadata_remote_url);
+        std::atomic<bool> writer_terminal{false};
+        wrapped_master_service->SetBatchOpLogTerminalCallback(
+            [&](const OrderedOpLogWriterTerminalState& state) {
+                if (writer_terminal.exchange(true)) return;
+                LOG(ERROR) << "Batch OpLog writer terminal: "
+                           << toString(state.error);
+                admin_server.SetServiceAvailable(false);
+                admin_server.SetServiceDelegate(nullptr);
+                label_reconciler.SetLeader(false);
+                SetRuntimeState(admin_server, MasterRuntimeState::kStandby);
+                server.stop();
+            });
 
         // Restore is the serving gate: do not register or expose a candidate
         // service until the complete promotion context has been applied.

--- a/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
+++ b/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
@@ -268,6 +268,20 @@ OrderedOpLogWriter::GetTerminalState() const {
     return impl_->terminal_state;
 }
 
+void OrderedOpLogWriter::SetTerminalCallback(TerminalCallback callback) {
+    std::optional<OrderedOpLogWriterTerminalState> terminal;
+    TerminalCallback notify;
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        impl_->terminal_callback = std::move(callback);
+        notify = impl_->terminal_callback;
+        terminal = impl_->terminal_state;
+    }
+    if (terminal && notify) {
+        notify(*terminal);
+    }
+}
+
 void OrderedOpLogWriter::Start() {
     std::lock_guard<std::mutex> lock(impl_->mutex);
     if (impl_->running || impl_->stop_requested) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -725,6 +725,13 @@ void MasterService::SetBatchOpLogWriterFactoryForTesting(
     batch_oplog_writer_factory_ = std::move(factory);
 }
 
+void MasterService::SetBatchOpLogTerminalCallback(
+    OrderedOpLogWriter::TerminalCallback callback) {
+    if (ordered_oplog_writer_) {
+        ordered_oplog_writer_->SetTerminalCallback(std::move(callback));
+    }
+}
+
 void MasterService::RunBatchEvictForTesting(double evict_ratio_target,
                                             double evict_ratio_lowerbound) {
     BatchEvict(evict_ratio_target, evict_ratio_lowerbound);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -732,6 +732,10 @@ void MasterService::SetBatchOpLogTerminalCallback(
     }
 }
 
+void MasterService::StopBatchOpLogWriter() {
+    if (ordered_oplog_writer_) ordered_oplog_writer_->Stop();
+}
+
 void MasterService::RunBatchEvictForTesting(double evict_ratio_target,
                                             double evict_ratio_lowerbound) {
     BatchEvict(evict_ratio_target, evict_ratio_lowerbound);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -98,6 +98,10 @@ void WrappedMasterService::SetBatchOpLogTerminalCallback(
     master_service_.SetBatchOpLogTerminalCallback(std::move(callback));
 }
 
+void WrappedMasterService::StopBatchOpLogWriter() {
+    master_service_.StopBatchOpLogWriter();
+}
+
 tl::expected<MasterMetricManager::CacheHitStatDict, ErrorCode>
 WrappedMasterService::CalcCacheStats() {
     return MasterMetricManager::instance().calculate_cache_stats();

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -93,6 +93,11 @@ WrappedMasterService::WrappedMasterService(
 
 WrappedMasterService::~WrappedMasterService() = default;
 
+void WrappedMasterService::SetBatchOpLogTerminalCallback(
+    OrderedOpLogWriter::TerminalCallback callback) {
+    master_service_.SetBatchOpLogTerminalCallback(std::move(callback));
+}
+
 tl::expected<MasterMetricManager::CacheHitStatDict, ErrorCode>
 WrappedMasterService::CalcCacheStats() {
     return MasterMetricManager::instance().calculate_cache_stats();


### PR DESCRIPTION
## Description

When the batch OpLog writer reaches a terminal failure, the HA supervisor now fail-stops serving: mutation admission is closed through admin availability, the RPC delegate and leader label are removed, runtime state becomes standby, and the RPC server is stopped. Terminal notifications are delivered outside writer locks and duplicate notifications are ignored.

Related: Oplog HA PR-F02 design.

## Module

- [x] Mooncake Store

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files mooncake-store/include/ha/oplog/ordered_oplog_writer.h mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp mooncake-store/include/master_service.h mooncake-store/src/master_service.cpp mooncake-store/include/rpc_service.h mooncake-store/src/rpc_service.cpp mooncake-store/src/ha/leadership/master_service_supervisor.cpp
git diff --check
```

**Test results:**
- [x] Pre-commit passed
- [ ] Unit tests pass (build directory unavailable in this worktree)
- [ ] Integration tests pass
- [ ] Manual testing done

## Checklist

- [x] Self-review completed
- [x] Formatting and pre-commit checks passed
- [x] AI tools were used; the submitter must review every changed line

## AI Assistance Disclosure

Codex assisted with implementation and validation.