### PR TITLE
[Store] Add optional RocksDB storage backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(
   OFF)
 option(WITH_EP "build mooncake with expert parallelism support" OFF)
 option(USE_NOF "build mooncake store with NoF SSD pool support" OFF)
+option(MOONCAKE_USE_ROCKSDB "build Mooncake Store with RocksDB backend" OFF)
 option(MOONCAKE_ENABLE_TEST_FAILPOINTS
        "Enable file-handshake failpoints for integration tests" OFF)
 if(MOONCAKE_ENABLE_TEST_FAILPOINTS)

--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -92,6 +92,9 @@
 
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#ifdef MOONCAKE_USE_ROCKSDB
+#include "storage/local/rocksdb/rocksdb_backend.h"
+#endif
 #include "storage_backend.h"
 
 namespace fs = std::filesystem;
@@ -102,7 +105,8 @@ namespace fs = std::filesystem;
 
 // === Core Parameters ===
 DEFINE_string(backend, "offset_allocator",
-              "Backend type: offset_allocator, bucket, file_per_key, or all");
+              "Backend type: offset_allocator, bucket, file_per_key, rocksdb, "
+              "or all");
 DEFINE_uint64(value_size, 128 * 1024, "Value size in bytes (default: 128KB)");
 DEFINE_uint64(batch_size, 32, "Batch size for operations (default: 32)");
 DEFINE_uint64(num_operations, 1000,
@@ -242,7 +246,14 @@ AccessPattern StringToAccessPattern(const std::string& str) {
 // Backend Types
 // ============================================================================
 
-enum class BackendType { OFFSET_ALLOCATOR, BUCKET, FILE_PER_KEY };
+enum class BackendType {
+    OFFSET_ALLOCATOR,
+    BUCKET,
+    FILE_PER_KEY,
+#ifdef MOONCAKE_USE_ROCKSDB
+    ROCKSDB
+#endif
+};
 
 std::string BackendTypeToString(BackendType type) {
     switch (type) {
@@ -252,6 +263,10 @@ std::string BackendTypeToString(BackendType type) {
             return "bucket";
         case BackendType::FILE_PER_KEY:
             return "file_per_key";
+#ifdef MOONCAKE_USE_ROCKSDB
+        case BackendType::ROCKSDB:
+            return "rocksdb";
+#endif
     }
     return "unknown";
 }
@@ -260,6 +275,9 @@ BackendType StringToBackendType(const std::string& str) {
     if (str == "offset_allocator") return BackendType::OFFSET_ALLOCATOR;
     if (str == "bucket") return BackendType::BUCKET;
     if (str == "file_per_key") return BackendType::FILE_PER_KEY;
+#ifdef MOONCAKE_USE_ROCKSDB
+    if (str == "rocksdb") return BackendType::ROCKSDB;
+#endif
     LOG(FATAL) << "Unknown backend type: " << str;
     return BackendType::OFFSET_ALLOCATOR;
 }
@@ -831,6 +849,13 @@ std::shared_ptr<mooncake::StorageBackendInterface> CreateBackend(
             return std::make_shared<mooncake::StorageBackendAdaptor>(
                 config, fpk_config);
         }
+#ifdef MOONCAKE_USE_ROCKSDB
+        case BackendType::ROCKSDB: {
+            config.storage_backend_type =
+                mooncake::StorageBackendType::kRocksDb;
+            return std::make_shared<mooncake::RocksDBStorageBackend>(config);
+        }
+#endif
     }
     return nullptr;
 }
@@ -2282,7 +2307,12 @@ struct BenchmarkResult {
 void RunAllBenchmarks(const std::string& storage_path, size_t capacity) {
     std::vector<BackendType> backends = {BackendType::OFFSET_ALLOCATOR,
                                          BackendType::BUCKET,
-                                         BackendType::FILE_PER_KEY};
+                                         BackendType::FILE_PER_KEY
+#ifdef MOONCAKE_USE_ROCKSDB
+                                         ,
+                                         BackendType::ROCKSDB
+#endif
+    };
 
     std::vector<BenchmarkResult> results;
 

--- a/mooncake-store/include/storage/local/rocksdb/rocksdb_backend.h
+++ b/mooncake-store/include/storage/local/rocksdb/rocksdb_backend.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+
+#include "storage_backend.h"
+
+namespace rocksdb {
+class DB;
+}
+
+namespace mooncake {
+
+struct RocksDBBackendConfig {
+    uint64_t min_blob_size{64ULL * 1024};
+    uint64_t blob_file_size{256ULL * 1024 * 1024};
+    uint32_t blob_direct_write_partitions{1};
+    bool enable_blob_files{true};
+    bool enable_blob_direct_write{false};
+    bool sync_writes{true};
+
+    static RocksDBBackendConfig FromEnvironment();
+    bool Validate() const;
+};
+
+class RocksDBStorageBackend final : public StorageBackendInterface {
+   public:
+    explicit RocksDBStorageBackend(const FileStorageConfig& config,
+                                   RocksDBBackendConfig backend_config =
+                                       RocksDBBackendConfig::FromEnvironment());
+    ~RocksDBStorageBackend() override;
+
+    tl::expected<void, ErrorCode> Init() override;
+    tl::expected<int64_t, ErrorCode> BatchOffload(
+        const std::unordered_map<std::string, std::vector<Slice>>& batch_object,
+        std::function<ErrorCode(const std::vector<std::string>& keys,
+                                std::vector<StorageObjectMetadata>& metadatas)>
+            complete_handler,
+        EvictionHandler eviction_handler = nullptr) override;
+    tl::expected<void, ErrorCode> BatchLoad(
+        std::unordered_map<std::string, Slice>& batched_slices) override;
+    tl::expected<bool, ErrorCode> IsExist(const std::string& key) override;
+    tl::expected<bool, ErrorCode> IsEnableOffloading() override;
+    tl::expected<void, ErrorCode> ScanMeta(
+        const std::function<ErrorCode(
+            const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metadatas)>& handler) override;
+    void SetTestFailurePredicate(
+        std::function<bool(const std::string& key)> predicate) override;
+    void RemoveAll() override;
+
+   private:
+    tl::expected<void, ErrorCode> OpenDatabase();
+    tl::expected<void, ErrorCode> RecoverState();
+    static tl::expected<std::string, ErrorCode> ConcatSlices(
+        const std::vector<Slice>& slices);
+
+    RocksDBBackendConfig backend_config_;
+    mutable std::shared_mutex mutex_;
+    mutable std::shared_mutex publication_mutex_;
+    std::array<std::mutex, 256> key_mutexes_;
+    std::unique_ptr<rocksdb::DB> db_;
+    std::function<bool(const std::string& key)> test_failure_predicate_;
+    std::atomic<uint64_t> next_version_{1};
+    std::atomic<uint64_t> key_count_{0};
+    std::atomic<uint64_t> logical_bytes_{0};
+    std::atomic<bool> initialized_{false};
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -166,7 +166,8 @@ enum class StorageBackendType {
     kBucket,
     kOffsetAllocator,
     kDistributed,
-    kNvmeKv
+    kNvmeKv,
+    kRocksDb
 };
 
 static constexpr size_t kKB = 1024;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -71,6 +71,20 @@ set(MOONCAKE_STORE_MASTER_SOURCES
     standby_state_machine.cpp
     ha_metric_manager.cpp)
 
+if(MOONCAKE_USE_ROCKSDB)
+  set(ROCKSDB_EXTRA_LIBRARIES
+      ""
+      CACHE STRING "Additional libraries required by a static RocksDB build")
+  find_path(ROCKSDB_INCLUDE_DIR rocksdb/db.h)
+  find_library(ROCKSDB_LIBRARY NAMES rocksdb)
+  if(NOT ROCKSDB_INCLUDE_DIR OR NOT ROCKSDB_LIBRARY)
+    message(
+      FATAL_ERROR
+        "MOONCAKE_USE_ROCKSDB=ON requires ROCKSDB_INCLUDE_DIR and ROCKSDB_LIBRARY"
+    )
+  endif()
+endif()
+
 set(MOONCAKE_STORE_CLIENT_SOURCES
     client_buffer_allocation.cpp
     client_service.cpp
@@ -117,6 +131,11 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     memory_alloc.cpp
     ssd_register_client.cpp
     engram/engram_store.cpp)
+
+if(MOONCAKE_USE_ROCKSDB)
+  list(APPEND MOONCAKE_STORE_CLIENT_SOURCES
+       storage/local/rocksdb/rocksdb_backend.cpp)
+endif()
 
 if(BUILD_UNIT_TESTS)
   list(APPEND MOONCAKE_STORE_CLIENT_SOURCES nvme_kv_executor_stub.cpp)
@@ -433,6 +452,12 @@ set_target_properties(mooncake_store_client_objects
                       PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mooncake_store_client_objects
                            PRIVATE ${MOONCAKE_STORE_INCLUDE_DIRS})
+if(MOONCAKE_USE_ROCKSDB)
+  target_include_directories(mooncake_store_client_objects
+                             PRIVATE ${ROCKSDB_INCLUDE_DIR})
+  target_compile_definitions(mooncake_store_client_objects
+                             PRIVATE MOONCAKE_USE_ROCKSDB=1)
+endif()
 target_link_libraries(
   mooncake_store_client_objects
   PRIVATE mooncake_store_shared_objects
@@ -537,6 +562,12 @@ target_link_libraries(
          transfer_engine
          yalantinglibs::yalantinglibs
   PRIVATE gflags::gflags JsonCpp::JsonCpp yaml-cpp Mooncake::xxhash numa)
+if(MOONCAKE_USE_ROCKSDB)
+  target_compile_definitions(mooncake_store PUBLIC MOONCAKE_USE_ROCKSDB=1)
+  target_include_directories(mooncake_store PUBLIC ${ROCKSDB_INCLUDE_DIR})
+  target_link_libraries(mooncake_store PUBLIC ${ROCKSDB_LIBRARY}
+                                              ${ROCKSDB_EXTRA_LIBRARIES})
+endif()
 if(KV_EVENTS_ZMQ_FOUND)
   target_link_libraries(mooncake_store PRIVATE Mooncake::libzmq)
 endif()

--- a/mooncake-store/src/config/file_storage_config.cpp
+++ b/mooncake-store/src/config/file_storage_config.cpp
@@ -64,6 +64,8 @@ FileStorageConfig FileStorageConfig::FromEnvironment() {
         config.enable_dfs = true;
     } else if (storage_backend_descriptor == "nvme_kv_storage_backend") {
         config.storage_backend_type = StorageBackendType::kNvmeKv;
+    } else if (storage_backend_descriptor == "rocksdb_storage_backend") {
+        config.storage_backend_type = StorageBackendType::kRocksDb;
     } else {
         LOG(ERROR) << "Unknown storage backend.";
     }

--- a/mooncake-store/src/storage/local/rocksdb/rocksdb_backend.cpp
+++ b/mooncake-store/src/storage/local/rocksdb/rocksdb_backend.cpp
@@ -1,0 +1,551 @@
+#include "storage/local/rocksdb/rocksdb_backend.h"
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <string_view>
+#include <unordered_set>
+
+#include <glog/logging.h>
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <rocksdb/slice.h>
+#include <rocksdb/write_batch.h>
+
+#include "environ.h"
+
+namespace mooncake {
+namespace {
+
+constexpr char kCurrentPrefix = '\x01';
+constexpr char kDataPrefix = '\x02';
+constexpr size_t kEncodedSizeBytes = sizeof(uint64_t);
+
+std::string CurrentKey(std::string_view key) {
+    std::string encoded;
+    encoded.reserve(1 + key.size());
+    encoded.push_back(kCurrentPrefix);
+    encoded.append(key);
+    return encoded;
+}
+
+std::string DataKey(uint64_t version, std::string_view key) {
+    std::string encoded;
+    encoded.reserve(1 + sizeof(version) + key.size());
+    encoded.push_back(kDataPrefix);
+    for (size_t index = 0; index < sizeof(version); ++index) {
+        encoded.push_back(static_cast<char>(version >> (index * 8)));
+    }
+    encoded.append(key);
+    return encoded;
+}
+
+uint64_t DecodeVersion(std::string_view key) {
+    if (key.size() < 1 + sizeof(uint64_t) || key.front() != kDataPrefix) {
+        return 0;
+    }
+    uint64_t version = 0;
+    for (size_t index = 0; index < sizeof(version); ++index) {
+        version |=
+            static_cast<uint64_t>(static_cast<unsigned char>(key[1 + index]))
+            << (index * 8);
+    }
+    return version;
+}
+
+std::string EncodeCurrentValue(uint64_t value_size, std::string_view data_key) {
+    std::string encoded;
+    encoded.reserve(kEncodedSizeBytes + data_key.size());
+    for (size_t index = 0; index < kEncodedSizeBytes; ++index) {
+        encoded.push_back(static_cast<char>(value_size >> (index * 8)));
+    }
+    encoded.append(data_key);
+    return encoded;
+}
+
+bool DecodeCurrentValue(std::string_view encoded, uint64_t* value_size,
+                        std::string_view* data_key) {
+    if (encoded.size() < kEncodedSizeBytes) return false;
+    *value_size = 0;
+    for (size_t index = 0; index < kEncodedSizeBytes; ++index) {
+        *value_size |=
+            static_cast<uint64_t>(static_cast<unsigned char>(encoded[index]))
+            << (index * 8);
+    }
+    *data_key = encoded.substr(kEncodedSizeBytes);
+    return !data_key->empty() && data_key->front() == kDataPrefix;
+}
+
+ErrorCode ToWriteError(const rocksdb::Status& status) {
+    if (status.IsInvalidArgument()) return ErrorCode::INVALID_PARAMS;
+    return ErrorCode::FILE_WRITE_FAIL;
+}
+
+ErrorCode ToReadError(const rocksdb::Status& status) {
+    if (status.IsNotFound()) return ErrorCode::OBJECT_NOT_FOUND;
+    if (status.IsInvalidArgument()) return ErrorCode::INVALID_PARAMS;
+    return ErrorCode::FILE_READ_FAIL;
+}
+
+}  // namespace
+
+RocksDBBackendConfig RocksDBBackendConfig::FromEnvironment() {
+    RocksDBBackendConfig config;
+    config.min_blob_size = Environ::GetUInt64("MOONCAKE_ROCKSDB_MIN_BLOB_SIZE",
+                                              config.min_blob_size);
+    config.blob_file_size = Environ::GetUInt64(
+        "MOONCAKE_ROCKSDB_BLOB_FILE_SIZE", config.blob_file_size);
+    config.blob_direct_write_partitions = static_cast<uint32_t>(
+        Environ::GetUInt64("MOONCAKE_ROCKSDB_BLOB_DIRECT_WRITE_PARTITIONS",
+                           config.blob_direct_write_partitions));
+    config.enable_blob_files = Environ::GetBool(
+        "MOONCAKE_ROCKSDB_ENABLE_BLOB_FILES", config.enable_blob_files);
+    config.enable_blob_direct_write =
+        Environ::GetBool("MOONCAKE_ROCKSDB_ENABLE_BLOB_DIRECT_WRITE",
+                         config.enable_blob_direct_write);
+    config.sync_writes =
+        Environ::GetBool("MOONCAKE_ROCKSDB_SYNC_WRITES", config.sync_writes);
+    return config;
+}
+
+bool RocksDBBackendConfig::Validate() const {
+    return min_blob_size > 0 && blob_file_size >= min_blob_size &&
+           blob_direct_write_partitions > 0 &&
+           (!enable_blob_direct_write || enable_blob_files);
+}
+
+RocksDBStorageBackend::RocksDBStorageBackend(
+    const FileStorageConfig& config, RocksDBBackendConfig backend_config)
+    : StorageBackendInterface(config),
+      backend_config_(std::move(backend_config)) {}
+
+RocksDBStorageBackend::~RocksDBStorageBackend() = default;
+
+tl::expected<void, ErrorCode> RocksDBStorageBackend::OpenDatabase() {
+    const auto root =
+        std::filesystem::path(file_storage_config_.storage_filepath) /
+        "rocksdb";
+    std::error_code error;
+    std::filesystem::create_directories(root, error);
+    if (error) return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+
+    rocksdb::Options options;
+    options.create_if_missing = true;
+    options.compression = rocksdb::kNoCompression;
+    options.enable_blob_files = backend_config_.enable_blob_files;
+    options.enable_blob_direct_write = backend_config_.enable_blob_direct_write;
+    options.allow_concurrent_memtable_write = false;
+    options.min_blob_size = backend_config_.min_blob_size;
+    options.blob_file_size = backend_config_.blob_file_size;
+    options.blob_direct_write_partitions =
+        backend_config_.blob_direct_write_partitions;
+
+    std::unique_ptr<rocksdb::DB> database;
+    const auto status = rocksdb::DB::Open(options, root.string(), &database);
+    if (!status.ok()) {
+        LOG(ERROR) << "Failed to open RocksDB backend at " << root << ": "
+                   << status.ToString();
+        return tl::make_unexpected(ToWriteError(status));
+    }
+    db_ = std::move(database);
+    return {};
+}
+
+tl::expected<void, ErrorCode> RocksDBStorageBackend::RecoverState() {
+    uint64_t next_version = 1;
+    uint64_t key_count = 0;
+    uint64_t logical_bytes = 0;
+    std::unordered_set<std::string> referenced_data;
+    rocksdb::ReadOptions read_options;
+    std::unique_ptr<rocksdb::Iterator> iterator(db_->NewIterator(read_options));
+    for (iterator->Seek(rocksdb::Slice(&kCurrentPrefix, 1));
+         iterator->Valid() && iterator->key().size() > 0 &&
+         iterator->key()[0] == kCurrentPrefix;
+         iterator->Next()) {
+        uint64_t value_size = 0;
+        std::string_view data_key;
+        const auto value = iterator->value().ToStringView();
+        if (!DecodeCurrentValue(value, &value_size, &data_key)) {
+            LOG(ERROR) << "Invalid RocksDB current mapping during recovery";
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        referenced_data.emplace(data_key);
+        ++key_count;
+        logical_bytes += value_size;
+    }
+    if (!iterator->status().ok()) {
+        return tl::make_unexpected(ToReadError(iterator->status()));
+    }
+
+    rocksdb::WriteBatch cleanup;
+    for (iterator->Seek(rocksdb::Slice(&kDataPrefix, 1));
+         iterator->Valid() && iterator->key().size() > 0 &&
+         iterator->key()[0] == kDataPrefix;
+         iterator->Next()) {
+        const auto key = iterator->key().ToString();
+        const uint64_t version = DecodeVersion(key);
+        if (version == 0) {
+            LOG(ERROR) << "Invalid RocksDB data key during recovery";
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        next_version = std::max(next_version, version + 1);
+        if (referenced_data.erase(key) == 0) cleanup.Delete(key);
+    }
+    if (!iterator->status().ok()) {
+        return tl::make_unexpected(ToReadError(iterator->status()));
+    }
+    if (!referenced_data.empty()) {
+        LOG(ERROR) << "RocksDB current mapping references missing payload";
+        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+    }
+    if (cleanup.Count() != 0) {
+        rocksdb::WriteOptions write_options;
+        write_options.sync = backend_config_.sync_writes;
+        const auto status = db_->Write(write_options, &cleanup);
+        if (!status.ok()) return tl::make_unexpected(ToWriteError(status));
+    }
+    next_version_.store(next_version, std::memory_order_relaxed);
+    key_count_.store(key_count, std::memory_order_relaxed);
+    logical_bytes_.store(logical_bytes, std::memory_order_relaxed);
+    return {};
+}
+
+tl::expected<void, ErrorCode> RocksDBStorageBackend::Init() {
+    std::lock_guard lock(mutex_);
+    if (initialized_.load(std::memory_order_acquire)) return {};
+    if (!backend_config_.Validate()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    auto opened = OpenDatabase();
+    if (!opened) return opened;
+    auto recovered = RecoverState();
+    if (!recovered) {
+        db_.reset();
+        return recovered;
+    }
+    initialized_.store(true, std::memory_order_release);
+    return {};
+}
+
+tl::expected<std::string, ErrorCode> RocksDBStorageBackend::ConcatSlices(
+    const std::vector<Slice>& slices) {
+    size_t total_size = 0;
+    for (const auto& slice : slices) {
+        if (slice.size != 0 && slice.ptr == nullptr) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        if (slice.size > std::numeric_limits<size_t>::max() - total_size) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        total_size += slice.size;
+    }
+    std::string value;
+    value.reserve(total_size);
+    for (const auto& slice : slices) {
+        if (slice.size != 0) {
+            value.append(static_cast<const char*>(slice.ptr), slice.size);
+        }
+    }
+    return value;
+}
+
+tl::expected<int64_t, ErrorCode> RocksDBStorageBackend::BatchOffload(
+    const std::unordered_map<std::string, std::vector<Slice>>& batch_object,
+    std::function<ErrorCode(const std::vector<std::string>&,
+                            std::vector<StorageObjectMetadata>&)>
+        complete_handler,
+    EvictionHandler) {
+    std::shared_lock lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !db_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (batch_object.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_KEY);
+    }
+
+    std::vector<size_t> stripes;
+    stripes.reserve(batch_object.size());
+    for (const auto& [key, slices] : batch_object) {
+        static_cast<void>(slices);
+        stripes.push_back(std::hash<std::string>{}(key) % key_mutexes_.size());
+    }
+    std::sort(stripes.begin(), stripes.end());
+    stripes.erase(std::unique(stripes.begin(), stripes.end()), stripes.end());
+    std::vector<std::unique_lock<std::mutex>> key_locks;
+    key_locks.reserve(stripes.size());
+    for (const size_t stripe : stripes) {
+        key_locks.emplace_back(key_mutexes_[stripe]);
+    }
+
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    std::vector<std::string> data_keys;
+    std::vector<StorageObjectMetadata> metadatas;
+    std::optional<ErrorCode> first_error;
+    keys.reserve(batch_object.size());
+    values.reserve(batch_object.size());
+    data_keys.reserve(batch_object.size());
+    metadatas.reserve(batch_object.size());
+    rocksdb::WriteBatch prepare_batch;
+    for (const auto& [key, slices] : batch_object) {
+        if (test_failure_predicate_ && test_failure_predicate_(key)) {
+            first_error = ErrorCode::FILE_WRITE_FAIL;
+            continue;
+        }
+        auto value = ConcatSlices(slices);
+        if (!value) {
+            first_error = value.error();
+            continue;
+        }
+        const uint64_t version =
+            next_version_.fetch_add(1, std::memory_order_relaxed);
+        keys.push_back(key);
+        values.push_back(std::move(value.value()));
+        data_keys.push_back(DataKey(version, key));
+        prepare_batch.Put(data_keys.back(), values.back());
+        metadatas.push_back(StorageObjectMetadata{
+            -1, 0, static_cast<int64_t>(key.size()),
+            static_cast<int64_t>(values.back().size()), ""});
+    }
+    if (keys.empty()) {
+        return tl::make_unexpected(
+            first_error.value_or(ErrorCode::FILE_WRITE_FAIL));
+    }
+
+    rocksdb::WriteOptions write_options;
+    write_options.sync = backend_config_.sync_writes;
+    auto status = db_->Write(write_options, &prepare_batch);
+    if (!status.ok()) return tl::make_unexpected(ToWriteError(status));
+
+    const auto cleanup_prepared = [&]() {
+        rocksdb::WriteBatch cleanup;
+        for (const auto& data_key : data_keys) cleanup.Delete(data_key);
+        const auto cleanup_status = db_->Write(write_options, &cleanup);
+        if (!cleanup_status.ok()) {
+            LOG(ERROR) << "Failed to remove unpublished RocksDB values: "
+                       << cleanup_status.ToString();
+        }
+    };
+
+    std::unique_lock publication_lock(publication_mutex_);
+    if (complete_handler) {
+        try {
+            const auto result = complete_handler(keys, metadatas);
+            if (result != ErrorCode::OK) {
+                cleanup_prepared();
+                return tl::make_unexpected(result);
+            }
+        } catch (...) {
+            cleanup_prepared();
+            throw;
+        }
+    }
+
+    rocksdb::ReadOptions read_options;
+    rocksdb::WriteBatch commit_batch;
+    uint64_t inserted = 0;
+    uint64_t old_bytes = 0;
+    uint64_t new_bytes = 0;
+    for (size_t index = 0; index < keys.size(); ++index) {
+        std::string old_mapping;
+        const auto current_key = CurrentKey(keys[index]);
+        status = db_->Get(read_options, current_key, &old_mapping);
+        if (status.ok()) {
+            uint64_t old_size = 0;
+            std::string_view old_data_key;
+            if (!DecodeCurrentValue(old_mapping, &old_size, &old_data_key)) {
+                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+            }
+            old_bytes += old_size;
+            commit_batch.Delete(old_data_key);
+        } else if (status.IsNotFound()) {
+            ++inserted;
+        } else {
+            return tl::make_unexpected(ToReadError(status));
+        }
+        new_bytes += values[index].size();
+        commit_batch.Put(current_key, EncodeCurrentValue(values[index].size(),
+                                                         data_keys[index]));
+    }
+    status = db_->Write(write_options, &commit_batch);
+    if (!status.ok()) return tl::make_unexpected(ToWriteError(status));
+    key_count_.fetch_add(inserted, std::memory_order_relaxed);
+    if (new_bytes >= old_bytes) {
+        logical_bytes_.fetch_add(new_bytes - old_bytes,
+                                 std::memory_order_relaxed);
+    } else {
+        logical_bytes_.fetch_sub(old_bytes - new_bytes,
+                                 std::memory_order_relaxed);
+    }
+    return static_cast<int64_t>(keys.size());
+}
+
+tl::expected<void, ErrorCode> RocksDBStorageBackend::BatchLoad(
+    std::unordered_map<std::string, Slice>& batched_slices) {
+    std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !db_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    std::vector<std::string> current_keys;
+    std::vector<Slice*> destinations;
+    current_keys.reserve(batched_slices.size());
+    destinations.reserve(batched_slices.size());
+    for (auto& [key, slice] : batched_slices) {
+        if (slice.size != 0 && slice.ptr == nullptr) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        current_keys.push_back(CurrentKey(key));
+        destinations.push_back(&slice);
+    }
+
+    std::vector<rocksdb::Slice> current_key_slices;
+    current_key_slices.reserve(current_keys.size());
+    for (const auto& key : current_keys) current_key_slices.emplace_back(key);
+    std::vector<std::string> mappings;
+    const auto mapping_statuses =
+        db_->MultiGet(rocksdb::ReadOptions(), current_key_slices, &mappings);
+
+    std::vector<rocksdb::Slice> data_key_slices;
+    data_key_slices.reserve(mappings.size());
+    for (size_t index = 0; index < mappings.size(); ++index) {
+        if (!mapping_statuses[index].ok()) {
+            return tl::make_unexpected(ToReadError(mapping_statuses[index]));
+        }
+        uint64_t value_size = 0;
+        std::string_view data_key;
+        if (!DecodeCurrentValue(mappings[index], &value_size, &data_key) ||
+            value_size != destinations[index]->size) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        data_key_slices.emplace_back(data_key);
+    }
+
+    std::vector<std::string> values;
+    const auto value_statuses =
+        db_->MultiGet(rocksdb::ReadOptions(), data_key_slices, &values);
+    for (size_t index = 0; index < values.size(); ++index) {
+        if (!value_statuses[index].ok()) {
+            return tl::make_unexpected(ToReadError(value_statuses[index]));
+        }
+        if (values[index].size() != destinations[index]->size) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        std::memcpy(destinations[index]->ptr, values[index].data(),
+                    values[index].size());
+    }
+    return {};
+}
+
+tl::expected<bool, ErrorCode> RocksDBStorageBackend::IsExist(
+    const std::string& key) {
+    std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !db_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    std::string mapping;
+    const auto status =
+        db_->Get(rocksdb::ReadOptions(), CurrentKey(key), &mapping);
+    if (status.IsNotFound()) return false;
+    if (!status.ok()) return tl::make_unexpected(ToReadError(status));
+    return true;
+}
+
+tl::expected<bool, ErrorCode> RocksDBStorageBackend::IsEnableOffloading() {
+    std::shared_lock lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !db_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (file_storage_config_.total_keys_limit <= 0 ||
+        file_storage_config_.total_size_limit <= 0) {
+        return false;
+    }
+    return key_count_.load(std::memory_order_relaxed) <
+               static_cast<uint64_t>(file_storage_config_.total_keys_limit) &&
+           logical_bytes_.load(std::memory_order_relaxed) <
+               static_cast<uint64_t>(file_storage_config_.total_size_limit);
+}
+
+tl::expected<void, ErrorCode> RocksDBStorageBackend::ScanMeta(
+    const std::function<ErrorCode(const std::vector<std::string>&,
+                                  std::vector<StorageObjectMetadata>&)>&
+        handler) {
+    std::shared_lock lock(mutex_);
+    std::shared_lock publication_lock(publication_mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !db_) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    const size_t batch_limit = static_cast<size_t>(std::max<int64_t>(
+        1, file_storage_config_.scanmeta_iterator_keys_limit));
+    std::vector<std::string> keys;
+    std::vector<StorageObjectMetadata> metadatas;
+    keys.reserve(batch_limit);
+    metadatas.reserve(batch_limit);
+    std::unique_ptr<rocksdb::Iterator> iterator(
+        db_->NewIterator(rocksdb::ReadOptions()));
+    for (iterator->Seek(rocksdb::Slice(&kCurrentPrefix, 1));
+         iterator->Valid() && iterator->key().size() > 0 &&
+         iterator->key()[0] == kCurrentPrefix;
+         iterator->Next()) {
+        uint64_t value_size = 0;
+        std::string_view data_key;
+        if (!DecodeCurrentValue(iterator->value().ToStringView(), &value_size,
+                                &data_key)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        keys.push_back(iterator->key().ToString().substr(1));
+        metadatas.push_back(StorageObjectMetadata{
+            -1, 0, static_cast<int64_t>(keys.back().size()),
+            static_cast<int64_t>(value_size), ""});
+        if (keys.size() < batch_limit) continue;
+        const auto result = handler(keys, metadatas);
+        if (result != ErrorCode::OK) return tl::make_unexpected(result);
+        keys.clear();
+        metadatas.clear();
+    }
+    if (!iterator->status().ok()) {
+        return tl::make_unexpected(ToReadError(iterator->status()));
+    }
+    if (!keys.empty()) {
+        const auto result = handler(keys, metadatas);
+        if (result != ErrorCode::OK) return tl::make_unexpected(result);
+    }
+    return {};
+}
+
+void RocksDBStorageBackend::SetTestFailurePredicate(
+    std::function<bool(const std::string& key)> predicate) {
+    std::unique_lock lock(mutex_);
+    test_failure_predicate_ = std::move(predicate);
+}
+
+void RocksDBStorageBackend::RemoveAll() {
+    std::unique_lock lock(mutex_);
+    if (!initialized_.load(std::memory_order_acquire) || !db_) return;
+    std::unique_lock publication_lock(publication_mutex_);
+    const auto root =
+        std::filesystem::path(file_storage_config_.storage_filepath) /
+        "rocksdb";
+    db_.reset();
+    const auto destroy_status =
+        rocksdb::DestroyDB(root.string(), rocksdb::Options());
+    if (!destroy_status.ok()) {
+        LOG(ERROR) << "Failed to destroy RocksDB backend: "
+                   << destroy_status.ToString();
+        initialized_.store(false, std::memory_order_release);
+        return;
+    }
+    auto opened = OpenDatabase();
+    if (!opened) {
+        initialized_.store(false, std::memory_order_release);
+        return;
+    }
+    next_version_.store(1, std::memory_order_relaxed);
+    key_count_.store(0, std::memory_order_relaxed);
+    logical_bytes_.store(0, std::memory_order_relaxed);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -51,6 +51,9 @@ struct FdGuard {
 
 #include "storage/distributed/distributed_storage_backend.h"
 #include "storage/distributed/posix_fs_adapter.h"
+#ifdef MOONCAKE_USE_ROCKSDB
+#include "storage/local/rocksdb/rocksdb_backend.h"
+#endif
 #ifdef USE_3FS
 #include "storage/distributed/hf3fs_adapter.h"
 #endif
@@ -5525,6 +5528,14 @@ CreateStorageBackend(const FileStorageConfig& config) {
         }
         case StorageBackendType::kNvmeKv:
             return std::make_shared<NvmeKvStorageBackend>(config);
+
+        case StorageBackendType::kRocksDb:
+#ifdef MOONCAKE_USE_ROCKSDB
+            return std::make_shared<RocksDBStorageBackend>(config);
+#else
+            LOG(ERROR) << "RocksDB backend was not enabled at build time";
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+#endif
 
         case StorageBackendType::kDistributed: {
             auto distributed_config =

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -177,6 +177,12 @@ target_include_directories(local_ssd_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(local_ssd_test PRIVATE mooncake_local_ssd gtest
                                              gtest_main)
 add_test(NAME local_ssd_test COMMAND local_ssd_test)
+if(MOONCAKE_USE_ROCKSDB)
+  add_executable(rocksdb_backend_test storage/local/rocksdb/backend_test.cpp)
+  target_link_libraries(rocksdb_backend_test PRIVATE mooncake_store gtest
+                                                     gtest_main)
+  add_test(NAME rocksdb_backend_test COMMAND rocksdb_backend_test)
+endif()
 add_store_test(local_ssd_codec_test ha/snapshot/local_ssd_codec_test.cpp)
 add_store_test(offset_allocator_test offset_allocator_test.cpp)
 add_store_test(utils_test utils_test.cpp)

--- a/mooncake-store/tests/storage/local/rocksdb/backend_test.cpp
+++ b/mooncake-store/tests/storage/local/rocksdb/backend_test.cpp
@@ -1,0 +1,179 @@
+#include "storage/local/rocksdb/rocksdb_backend.h"
+
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "tenant_id.h"
+
+namespace mooncake {
+namespace {
+
+class BackendTempDirectory {
+   public:
+    BackendTempDirectory() {
+        const auto id = next_id_.fetch_add(1, std::memory_order_relaxed);
+        const char* tmpdir = std::getenv("TMPDIR");
+        const std::filesystem::path base =
+            tmpdir == nullptr ? std::filesystem::temp_directory_path()
+                              : std::filesystem::path(tmpdir);
+        path_ = base / ("mooncake-rocksdb-backend-test-" +
+                        std::to_string(getpid()) + "-" + std::to_string(id));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~BackendTempDirectory() {
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    const std::filesystem::path& path() const { return path_; }
+
+   private:
+    inline static std::atomic<uint64_t> next_id_{0};
+    std::filesystem::path path_;
+};
+
+FileStorageConfig BackendConfig(const BackendTempDirectory& temp) {
+    FileStorageConfig config;
+    config.storage_backend_type = StorageBackendType::kRocksDb;
+    config.storage_filepath = temp.path().string();
+    config.total_keys_limit = 100;
+    config.total_size_limit = 16 * 1024 * 1024;
+    config.scanmeta_iterator_keys_limit = 1;
+    return config;
+}
+
+std::unordered_map<std::string, std::vector<Slice>> MakeBatch(
+    std::unordered_map<std::string, std::string>& values) {
+    std::unordered_map<std::string, std::vector<Slice>> batch;
+    for (auto& [key, value] : values) {
+        const size_t midpoint = value.size() / 2;
+        batch[key] = {Slice{value.data(), midpoint},
+                      Slice{value.data() + midpoint, value.size() - midpoint}};
+    }
+    return batch;
+}
+
+TEST(RocksDBStorageBackendTest, BatchLifecycleSurvivesRestartAndRemoveAll) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    std::unordered_map<std::string, std::string> values{
+        {TenantId("tenant-a").MakeScopedKey("key-1"), "first-payload"},
+        {TenantId("tenant-b").MakeScopedKey("key-2"),
+         std::string(128 * 1024, 'b')}};
+
+    {
+        RocksDBStorageBackend backend(config);
+        ASSERT_TRUE(backend.Init().has_value());
+        auto written = backend.BatchOffload(
+            MakeBatch(values),
+            [&](const std::vector<std::string>& keys,
+                std::vector<StorageObjectMetadata>& metadatas) {
+                EXPECT_EQ(keys.size(), values.size());
+                EXPECT_EQ(metadatas.size(), values.size());
+                return ErrorCode::OK;
+            });
+        ASSERT_TRUE(written.has_value());
+        EXPECT_EQ(*written, static_cast<int64_t>(values.size()));
+
+        std::unordered_map<std::string, std::string> loaded;
+        std::unordered_map<std::string, Slice> slices;
+        for (const auto& [key, value] : values) {
+            auto [iterator, inserted] =
+                loaded.emplace(key, std::string(value.size(), '\0'));
+            ASSERT_TRUE(inserted);
+            slices.emplace(
+                key, Slice{iterator->second.data(), iterator->second.size()});
+        }
+        ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+        EXPECT_EQ(loaded, values);
+    }
+
+    RocksDBStorageBackend recovered(config);
+    ASSERT_TRUE(recovered.Init().has_value());
+    std::unordered_map<std::string, int64_t> scanned;
+    ASSERT_TRUE(
+        recovered
+            .ScanMeta([&](const std::vector<std::string>& keys,
+                          std::vector<StorageObjectMetadata>& metadata) {
+                EXPECT_EQ(keys.size(), metadata.size());
+                for (size_t index = 0; index < keys.size(); ++index) {
+                    scanned[keys[index]] = metadata[index].data_size;
+                }
+                return ErrorCode::OK;
+            })
+            .has_value());
+    ASSERT_EQ(scanned.size(), values.size());
+    for (const auto& [key, value] : values) {
+        EXPECT_EQ(scanned[key], static_cast<int64_t>(value.size()));
+        ASSERT_TRUE(recovered.IsExist(key).has_value());
+        EXPECT_TRUE(*recovered.IsExist(key));
+    }
+
+    recovered.RemoveAll();
+    for (const auto& [key, value] : values) {
+        static_cast<void>(value);
+        ASSERT_TRUE(recovered.IsExist(key).has_value());
+        EXPECT_FALSE(*recovered.IsExist(key));
+    }
+    size_t scanned_after_remove = 0;
+    ASSERT_TRUE(recovered
+                    .ScanMeta([&](const std::vector<std::string>& keys,
+                                  std::vector<StorageObjectMetadata>&) {
+                        scanned_after_remove += keys.size();
+                        return ErrorCode::OK;
+                    })
+                    .has_value());
+    EXPECT_EQ(scanned_after_remove, 0);
+}
+
+TEST(RocksDBStorageBackendTest, FactoryCreatesEnabledBackend) {
+    BackendTempDirectory temp;
+    auto backend = CreateStorageBackend(BackendConfig(temp));
+    ASSERT_TRUE(backend.has_value());
+    ASSERT_TRUE((*backend)->Init().has_value());
+}
+
+TEST(RocksDBStorageBackendTest,
+     RejectedOverwritePreservesPreviouslyCommittedValue) {
+    BackendTempDirectory temp;
+    const auto config = BackendConfig(temp);
+    const std::string key = TenantId("tenant-a").MakeScopedKey("key");
+    std::unordered_map<std::string, std::string> original{{key, "old-value"}};
+    std::unordered_map<std::string, std::string> replacement{
+        {key, "new-value"}};
+
+    RocksDBStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+    ASSERT_TRUE(backend
+                    .BatchOffload(MakeBatch(original),
+                                  [](const std::vector<std::string>&,
+                                     std::vector<StorageObjectMetadata>&) {
+                                      return ErrorCode::OK;
+                                  })
+                    .has_value());
+    auto rejected = backend.BatchOffload(
+        MakeBatch(replacement), [](const std::vector<std::string>&,
+                                   std::vector<StorageObjectMetadata>&) {
+            return ErrorCode::INTERNAL_ERROR;
+        });
+    ASSERT_FALSE(rejected.has_value());
+    EXPECT_EQ(rejected.error(), ErrorCode::INTERNAL_ERROR);
+
+    std::string loaded(original.at(key).size(), '\0');
+    std::unordered_map<std::string, Slice> slices{
+        {key, Slice{loaded.data(), loaded.size()}}};
+    ASSERT_TRUE(backend.BatchLoad(slices).has_value());
+    EXPECT_EQ(loaded, original.at(key));
+}
+
+}  // namespace
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Adds an opt-in RocksDB-backed `LOCAL_DISK` storage backend as an alternative implementation for the design space discussed in #3856.

The backend uses RocksDB transactions and BlobDB storage to provide:

- durable prepare payload writes followed by callback-controlled commit or rollback;
- atomic logical-key to committed-version publication;
- overwrite cleanup while preserving the previous value when publication is rejected;
- batched reads through `MultiGet`;
- restart recovery, `ScanMeta`, `IsExist`, and `RemoveAll`;
- an isolated on-disk directory and backend descriptor: `rocksdb_storage_backend`.

This PR does **not** implement the custom Segment/WAL/checkpoint format proposed by #3856. Instead, it evaluates whether Mooncake should reuse a mature storage engine for the same holder-local physical-placement boundary. Master metadata remains unchanged and stores only the logical `LOCAL_DISK` replica location.

RocksDB support is disabled by default through `MOONCAKE_USE_ROCKSDB=OFF`, so default builds do not acquire a RocksDB dependency. Blob files are enabled by default. Direct blob writes remain disabled by default for conservative durability semantics and can be enabled explicitly for controlled benchmarking.

This is not a DFS implementation and does not address #3641.

### Local-SSD baseline and durability correction

The previous four-backend table was not an apples-to-apples write comparison. The current Bucket POSIX write path explicitly syncs neither its data file nor its metadata file, while the prior Custom Log run used `MOONCAKE_LOG_SYNC_POLICY=record` and RocksDB used `MOONCAKE_ROCKSDB_SYNC_WRITES=true`. The earlier numbers are therefore not used as the primary performance evidence below.

The write benchmark was rerun as a fully interleaved five-round comparison with the three relevant implementations using no explicit sync:

- Bucket used its current buffered POSIX write path;
- Custom Log used `MOONCAKE_LOG_SYNC_POLICY=none`, compaction disabled, and payload write parallelism `4/16/32` for `4 KiB/128 KiB/4 MiB` values;
- RocksDB 11.8.1 used WAL enabled, `MOONCAKE_ROCKSDB_SYNC_WRITES=false`, BlobDB, and opt-in direct blob writes;
- all backends used the same Release binary, buffered I/O, ext4 NVMe-backed volume, workload shape, and readback verification;
- all 45 runs completed with zero operation or verification errors;
- the shared 384-CPU host was heavily loaded (`load average 303-313`), so five-run medians and full ranges are reported.

| Scenario | Bucket | Custom Log | RocksDB |
| --- | ---: | ---: | ---: |
| Write 4 KiB × 32 | 342.54 MB/s | 182.20 MB/s | **386.19 MB/s** |
| Write 128 KiB × 32 | **2971.79 MB/s** | 1148.90 MB/s | 1619.35 MB/s |
| Write 4 MiB × 8 | **4505.00 MB/s** | 1261.87 MB/s | 851.40 MB/s |

| Scenario | Bucket p99 | Custom Log p99 | RocksDB p99 |
| --- | ---: | ---: | ---: |
| Write 4 KiB × 32 | 1.68 ms | 1.43 ms | **1.34 ms** |
| Write 128 KiB × 32 | **2.93 ms** | 8.75 ms | 21.21 ms |
| Write 4 MiB × 8 | **12.83 ms** | 39.25 ms | 50.49 ms |

Five-run throughput ranges:

- Bucket: 4 KiB `312.31-372.98`, 128 KiB `2763.63-3219.74`, 4 MiB `4018.41-4838.22 MB/s`.
- Custom Log: 4 KiB `175.70-190.40`, 128 KiB `1047.78-1256.52`, 4 MiB `1192.39-1325.61 MB/s`.
- RocksDB: 4 KiB `384.16-459.79`, 128 KiB `1016.91-1656.54`, 4 MiB `804.08-873.32 MB/s`.

This correction materially changes the interpretation:

- RocksDB is the fastest implementation for the 4 KiB workload when sync is disabled for all compared backends.
- Bucket remains substantially faster for 128 KiB and 4 MiB values because one `BatchOffload` becomes a packed immutable file with minimal indexing and no WAL/LSM maintenance.
- Custom Log improves substantially without per-record durability work, but it still does not beat Bucket in this short append-only workload.
- The earlier large Bucket advantage over RocksDB at 4 KiB was primarily a durability-configuration artifact.

The hot-read measurements from the preceding run are unaffected by the write-sync configuration and remain useful as a read-path reference: Bucket `6802.20 MB/s`, Custom Log `5380.42 MB/s`, and RocksDB `2187.27 MB/s` for 128 KiB × 32 hot reads. OffsetAllocator was excluded from the corrected no-sync write table because its existing persistence modes are not equivalent to the simple no-sync switch used by Custom Log and RocksDB.

These are buffered/page-cache microbenchmarks, not physical-media durability or SSD-endurance measurements. They do not cover power-loss recovery, steady-state compaction/Blob GC, capacity turnover, or host/device write amplification. A separate durable comparison requires a common contract—ideally one durable commit per `BatchOffload`—and a corrected Bucket data/metadata publication protocol.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Default dependency-free configuration
cmake ... -DMOONCAKE_USE_ROCKSDB=OFF
cmake --build ... --target mooncake_store storage_backend_bench

# RocksDB 11.8.1 configuration
cmake ... -DMOONCAKE_USE_ROCKSDB=ON \
  -DROCKSDB_INCLUDE_DIR=<rocksdb>/include \
  -DROCKSDB_LIBRARY=<rocksdb>/librocksdb.so
cmake --build ... --target rocksdb_backend_test storage_backend_bench
ctest --test-dir ... --output-on-failure -R '^rocksdb_backend_test$'

./scripts/code_format.sh --check --changed-lines --base origin/main
uvx pre-commit run --files <changed-files>
```

**Test results:**
- [x] Default `MOONCAKE_USE_ROCKSDB=OFF` build passes.
- [x] RocksDB-enabled build passes with RocksDB 11.8.1 and GCC 11.4.
- [x] `rocksdb_backend_test` passes, covering batch write/read, restart plus `ScanMeta`, `RemoveAll`, factory creation, and rejected-overwrite rollback.
- [x] `storage_backend_bench` builds in both configurations.
- [x] Three-run A/B benchmark matrix completed.
- [ ] Integration tests pass (not run against a dedicated physical SSD host).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (the implementation choice and tradeoffs are documented here and in RFC #3856 discussion)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3856)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (OpenAI Codex assisted with implementation, tests, review, and benchmark scripting; the submitter reviewed the resulting changes and evidence.)