### PR TITLE
[TENT] Fix HP TCP coalescing limits and short READ stalls

### DIFF
--- a/docs/source/design/tent/hp-tcp.md
+++ b/docs/source/design/tent/hp-tcp.md
@@ -15,6 +15,11 @@ never moves between workers, and operations on a lane are FIFO. ASIO provides
 the event queue; process-wide task and byte admission limits bound all accepted
 work, including callbacks waiting in that queue.
 
+Both ends disable Nagle's algorithm on these persistent sockets. Request and
+response headers are sent separately from their payloads; waiting for a
+delayed ACK between those writes can otherwise add tens of milliseconds to
+small transfers, even without queue pressure.
+
 The server uses the same worker pool. Accepted sockets are assigned to workers
 and stored in worker-owned session sets. A global connection limit bounds live
 sessions; closing a session removes it immediately rather than retaining one
@@ -42,6 +47,17 @@ persistent lane. A READ large enough to contribute at least one internal I/O
 step per configured rail is split into one contiguous slice per rail. The
 slices reuse the persistent lanes and complete as one TENT task. `hp_tcp` does
 not rebalance traffic or fail over between rails.
+
+The current internal step is 1 MiB: with two rails, READs of at least 2 MiB
+are sliced; smaller READs and single-rail READs are not. Remainder bytes are
+assigned to the first slices, so uneven lengths still cover the request
+exactly. Multiple independent WRITEs can use different rails, but each WRITE
+stays on one lane and waits for its own remote completion ACK.
+
+`connections_per_peer` is the **total** lane budget, not a per-rail multiplier.
+For example, four lanes and two rails give two lanes per rail. Worker count is
+independent of rail count: several lanes may share an owner worker. Increasing
+lanes on a single rail does not split a single READ into multiple streams.
 
 ## Protocol and memory safety
 
@@ -76,6 +92,13 @@ deadline resumes as soon as the next header begins. A timeout cancels the
 resolver or socket; terminal completion is published only after the
 corresponding callback retires.
 
+A failed READ slice cancels its siblings; the logical task settles only after
+all slice callbacks retire. A stale-registration result can trigger the
+existing bounded metadata refresh/retry, not migration onto another rail.
+Independent peers can continue while a peer is waiting for its progress
+timeout. FIFO sharing within one peer's lanes can still delay small requests
+behind large ones; slicing is not a priority or preemption mechanism.
+
 Shutdown closes admission and the listener, drains queued dispatch callbacks,
 cancels every client lane and server session on its owner, waits for operations
 and leases, then stops and joins worker threads. This makes shutdown bounded
@@ -106,10 +129,105 @@ The transport is configured under `transports.hp_tcp`:
 | `worker_count` | ASIO event-loop threads. |
 | `connections_per_peer` | Persistent lanes per peer. |
 | `max_outstanding_tasks`, `max_outstanding_bytes` | Global admission bounds. |
-| `max_transfer_bytes` | Maximum request size. I/O progress is tracked in fixed internal steps. |
+| `max_transfer_bytes` | Maximum request size. Runtime coalescing respects this limit when HP TCP is enabled; an individually oversized request is still rejected. |
 | `connect_timeout_ms`, `progress_timeout_ms` | Connection and I/O deadlines. |
 
-Tests cover wire validation, rail metadata and source binding, admission,
-buffer leases, connection reuse, session reaping, client/server timeout,
-stale-registration recovery, ambiguous WRITE completion and a two-process
-READ/WRITE smoke test.
+### Single-rail and paired-rail examples
+
+For a single rail, put this in the server's `MC_TENT_CONF` JSON file (replace
+the example address with an address assigned to the host):
+
+```json
+{
+  "transports": {
+    "tcp": {"enable": false},
+    "rdma": {"enable": false},
+    "shm": {"enable": false},
+    "hp_tcp": {
+      "enable": true,
+      "bind_address": "",
+      "rail_addresses": ["10.0.0.2"],
+      "worker_count": 4,
+      "connections_per_peer": 4
+    }
+  }
+}
+```
+
+Use the same configuration on the client with its local address `10.0.0.1`.
+For two rails, change only the lists:
+
+| Host | `rail_addresses` |
+| --- | --- |
+| Client | `["10.0.0.1", "10.1.0.1"]` |
+| Server | `["10.0.0.2", "10.1.0.2"]` |
+
+Entries pair by index: client entry 0 connects to server entry 0, and likewise
+for entry 1. Both hosts need working source-address routes for those pairs.
+Unequal rail counts are rejected, not silently truncated. Reused sockets keep
+their original lane/source/destination mapping; failed sockets are closed
+before later requests reconnect. No global route or socket tuning is required
+by these examples.
+
+`MC_TENT_CONF` loads a complete configuration, so include the transport enable
+flags even when using tebench's `--xport_type=hp_tcp`. To check data with the
+existing benchmark, start its target, then run an initiator with its advertised
+segment name:
+
+```bash
+MC_TENT_CONF=client.json tebench --backend=tent --xport_type=hp_tcp \
+  --tent_transport_hint=hp_tcp --target_seg_name=SERVER_SEGMENT \
+  --seg_type=DRAM --op_type=mix --check_consistency=true \
+  --start_block_size=67108864 --max_block_size=67108864 --duration=3
+```
+
+Repeat with both block-size flags set to `4096` for the unsliced path. This
+checks WRITE/READ payloads; run throughput measurements separately without
+in-loop data generation/comparison. With `--xport_type=hp_tcp`, the CPU checker
+generates seed-reproducible, non-constant data so a reordered slice cannot pass
+merely because every byte has the same value. Other backends' patterns are
+unchanged. Use matching tebench builds for `write_seed` and `read_verify`.
+
+### Checking rail use
+
+The transport test uses test-local socket relays to record the accepted peer
+and local addresses together with each completed wire request's offset and
+length. It checks non-zero offsets, guards, threshold-adjacent and uneven
+lengths, full payloads, and fresh/reused connections through `TransferEngine`.
+The two-process test also writes distinguishable data and reads it back over
+the sliced path. CTest runs all HP TCP E2E cases.
+
+On two machines, inspect established source/destination pairs with `ss -tnp`,
+the selected routes with `ip route get REMOTE from LOCAL`, and per-interface
+byte counters before/after a transfer. For READ, payload moves from server TX
+to client RX. Compare both rails' deltas with successful application bytes;
+headers and ACKs alone do not establish payload use. Interface counters also
+include protocol overhead and unrelated traffic, so use an otherwise idle
+window and retain process-specific connections.
+
+Two loopback addresses prove routing behavior, not two physical NICs. Inspect
+interface PCI devices and shared host/fabric limits before interpreting
+bandwidth scaling. Use one rail/one lane, one rail/multiple lanes, and two
+rails/the same total lanes as separate comparisons. The last two differ in
+both single-READ slicing and rail placement, not just physical NIC count.
+
+### Measured scope
+
+In a two-host CPU DRAM check on Xeon 8457C virtual machines, four HP TCP
+workers and four total lanes were held fixed. Median results from three
+interleaved 3-second measurement windows (after 1-second warmup) were:
+single-task 64 MiB READ, 3.22 GB/s with one rail versus 6.46 GB/s with two;
+four concurrent READs, 11.13 versus 10.96 GB/s, with overlapping run-to-run
+ranges. The second case did not show an additional throughput benefit.
+Connection addresses and interface counters showed approximately half the
+dual-rail payload-direction traffic on each interface, not guaranteed
+independence of their underlying physical resources.
+
+Small 4 KiB READs averaged 72 versus 78 microseconds. In a same-engine,
+same-peer mixed READ workload (one thread per 4 KiB/64 MiB class, each waiting
+1 ms before its next request), small-request transfer p99 was 27.1 ms with one
+rail and 12.2 ms with two. It remained far above the isolated small-request
+p99 of 0.11/0.14 ms. This is a closed-loop 1:1 thread mix, not a fixed 1:1
+completion ratio or a production arrival trace; transfer p99 excludes the
+explicit pre-submit wait. Static slicing improves this large-READ case but
+does not provide small-request latency isolation or universal scaling.

--- a/docs/source/design/tent/hp-tcp.md
+++ b/docs/source/design/tent/hp-tcp.md
@@ -15,10 +15,8 @@ never moves between workers, and operations on a lane are FIFO. ASIO provides
 the event queue; process-wide task and byte admission limits bound all accepted
 work, including callbacks waiting in that queue.
 
-Both ends disable Nagle's algorithm on these persistent sockets. Request and
-response headers are sent separately from their payloads; waiting for a
-delayed ACK between those writes can otherwise add tens of milliseconds to
-small transfers, even without queue pressure.
+Both ends disable Nagle's algorithm: headers and payloads use separate writes,
+so a delayed ACK must not hold up a short payload on a persistent socket.
 
 The server uses the same worker pool. Accepted sockets are assigned to workers
 and stored in worker-owned session sets. A global connection limit bounds live
@@ -129,7 +127,7 @@ The transport is configured under `transports.hp_tcp`:
 | `worker_count` | ASIO event-loop threads. |
 | `connections_per_peer` | Persistent lanes per peer. |
 | `max_outstanding_tasks`, `max_outstanding_bytes` | Global admission bounds. |
-| `max_transfer_bytes` | Maximum request size. Runtime coalescing respects this limit when HP TCP is enabled; an individually oversized request is still rejected. |
+| `max_transfer_bytes` | Maximum request size. When HP TCP is enabled, coalescing of HP TCP/UNSPEC requests respects both local and advertised remote limits; an individually oversized request is still rejected. |
 | `connect_timeout_ms`, `progress_timeout_ms` | Connection and I/O deadlines. |
 
 ### Single-rail and paired-rail examples
@@ -162,12 +160,9 @@ For two rails, change only the lists:
 | Client | `["10.0.0.1", "10.1.0.1"]` |
 | Server | `["10.0.0.2", "10.1.0.2"]` |
 
-Entries pair by index: client entry 0 connects to server entry 0, and likewise
-for entry 1. Both hosts need working source-address routes for those pairs.
-Unequal rail counts are rejected, not silently truncated. Reused sockets keep
-their original lane/source/destination mapping; failed sockets are closed
-before later requests reconnect. No global route or socket tuning is required
-by these examples.
+Entries pair by index, and both hosts need working source-address routes for
+those pairs. Reused sockets retain that mapping; failed sockets are closed
+before later requests reconnect.
 
 `MC_TENT_CONF` loads a complete configuration, so include the transport enable
 flags even when using tebench's `--xport_type=hp_tcp`. To check data with the
@@ -181,53 +176,38 @@ MC_TENT_CONF=client.json tebench --backend=tent --xport_type=hp_tcp \
   --start_block_size=67108864 --max_block_size=67108864 --duration=3
 ```
 
-Repeat with both block-size flags set to `4096` for the unsliced path. This
-checks WRITE/READ payloads; run throughput measurements separately without
-in-loop data generation/comparison. With `--xport_type=hp_tcp`, the CPU checker
-generates seed-reproducible, non-constant data so a reordered slice cannot pass
-merely because every byte has the same value. Other backends' patterns are
-unchanged. Use matching tebench builds for `write_seed` and `read_verify`.
+Repeat with both block-size flags set to `4096` for the unsliced path.
+With `--xport_type=hp_tcp --check_consistency=true`, the CPU checker uses
+seed-reproducible, non-constant data and a full byte comparison to detect
+reordered slices. Run throughput separately without this checking overhead.
+Ordinary `mix`, other backends and `write_seed`/`read_verify` retain their
+existing data patterns.
 
 ### Checking rail use
 
-The transport test uses test-local socket relays to record the accepted peer
-and local addresses together with each completed wire request's offset and
-length. It checks non-zero offsets, guards, threshold-adjacent and uneven
-lengths, full payloads, and fresh/reused connections through `TransferEngine`.
-The two-process test also writes distinguishable data and reads it back over
-the sliced path. CTest runs all HP TCP E2E cases.
+Test-local socket relays record the peer/local addresses and completed slice
+ranges. Full-engine tests check payloads, guards, the slicing threshold and
+connection reuse; two-process E2Es also cover unequal transfer-size limits.
 
-On two machines, inspect established source/destination pairs with `ss -tnp`,
-the selected routes with `ip route get REMOTE from LOCAL`, and per-interface
-byte counters before/after a transfer. For READ, payload moves from server TX
-to client RX. Compare both rails' deltas with successful application bytes;
-headers and ACKs alone do not establish payload use. Interface counters also
-include protocol overhead and unrelated traffic, so use an otherwise idle
-window and retain process-specific connections.
+On two machines, inspect connections with `ss -tnp`, source-address routes with
+`ip route get REMOTE from LOCAL`, and per-interface byte counters before/after
+a transfer. READ payload moves from server TX to client RX. Compare both
+rails' deltas with successful application bytes; account for protocol overhead
+and unrelated traffic. Two open connections alone do not prove payload use.
 
-Two loopback addresses prove routing behavior, not two physical NICs. Inspect
-interface PCI devices and shared host/fabric limits before interpreting
-bandwidth scaling. Use one rail/one lane, one rail/multiple lanes, and two
-rails/the same total lanes as separate comparisons. The last two differ in
-both single-READ slicing and rail placement, not just physical NIC count.
+Loopback proves routing, not physical NIC use. Check PCI devices and shared
+host/fabric limits. Compare one rail/one lane, one rail/multiple lanes, and two
+rails/the same total lanes: the last two differ in single-READ slicing as well
+as rail placement.
 
 ### Measured scope
 
-In a two-host CPU DRAM check on Xeon 8457C virtual machines, four HP TCP
-workers and four total lanes were held fixed. Median results from three
-interleaved 3-second measurement windows (after 1-second warmup) were:
-single-task 64 MiB READ, 3.22 GB/s with one rail versus 6.46 GB/s with two;
-four concurrent READs, 11.13 versus 10.96 GB/s, with overlapping run-to-run
-ranges. The second case did not show an additional throughput benefit.
-Connection addresses and interface counters showed approximately half the
-dual-rail payload-direction traffic on each interface, not guaranteed
-independence of their underlying physical resources.
-
-Small 4 KiB READs averaged 72 versus 78 microseconds. In a same-engine,
-same-peer mixed READ workload (one thread per 4 KiB/64 MiB class, each waiting
-1 ms before its next request), small-request transfer p99 was 27.1 ms with one
-rail and 12.2 ms with two. It remained far above the isolated small-request
-p99 of 0.11/0.14 ms. This is a closed-loop 1:1 thread mix, not a fixed 1:1
-completion ratio or a production arrival trace; transfer p99 excludes the
-explicit pre-submit wait. Static slicing improves this large-READ case but
-does not provide small-request latency isolation or universal scaling.
+On two Xeon 8457C virtual machines, with four workers and four total lanes,
+three interleaved runs (1-second warmup, 3-second measurement) gave median
+single-task 64 MiB READ throughput of 3.22 GB/s on one rail and 6.46 GB/s on
+two. Four concurrent READs showed no additional gain (11.13 vs 10.96 GB/s).
+Small 4 KiB READs averaged 72 vs 78 microseconds. Both interfaces carried
+payload-direction traffic, but their underlying resource independence is not
+guaranteed. A same-pool 4 KiB/64 MiB closed-loop mix still delayed small tasks
+behind large ones: static slicing offers neither latency isolation nor
+universal bandwidth scaling.

--- a/docs/source/design/tent/hp-tcp.md
+++ b/docs/source/design/tent/hp-tcp.md
@@ -203,11 +203,17 @@ as rail placement.
 ### Measured scope
 
 On two Xeon 8457C virtual machines, with four workers and four total lanes,
-three interleaved runs (1-second warmup, 3-second measurement) gave median
-single-task 64 MiB READ throughput of 3.22 GB/s on one rail and 6.46 GB/s on
-two. Four concurrent READs showed no additional gain (11.13 vs 10.96 GB/s).
-Small 4 KiB READs averaged 72 vs 78 microseconds. Both interfaces carried
-payload-direction traffic, but their underlying resource independence is not
-guaranteed. A same-pool 4 KiB/64 MiB closed-loop mix still delayed small tasks
-behind large ones: static slicing offers neither latency isolation nor
+three interleaved runs (1-second warmup, 3-second measurement) gave the
+following medians:
+
+| READ workload | Metric | One rail | Two rails |
+| --- | --- | ---: | ---: |
+| 64 MiB, one concurrent task | Throughput (GB/s) | 3.22 | 6.46 |
+| 64 MiB, four concurrent tasks | Throughput (GB/s) | 11.13 | 10.96 |
+| 4 KiB, one concurrent task | Mean latency (microseconds) | 72 | 78 |
+
+Both interfaces carried payload-direction traffic, but their underlying
+resource independence is not guaranteed. Four concurrent READs showed no
+additional gain. A same-pool 4 KiB/64 MiB closed-loop mix still delayed small
+tasks behind large ones: static slicing offers neither latency isolation nor
 universal bandwidth scaling.

--- a/mooncake-transfer-engine/benchmark/tests/target_metrics_test.cpp
+++ b/mooncake-transfer-engine/benchmark/tests/target_metrics_test.cpp
@@ -25,6 +25,26 @@ namespace mooncake {
 namespace tent {
 namespace {
 
+TEST(TargetMetricsTest, NonConstantPayloadOnlyForHpTcpConsistencyChecks) {
+    const auto saved_transport = XferBenchConfig::xport_type;
+    const bool saved_check = XferBenchConfig::check_consistency;
+    std::vector<uint8_t> data(4096);
+    for (const auto* transport : {"hp_tcp", "tcp"}) {
+        XferBenchConfig::xport_type = transport;
+        for (bool check : {false, true}) {
+            XferBenchConfig::check_consistency = check;
+            fillData(data.data(), data.size(), 37);
+            const bool constant = std::all_of(
+                data.begin(), data.end(), [](uint8_t b) { return b == 37; });
+            EXPECT_EQ(constant,
+                      !(check && XferBenchConfig::xport_type == "hp_tcp"));
+            verifyData(data.data(), data.size(), 37);
+        }
+    }
+    XferBenchConfig::xport_type = saved_transport;
+    XferBenchConfig::check_consistency = saved_check;
+}
+
 TEST(TargetMetricsTest, ReportsEachTargetAndWritesJsonl) {
     std::vector<TargetBenchStats> stats(2);
     stats[0].segment_name = "target-a";

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -263,7 +263,8 @@ static inline void fillData(void* addr, size_t length, uint8_t seed) {
         return;
     }
 #endif
-    if (XferBenchConfig::xport_type != "hp_tcp") {
+    if (XferBenchConfig::xport_type != "hp_tcp" ||
+        !XferBenchConfig::check_consistency) {
         memset(addr, seed, length);
         return;
     }
@@ -315,7 +316,10 @@ static inline void verifyData(void* addr, size_t length, uint8_t seed) {
         return;
     }
 #endif
-    fillData(ref_data.data(), length, seed);
+    if (XferBenchConfig::xport_type == "hp_tcp" &&
+        XferBenchConfig::check_consistency) {
+        fillData(ref_data.data(), length, seed);
+    }
     if (memcmp(addr, ref_data.data(), length)) {
         LOG(FATAL) << "Inconsistent data detected";
     }

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -27,6 +27,7 @@
 #include <stdexcept>
 #include <chrono>
 #include <limits>
+#include <random>
 
 #include "tent/common/utils/os.h"
 #include "tent/common/utils/random.h"
@@ -262,7 +263,16 @@ static inline void fillData(void* addr, size_t length, uint8_t seed) {
         return;
     }
 #endif
-    memset(addr, seed, length);
+    if (XferBenchConfig::xport_type != "hp_tcp") {
+        memset(addr, seed, length);
+        return;
+    }
+    // A constant byte pattern cannot detect reordered or duplicated slices.
+    std::mt19937 data(seed);
+    auto* bytes = static_cast<uint8_t*>(addr);
+    for (size_t i = 0; i < length; ++i) {
+        bytes[i] = static_cast<uint8_t>(data());
+    }
 }
 
 static inline uint8_t fillData(void* addr, size_t length) {
@@ -305,6 +315,7 @@ static inline void verifyData(void* addr, size_t length, uint8_t seed) {
         return;
     }
 #endif
+    fillData(ref_data.data(), length, seed);
     if (memcmp(addr, ref_data.data(), length)) {
         LOG(FATAL) << "Inconsistent data detected";
     }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -42,6 +42,7 @@
 #include "tent/common/utils/random.h"
 #include "tent/metrics/tent_metrics.h"
 #include "tent/metrics/config_loader.h"
+#include "tent/transport/hp_tcp/hp_tcp_protocol.h"
 
 namespace mooncake {
 namespace tent {
@@ -1478,6 +1479,7 @@ struct BufferKey {
 struct RequestBoundaryInfo {
     std::optional<BufferKey> source_key;
     std::optional<BufferKey> target_key;
+    uint64_t max_merge_bytes{std::numeric_limits<uint64_t>::max()};
 };
 
 struct MergeResult {
@@ -1532,7 +1534,7 @@ uint64_t requestSourceAddr(const Request& request) {
 
 MergeResult mergeRequests(const std::vector<Request>& requests,
                           const std::vector<RequestBoundaryInfo>& boundaries,
-                          bool do_merge, uint64_t hp_tcp_max_transfer_bytes) {
+                          bool do_merge) {
     if (requests.empty()) return {};
     if (!do_merge || boundaries.size() != requests.size()) {
         return makePassThroughMergeResult(requests);
@@ -1561,8 +1563,7 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
         return requestSourceAddr(a.req) < requestSourceAddr(b.req);
     });
 
-    auto can_merge = [hp_tcp_max_transfer_bytes](const Item& last,
-                                                 const Item& curr) {
+    auto can_merge = [](const Item& last, const Item& curr) {
         if (last.req.opcode != curr.req.opcode ||
             last.req.target_id != curr.req.target_id) {
             return false;
@@ -1591,11 +1592,8 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
             std::numeric_limits<size_t>::max() - last.req.length) {
             return false;
         }
-        // Coalescing must not turn valid HP TCP requests into an oversized
-        // request. UNSPEC may select HP TCP after merging as well.
-        if ((last.req.transport_hint == HP_TCP ||
-             last.req.transport_hint == UNSPEC) &&
-            last.req.length + curr.req.length > hp_tcp_max_transfer_bytes) {
+        // Requests to the same peer share the resolved transfer-size limit.
+        if (last.req.length + curr.req.length > last.boundary.max_merge_bytes) {
             return false;
         }
 
@@ -1637,7 +1635,8 @@ std::optional<BufferKey> toBufferKey(BufferDesc* buffer) {
 }
 
 std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
-    ControlService* metadata, const std::vector<Request>& requests) {
+    ControlService* metadata, const std::vector<Request>& requests,
+    const HpTcpTransportConfig& hp_tcp_config) {
     // Group requests by target_id so withCachedSegment fires at most once per
     // peer.
     std::vector<RequestBoundaryInfo> boundaries(requests.size());
@@ -1661,9 +1660,28 @@ std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
     for (auto& [target_id, idxs] : by_target) {
         metadata->segmentManager().withCachedSegment(
             target_id, [&](SegmentDesc* target_desc) {
+                auto hp_tcp_limit = hp_tcp_config.params.max_transfer_bytes;
+                if (hp_tcp_config.enabled && idxs.size() > 1 &&
+                    target_desc->type == SegmentType::Memory) {
+                    const auto* encoded =
+                        target_desc->getMemory().getTransportAttrs(HP_TCP);
+                    HighPerformanceTcpEndpointAttr endpoint;
+                    if (encoded && DecodeHighPerformanceTcpEndpointAttr(
+                                       *encoded, &endpoint)
+                                       .ok()) {
+                        hp_tcp_limit =
+                            std::min(hp_tcp_limit, endpoint.max_transfer_bytes);
+                    }
+                }
                 bool any_missing = false;
                 for (size_t i : idxs) {
                     const auto& r = requests[i];
+                    // UNSPEC may select HP TCP after merging. Respect both
+                    // endpoints' limits without changing explicit other hints.
+                    if (hp_tcp_config.enabled && (r.transport_hint == HP_TCP ||
+                                                  r.transport_hint == UNSPEC)) {
+                        boundaries[i].max_merge_bytes = hp_tcp_limit;
+                    }
                     auto* buffer =
                         target_desc->findBuffer(r.target_offset, r.length);
                     if (!buffer) {
@@ -1816,13 +1834,11 @@ Status TransferEngineImpl::prepareSubmit(
     prepared.submit_time = std::chrono::steady_clock::now();
     auto merge_boundaries =
         merge_requests_
-            ? resolveRequestBoundaries(metadata_.get(), request_list)
+            ? resolveRequestBoundaries(metadata_.get(), request_list,
+                                       hp_tcp_transport_config_)
             : std::vector<RequestBoundaryInfo>{};
     auto merged =
-        mergeRequests(request_list, merge_boundaries, merge_requests_,
-                      hp_tcp_transport_config_.enabled
-                          ? hp_tcp_transport_config_.params.max_transfer_bytes
-                          : std::numeric_limits<uint64_t>::max());
+        mergeRequests(request_list, merge_boundaries, merge_requests_);
 
     prepared.owners.reserve(merged.request_list.size());
     for (const auto& request : merged.request_list) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1532,7 +1532,7 @@ uint64_t requestSourceAddr(const Request& request) {
 
 MergeResult mergeRequests(const std::vector<Request>& requests,
                           const std::vector<RequestBoundaryInfo>& boundaries,
-                          bool do_merge) {
+                          bool do_merge, uint64_t hp_tcp_max_transfer_bytes) {
     if (requests.empty()) return {};
     if (!do_merge || boundaries.size() != requests.size()) {
         return makePassThroughMergeResult(requests);
@@ -1561,7 +1561,8 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
         return requestSourceAddr(a.req) < requestSourceAddr(b.req);
     });
 
-    auto can_merge = [](const Item& last, const Item& curr) {
+    auto can_merge = [hp_tcp_max_transfer_bytes](const Item& last,
+                                                 const Item& curr) {
         if (last.req.opcode != curr.req.opcode ||
             last.req.target_id != curr.req.target_id) {
             return false;
@@ -1588,6 +1589,13 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
         }
         if (curr.req.length >
             std::numeric_limits<size_t>::max() - last.req.length) {
+            return false;
+        }
+        // Coalescing must not turn valid HP TCP requests into an oversized
+        // request. UNSPEC may select HP TCP after merging as well.
+        if ((last.req.transport_hint == HP_TCP ||
+             last.req.transport_hint == UNSPEC) &&
+            last.req.length + curr.req.length > hp_tcp_max_transfer_bytes) {
             return false;
         }
 
@@ -1811,7 +1819,10 @@ Status TransferEngineImpl::prepareSubmit(
             ? resolveRequestBoundaries(metadata_.get(), request_list)
             : std::vector<RequestBoundaryInfo>{};
     auto merged =
-        mergeRequests(request_list, merge_boundaries, merge_requests_);
+        mergeRequests(request_list, merge_boundaries, merge_requests_,
+                      hp_tcp_transport_config_.enabled
+                          ? hp_tcp_transport_config_.params.max_transfer_bytes
+                          : std::numeric_limits<uint64_t>::max());
 
     prepared.owners.reserve(merged.request_list.size());
     for (const auto& request : merged.request_list) {

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_server.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_server.cpp
@@ -505,6 +505,9 @@ void HighPerformanceTcpServer::installAcceptedSocket(
     }
     std::shared_ptr<Session> session;
     try {
+        // READ response headers and payloads are separate writes. Do not wait
+        // for a delayed ACK before sending a short payload on a reused socket.
+        socket->set_option(asio::ip::tcp::no_delay(true));
         session = std::make_shared<Session>(this, worker_id, socket, config_,
                                             registry_);
         sessions_[worker_id].insert(session);

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -234,11 +234,14 @@ target_link_libraries(tent_hp_tcp_e2e_test PRIVATE gtest gtest_main
                                                    tent_link_group)
 target_include_directories(tent_hp_tcp_e2e_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-add_test(
-  NAME tent_hp_tcp_e2e_test_concurrency_16
-  COMMAND tent_hp_tcp_e2e_test
-          --gtest_filter=HighPerformanceTcpE2eTest.WriteThenReadConcurrency16)
-set_tests_properties(tent_hp_tcp_e2e_test_concurrency_16 PROPERTIES TIMEOUT 120)
+# Each fork-based case starts before earlier cases can create runtime threads.
+foreach(case WriteThenReadConcurrency16 WriteThenReadAcrossTwoRails
+             UnevenSlicedReadAcrossProcesses)
+  add_test(NAME tent_hp_tcp_e2e_${case}
+           COMMAND tent_hp_tcp_e2e_test
+                   --gtest_filter=HighPerformanceTcpE2eTest.${case})
+  set_tests_properties(tent_hp_tcp_e2e_${case} PROPERTIES TIMEOUT 120)
+endforeach()
 
 add_executable(tent_tcp_datapath_roundtrip_test tcp_datapath_roundtrip_test.cpp)
 target_link_libraries(tent_tcp_datapath_roundtrip_test PRIVATE gtest gtest_main
@@ -615,10 +618,9 @@ target_include_directories(tent_runtime_queue_dispatch_test
 add_test(NAME tent_runtime_queue_dispatch_test
          COMMAND tent_runtime_queue_dispatch_test)
 
-add_executable(tent_local_memory_lifecycle_test
-               local_memory_lifecycle_test.cpp)
-target_link_libraries(tent_local_memory_lifecycle_test
-                      PRIVATE gtest gtest_main tent_link_group)
+add_executable(tent_local_memory_lifecycle_test local_memory_lifecycle_test.cpp)
+target_link_libraries(tent_local_memory_lifecycle_test PRIVATE gtest gtest_main
+                                                               tent_link_group)
 if(TARGET asio_shared)
   target_link_libraries(tent_local_memory_lifecycle_test PRIVATE asio_shared)
 endif()

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_e2e_test.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -26,8 +27,6 @@
 
 namespace mooncake::tent {
 namespace {
-
-constexpr size_t kDataLength = 256 * 1024;
 
 bool ReadExactly(int fd, void* buffer, size_t length) {
     auto* cursor = static_cast<uint8_t*>(buffer);
@@ -108,7 +107,8 @@ bool WaitBatchDone(TransferEngine& engine, BatchID batch) {
     return false;
 }
 
-void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail) {
+void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail,
+                                     size_t kDataLength = 256 * 1024) {
     const size_t remote_buffer_length = task_count * kDataLength;
     const size_t local_buffer_length = 2 * remote_buffer_length;
 
@@ -183,13 +183,14 @@ void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail) {
     }
     close(ready_pipe[0]);
 
+    std::vector<uint8_t> local(local_buffer_length, 0);
     TransferEngine client(MakeHpConfig(multi_rail));
     ASSERT_TRUE(client.available());
-    std::vector<uint8_t> local(local_buffer_length, 0);
+    std::mt19937 data(3834);
     for (size_t task = 0; task < task_count; ++task) {
         uint8_t* source = local.data() + task * kDataLength;
         for (size_t i = 0; i < kDataLength; ++i) {
-            source[i] = static_cast<uint8_t>((task * 131 + i * 7) & 0xff);
+            source[i] = static_cast<uint8_t>(data());
         }
     }
     ASSERT_TRUE(
@@ -266,6 +267,10 @@ TEST(HighPerformanceTcpE2eTest, WriteThenReadConcurrency16) {
 
 TEST(HighPerformanceTcpE2eTest, WriteThenReadAcrossTwoRails) {
     RunWriteThenReadAcrossProcesses(16, true);
+}
+
+TEST(HighPerformanceTcpE2eTest, UnevenSlicedReadAcrossProcesses) {
+    RunWriteThenReadAcrossProcesses(4, true, (4ULL << 20) + 3);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_e2e_test.cpp
@@ -108,8 +108,8 @@ bool WaitBatchDone(TransferEngine& engine, BatchID batch) {
 }
 
 void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail,
-                                     size_t kDataLength = 256 * 1024) {
-    const size_t remote_buffer_length = task_count * kDataLength;
+                                     size_t data_length = 256 * 1024) {
+    const size_t remote_buffer_length = task_count * data_length;
     const size_t local_buffer_length = 2 * remote_buffer_length;
 
     int ready_pipe[2];
@@ -125,11 +125,11 @@ void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail,
 
         int exit_code = 0;
         {
+            std::vector<uint8_t> remote(remote_buffer_length, 0);
             TransferEngine server(MakeHpConfig(multi_rail));
             if (!server.available()) {
                 exit_code = 2;
             } else {
-                std::vector<uint8_t> remote(remote_buffer_length, 0);
                 const Status registered = server.registerLocalMemory(
                     remote.data(), remote.size(), kGlobalReadWrite);
                 if (!registered.ok()) {
@@ -184,12 +184,15 @@ void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail,
     close(ready_pipe[0]);
 
     std::vector<uint8_t> local(local_buffer_length, 0);
-    TransferEngine client(MakeHpConfig(multi_rail));
+    auto client_config = MakeHpConfig(multi_rail);
+    // The remote limit (8 MiB), not just the local limit, must bound merging.
+    client_config->set("transports/hp_tcp/max_transfer_bytes", 16ULL << 20);
+    TransferEngine client(client_config);
     ASSERT_TRUE(client.available());
     std::mt19937 data(3834);
     for (size_t task = 0; task < task_count; ++task) {
-        uint8_t* source = local.data() + task * kDataLength;
-        for (size_t i = 0; i < kDataLength; ++i) {
+        uint8_t* source = local.data() + task * data_length;
+        for (size_t i = 0; i < data_length; ++i) {
             source[i] = static_cast<uint8_t>(data());
         }
     }
@@ -217,21 +220,22 @@ void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail,
     for (size_t task = 0; task < task_count; ++task) {
         Request write_request{};
         write_request.opcode = Request::WRITE;
-        write_request.source = local.data() + task * kDataLength;
+        write_request.source = local.data() + task * data_length;
         write_request.target_id = segment;
-        write_request.target_offset = info.buffers[0].base + task * kDataLength;
-        write_request.length = kDataLength;
+        write_request.target_offset = info.buffers[0].base + task * data_length;
+        write_request.length = data_length;
         write_request.transport_hint = HP_TCP;
         writes.push_back(write_request);
 
         Request read_request{};
         read_request.opcode = Request::READ;
         read_request.source =
-            local.data() + remote_buffer_length + task * kDataLength;
+            local.data() + remote_buffer_length + task * data_length;
         read_request.target_id = segment;
-        read_request.target_offset = info.buffers[0].base + task * kDataLength;
-        read_request.length = kDataLength;
-        read_request.transport_hint = HP_TCP;
+        read_request.target_offset = info.buffers[0].base + task * data_length;
+        read_request.length = data_length;
+        // With only HP TCP enabled, also cover its implicit selection.
+        read_request.transport_hint = UNSPEC;
         reads.push_back(read_request);
     }
 
@@ -246,10 +250,10 @@ void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail,
     ASSERT_TRUE(client.freeBatch(batch).ok());
 
     for (size_t task = 0; task < task_count; ++task) {
-        const uint8_t* written = local.data() + task * kDataLength;
+        const uint8_t* written = local.data() + task * data_length;
         const uint8_t* read_back =
-            local.data() + remote_buffer_length + task * kDataLength;
-        EXPECT_EQ(std::memcmp(written, read_back, kDataLength), 0)
+            local.data() + remote_buffer_length + task * data_length;
+        EXPECT_EQ(std::memcmp(written, read_back, data_length), 0)
             << "task " << task << " mismatch";
     }
 

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
@@ -44,9 +44,9 @@ class HighPerformanceTcpTransportTestPeer {
 namespace {
 
 template <class Predicate>
-bool WaitUntil(Predicate predicate) {
-    const auto deadline =
-        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+bool WaitUntil(Predicate predicate,
+               std::chrono::milliseconds timeout = std::chrono::seconds(2)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (!predicate() && std::chrono::steady_clock::now() < deadline) {
         std::this_thread::yield();
     }
@@ -407,7 +407,9 @@ void CheckRailPayloads(bool multi_rail) {
     config->set("transports/hp_tcp/bind_address", "");
     config->set("transports/hp_tcp/rail_addresses", params.rail_addresses);
     config->set("transports/hp_tcp/connections_per_peer", 2);
-    config->set("transports/hp_tcp/progress_timeout_ms", 1000);
+    // A stalled peer must not block the healthy peer on this same worker.
+    config->set("transports/hp_tcp/worker_count", 1);
+    config->set("transports/hp_tcp/progress_timeout_ms", 5000);
     std::vector<uint8_t> local(kLength, 0);
     std::vector<uint8_t> stalled_buffer(kLength);
     TransferEngine client(config);
@@ -416,87 +418,89 @@ void CheckRailPayloads(bool multi_rail) {
     ASSERT_TRUE(client.openSegment(target, server_name).ok());
 
     ASSERT_TRUE(client.registerLocalMemory(local.data(), local.size()).ok());
-    // Repeat on the same pool to exercise both fresh and reused connections.
-    for (int round = 0; round < 2; ++round) {
-        for (auto opcode : {Request::READ, Request::WRITE}) {
-            for (size_t length : std::array<size_t, 4>{
-                     4096, (2ULL << 20) - 1, 2ULL << 20, (4ULL << 20) + 3}) {
-                SCOPED_TRACE(::testing::Message()
-                             << multi_rail << ":" << round << ":" << opcode
-                             << ":" << length);
-                std::fill(local.begin(), local.end(), 0xa5);
-                if (opcode == Request::WRITE) {
-                    for (size_t i = kOffset; i < kOffset + length; ++i)
-                        expected[i] ^= 0xff;
-                    std::copy_n(expected.data() + kOffset, length,
-                                local.data() + kOffset);
-                }
-                for (auto& relay : relays) relay->observations.clear();
-                Request request{};
-                request.opcode = opcode;
-                request.source = local.data() + kOffset;
-                request.target_id = target;
-                request.target_offset = remote_desc.addr + kOffset;
-                request.length = length;
-                request.transport_hint = HP_TCP;
-                const auto batch = client.allocateBatch(1);
-                ASSERT_TRUE(client.submitTransfer(batch, {request}).ok());
-                TransferStatus status{PENDING, 0};
-                ASSERT_TRUE(WaitUntil([&] {
-                    for (auto& relay : relays) relay->poll();
-                    EXPECT_TRUE(client.getTransferStatus(batch, status).ok());
-                    return status.s != PENDING;
-                }));
-                ASSERT_EQ(status.s, COMPLETED);
-                EXPECT_EQ(status.transferred_bytes, length);
-                const size_t count = multi_rail && opcode == Request::READ &&
-                                             length >= (2ULL << 20)
-                                         ? 2
-                                         : 1;
-                ASSERT_TRUE(WaitUntil([&] {
-                    size_t observed = 0;
-                    for (auto& relay : relays) {
-                        relay->poll();
-                        observed += relay->observations.size();
-                    }
-                    return observed == count;
-                }));
-                uint64_t cursor = request.target_offset;
-                for (size_t rail = 0; rail < relays.size(); ++rail) {
-                    if (count == 2)
-                        ASSERT_EQ(relays[rail]->observations.size(), 1U);
-                    for (const auto& seen : relays[rail]->observations) {
-                        EXPECT_EQ(seen.source, params.rail_addresses[rail]);
-                        EXPECT_EQ(seen.destination,
-                                  params.rail_addresses[rail]);
-                        EXPECT_EQ(seen.request.opcode,
-                                  opcode == Request::READ
-                                      ? HighPerformanceTcpOpcode::kRead
-                                      : HighPerformanceTcpOpcode::kWrite);
-                        EXPECT_EQ(seen.request.remote_addr, cursor);
-                        EXPECT_EQ(
-                            seen.request.length,
-                            length / count + (rail < length % count ? 1 : 0));
-                        cursor += seen.request.length;
-                    }
-                }
-                EXPECT_EQ(cursor, request.target_offset + length);
-                EXPECT_EQ(std::memcmp(local.data() + kOffset,
-                                      expected.data() + kOffset, length),
-                          0);
-                if (opcode == Request::WRITE)
-                    EXPECT_TRUE(SocketOrderedEqual(remote, expected));
-                EXPECT_TRUE(std::all_of(local.begin(), local.begin() + kOffset,
-                                        [](uint8_t b) { return b == 0xa5; }));
-                EXPECT_TRUE(std::all_of(local.begin() + kOffset + length,
-                                        local.end(),
-                                        [](uint8_t b) { return b == 0xa5; }));
-                ASSERT_TRUE(client.freeBatch(batch).ok());
+    // The first two small READs create both lanes; later cases reuse them.
+    for (auto opcode : {Request::READ, Request::WRITE}) {
+        const auto lengths =
+            opcode == Request::READ
+                ? std::vector<size_t>{4096, (2ULL << 20) - 1, 2ULL << 20,
+                                      (4ULL << 20) + 3}
+                : std::vector<size_t>{4096, (4ULL << 20) + 3};
+        for (size_t length : lengths) {
+            SCOPED_TRACE(::testing::Message()
+                         << multi_rail << ":" << opcode << ":" << length);
+            std::fill(local.begin(), local.end(), 0xa5);
+            if (opcode == Request::WRITE) {
+                for (size_t i = kOffset; i < kOffset + length; ++i)
+                    expected[i] ^= 0xff;
+                std::copy_n(expected.data() + kOffset, length,
+                            local.data() + kOffset);
             }
+            for (auto& relay : relays) relay->observations.clear();
+            Request request{};
+            request.opcode = opcode;
+            request.source = local.data() + kOffset;
+            request.target_id = target;
+            request.target_offset = remote_desc.addr + kOffset;
+            request.length = length;
+            request.transport_hint = HP_TCP;
+            const auto batch = client.allocateBatch(1);
+            ASSERT_TRUE(client.submitTransfer(batch, {request}).ok());
+            TransferStatus status{PENDING, 0};
+            ASSERT_TRUE(WaitUntil([&] {
+                for (auto& relay : relays) relay->poll();
+                EXPECT_TRUE(client.getTransferStatus(batch, status).ok());
+                return status.s != PENDING;
+            }));
+            ASSERT_EQ(status.s, COMPLETED);
+            EXPECT_EQ(status.transferred_bytes, length);
+            const size_t count =
+                multi_rail && opcode == Request::READ && length >= (2ULL << 20)
+                    ? 2
+                    : 1;
+            ASSERT_TRUE(WaitUntil([&] {
+                size_t observed = 0;
+                for (auto& relay : relays) {
+                    relay->poll();
+                    observed += relay->observations.size();
+                }
+                return observed == count;
+            }));
+            uint64_t cursor = request.target_offset;
+            for (size_t rail = 0; rail < relays.size(); ++rail) {
+                if (count == 2) {
+                    ASSERT_EQ(relays[rail]->observations.size(), 1U);
+                }
+                for (const auto& seen : relays[rail]->observations) {
+                    EXPECT_EQ(seen.source, params.rail_addresses[rail]);
+                    EXPECT_EQ(seen.destination, params.rail_addresses[rail]);
+                    EXPECT_EQ(seen.request.opcode,
+                              opcode == Request::READ
+                                  ? HighPerformanceTcpOpcode::kRead
+                                  : HighPerformanceTcpOpcode::kWrite);
+                    EXPECT_EQ(seen.request.remote_addr, cursor);
+                    EXPECT_EQ(seen.request.length,
+                              length / count + (rail < length % count ? 1 : 0));
+                    cursor += seen.request.length;
+                }
+            }
+            EXPECT_EQ(cursor, request.target_offset + length);
+            EXPECT_EQ(std::memcmp(local.data() + kOffset,
+                                  expected.data() + kOffset, length),
+                      0);
+            if (opcode == Request::WRITE) {
+                EXPECT_TRUE(SocketOrderedEqual(remote, expected));
+            }
+            EXPECT_TRUE(std::all_of(local.begin(), local.begin() + kOffset,
+                                    [](uint8_t b) { return b == 0xa5; }));
+            EXPECT_TRUE(std::all_of(local.begin() + kOffset + length,
+                                    local.end(),
+                                    [](uint8_t b) { return b == 0xa5; }));
+            ASSERT_TRUE(client.freeBatch(batch).ok());
+            size_t connections = 0;
+            for (auto& relay : relays) connections += relay->connections;
+            EXPECT_EQ(connections,
+                      opcode == Request::READ && length == 4096 ? 1U : 2U);
         }
-        size_t connections = 0;
-        for (auto& relay : relays) connections += relay->connections;
-        EXPECT_EQ(connections, 2U);
     }
     if (multi_rail) {
         // A second peer sends one payload byte per slice, then stalls. The
@@ -528,8 +532,12 @@ void CheckRailPayloads(bool multi_rail) {
         ASSERT_TRUE(client.openSegment(stalled_target, stalled_name).ok());
         ASSERT_TRUE(
             client.registerLocalMemory(stalled_buffer.data(), kLength).ok());
-        Request request{Request::READ, stalled_buffer.data(), stalled_target,
-                        remote_desc.addr, (4ULL << 20) + 3};
+        Request request{};
+        request.opcode = Request::READ;
+        request.source = stalled_buffer.data();
+        request.target_id = stalled_target;
+        request.target_offset = remote_desc.addr;
+        request.length = (4ULL << 20) + 3;
         request.transport_hint = HP_TCP;
         auto slow = client.allocateBatch(1);
         ASSERT_TRUE(client.submitTransfer(slow, {request}).ok());
@@ -569,10 +577,12 @@ void CheckRailPayloads(bool multi_rail) {
         ASSERT_TRUE(client.freeBatch(healthy).ok());
         ASSERT_TRUE(client.getTransferStatus(slow, status).ok());
         EXPECT_EQ(status.s, PENDING);
-        ASSERT_TRUE(WaitUntil([&] {
-            EXPECT_TRUE(client.getTransferStatus(slow, status).ok());
-            return status.s != PENDING;
-        }));
+        ASSERT_TRUE(WaitUntil(
+            [&] {
+                EXPECT_TRUE(client.getTransferStatus(slow, status).ok());
+                return status.s != PENDING;
+            },
+            std::chrono::seconds(6)));
         EXPECT_EQ(status.s, TIMEOUT);
         ASSERT_TRUE(client.freeBatch(slow).ok());
         ASSERT_TRUE(
@@ -595,6 +605,8 @@ TEST(HighPerformanceTcpTransportTest, SingleRailPayloadsAndConnectionReuse) {
 TEST(HighPerformanceTcpTransportTest,
      SlicedStaleRegistrationCancelsAndRetries) {
     constexpr size_t kLength = 4ULL << 20;
+    std::vector<uint8_t> remote_storage(kLength, 0x5a);
+    std::vector<uint8_t> local_storage(kLength);
     auto params = MakeParams();
     params.bind_address.clear();
     params.rail_addresses = {"127.0.0.1", "127.0.0.2"};
@@ -625,7 +637,6 @@ TEST(HighPerformanceTcpTransportTest,
     ASSERT_TRUE(
         server.install(installed_server_name, server_metadata, nullptr, nullptr)
             .ok());
-    std::vector<uint8_t> remote_storage(kLength, 0x5a);
     BufferDesc registration_a;
     registration_a.addr = reinterpret_cast<uint64_t>(remote_storage.data());
     registration_a.length = remote_storage.size();
@@ -693,7 +704,6 @@ TEST(HighPerformanceTcpTransportTest,
     ASSERT_NE(attr_a.registration_id, attr_b.registration_id);
     ASSERT_TRUE(PublishBuffers(server_metadata, {registration_b}).ok());
 
-    std::vector<uint8_t> local_storage(kLength);
     BufferDesc local;
     local.addr = reinterpret_cast<uint64_t>(local_storage.data());
     local.length = local_storage.size();

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
@@ -39,6 +39,10 @@ class HighPerformanceTcpTransportTestPeer {
     static bool hasFailedWorker(const HighPerformanceTcpTransport& transport) {
         return transport.workers_->hasFailedWorker();
     }
+
+    static Status barrier(HighPerformanceTcpTransport& transport) {
+        return transport.workers_->barrier();
+    }
 };
 
 namespace {
@@ -325,13 +329,6 @@ class RailRelay {
     std::exception_ptr error_;
 };
 
-// As in the socket tests, the kernel orders the remote WRITE before its ACK,
-// but that ordering is not a C++ happens-before edge visible to TSan.
-__attribute__((no_sanitize("thread"))) bool SocketOrderedEqual(
-    const std::vector<uint8_t>& actual, const std::vector<uint8_t>& expected) {
-    return actual == expected;
-}
-
 void CheckRailPayloads(bool multi_rail) {
     constexpr size_t kLength = (4ULL << 20) + 97;
     constexpr size_t kOffset = 37;
@@ -488,7 +485,11 @@ void CheckRailPayloads(bool multi_rail) {
                                   expected.data() + kOffset, length),
                       0);
             if (opcode == Request::WRITE) {
-                EXPECT_TRUE(SocketOrderedEqual(remote, expected));
+                // After the ACK, synchronize with the server workers before
+                // inspecting their memory from this test thread.
+                ASSERT_TRUE(
+                    HighPerformanceTcpTransportTestPeer::barrier(server).ok());
+                EXPECT_EQ(remote, expected);
             }
             EXPECT_TRUE(std::all_of(local.begin(), local.begin() + kOffset,
                                     [](uint8_t b) { return b == 0xa5; }));

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
@@ -14,12 +14,15 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "tent/runtime/control_plane.h"
+#include "tent/runtime/platform.h"
+#include "tent/transfer_engine.h"
 #include "tent/transport/hp_tcp/hp_tcp_protocol.h"
 #include "tent/transport/hp_tcp/hp_tcp_transport.h"
 
@@ -36,11 +39,6 @@ class HighPerformanceTcpTransportTestPeer {
     static bool hasFailedWorker(const HighPerformanceTcpTransport& transport) {
         return transport.workers_->hasFailedWorker();
     }
-
-    static uint64_t connectionsCreated(
-        const HighPerformanceTcpTransport& transport) {
-        return transport.client_->connectionsCreatedForTest();
-    }
 };
 
 namespace {
@@ -56,6 +54,9 @@ bool WaitUntil(Predicate predicate) {
 }
 
 std::shared_ptr<ControlService> MakeLocalMetadata() {
+    // Standalone transports also use the process-wide platform loader.
+    // Initialize it with a config before the full-engine cases probe topology.
+    (void)Platform::getLoader(std::make_shared<Config>());
     auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
     EXPECT_TRUE(metadata->segmentManager()
                     .updateLocal([](SegmentDesc& segment) -> Status {
@@ -241,11 +242,105 @@ Status WaitForTransportResult(HighPerformanceTcpTransport& transport,
     return Status::InternalError("HP TCP test transfer did not finish");
 }
 
-TEST(HighPerformanceTcpTransportTest, SlicesSingleLargeReadAcrossTwoRails) {
-    constexpr size_t kLength = 4ULL << 20;
+// Test-only relay: observe the wire request and forward it to the real server.
+// Pumped by the test thread; no transport worker waits for another callback.
+class RailRelay {
+   public:
+    struct Observation {
+        std::string source;
+        std::string destination;
+        HighPerformanceTcpRequestFrame request;
+    };
+
+    RailRelay(const std::string& address, uint16_t server_port)
+        : acceptor_(io_, {asio::ip::make_address(address), 0}),
+          backend_(asio::ip::make_address(address), server_port) {
+        asio::co_spawn(io_, accept(), [this](std::exception_ptr error) {
+            if (error) error_ = error;
+        });
+    }
+
+    uint16_t port() const { return acceptor_.local_endpoint().port(); }
+    void poll() {
+        io_.poll();
+        if (error_) std::rethrow_exception(error_);
+    }
+    size_t connections = 0;
+    std::vector<Observation> observations;
+
+   private:
+    asio::awaitable<void> accept() {
+        for (;;) {
+            auto socket = co_await acceptor_.async_accept(asio::use_awaitable);
+            ++connections;
+            asio::co_spawn(io_, forward(std::move(socket)),
+                           [this](std::exception_ptr error) {
+                               if (error) error_ = error;
+                           });
+        }
+    }
+
+    asio::awaitable<void> forward(asio::ip::tcp::socket socket) {
+        asio::ip::tcp::socket server(io_);
+        co_await server.async_connect(backend_, asio::use_awaitable);
+        for (;;) {
+            std::array<uint8_t, kHighPerformanceTcpRequestSize> header{};
+            co_await asio::async_read(socket, asio::buffer(header),
+                                      asio::use_awaitable);
+            HighPerformanceTcpRequestFrame request;
+            if (!DecodeHighPerformanceTcpRequest(header.data(), header.size(),
+                                                 &request)
+                     .ok()) {
+                throw std::runtime_error("invalid relayed HP TCP request");
+            }
+            co_await asio::async_write(server, asio::buffer(header),
+                                       asio::use_awaitable);
+            std::vector<uint8_t> payload(request.length);
+            if (request.opcode == HighPerformanceTcpOpcode::kWrite) {
+                co_await asio::async_read(socket, asio::buffer(payload),
+                                          asio::use_awaitable);
+                co_await asio::async_write(server, asio::buffer(payload),
+                                           asio::use_awaitable);
+            }
+            std::array<uint8_t, kHighPerformanceTcpResponseSize> response{};
+            co_await asio::async_read(server, asio::buffer(response),
+                                      asio::use_awaitable);
+            co_await asio::async_write(socket, asio::buffer(response),
+                                       asio::use_awaitable);
+            if (request.opcode == HighPerformanceTcpOpcode::kRead) {
+                co_await asio::async_read(server, asio::buffer(payload),
+                                          asio::use_awaitable);
+                co_await asio::async_write(socket, asio::buffer(payload),
+                                           asio::use_awaitable);
+            }
+            observations.push_back(
+                {socket.remote_endpoint().address().to_string(),
+                 socket.local_endpoint().address().to_string(), request});
+        }
+    }
+
+    asio::io_context io_;
+    asio::ip::tcp::acceptor acceptor_;
+    asio::ip::tcp::endpoint backend_;
+    std::exception_ptr error_;
+};
+
+// As in the socket tests, the kernel orders the remote WRITE before its ACK,
+// but that ordering is not a C++ happens-before edge visible to TSan.
+__attribute__((no_sanitize("thread"))) bool SocketOrderedEqual(
+    const std::vector<uint8_t>& actual, const std::vector<uint8_t>& expected) {
+    return actual == expected;
+}
+
+void CheckRailPayloads(bool multi_rail) {
+    constexpr size_t kLength = (4ULL << 20) + 97;
+    constexpr size_t kOffset = 37;
+    std::vector<uint8_t> remote(kLength);
     auto params = MakeParams();
     params.bind_address.clear();
-    params.rail_addresses = {"127.0.0.1", "127.0.0.2"};
+    params.rail_addresses =
+        multi_rail ? std::vector<std::string>{"127.0.0.1", "127.0.0.2"}
+                   : std::vector<std::string>{"127.0.0.1"};
     params.max_outstanding_bytes = 8ULL << 20;
     params.max_transfer_bytes = 8ULL << 20;
 
@@ -266,10 +361,11 @@ TEST(HighPerformanceTcpTransportTest, SlicesSingleLargeReadAcrossTwoRails) {
     ASSERT_TRUE(
         server.install(installed_server_name, server_metadata, nullptr, nullptr)
             .ok());
-    std::vector<uint8_t> remote(kLength);
+    std::mt19937 data(3689);
     for (size_t i = 0; i < remote.size(); ++i) {
-        remote[i] = static_cast<uint8_t>((i * 17) & 0xff);
+        remote[i] = static_cast<uint8_t>(data());
     }
+    auto expected = remote;
     BufferDesc remote_desc;
     remote_desc.addr = reinterpret_cast<uint64_t>(remote.data());
     remote_desc.length = remote.size();
@@ -280,53 +376,220 @@ TEST(HighPerformanceTcpTransportTest, SlicesSingleLargeReadAcrossTwoRails) {
     ASSERT_TRUE(server.addMemoryBuffer(remote_desc, remote_options).ok());
     ASSERT_TRUE(PublishBuffers(server_metadata, {remote_desc}).ok());
 
-    auto client_metadata = MakeLocalMetadata();
-    HighPerformanceTcpTransport client(params);
-    std::string client_name = "hp_transport_client";
-    ASSERT_TRUE(
-        client.install(client_name, client_metadata, nullptr, nullptr).ok());
-    SegmentID target = 0;
-    ASSERT_TRUE(
-        client_metadata->segmentManager().openRemote(target, server_name).ok());
+    HighPerformanceTcpEndpointAttr endpoint;
+    ASSERT_TRUE(DecodeHighPerformanceTcpEndpointAttr(
+                    server_metadata->segmentManager()
+                        .getLocal()
+                        ->getMemory()
+                        .transport_attrs.at(static_cast<int>(HP_TCP)),
+                    &endpoint)
+                    .ok());
+    std::vector<std::unique_ptr<RailRelay>> relays;
+    for (auto& rail : endpoint.endpoints) {
+        relays.push_back(std::make_unique<RailRelay>(rail.host, rail.port));
+        rail.port = relays.back()->port();
+    }
+    ASSERT_TRUE(server_metadata->segmentManager()
+                    .updateLocal([&](SegmentDesc& segment) {
+                        return EncodeHighPerformanceTcpEndpointAttr(
+                            endpoint,
+                            &std::get<MemorySegmentDesc>(segment.detail)
+                                 .transport_attrs[static_cast<int>(HP_TCP)]);
+                    })
+                    .ok());
 
+    auto config = std::make_shared<Config>();
+    config->set("metadata_type", "p2p");
+    config->set("transports/tcp/enable", false);
+    config->set("transports/rdma/enable", false);
+    config->set("transports/shm/enable", false);
+    config->set("transports/hp_tcp/enable", true);
+    config->set("transports/hp_tcp/bind_address", "");
+    config->set("transports/hp_tcp/rail_addresses", params.rail_addresses);
+    config->set("transports/hp_tcp/connections_per_peer", 2);
+    config->set("transports/hp_tcp/progress_timeout_ms", 1000);
     std::vector<uint8_t> local(kLength, 0);
-    BufferDesc local_desc;
-    local_desc.addr = reinterpret_cast<uint64_t>(local.data());
-    local_desc.length = local.size();
-    local_desc.location = "cpu:0";
-    MemoryOptions local_options;
-    local_options.type = HP_TCP;
-    local_options.perm = kLocalReadWrite;
-    ASSERT_TRUE(client.addMemoryBuffer(local_desc, local_options).ok());
+    std::vector<uint8_t> stalled_buffer(kLength);
+    TransferEngine client(config);
+    ASSERT_TRUE(client.available());
+    SegmentID target = 0;
+    ASSERT_TRUE(client.openSegment(target, server_name).ok());
 
-    Transport::SubBatchRef batch = nullptr;
-    ASSERT_TRUE(client.allocateSubBatch(batch, 1).ok());
-    Request request{};
-    request.opcode = Request::READ;
-    request.source = local.data();
-    request.target_id = target;
-    request.target_offset = remote_desc.addr;
-    request.length = remote_desc.length;
-    request.transport_hint = HP_TCP;
-    ASSERT_TRUE(client.submitTransferTasks(batch, {request}).ok());
-
-    TransferStatus transfer_status;
-    const Status result =
-        WaitForTransportResult(client, batch, transfer_status);
-    EXPECT_TRUE(result.ok()) << result.ToString();
-    EXPECT_EQ(transfer_status.s, COMPLETED);
-    EXPECT_EQ(transfer_status.transferred_bytes, kLength);
-    EXPECT_EQ(std::memcmp(local.data(), remote.data(), kLength), 0);
-    EXPECT_EQ(HighPerformanceTcpTransportTestPeer::connectionsCreated(client),
-              2);
-
-    ASSERT_TRUE(client.freeSubBatch(batch).ok());
-    ASSERT_TRUE(client.removeMemoryBuffer(local_desc).ok());
+    ASSERT_TRUE(client.registerLocalMemory(local.data(), local.size()).ok());
+    // Repeat on the same pool to exercise both fresh and reused connections.
+    for (int round = 0; round < 2; ++round) {
+        for (auto opcode : {Request::READ, Request::WRITE}) {
+            for (size_t length : std::array<size_t, 4>{
+                     4096, (2ULL << 20) - 1, 2ULL << 20, (4ULL << 20) + 3}) {
+                SCOPED_TRACE(::testing::Message()
+                             << multi_rail << ":" << round << ":" << opcode
+                             << ":" << length);
+                std::fill(local.begin(), local.end(), 0xa5);
+                if (opcode == Request::WRITE) {
+                    for (size_t i = kOffset; i < kOffset + length; ++i)
+                        expected[i] ^= 0xff;
+                    std::copy_n(expected.data() + kOffset, length,
+                                local.data() + kOffset);
+                }
+                for (auto& relay : relays) relay->observations.clear();
+                Request request{};
+                request.opcode = opcode;
+                request.source = local.data() + kOffset;
+                request.target_id = target;
+                request.target_offset = remote_desc.addr + kOffset;
+                request.length = length;
+                request.transport_hint = HP_TCP;
+                const auto batch = client.allocateBatch(1);
+                ASSERT_TRUE(client.submitTransfer(batch, {request}).ok());
+                TransferStatus status{PENDING, 0};
+                ASSERT_TRUE(WaitUntil([&] {
+                    for (auto& relay : relays) relay->poll();
+                    EXPECT_TRUE(client.getTransferStatus(batch, status).ok());
+                    return status.s != PENDING;
+                }));
+                ASSERT_EQ(status.s, COMPLETED);
+                EXPECT_EQ(status.transferred_bytes, length);
+                const size_t count = multi_rail && opcode == Request::READ &&
+                                             length >= (2ULL << 20)
+                                         ? 2
+                                         : 1;
+                ASSERT_TRUE(WaitUntil([&] {
+                    size_t observed = 0;
+                    for (auto& relay : relays) {
+                        relay->poll();
+                        observed += relay->observations.size();
+                    }
+                    return observed == count;
+                }));
+                uint64_t cursor = request.target_offset;
+                for (size_t rail = 0; rail < relays.size(); ++rail) {
+                    if (count == 2)
+                        ASSERT_EQ(relays[rail]->observations.size(), 1U);
+                    for (const auto& seen : relays[rail]->observations) {
+                        EXPECT_EQ(seen.source, params.rail_addresses[rail]);
+                        EXPECT_EQ(seen.destination,
+                                  params.rail_addresses[rail]);
+                        EXPECT_EQ(seen.request.opcode,
+                                  opcode == Request::READ
+                                      ? HighPerformanceTcpOpcode::kRead
+                                      : HighPerformanceTcpOpcode::kWrite);
+                        EXPECT_EQ(seen.request.remote_addr, cursor);
+                        EXPECT_EQ(
+                            seen.request.length,
+                            length / count + (rail < length % count ? 1 : 0));
+                        cursor += seen.request.length;
+                    }
+                }
+                EXPECT_EQ(cursor, request.target_offset + length);
+                EXPECT_EQ(std::memcmp(local.data() + kOffset,
+                                      expected.data() + kOffset, length),
+                          0);
+                if (opcode == Request::WRITE)
+                    EXPECT_TRUE(SocketOrderedEqual(remote, expected));
+                EXPECT_TRUE(std::all_of(local.begin(), local.begin() + kOffset,
+                                        [](uint8_t b) { return b == 0xa5; }));
+                EXPECT_TRUE(std::all_of(local.begin() + kOffset + length,
+                                        local.end(),
+                                        [](uint8_t b) { return b == 0xa5; }));
+                ASSERT_TRUE(client.freeBatch(batch).ok());
+            }
+        }
+        size_t connections = 0;
+        for (auto& relay : relays) connections += relay->connections;
+        EXPECT_EQ(connections, 2U);
+    }
+    if (multi_rail) {
+        // A second peer sends one payload byte per slice, then stalls. The
+        // original peer must still complete in this same engine and worker
+        // pool.
+        asio::io_context io;
+        asio::ip::tcp::acceptor stalled(io, {asio::ip::tcp::v4(), 0});
+        stalled.non_blocking(true);
+        auto stalled_metadata = MakeLocalMetadata();
+        uint16_t stalled_rpc_port = 0;
+        ASSERT_TRUE(stalled_metadata->start(stalled_rpc_port).ok());
+        const auto stalled_name =
+            "127.0.0.1:" + std::to_string(stalled_rpc_port);
+        auto stalled_endpoint = endpoint;
+        for (auto& rail : stalled_endpoint.endpoints)
+            rail.port = stalled.local_endpoint().port();
+        ASSERT_TRUE(
+            stalled_metadata->segmentManager()
+                .updateLocal([&](SegmentDesc& segment) {
+                    segment = *server_metadata->segmentManager().getLocal();
+                    segment.name = segment.rpc_server_addr = stalled_name;
+                    return EncodeHighPerformanceTcpEndpointAttr(
+                        stalled_endpoint,
+                        &std::get<MemorySegmentDesc>(segment.detail)
+                             .transport_attrs[static_cast<int>(HP_TCP)]);
+                })
+                .ok());
+        SegmentID stalled_target;
+        ASSERT_TRUE(client.openSegment(stalled_target, stalled_name).ok());
+        ASSERT_TRUE(
+            client.registerLocalMemory(stalled_buffer.data(), kLength).ok());
+        Request request{Request::READ, stalled_buffer.data(), stalled_target,
+                        remote_desc.addr, (4ULL << 20) + 3};
+        request.transport_hint = HP_TCP;
+        auto slow = client.allocateBatch(1);
+        ASSERT_TRUE(client.submitTransfer(slow, {request}).ok());
+        std::array<asio::ip::tcp::socket, 2> sockets{asio::ip::tcp::socket(io),
+                                                     asio::ip::tcp::socket(io)};
+        for (auto& socket : sockets) {
+            ASSERT_TRUE(WaitUntil([&] {
+                std::error_code error;
+                if (!socket.is_open()) stalled.accept(socket, error);
+                return socket.is_open();
+            }));
+            std::array<uint8_t, kHighPerformanceTcpRequestSize> header{};
+            asio::read(socket, asio::buffer(header));
+            HighPerformanceTcpRequestFrame frame;
+            ASSERT_TRUE(DecodeHighPerformanceTcpRequest(header.data(),
+                                                        header.size(), &frame)
+                            .ok());
+            const auto response = EncodeHighPerformanceTcpResponse(
+                {HighPerformanceTcpStatus::kOk, frame.request_id,
+                 frame.length});
+            asio::write(socket, asio::buffer(response));
+            asio::write(socket, asio::buffer(remote.data(), 1));
+        }
+        request.source = local.data();
+        request.target_id = target;
+        request.length = 4096;
+        auto healthy = client.allocateBatch(1);
+        ASSERT_TRUE(client.submitTransfer(healthy, {request}).ok());
+        TransferStatus status{PENDING, 0};
+        ASSERT_TRUE(WaitUntil([&] {
+            for (auto& relay : relays) relay->poll();
+            EXPECT_TRUE(client.getTransferStatus(healthy, status).ok());
+            return status.s != PENDING;
+        }));
+        EXPECT_EQ(status.s, COMPLETED);
+        EXPECT_EQ(std::memcmp(local.data(), expected.data(), 4096), 0);
+        ASSERT_TRUE(client.freeBatch(healthy).ok());
+        ASSERT_TRUE(client.getTransferStatus(slow, status).ok());
+        EXPECT_EQ(status.s, PENDING);
+        ASSERT_TRUE(WaitUntil([&] {
+            EXPECT_TRUE(client.getTransferStatus(slow, status).ok());
+            return status.s != PENDING;
+        }));
+        EXPECT_EQ(status.s, TIMEOUT);
+        ASSERT_TRUE(client.freeBatch(slow).ok());
+        ASSERT_TRUE(
+            client.unregisterLocalMemory(stalled_buffer.data(), kLength).ok());
+    }
+    ASSERT_TRUE(client.unregisterLocalMemory(local.data(), local.size()).ok());
     ASSERT_TRUE(server.removeMemoryBuffer(remote_desc).ok());
-    ASSERT_TRUE(client.quiesce().ok());
     ASSERT_TRUE(server.quiesce().ok());
-    ASSERT_TRUE(client.uninstall().ok());
     ASSERT_TRUE(server.uninstall().ok());
+}
+
+TEST(HighPerformanceTcpTransportTest, RailPayloadsAndConnectionReuse) {
+    CheckRailPayloads(true);
+}
+
+TEST(HighPerformanceTcpTransportTest, SingleRailPayloadsAndConnectionReuse) {
+    CheckRailPayloads(false);
 }
 
 TEST(HighPerformanceTcpTransportTest,

--- a/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
@@ -32,7 +32,8 @@ struct MergeResult {
 
 MergeResult mergeRequests(const std::vector<Request>& requests,
                           const std::vector<RequestBoundaryInfo>& boundaries,
-                          bool do_merge);
+                          bool do_merge,
+                          uint64_t hp_tcp_max_transfer_bytes = UINT64_MAX);
 
 namespace {
 
@@ -90,6 +91,15 @@ TEST(RequestMergeTest, MergesAdjacentRequestsInsideSameRegisteredBuffers) {
     EXPECT_EQ(merged.request_list[0].length, 2048u);
     EXPECT_EQ(merged.task_lookup.at(0), 0u);
     EXPECT_EQ(merged.task_lookup.at(1), 0u);
+    for (auto hint : {HP_TCP, UNSPEC, TCP}) {
+        for (auto& request : requests) request.transport_hint = hint;
+        EXPECT_EQ(
+            mergeRequests(requests, boundaries, true, 1024).request_list.size(),
+            hint == TCP ? 1u : 2u);
+        EXPECT_EQ(
+            mergeRequests(requests, boundaries, true, 2048).request_list.size(),
+            1u);
+    }
 }
 
 TEST(RequestMergeTest, KeepsNonContiguousRequestsSplit) {

--- a/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <optional>
 #include <vector>
@@ -23,6 +24,7 @@ struct BufferKey {
 struct RequestBoundaryInfo {
     std::optional<BufferKey> source_key;
     std::optional<BufferKey> target_key;
+    uint64_t max_merge_bytes{std::numeric_limits<uint64_t>::max()};
 };
 
 struct MergeResult {
@@ -32,8 +34,7 @@ struct MergeResult {
 
 MergeResult mergeRequests(const std::vector<Request>& requests,
                           const std::vector<RequestBoundaryInfo>& boundaries,
-                          bool do_merge,
-                          uint64_t hp_tcp_max_transfer_bytes = UINT64_MAX);
+                          bool do_merge);
 
 namespace {
 
@@ -91,14 +92,10 @@ TEST(RequestMergeTest, MergesAdjacentRequestsInsideSameRegisteredBuffers) {
     EXPECT_EQ(merged.request_list[0].length, 2048u);
     EXPECT_EQ(merged.task_lookup.at(0), 0u);
     EXPECT_EQ(merged.task_lookup.at(1), 0u);
-    for (auto hint : {HP_TCP, UNSPEC, TCP}) {
-        for (auto& request : requests) request.transport_hint = hint;
-        EXPECT_EQ(
-            mergeRequests(requests, boundaries, true, 1024).request_list.size(),
-            hint == TCP ? 1u : 2u);
-        EXPECT_EQ(
-            mergeRequests(requests, boundaries, true, 2048).request_list.size(),
-            1u);
+    for (uint64_t limit : {1024, 2048}) {
+        for (auto& boundary : boundaries) boundary.max_merge_bytes = limit;
+        EXPECT_EQ(mergeRequests(requests, boundaries, true).request_list.size(),
+                  limit == 1024 ? 2u : 1u);
     }
 }
 

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -390,6 +390,8 @@ TEST(TransferEngineConfigOverrideTest,
 
     const auto live_endpoint = buildHttpMetadataEndpoint(live_port);
     const auto dead_endpoint = buildHttpMetadataEndpoint(dead_port);
+    // The HTTP server keeps this port occupied, so automatic RPC port
+    // selection cannot legitimately choose the value from the file.
     TempConfigFile conf_file(
         "{\n"
         "  \"metadata_type\": \"p2p\",\n"
@@ -399,7 +401,9 @@ TEST(TransferEngineConfigOverrideTest,
         "  \"rpc_server_hostname\": \"" +
         std::string(kLoopbackHostname) +
         "\",\n"
-        "  \"rpc_server_port\": 15011,\n"
+        "  \"rpc_server_port\": " +
+        std::to_string(live_port) +
+        ",\n"
         "  \"log_level\": \"warning\",\n"
         "  \"merge_requests\": false\n"
         "}");
@@ -425,7 +429,7 @@ TEST(TransferEngineConfigOverrideTest,
         EXPECT_EQ(engine.getSegmentName(), kSegmentName);
         EXPECT_EQ(engine.getRpcServerAddress(), kLoopbackHostname);
         EXPECT_NE(engine.getRpcServerPort(), 0);
-        EXPECT_NE(engine.getRpcServerPort(), 15011);
+        EXPECT_NE(engine.getRpcServerPort(), live_port);
 
         EXPECT_EQ(config->get("log_level", ""), "warning");
         EXPECT_FALSE(config->get("merge_requests", true));


### PR DESCRIPTION
## Description

Follow-up to #3834, #3861 and #3883. This fixes the existing `hp_tcp`; it does not introduce a transport, GPU path or routing/scheduling mechanism as proposed in the older #1633 work.

- Keep runtime coalescing within both local and advertised remote HP TCP transfer-size limits, including unequal limits. Adjacent individually valid requests could otherwise merge into an oversized request and fail. Reuse existing boundary resolution; single-request submissions incur no extra metadata decoding.
- Complete #3883 on the server side: set TCP_NODELAY on accepted HP TCP sockets. #3883 already covers client sockets and small WRITEs. Separate READ response-header/payload writes could otherwise incur delayed-ACK stalls; three two-host repeats reduced 4 KiB READ p99 from about 48 ms to 94–99 µs.
- Observe actual source/destination addresses and completed slice ranges in test-local relays, with payload/guard/reuse checks and stalled/healthy peers sharing one client worker. Run all three fork-based E2E cases separately; use unequal endpoint limits to cover coalescing.
- Strengthen HP TCP CPU data only with `--check_consistency=true`, so reordered slices cannot pass a constant-byte check. Ordinary mix, other backends and write_seed/read_verify retain their existing patterns; a focused benchmark regression checks the gate. Shorten existing usage documentation.

Wire format, WRITE ACK/single-lane semantics, ownership, admission and bounded retry remain unchanged. No failover, WRITE slicing, new policy or public configuration is added.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Docs

## Type of Change

- [x] Bug fix
- [x] Documentation update

## How Has This Been Tested?

```bash
ctest --test-dir build \
  -R '^(request_merge_test|transfer_engine_config_override_test|tent_hp_tcp_transport_test|tent_hp_tcp_e2e_.*|tent_tcp_datapath_roundtrip_test_.*|tent_transport_selector_test|tebench_target_metrics_test)$' \
  --output-on-failure
```

- [x] Final-revision Release: 10/10 targeted CTest entries, 88 GTest cases with no skips, including unequal-limit E2E, single-worker peer isolation, merge, normal TCP, selector and benchmark pattern gating. `tebench` also builds.
- [x] Final-revision ASan+UBSan: 6/6 targeted CTest entries, 20 GTest cases with no skips; leak detection and halt-on-error enabled. No sanitizer errors. TSan and two-host performance were not rerun during the second-pass correction.
- [x] Prior revision `4682e076`: Release 16/16; HP TCP/request-merge ASan+UBSan (including leak detection) 10/10; TSan 10/10. These previous full gates are not claimed as rerun on the final revision.
- [x] Two-host `tebench --op_type=mix --check_consistency=true --xport_type=hp_tcp`: non-constant CPU data, 4 KiB and 64 MiB, full comparison passed.
- [x] Three interleaved two-host performance repeats and same-engine/same-peer mixed READ tests. With four workers/four total lanes, single 64 MiB READ improved from 3.22 to 6.46 GB/s with two rails. Four concurrent READs showed no additional gain (11.13 vs 10.96 GB/s). Both interfaces carried payload-direction traffic; this is not a claim of universal or purely physical-NIC scaling.
- [x] `git diff --check`, clang-format 20 / LLVM changed-line check, and documentation HTML build. Other applicable pre-commit hooks passed; the Windows C++ shell entry was replaced by the equivalent direct LLVM check.

## Checklist

- [x] Human submitter has reviewed every changed line and the measured limitations.
- [x] Documentation and targeted regression coverage updated.
- [x] No protocol or public API change; no new production abstraction.

## AI Assistance Disclosure

- [x] AI tools were used