### PR TITLE
[CI/Build] Run current weight snapshot API tests in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -401,7 +401,7 @@ jobs:
           master_pid=$!
           trap 'kill "$master_pid" 2>/dev/null || true; wait "$master_pid" 2>/dev/null || true' EXIT
           sleep 3
-          python scripts/test_tensor_api.py -n 1
+          python -m unittest mooncake-wheel.tests.test_weight_snapshot_api
           python scripts/test_async_store.py
           python scripts/test_copy_move_api.py
           python scripts/test_drain_http_api.py --timeout-sec 90


### PR DESCRIPTION
## Description

Nightly fails when it tries to run `scripts/test_tensor_api.py`, which #3772 removed. Run the replacement weight snapshot API tests using the same command already used by PR CI.

Addresses the missing-file failure in #3901 and #3928. This restores the migrated API checks, not the removed suite's full coverage.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/nightly.yml
git diff --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Pre-commit and diff checks pass. Parsed both workflow YAML files, confirmed the replacement matches PR CI and resolves to a module containing two tests, and checked the modified shell step with `bash -n`. The native Mooncake suite was not run locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools helped prepare the change; Astra reviewed the diff independently.