### PR TITLE
[TENT] Pin failover policy at transfer submission

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -125,11 +125,14 @@ class RuntimeConfig final : public LifecycleConfigView {
                               ConfigLifecycle::kRuntimeCandidate) {}
 };
 
+inline constexpr int kDefaultMaxFailoverAttempts = 3;
+inline constexpr bool kDefaultAutoFailoverOnPoll = true;
+
 struct RuntimeConfigSnapshot {
     uint64_t generation{0};
     std::shared_ptr<const RuntimeConfig> config;
-    int max_failover_attempts{3};
-    bool enable_auto_failover_on_poll{true};
+    int max_failover_attempts{kDefaultMaxFailoverAttempts};
+    bool enable_auto_failover_on_poll{kDefaultAutoFailoverOnPoll};
 };
 
 struct TentConfigBundle {

--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -128,6 +128,8 @@ class RuntimeConfig final : public LifecycleConfigView {
 struct RuntimeConfigSnapshot {
     uint64_t generation{0};
     std::shared_ptr<const RuntimeConfig> config;
+    int max_failover_attempts{3};
+    bool enable_auto_failover_on_poll{true};
 };
 
 struct TentConfigBundle {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -64,8 +64,8 @@ void waitBeforeNextPoll(uint64_t poll_count);
 
 struct LogicalTransferRuntimePolicy {
     uint64_t config_generation{0};
-    int max_failover_attempts{3};
-    bool enable_auto_failover_on_poll{true};
+    int max_failover_attempts{kDefaultMaxFailoverAttempts};
+    bool enable_auto_failover_on_poll{kDefaultAutoFailoverOnPoll};
 };
 
 struct TaskInfo {
@@ -335,11 +335,16 @@ class TransferEngineImpl {
         }
     }
 
-    void publishRuntimeConfigForTest(
+    Status publishRuntimeConfigForTest(
         std::shared_ptr<const RuntimeConfigSnapshot> snapshot) {
+        if (!snapshot) {
+            return Status::InvalidArgument(
+                "Runtime config snapshot must not be null" LOC_MARK);
+        }
         std::atomic_store_explicit(&runtime_config_snapshot_,
                                    std::move(snapshot),
                                    std::memory_order_release);
+        return Status::OK();
     }
 
     // Test-only hook: how many batches are still alive. Lets a test assert

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "tent/common/config.h"
+#include "tent/common/config_lifecycle.h"
 #include "tent/common/status.h"
 #include "tent/common/types.h"
 #include "tent/runtime/admission_queue.h"
@@ -61,6 +62,12 @@ std::chrono::microseconds nextPollDelay(uint64_t poll_count);
 // One backoff step: yields while nextPollDelay is zero, sleeps after that.
 void waitBeforeNextPoll(uint64_t poll_count);
 
+struct LogicalTransferRuntimePolicy {
+    uint64_t config_generation{0};
+    int max_failover_attempts{3};
+    bool enable_auto_failover_on_poll{true};
+};
+
 struct TaskInfo {
     TransportType type{UNSPEC};
     int sub_task_id{-1};
@@ -69,8 +76,9 @@ struct TaskInfo {
     int failover_count{0};                // number of failover attempts
     int metadata_refresh_retry_count{0};  // same-transport stale-cache retries
     bool suppress_failover{false};        // permanent transport result
-    uint64_t device_mask{~0ULL};          // Device mask for quota allocation
-    std::string qp_pool;  // Named QP pool (RFC #2568 step 3), "" = none
+    LogicalTransferRuntimePolicy runtime_policy;
+    uint64_t device_mask{~0ULL};  // Device mask for quota allocation
+    std::string qp_pool;          // Named QP pool (RFC #2568 step 3), "" = none
     Request request;
     bool staging{false};
     bool cancel_requested{false};
@@ -106,6 +114,7 @@ struct TaskInfo {
           failover_count(other.failover_count),
           metadata_refresh_retry_count(other.metadata_refresh_retry_count),
           suppress_failover(other.suppress_failover),
+          runtime_policy(other.runtime_policy),
           device_mask(other.device_mask),
           qp_pool(other.qp_pool),
           request(other.request),
@@ -129,6 +138,7 @@ struct TaskInfo {
           failover_count(other.failover_count),
           metadata_refresh_retry_count(other.metadata_refresh_retry_count),
           suppress_failover(other.suppress_failover),
+          runtime_policy(other.runtime_policy),
           device_mask(other.device_mask),
           qp_pool(std::move(other.qp_pool)),
           request(std::move(other.request)),
@@ -153,6 +163,7 @@ struct TaskInfo {
             failover_count = other.failover_count;
             metadata_refresh_retry_count = other.metadata_refresh_retry_count;
             suppress_failover = other.suppress_failover;
+            runtime_policy = other.runtime_policy;
             device_mask = other.device_mask;
             qp_pool = other.qp_pool;
             request = other.request;
@@ -182,6 +193,7 @@ struct TaskInfo {
             failover_count = other.failover_count;
             metadata_refresh_retry_count = other.metadata_refresh_retry_count;
             suppress_failover = other.suppress_failover;
+            runtime_policy = other.runtime_policy;
             device_mask = other.device_mask;
             qp_pool = std::move(other.qp_pool);
             request = std::move(other.request);
@@ -323,6 +335,13 @@ class TransferEngineImpl {
         }
     }
 
+    void publishRuntimeConfigForTest(
+        std::shared_ptr<const RuntimeConfigSnapshot> snapshot) {
+        std::atomic_store_explicit(&runtime_config_snapshot_,
+                                   std::move(snapshot),
+                                   std::memory_order_release);
+    }
+
     // Test-only hook: how many batches are still alive. Lets a test assert
     // that a failed transfer released its batch rather than leaking it.
     size_t aliveBatchCountForTest() {
@@ -369,7 +388,7 @@ class TransferEngineImpl {
 
     // Submit-stage failover: recover a task whose synchronous
     // submitTransferTasks() failed by walking the remaining candidate
-    // transports (bounded by max_failover_attempts_), mirroring the poll-time
+    // transports (bounded by the task's pinned limit), mirroring the poll-time
     // failover in updateTaskStatusAfterPoll. Returns true when the task is
     // PENDING again on a fallback transport; otherwise the task is
     // terminally FAILED with task.type left at the last attempted transport
@@ -444,7 +463,7 @@ class TransferEngineImpl {
                                    bool allow_failover);
 
     Status getBatchStatus(BatchID batch_id, TransferStatus& overall_status,
-                          bool allow_failover);
+                          bool force_failover);
 
     SelectionResult resolveTransport(const Request& req, int transport_index,
                                      bool invalidate_on_fail = true);
@@ -534,8 +553,7 @@ class TransferEngineImpl {
 
     std::unique_ptr<ProxyManager> staging_proxy_;
     bool merge_requests_;
-    int max_failover_attempts_{3};
-    bool enable_auto_failover_on_poll_{true};
+    std::shared_ptr<const RuntimeConfigSnapshot> runtime_config_snapshot_;
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -137,8 +137,10 @@ TentConfigBundle buildTentConfigBundle(const Config& effective_config,
     bundle.runtime =
         std::make_shared<const RuntimeConfigSnapshot>(RuntimeConfigSnapshot{
             generation, runtime_config,
-            runtime_config->get("max_failover_attempts", 3),
-            runtime_config->get("enable_auto_failover_on_poll", true)});
+            runtime_config->get("max_failover_attempts",
+                                kDefaultMaxFailoverAttempts),
+            runtime_config->get("enable_auto_failover_on_poll",
+                                kDefaultAutoFailoverOnPoll)});
 
     for (const auto& path : frozen->paths()) {
         if (path.empty()) {

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -134,8 +134,11 @@ TentConfigBundle buildTentConfigBundle(const Config& effective_config,
     bundle.bootstrap = std::make_shared<const BootstrapConfig>(frozen);
 
     auto runtime_config = std::make_shared<const RuntimeConfig>(frozen);
-    bundle.runtime = std::make_shared<const RuntimeConfigSnapshot>(
-        RuntimeConfigSnapshot{generation, std::move(runtime_config)});
+    bundle.runtime =
+        std::make_shared<const RuntimeConfigSnapshot>(RuntimeConfigSnapshot{
+            generation, runtime_config,
+            runtime_config->get("max_failover_attempts", 3),
+            runtime_config->get("enable_auto_failover_on_poll", true)});
 
     for (const auto& path : frozen->paths()) {
         if (path.empty()) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -338,6 +338,9 @@ Status TransferEngineImpl::setupLocalSegment() {
 
 Status TransferEngineImpl::construct() {
     CHECK_STATUS(ParseHpTcpTransportConfig(*conf_, &hp_tcp_transport_config_));
+    std::atomic_store_explicit(&runtime_config_snapshot_,
+                               buildTentConfigBundle(*conf_).runtime,
+                               std::memory_order_relaxed);
     auto metadata_type = conf_->get("metadata_type", "p2p");
     auto metadata_servers = conf_->get("metadata_servers", "");
 
@@ -358,9 +361,6 @@ Status TransferEngineImpl::construct() {
     CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, rpc_threads_default,
                                                rpc_server_threads));
     merge_requests_ = conf_->get("merge_requests", true);
-    max_failover_attempts_ = conf_->get("max_failover_attempts", 3);
-    enable_auto_failover_on_poll_ =
-        conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
@@ -1502,6 +1502,7 @@ struct TransferEngineImpl::PreparedSubmit {
     };
 
     std::chrono::steady_clock::time_point submit_time{};
+    LogicalTransferRuntimePolicy runtime_policy;
     std::vector<Task> tasks;
     std::vector<Owner> owners;
 };
@@ -1804,6 +1805,13 @@ Status TransferEngineImpl::prepareSubmit(
     }
 
     prepared = PreparedSubmit{};
+    auto runtime_config = std::atomic_load_explicit(&runtime_config_snapshot_,
+                                                    std::memory_order_acquire);
+    prepared.runtime_policy.config_generation = runtime_config->generation;
+    prepared.runtime_policy.max_failover_attempts =
+        runtime_config->max_failover_attempts;
+    prepared.runtime_policy.enable_auto_failover_on_poll =
+        runtime_config->enable_auto_failover_on_poll;
     const size_t start_task_id = batch->task_list.size();
     prepared.submit_time = std::chrono::steady_clock::now();
     auto merge_boundaries =
@@ -1893,6 +1901,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
 
         task.failover_count = 0;
         task.xport_priority = 0;
+        task.runtime_policy = prepared.runtime_policy;
         task.status = PENDING;
         task.request = merged_request;
         task.staging = false;
@@ -2097,6 +2106,7 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
         const auto& owner = prepared.owners[task_plan.merged_task_index];
         task.failover_count = 0;
         task.xport_priority = 0;
+        task.runtime_policy = prepared.runtime_policy;
         task.status = PENDING;
         task.request = owner.request;
         task.staging = false;
@@ -2505,9 +2515,9 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     auto& task = batch->task_list[task_id];
     auto prev_type = task.type;
 
-    if (++task.failover_count > max_failover_attempts_) {
+    if (++task.failover_count > task.runtime_policy.max_failover_attempts) {
         LOG(WARNING) << "Task failover limit reached ("
-                     << max_failover_attempts_
+                     << task.runtime_policy.max_failover_attempts
                      << "), last transport=" << transportTypeName(prev_type);
         return Status::InvalidEntry(
             "Failover limit exceeded, all transports exhausted");
@@ -2528,7 +2538,9 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
 
     LOG(INFO) << "Transport failover: " << transportTypeName(prev_type)
               << " -> " << transportTypeName(type) << " (attempt "
-              << task.failover_count << "/" << max_failover_attempts_ << ")";
+              << task.failover_count << "/"
+              << task.runtime_policy.max_failover_attempts << ", generation "
+              << task.runtime_policy.config_generation << ")";
     TENT_RECORD_TRANSPORT_FAILOVER(prev_type, type);
 
     auto& transport = transport_list_[type];
@@ -2563,7 +2575,8 @@ bool TransferEngineImpl::attemptSubmitStageFailover(Batch* batch,
     // failover in updateTaskStatusAfterPoll, which sets task.status = FAILED
     // before calling resubmitTransferTask).
     task.status = FAILED;
-    for (int attempt = 0; attempt < max_failover_attempts_; ++attempt) {
+    for (int attempt = 0; attempt < task.runtime_policy.max_failover_attempts;
+         ++attempt) {
         if (resubmitTransferTask(batch, task_id).ok()) {
             task.status = PENDING;
             return true;
@@ -2765,7 +2778,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
     auto prev_status = task.status;
     CHECK_STATUS(pollTaskStatus(batch, poll_task_id, task_status));
     updateTaskStatusAfterPoll(batch, poll_task_id, task_status,
-                              enable_auto_failover_on_poll_);
+                              task.runtime_policy.enable_auto_failover_on_poll);
     if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
         task_status.s != PENDING) {
         QueueOwnerId owner_id = 0;
@@ -2803,7 +2816,7 @@ Status TransferEngineImpl::getTransferStatus(
 
 Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                                           TransferStatus& overall_status,
-                                          bool allow_failover) {
+                                          bool force_failover) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     std::lock_guard<std::recursive_mutex> lk(progressLockFor(batch_id));
     if (!isBatchAlive(batch_id))
@@ -2865,7 +2878,9 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         }
         auto prev_status = task.status;
         CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
-        updateTaskStatusAfterPoll(batch, task_id, task_status, allow_failover);
+        updateTaskStatusAfterPoll(
+            batch, task_id, task_status,
+            force_failover || task.runtime_policy.enable_auto_failover_on_poll);
         if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
             task_status.s != PENDING) {
             QueueOwnerId owner_id = 0;
@@ -2911,8 +2926,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
 
 Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
                                              TransferStatus& overall_status) {
-    return getBatchStatus(batch_id, overall_status,
-                          enable_auto_failover_on_poll_);
+    return getBatchStatus(batch_id, overall_status, false);
 }
 
 Status TransferEngineImpl::progressBatch(BatchID batch_id,

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -337,10 +337,11 @@ Status TransferEngineImpl::setupLocalSegment() {
 }
 
 Status TransferEngineImpl::construct() {
-    CHECK_STATUS(ParseHpTcpTransportConfig(*conf_, &hp_tcp_transport_config_));
+    // Publish the snapshot before any setup step can return an error.
     std::atomic_store_explicit(&runtime_config_snapshot_,
                                buildTentConfigBundle(*conf_).runtime,
                                std::memory_order_relaxed);
+    CHECK_STATUS(ParseHpTcpTransportConfig(*conf_, &hp_tcp_transport_config_));
     auto metadata_type = conf_->get("metadata_type", "p2p");
     auto metadata_servers = conf_->get("metadata_servers", "");
 

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -599,8 +599,13 @@ TEST_P(PinnedFailoverPolicyTest, PolicyIsPinnedAtSubmit) {
     // Change each field independently so one cannot mask the other.
     next_cfg->set("max_failover_attempts", GetParam() ? 1 : 0);
     next_cfg->set("enable_auto_failover_on_poll", !GetParam());
-    engine.publishRuntimeConfigForTest(
-        buildTentConfigBundle(*next_cfg, 1).runtime);
+    ASSERT_TRUE(engine
+                    .publishRuntimeConfigForTest(
+                        buildTentConfigBundle(*next_cfg, 1).runtime)
+                    .ok());
+    // Reject a null publication without replacing the active policy.
+    EXPECT_TRUE(
+        engine.publishRuntimeConfigForTest(nullptr).IsInvalidArgument());
 
     auto old_status = pollUntilDone(engine, old_generation.batch_id, 0);
     EXPECT_EQ(old_status.s, TransferStatusEnum::COMPLETED);

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include "tent/common/config.h"
+#include "tent/common/config_lifecycle.h"
 #include "tent/common/types.h"
 #include "tent/runtime/segment.h"
 #include "tent/runtime/transfer_engine_impl.h"
@@ -581,6 +582,52 @@ TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledLeavesTaskFailed) {
     EXPECT_TRUE(
         engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
 }
+
+class PinnedFailoverPolicyTest : public ::testing::TestWithParam<bool> {};
+
+TEST_P(PinnedFailoverPolicyTest, PolicyIsPinnedAtSubmit) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("max_failover_attempts", 1);
+    cfg->set("enable_auto_failover_on_poll", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch old_generation;
+    submitCorruptedRdmaBatch(engine, old_generation, 0xB1);
+
+    auto next_cfg = makeMinimalP2PConfig();
+    // Change each field independently so one cannot mask the other.
+    next_cfg->set("max_failover_attempts", GetParam() ? 1 : 0);
+    next_cfg->set("enable_auto_failover_on_poll", !GetParam());
+    engine.publishRuntimeConfigForTest(
+        buildTentConfigBundle(*next_cfg, 1).runtime);
+
+    auto old_status = pollUntilDone(engine, old_generation.batch_id, 0);
+    EXPECT_EQ(old_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(old_generation.fake_tcp->submit_calls.load(), 1);
+
+    CorruptedRdmaBatch new_generation;
+    submitCorruptedRdmaBatch(engine, new_generation, 0xB2);
+    TransferStatus new_status{};
+    ASSERT_TRUE(
+        engine.getTransferStatus(new_generation.batch_id, 0, new_status).ok());
+    EXPECT_EQ(new_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(new_generation.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(old_generation.batch_id).ok());
+    EXPECT_TRUE(engine
+                    .unregisterLocalMemory(old_generation.buf.data(),
+                                           old_generation.buf.size())
+                    .ok());
+    EXPECT_TRUE(engine.freeBatch(new_generation.batch_id).ok());
+    EXPECT_TRUE(engine
+                    .unregisterLocalMemory(new_generation.buf.data(),
+                                           new_generation.buf.size())
+                    .ok());
+}
+
+INSTANTIATE_TEST_SUITE_P(EngineFailoverE2E, PinnedFailoverPolicyTest,
+                         ::testing::Bool());
 
 TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledAppliesToVectorStatus) {
     auto cfg = makeMinimalP2PConfig();


### PR DESCRIPTION
## Description

Focused follow-up to the configuration lifecycle foundation merged in #3836. Supersedes the closed #3857, now based directly on `main` with only this change (five files).

- Capture the runtime generation, failover-attempt limit and auto-failover-on-poll flag once at transfer submission.
- Copy that policy into direct and runtime-queued tasks, including task copies/moves, and retain it across cross-transport retries.
- Use the pinned policy during status polling while preserving explicit/background progress semantics and the current HP TCP metadata-refresh/permanent-error handling.
- Use shared failover defaults and parse the two policy values when building the snapshot, keeping configuration lookup off the submission hot path.
- Add two regression cases that change each policy field independently: an in-flight transfer retains the old policy, while a new transfer observes the published policy.

The initial snapshot is installed before fallible setup steps. Publication is exposed only through a test hook, which rejects null snapshots without replacing the active policy. This does **not** add a production live-update API, configuration provider, rollback mechanism, or propagation of a parent's generation into staging children.

Refs #3833.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Ubuntu 24.04 (WSL), GCC 13.3, RelWithDebInfo, CUDA disabled. The engine regressions use fake transports and local P2P metadata; no GPU or two-host performance result is claimed for this revision.

**Test commands:**
```bash
cmake --build build/failover --target config_lifecycle_test tent_engine_failover_e2e_test tent_runtime_queue_dispatch_test tent_progress_worker_test -j4
ctest --test-dir build/failover --parallel 1 --output-on-failure -R '^(config_lifecycle_test|tent_engine_failover_e2e_test|tent_runtime_queue_dispatch_test|tent_progress_worker_test)$'
pre-commit run --files mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
git diff --check origin/main...HEAD
```

**Test results:**
- [x] Unit tests pass: configuration lifecycle, 15 tests.
- [x] Integration tests pass: engine failover, 30; progress worker, 23; runtime queue dispatch, 12.
- [ ] Manual hardware testing done.

All four test executables passed (80 tests total), including both pinned-policy cases and their null-publication rejection checks. All applicable PR-scoped pre-commit hooks passed, including changed-line formatting with clang-format 20.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: no new user-facing API)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

