### PR TITLE
[TENT] Spin with pause before yielding in TicketLock

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/ticket_lock.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/ticket_lock.h
@@ -16,26 +16,44 @@
 #define TENT_TICKET_LOCK_H
 
 #include <atomic>
+#include <cstdint>
 #include <thread>
 
 #include "tent/common/types.h"
+#include "tent/common/utils/os.h"
 
 namespace mooncake {
 namespace tent {
+// FIFO spinlock for short, bounded critical sections: arrivals take a ticket
+// and are served in order, so no waiter can be starved by a re-acquiring
+// holder. Not reentrant, no try_lock.
 class TicketLock {
    public:
     TicketLock() : next_ticket_(0), now_serving_(0) {}
 
     void lock() {
-        int my_ticket = next_ticket_.fetch_add(1, std::memory_order_relaxed);
+        const int my_ticket =
+            next_ticket_.fetch_add(1, std::memory_order_relaxed);
+        // A running holder leaves a short critical section well within the
+        // spin budget, and pause keeps the loop from clogging the pipeline.
+        // Past the budget the holder is most likely preempted, so the CPU is
+        // better given away than burned; same policy as RWSpinlock.
+        uint32_t spins = 0;
         while (now_serving_.load(std::memory_order_acquire) != my_ticket) {
-            std::this_thread::yield();
+            if (++spins < kSpinsBeforeYield)
+                PAUSE();
+            else
+                std::this_thread::yield();
         }
     }
 
     void unlock() { now_serving_.fetch_add(1, std::memory_order_release); }
 
    private:
+    friend class TicketLockTestPeer;  // tests read the ticket counters
+
+    static constexpr uint32_t kSpinsBeforeYield = 1000;
+
     std::atomic<int> next_ticket_;
     std::atomic<int> now_serving_;
     uint64_t padding_[14];

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -140,6 +140,13 @@ target_include_directories(tent_qp_pool_layout_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_qp_pool_layout_test COMMAND tent_qp_pool_layout_test)
 
+add_executable(tent_ticket_lock_test ticket_lock_test.cpp)
+target_link_libraries(tent_ticket_lock_test PRIVATE tent_common gtest
+                                                    gtest_main)
+target_include_directories(tent_ticket_lock_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_ticket_lock_test COMMAND tent_ticket_lock_test)
+
 add_executable(tent_coalesce_regions_test coalesce_regions_test.cpp)
 target_link_libraries(tent_coalesce_regions_test PRIVATE tent_common gtest
                                                          gtest_main)

--- a/mooncake-transfer-engine/tent/tests/ticket_lock_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/ticket_lock_test.cpp
@@ -1,0 +1,144 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit tests for TicketLock: mutual exclusion under contention, hand-off in
+// arrival order, and hand-off after a hold long enough to push waiters past
+// the spin budget into the yield path.
+
+#include "tent/common/concurrent/ticket_lock.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+
+// Tickets are the lock's only observable state, and a test that wants to
+// arrange waiters in a known order has to see them handed out: a sleep only
+// makes the order likely, not certain.
+class TicketLockTestPeer {
+   public:
+    static int ticketsIssued(const TicketLock& lock) {
+        return lock.next_ticket_.load(std::memory_order_acquire);
+    }
+};
+
+namespace {
+
+using namespace std::chrono_literals;
+
+// Spin until `n` tickets have been handed out, i.e. n-1 waiters are queued
+// behind the holder.
+void waitForTickets(const TicketLock& lock, int n) {
+    while (TicketLockTestPeer::ticketsIssued(lock) < n)
+        std::this_thread::yield();
+}
+
+TEST(TicketLockTest, UncontendedLockUnlockRoundTrips) {
+    TicketLock lock;
+    for (int i = 0; i < 1000; ++i) {
+        std::lock_guard<TicketLock> guard(lock);
+    }
+}
+
+// Eight threads bump a plain counter under the lock and check that no two
+// of them are ever inside the critical section together. Overlap would lose
+// increments or show a nesting depth above one.
+TEST(TicketLockTest, ExcludesConcurrentCriticalSections) {
+    constexpr int kThreads = 8;
+    constexpr int kIters = 20000;
+    TicketLock lock;
+    long counter = 0;    // deliberately not atomic
+    int in_section = 0;  // deliberately not atomic
+    std::atomic<bool> overlap{false};
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&] {
+            for (int i = 0; i < kIters; ++i) {
+                std::lock_guard<TicketLock> guard(lock);
+                if (++in_section != 1) overlap.store(true);
+                ++counter;
+                --in_section;
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    EXPECT_EQ(counter, static_cast<long>(kThreads) * kIters);
+    EXPECT_FALSE(overlap.load());
+}
+
+// With the lock held (ticket 0), B queues up (ticket 1) and then C does
+// (ticket 2). On release B must be served before C: tickets are handed out on
+// arrival and served in order. Each waiter is started only once the previous
+// one is seen holding its ticket, so the arrival order is a fact, not a race
+// the test hopes to win.
+TEST(TicketLockTest, ServesWaitersInArrivalOrder) {
+    constexpr int kRounds = 20;
+    for (int round = 0; round < kRounds; ++round) {
+        TicketLock lock;
+        std::vector<char> order;  // written under the lock
+
+        lock.lock();
+        std::thread b([&] {
+            lock.lock();
+            order.push_back('B');
+            lock.unlock();
+        });
+        waitForTickets(lock, 2);  // B holds ticket 1
+        std::thread c([&] {
+            lock.lock();
+            order.push_back('C');
+            lock.unlock();
+        });
+        waitForTickets(lock, 3);  // C holds ticket 2
+        lock.unlock();
+
+        b.join();
+        c.join();
+        ASSERT_EQ(order, (std::vector<char>{'B', 'C'})) << "round " << round;
+    }
+}
+
+// A hold of tens of milliseconds is far past the spin budget, so a waiter
+// that is already queued falls through to yield(); it must still take the
+// lock on release.
+TEST(TicketLockTest, HandsOverAfterAHoldLongerThanTheSpinBudget) {
+    TicketLock lock;
+    std::atomic<bool> acquired{false};
+
+    lock.lock();
+    std::thread waiter([&] {
+        lock.lock();
+        acquired.store(true);
+        lock.unlock();
+    });
+    waitForTickets(lock, 2);            // the waiter is queued...
+    std::this_thread::sleep_for(20ms);  // ...and spins past its budget
+    EXPECT_FALSE(acquired.load());      // still held here
+
+    lock.unlock();
+    waiter.join();
+    EXPECT_TRUE(acquired.load());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

  `TicketLock::lock()` called `std::this_thread::yield()` on every spin, so a waiter paid a `sched_yield` syscall per iteration even when the holder was running and about to release. Wait with `PAUSE()` for up to 1000 spins first and only then yield — the same policy `RWSpinlock` already uses. Contended hand-off drops to the cost of a cross-core cache-line transfer; the yield path is kept for a preempted holder. Adds `tent_ticket_lock_test`. No callers change.

  Two-thread microbenchmark, build container (`-O2`, glibc futex mutex as reference):

  | lock+unlock | before | after |
  |---|---|---|
  | uncontended | 2.9 ns | 1.6–2.3 ns |
  | 2 threads contending, empty critical section | 123 ns/op | 40–65 ns/op |
  | (`std::mutex`, same test, unfair) | 17–39 ns/op | — |

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] Performance improvement

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  cmake --build build-tent --target tent_ticket_lock_test tent tent_xport_rdma tentpy -j4
  ./build-tent/mooncake-transfer-engine/tent/tests/tent_ticket_lock_test

  Test results:
  - [x] Unit tests pass (tent_ticket_lock_test: mutual exclusion under 8 threads, hand-off in arrival order, hand-off after a hold past the spin budget; 4/4, stable over 5 runs)
  - [x] Manual testing done (microbenchmark above; all tent* libraries and tentpy build clean)

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass (cmake-format wants to reflow an unrelated pre-existing block in tests/CMakeLists.txt; left out per AGENTS.md)
  - [x] I have added tests to prove my changes are effective

  AI Assistance Disclosure

  - [x] AI tools were used (specify below)