### PR TITLE
[Bugfix][TENT] Serialize lanes sharing a queue pair on its slice queue

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "context.h"
+#include "tent/common/concurrent/ticket_lock.h"
 
 namespace mooncake {
 namespace tent {
@@ -32,6 +33,8 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
         uint64_t padding[7];
     };
 
+    // Not synchronized: every access goes through queue_lock_list_[qp_index]
+    // (submitSlices / acknowledge) or the endpoint write lock (teardown).
     struct BoundedSliceQueue {
         size_t head, tail, capacity, count;
         std::vector<RdmaSlice*> entries;
@@ -231,16 +234,14 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     // Empty = default single pool spanning all of qp_list_. Each segment's
     // [begin, begin+num_qp) indexes into qp_list_. Read-only after construct().
     std::vector<QpPoolSegment> qp_pool_segments_;
-    // One queue per data QP. With the default lane layout a queue pair is
-    // posted and polled by a single worker lane. A qp_pools layout with
-    // fewer QPs than lanes folds several lanes onto one queue pair, and
-    // then two lanes can reach the same queue at once: submitSlices and
-    // acknowledge both hold only a read guard, which does not exclude them
-    // from each other, and the queue itself is unsynchronized. That is a
-    // data race in that layout, not a property this code relies on; it
-    // needs a per-QP lock. reset/deconstruct are synchronized by the
-    // endpoint lifecycle lock.
+    // One queue per data QP, in posting order, so acknowledge() can retire
+    // everything up to a completed slice. A qp_pools layout with fewer QPs
+    // than lanes lets several lanes reach one queue under the shared read
+    // guard; queue_lock_list_[i] serializes posting and acknowledging on
+    // QP i, and is uncontended in the default one-lane-per-QP layout.
+    // reset/deconstruct are synchronized by the endpoint lifecycle lock.
     std::vector<BoundedSliceQueue> slice_queue_;
+    TicketLock* queue_lock_list_;
     WrDepthBlock* wr_depth_list_;
     std::atomic<int> inflight_slices_;
     uint32_t padding_[7];

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -79,6 +79,7 @@ RdmaEndPoint::RdmaEndPoint()
     : status_(EP_UNINIT),
       context_(nullptr),
       params_(nullptr),
+      queue_lock_list_(nullptr),
       wr_depth_list_(nullptr),
       inflight_slices_(0),
       destroy_start_time_(0) {}
@@ -119,6 +120,7 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
     // Value-initialize the full array because cleanup may run after only a
     // prefix of QPs has been created.
     wr_depth_list_ = new WrDepthBlock[total_qp]();
+    queue_lock_list_ = new TicketLock[total_qp];
 
     for (int i = 0; i < total_qp; ++i) {
         wr_depth_list_[i].value.store(0, std::memory_order_relaxed);
@@ -294,6 +296,8 @@ int RdmaEndPoint::deconstructUnlocked() {
     if (all_qps_destroyed) {
         qp_list_.clear();
         slice_queue_.clear();
+        delete[] queue_lock_list_;
+        queue_lock_list_ = nullptr;
         delete[] wr_depth_list_;
         wr_depth_list_ = nullptr;
     }
@@ -815,23 +819,29 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
         sge_idx += wr.num_sge;
     }
 
-    int rc = ibv_post_send(qp_list_[qp_index], wr_list.data(), &bad_wr);
+    int rc = 0;
+    {
+        // The queue mirrors the QP's posting order, so posting and
+        // enqueueing must not interleave with another lane's post or
+        // acknowledge on this QP.
+        std::lock_guard<TicketLock> qp_guard(queue_lock_list_[qp_index]);
+        rc = ibv_post_send(qp_list_[qp_index], wr_list.data(), &bad_wr);
+        if (rc) {
+            while (bad_wr) {
+                slice_list[bad_wr - wr_list.data()]->failed = true;
+                cancelQuota(qp_index, 1);
+                bad_wr = bad_wr->next;
+            }
+        }
+        auto& queue = slice_queue_[qp_index];
+        for (int wr_idx = 0; wr_idx < wr_count; ++wr_idx) {
+            auto current = slice_list[wr_idx];
+            if (!current->failed) queue.push(current);
+        }
+    }
     if (rc) {
         LOG(ERROR) << "ibv_post_send: " << strerror(abs(rc)) << " [" << rc
                    << "]";
-        while (bad_wr) {
-            slice_list[bad_wr - wr_list.data()]->failed = true;
-            cancelQuota(qp_index, 1);
-            bad_wr = bad_wr->next;
-        }
-    }
-
-    auto& queue = slice_queue_[qp_index];
-    for (int wr_idx = 0; wr_idx < wr_count; ++wr_idx) {
-        auto current = slice_list[wr_idx];
-        if (!current->failed) {
-            queue.push(current);
-        }
     }
     return wr_count;
 }
@@ -874,6 +884,9 @@ size_t RdmaEndPoint::acknowledge(
     RWSpinlock::ReadGuard guard(lock_);
     auto qp_index = slice->qp_index;
     if (qp_index < 0 || qp_index >= (int)slice_queue_.size()) return 0;
+    // Everything below, on_each and updateSliceStatus included, runs under
+    // the QP lock: keep the callbacks cheap and free of endpoint re-entry.
+    std::lock_guard<TicketLock> qp_guard(queue_lock_list_[qp_index]);
     auto& queue = slice_queue_[qp_index];
     if (!queue.contains(slice)) return 0;
     int num_entries = 0;

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -20,10 +20,14 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -233,7 +237,23 @@ class RdmaEndPointTestPeer {
         ASSERT_TRUE(endpoint->reserveQuota(qp_index, 1));
         slice->qp_index = qp_index;
         slice->ep_weak_ptr = endpoint;
+        std::lock_guard<TicketLock> guard(endpoint->queue_lock_list_[qp_index]);
         endpoint->slice_queue_[qp_index].push(slice);
+    }
+    static void markReady(const std::shared_ptr<RdmaEndPoint>& endpoint) {
+        endpoint->status_.store(RdmaEndPoint::EP_READY,
+                                std::memory_order_relaxed);
+    }
+    static bool queueEmpty(const std::shared_ptr<RdmaEndPoint>& endpoint,
+                           int qp_index) {
+        return endpoint->slice_queue_[qp_index].empty();
+    }
+    static int wrDepth(const std::shared_ptr<RdmaEndPoint>& endpoint,
+                       int qp_index) {
+        return endpoint->wr_depth_list_[qp_index].value.load();
+    }
+    static int inflightSlices(const std::shared_ptr<RdmaEndPoint>& endpoint) {
+        return endpoint->inflight_slices_.load();
     }
 };
 
@@ -1516,6 +1536,10 @@ class RdmaWorkersSharedQpTest : public ::testing::Test {
         ibv_mr mr{};
     };
     static FakeState fake;
+    // Posting order as the hardware saw it: postSend appends every work
+    // request it is handed, so a poller can replay completions in that order.
+    static std::mutex post_mutex;
+    static std::vector<RdmaSlice*> post_order;
 
     static ibv_cq* createCq(ibv_context*, int, void*, ibv_comp_channel*, int) {
         return &fake.cq;
@@ -1528,10 +1552,25 @@ class RdmaWorkersSharedQpTest : public ::testing::Test {
     static int modifyQp(ibv_qp*, ibv_qp_attr*, int) { return 0; }
     static ibv_mr* regMr(ibv_pd*, void*, size_t, int) { return &fake.mr; }
     static int deregMr(ibv_mr*) { return 0; }
+    // ibv_post_send is an inline over qp->context->ops, so a fake context
+    // with this op lets submitSlices run for real against the fake QPs.
+    static int postSend(ibv_qp*, ibv_send_wr* wr, ibv_send_wr** bad_wr) {
+        std::lock_guard<std::mutex> guard(post_mutex);
+        for (auto* w = wr; w; w = w->next)
+            post_order.push_back(reinterpret_cast<RdmaSlice*>(w->wr_id));
+        *bad_wr = nullptr;
+        return 0;
+    }
 
     void SetUp() override {
         fake = FakeState{};
+        {
+            std::lock_guard<std::mutex> guard(post_mutex);
+            post_order.clear();
+        }
         fake.native.num_comp_vectors = 1;
+        fake.native.ops.post_send = postSend;
+        for (auto& qp : fake.qp) qp.context = &fake.native;
 
         auto topology = std::make_shared<Topology>();
         ASSERT_TRUE(topology
@@ -1591,6 +1630,25 @@ class RdmaWorkersSharedQpTest : public ::testing::Test {
             RdmaContextTestPeer::unbindResources(*context_);
             RdmaContextTestPeer::unbindDevice(*context_);
         }
+    }
+
+    // A slice with a task behind it, not yet posted anywhere.
+    RdmaSlice* makeSlice() {
+        auto* task = RdmaTaskStorage::Get().allocate();
+        task->num_slices = 1;
+        task->status_word = PENDING;
+        task->first_error = PENDING;
+        task->request.opcode = Request::WRITE;
+        task->ref();  // the batch's reference
+        task->ref();  // the slice's, dropped by updateSliceStatus()
+        auto* slice = RdmaSliceStorage::Get().allocate();
+        slice->task = task;
+        slice->length = kLen;
+        slice->word = PENDING;
+        slice->rail_monitor = nullptr;
+        tasks_.push_back(task);
+        slices_.push_back(slice);
+        return slice;
     }
 
     // A slice charged to the NIC, owned by `lane`, and posted on the shared
@@ -1662,6 +1720,8 @@ class RdmaWorkersSharedQpTest : public ::testing::Test {
 };
 
 RdmaWorkersSharedQpTest::FakeState RdmaWorkersSharedQpTest::fake;
+std::mutex RdmaWorkersSharedQpTest::post_mutex;
+std::vector<RdmaSlice*> RdmaWorkersSharedQpTest::post_order;
 
 TEST_F(RdmaWorkersSharedQpTest, TimeoutSweepGivesTheOtherLaneItsSliceBack) {
     // Lane 1 posted first, so lane 0's timeout sweeps it off the queue pair
@@ -1879,6 +1939,111 @@ TEST_F(RdmaWorkersSharedQpTest, SliceResolvedWhileQueuedIsDroppedNotPosted) {
     EXPECT_TRUE(
         RdmaTransportTestPeer::dropUnpostableSlice(*workers_, lane0, slice));
     EXPECT_EQ(lane0.inflight_slices.load(), 0);
+}
+
+// A qp_pools layout with fewer queue pairs than lanes has two lanes posting
+// to and acknowledging on one queue pair at once. They share the endpoint's
+// read guard, so the queue pair's slice queue has to serialize them itself:
+// every slice posted is acknowledged exactly once, and the queue and its
+// work-request depth end empty.
+TEST_F(RdmaWorkersSharedQpTest, TwoLanesOnOneQueuePairKeepTheSliceQueueIntact) {
+    constexpr int kSlices = 20000;
+    RdmaEndPointTestPeer::markReady(endpoint_);
+    std::vector<RdmaSlice*> slices;
+    for (int i = 0; i < kSlices; ++i) slices.push_back(makeSlice());
+
+    std::atomic<int> posted{0};
+    std::atomic<int> overflows{0};
+    std::thread poster([&] {
+        for (int i = 0; i < kSlices; ++i) {
+            std::vector<RdmaSlice*> one{slices[i]};
+            for (;;) {
+                int n = 0;
+                try {
+                    n = endpoint_->submitSlices(one, /*qp_index=*/0, nullptr);
+                } catch (const std::runtime_error&) {
+                    overflows.fetch_add(1);
+                    break;
+                }
+                if (n == 1) break;
+                std::this_thread::yield();  // queue pair full; the poller
+                                            // drains
+            }
+            posted.store(i + 1, std::memory_order_release);
+        }
+    });
+    std::thread poller([&] {
+        for (int i = 0; i < kSlices; ++i) {
+            while (posted.load(std::memory_order_acquire) <= i)
+                std::this_thread::yield();
+            endpoint_->acknowledge(slices[i], COMPLETED);
+        }
+    });
+    poster.join();
+    poller.join();
+
+    EXPECT_EQ(overflows.load(), 0);
+    int completed = 0, tasks_completed = 0;
+    for (auto* slice : slices) {
+        completed += (slice->word == COMPLETED);
+        tasks_completed += (slice->task->status_word == COMPLETED);
+    }
+    EXPECT_EQ(completed, kSlices);
+    EXPECT_EQ(tasks_completed, kSlices);
+    EXPECT_TRUE(RdmaEndPointTestPeer::queueEmpty(endpoint_, 0));
+    EXPECT_EQ(RdmaEndPointTestPeer::wrDepth(endpoint_, 0), 0);
+    EXPECT_EQ(RdmaEndPointTestPeer::inflightSlices(endpoint_), 0);
+}
+
+// Two lanes posting to one queue pair must leave the slice queue in the order
+// the hardware received the work requests: acknowledge() retires everything
+// ahead of a completed slice, so a queue that disagrees with the QP would
+// stamp a later slice with an earlier one's outcome. The fake post_send
+// records the hardware order; replaying completions in that order must find
+// each slice at the head and pop exactly one.
+TEST_F(RdmaWorkersSharedQpTest, TwoPostersOnOneQueuePairKeepPostingOrder) {
+    constexpr size_t kPerLane = 10000;
+    RdmaEndPointTestPeer::markReady(endpoint_);
+    std::vector<RdmaSlice*> lane0, lane1;
+    for (size_t i = 0; i < kPerLane; ++i) {
+        lane0.push_back(makeSlice());
+        lane1.push_back(makeSlice());
+    }
+
+    auto post_all = [&](std::vector<RdmaSlice*>& mine) {
+        for (auto* slice : mine) {
+            std::vector<RdmaSlice*> one{slice};
+            while (endpoint_->submitSlices(one, /*qp_index=*/0, nullptr) != 1)
+                std::this_thread::yield();  // queue pair full; the poller
+                                            // drains
+        }
+    };
+    std::atomic<size_t> popped_one{0};
+    std::thread poster0(post_all, std::ref(lane0));
+    std::thread poster1(post_all, std::ref(lane1));
+    std::thread poller([&] {
+        for (size_t i = 0; i < 2 * kPerLane; ++i) {
+            RdmaSlice* next = nullptr;
+            while (!next) {
+                {
+                    std::lock_guard<std::mutex> guard(post_mutex);
+                    if (post_order.size() > i) next = post_order[i];
+                }
+                if (!next) std::this_thread::yield();
+            }
+            if (endpoint_->acknowledge(next, COMPLETED) == 1u)
+                popped_one.fetch_add(1);
+        }
+    });
+    poster0.join();
+    poster1.join();
+    poller.join();
+
+    // Every completion found its slice at the head of the queue.
+    EXPECT_EQ(popped_one.load(), 2 * kPerLane);
+    EXPECT_TRUE(RdmaEndPointTestPeer::queueEmpty(endpoint_, 0));
+    EXPECT_EQ(RdmaEndPointTestPeer::wrDepth(endpoint_, 0), 0);
+    EXPECT_EQ(RdmaEndPointTestPeer::inflightSlices(endpoint_), 0);
 }
 
 TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {


### PR DESCRIPTION
## Description
  
  A `qp_pools` layout with fewer QPs than lanes folds several worker lanes onto one queue pair. `submitSlices` and `acknowledge` then reach the same `BoundedSliceQueue` under the endpoint's shared read guard, which does not exclude them from each other, and the queue itself is unsynchronized: concurrent push/pop tears the ring (crash), and a post that interleaves with another lane's post/push puts the queue out of the QP's posting order, so `acknowledge()` — which retires everything up to a completed slice — stamps a later slice with an earlier one's outcome. The comment on `slice_queue_` already named this race; #3780's shared-QP accounting fixes assumed the queue was safe.

  This adds one `TicketLock` per QP (`queue_lock_list_`, allocated and freed with `wr_depth_list_`). `submitSlices` holds it from `ibv_post_send` through the enqueue loop so the queue mirrors the hardware order; `acknowledge` holds it across the queue walk. The lock is uncontended in the default one-lane-per-QP layout; the error log is kept outside it. The default path is otherwise unchanged. Follow-up left open by #3780.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  Two new hardware-free tests in `RdmaWorkersSharedQpTest` run the real `submitSlices`/`acknowledge` against fake QPs (a fake `ibv_post_send` via `qp->context->ops`, which also records the hardware posting order):
  - `TwoLanesOnOneQueuePairKeepTheSliceQueueIntact`: one lane posts 20k slices while another acknowledges them; every slice completes once, queue / WR depth / inflight end at zero. Segfaults 3/3 without the fix.
  - `TwoPostersOnOneQueuePairKeepPostingOrder`: two lanes post concurrently; replaying completions in the recorded post order must pop exactly one slice each time. With `ibv_post_send` moved outside the lock it fails 3/3
  (19923–19939 of 20000) without crashing — the ordering bug on its own.

  **Test commands:**
  ```bash
  cmake --build build-tent --target tent_rdma_transport_test tent_endpoint_lifecycle_test tent_endpoint_store_test tent_rdma_async_event_drain_test rdma_cancel_test -j4
  ./build-tent/mooncake-transfer-engine/tent/tests/tent_rdma_transport_test

  Test results:
  - [x] Unit tests pass (tent_rdma_transport_test 55 passed / 2 skipped (hardware); endpoint lifecycle 20, endpoint store 8, async event drain 5, rdma_cancel 2 all pass)
  - [x] Manual testing done (uncontended lock+unlock measured at ~3 ns in the build container)
  
  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [x] I have added tests to prove my changes are effective

  AI Assistance Disclosure

  - [x] AI tools were used (specify below)