### PR TITLE
[Store] Defer a client mass expiry the master cannot rule out as its own stall

### DIFF
--- a/mooncake-store/conf/master.json
+++ b/mooncake-store/conf/master.json
@@ -24,6 +24,8 @@
   "cluster_id": "mooncake_cluster",
   "memory_allocator": "offset",
   "client_live_ttl_sec": 60,
+  "client_mass_expiry_guard": true,
+  "client_mass_expiry_grace_sec": 60,
   "enable_http_metadata_server": false,
   "http_metadata_server_host": "0.0.0.0",
   "http_metadata_server_port": 8080,

--- a/mooncake-store/conf/master.yaml
+++ b/mooncake-store/conf/master.yaml
@@ -35,6 +35,13 @@ root_fs_dir: ""
 cluster_id: "mooncake_cluster"
 memory_allocator: "offset"
 client_live_ttl_sec: 60
+# Client mass-expiry circuit breaker: hold back an expiry the master cannot
+# rule out being its own stall, bounded by the grace. The rule and the cases
+# it covers are written out at MasterService::ClientMonitorFunc in
+# src/master_service.cpp. Either a false guard or a zero grace leaves the
+# master with no stall detection at all.
+client_mass_expiry_guard: true
+client_mass_expiry_grace_sec: 60
 
 # OpLog store configuration for HA hot-standby replication
 enable_oplog: false

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -47,6 +47,10 @@ struct MasterConfig {
     double nof_eviction_ratio;
     double nof_eviction_high_watermark_ratio;
     int64_t client_live_ttl_sec;
+    // Client mass-expiry circuit breaker; see
+    // DEFAULT_CLIENT_MASS_EXPIRY_GUARD.
+    bool client_mass_expiry_guard = DEFAULT_CLIENT_MASS_EXPIRY_GUARD;
+    int64_t client_mass_expiry_grace_sec = DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC;
     int64_t nof_heartbeat_interval_sec;
     uint32_t nof_heartbeat_probe_timeout_ms;
     uint32_t nof_heartbeat_failures_threshold;
@@ -245,6 +249,8 @@ class MasterServiceSupervisorConfig {
     bool offload_force_evict = false;
     size_t offloading_queue_limit = 50000;
     double offload_cap_ratio = 0.5;
+    bool client_mass_expiry_guard = DEFAULT_CLIENT_MASS_EXPIRY_GUARD;
+    int64_t client_mass_expiry_grace_sec = DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC;
     bool promotion_on_hit = false;
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
@@ -296,6 +302,8 @@ class MasterServiceSupervisorConfig {
         nof_eviction_high_watermark_ratio =
             config.nof_eviction_high_watermark_ratio;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        client_mass_expiry_guard = config.client_mass_expiry_guard;
+        client_mass_expiry_grace_sec = config.client_mass_expiry_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -490,6 +498,8 @@ class WrappedMasterServiceConfig {
         DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO;
     ViewVersionId view_version = 0;
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    bool client_mass_expiry_guard = DEFAULT_CLIENT_MASS_EXPIRY_GUARD;
+    int64_t client_mass_expiry_grace_sec = DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC;
     int64_t nof_heartbeat_interval_sec = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
     uint32_t nof_heartbeat_probe_timeout_ms =
         DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
@@ -585,6 +595,8 @@ class WrappedMasterServiceConfig {
             config.nof_eviction_high_watermark_ratio;
         view_version = view_version_param;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        client_mass_expiry_guard = config.client_mass_expiry_guard;
+        client_mass_expiry_grace_sec = config.client_mass_expiry_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -708,6 +720,8 @@ class WrappedMasterServiceConfig {
             config.nof_eviction_high_watermark_ratio;
         view_version = view_version_param;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        client_mass_expiry_guard = config.client_mass_expiry_guard;
+        client_mass_expiry_grace_sec = config.client_mass_expiry_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -804,6 +818,9 @@ class MasterServiceConfigBuilder {
         DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO;
     ViewVersionId view_version_ = 0;
     int64_t client_live_ttl_sec_ = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    bool client_mass_expiry_guard_ = DEFAULT_CLIENT_MASS_EXPIRY_GUARD;
+    int64_t client_mass_expiry_grace_sec_ =
+        DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC;
     int64_t nof_heartbeat_interval_sec_ = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
     uint32_t nof_heartbeat_probe_timeout_ms_ =
         DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
@@ -904,6 +921,19 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_client_live_ttl_sec(int64_t ttl) {
         client_live_ttl_sec_ = ttl;
+        return *this;
+    }
+
+    // Client mass-expiry circuit breaker; see
+    // DEFAULT_CLIENT_MASS_EXPIRY_GUARD.
+    MasterServiceConfigBuilder& set_client_mass_expiry_guard(bool guard) {
+        client_mass_expiry_guard_ = guard;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_client_mass_expiry_grace_sec(
+        int64_t grace_sec) {
+        client_mass_expiry_grace_sec_ = grace_sec;
         return *this;
     }
 
@@ -1169,6 +1199,8 @@ class MasterServiceConfig {
     // HA supervisor serving paths always inject the acquired non-zero view.
     ViewVersionId view_version = 0;
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    bool client_mass_expiry_guard = DEFAULT_CLIENT_MASS_EXPIRY_GUARD;
+    int64_t client_mass_expiry_grace_sec = DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC;
     int64_t nof_heartbeat_interval_sec = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
     uint32_t nof_heartbeat_probe_timeout_ms =
         DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
@@ -1260,6 +1292,8 @@ class MasterServiceConfig {
             config.nof_eviction_high_watermark_ratio;
         view_version = config.view_version;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        client_mass_expiry_guard = config.client_mass_expiry_guard;
+        client_mass_expiry_grace_sec = config.client_mass_expiry_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -1357,6 +1391,8 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
         nof_eviction_high_watermark_ratio_;
     config.view_version = view_version_;
     config.client_live_ttl_sec = client_live_ttl_sec_;
+    config.client_mass_expiry_guard = client_mass_expiry_guard_;
+    config.client_mass_expiry_grace_sec = client_mass_expiry_grace_sec_;
     config.nof_heartbeat_interval_sec = nof_heartbeat_interval_sec_;
     config.nof_heartbeat_probe_timeout_ms = nof_heartbeat_probe_timeout_ms_;
     config.nof_heartbeat_failures_threshold = nof_heartbeat_failures_threshold_;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -136,6 +136,20 @@ class MasterMetricManager {
     void inc_active_clients(int64_t val = 1);
     void dec_active_clients(int64_t val = 1);
     int64_t get_active_clients();
+    // One increment per client-monitor tick whose client mass expiry the
+    // circuit breaker held back. Any increase means a master declined to erase
+    // its clients' keys because it could not rule out its own stall.
+    void inc_client_expiry_deferred();
+    int64_t get_client_expiry_deferred();
+    // How many clients are being held back right now. This is the one an
+    // alert watches: a non-zero value is a suspected stall in progress. Each
+    // client monitor adds and removes its own contribution, the way
+    // active_clients does, so two MasterService instances in one process
+    // compose instead of overwriting each other, and a monitor that stops
+    // while deferring takes its contribution back.
+    void inc_client_expiry_deferred_clients(int64_t val = 1);
+    void dec_client_expiry_deferred_clients(int64_t val = 1);
+    int64_t get_client_expiry_deferred_clients();
 
     // Snapshot Metrics
     void set_snapshot_duration_ms(int64_t size);
@@ -578,6 +592,8 @@ class MasterMetricManager {
 
     // Cluster Metrics
     ylt::metric::gauge_t active_clients_;
+    ylt::metric::counter_t client_expiry_deferred_;
+    ylt::metric::gauge_t client_expiry_deferred_clients_;
 
     // Operation Statistics
     ylt::metric::counter_t put_start_requests_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -130,6 +130,86 @@ void ShrinkBucketsIfSparse(UnorderedContainer& container) {
     }
 }
 
+// The exclusive client_mutex_ hold windows the master has recorded, as the
+// client monitor reads them. Ping needs client_mutex_ shared, so an exclusive
+// holder is the one thing that stops the Ping handler running at all, which
+// makes these windows the cause the monitor judges on rather than the symptom.
+struct ExclusiveClientLockHolds {
+    // Start of a hold that has not been released yet. Such a hold runs to the
+    // present instant, so it overlaps any window that has not closed.
+    std::optional<std::chrono::steady_clock::time_point> in_progress_start;
+    // The most recently released hold's window, [first, second].
+    std::optional<std::pair<std::chrono::steady_clock::time_point,
+                            std::chrono::steady_clock::time_point>>
+        last_completed;
+
+    // Whether any recorded hold overlapped [window_start, window_end].
+    bool Overlaps(std::chrono::steady_clock::time_point window_start,
+                  std::chrono::steady_clock::time_point window_end) const {
+        if (in_progress_start.has_value() && *in_progress_start <= window_end) {
+            return true;
+        }
+        if (last_completed.has_value() && last_completed->first <= window_end &&
+            last_completed->second >= window_start) {
+            return true;
+        }
+        return false;
+    }
+};
+
+// Tracked clients the mass-expiry circuit breaker needs before it treats its
+// own silence as evidence about itself. With two or more clients, hearing from
+// nobody says the master is serving nobody; with exactly one it says only that
+// that client stopped, which is the client's own problem -- the store process
+// restarted or lost its host -- and the master must act on it at once. A
+// single-client cluster is protected by the hold condition instead, which
+// measures the cause rather than the silence.
+inline constexpr size_t kMinTrackedClientsForSilenceEvidence = 2;
+
+// Everything the client monitor's mass-expiry judgement is made from. Grouped
+// so the judgement is a pure function of one tick's readings and can be tested
+// over its boundary cases without running a monitor thread.
+struct ClientMassExpiryInputs {
+    bool guard_enabled = true;
+    std::chrono::seconds grace{0};
+    size_t expired_count = 0;
+    // Clients the monitor tracks, i.e. the size of its own ttl map.
+    size_t tracked_clients = 0;
+    ExclusiveClientLockHolds holds;
+    std::chrono::steady_clock::time_point now{};
+    // Last tick that popped at least one heartbeat, and so the left edge of
+    // the window an exclusive hold has to overlap to explain this tick's
+    // candidates: a hold that released before it is refuted by that heartbeat.
+    std::chrono::steady_clock::time_point last_ping_batch_at{};
+    // Newest deadline among the clients this tick would expire.
+    std::chrono::steady_clock::time_point newest_expired_deadline{};
+    // When the episode in progress began, or nullopt to open a new one at now.
+    std::optional<std::chrono::steady_clock::time_point> episode_since{};
+};
+
+// What the monitor does with one tick's expiry candidates.
+struct ClientMassExpiryDecision {
+    // Either condition holds, so this tick's candidates are an episode the
+    // master cannot distinguish from its own stall.
+    bool is_mass_expiry = false;
+    // Hold the candidates back this tick.
+    bool defer = false;
+    // The episode outlived the grace bound, so the candidates are expired.
+    bool grace_exceeded = false;
+    // An exclusive client_mutex_ hold overlapped the window in which these
+    // clients' heartbeats could have been refreshed.
+    bool exclusive_hold_overlap = false;
+    // No heartbeat was processed after the newest candidate went overdue.
+    bool master_silent = false;
+    std::chrono::steady_clock::duration deferred_for{};
+    std::chrono::steady_clock::duration silent_for{};
+};
+
+// Judge one client-monitor tick. The full reasoning behind the rule lives at
+// its only caller, MasterService::ClientMonitorFunc in master_service.cpp.
+ClientMassExpiryDecision EvaluateClientMassExpiry(
+    const ClientMassExpiryInputs& inputs);
+
 /*
  * @brief MasterService is the main class for the master server.
  * Lock order: To avoid deadlocks, the following lock order should be followed:
@@ -2614,6 +2694,61 @@ class MasterService {
         128 * 1024;  // Size of the client ping queue
     boost::lockfree::queue<PodUUID> client_ping_queue_{kClientPingQueueSize};
     const int64_t client_live_ttl_sec_;
+    // Client mass-expiry circuit breaker. ClientMonitorFunc carries the rule
+    // and the reasoning behind it.
+    const bool client_mass_expiry_guard_;
+    const std::chrono::seconds client_mass_expiry_grace_;
+
+    // Exclusive client_mutex_ hold windows, as steady_clock nanoseconds since
+    // its epoch, or kNoClientLockHold for "none recorded". Ping needs
+    // client_mutex_ shared, so an exclusive holder stops it running at all;
+    // recording the holds lets ClientMonitorFunc name the cause of a heartbeat
+    // gap instead of inferring one from the gap itself. Only the thread
+    // holding the lock writes these, so relaxed atomics are enough -- the
+    // monitor reads them once a second and a nanosecond either way changes
+    // nothing.
+    static constexpr int64_t kNoClientLockHold =
+        std::numeric_limits<int64_t>::min();
+    std::atomic<int64_t> client_lock_hold_start_ns_{kNoClientLockHold};
+    std::atomic<int64_t> client_lock_last_hold_start_ns_{kNoClientLockHold};
+    std::atomic<int64_t> client_lock_last_hold_end_ns_{kNoClientLockHold};
+
+    // Records one exclusive client_mutex_ hold on the service for the client
+    // monitor to read. Construct it immediately after acquiring the lock, so
+    // that the mutex itself guarantees a single writer, and never at
+    // ClientMonitorFunc's own expiry branch: that branch holds the lock
+    // exclusively too, and a previous tick's expiry work must not come back as
+    // evidence that the master was stalling.
+    class ExclusiveClientLockWindow {
+       public:
+        explicit ExclusiveClientLockWindow(MasterService& service)
+            : service_(service) {
+            service_.client_lock_hold_start_ns_.store(
+                std::chrono::steady_clock::now().time_since_epoch().count(),
+                std::memory_order_relaxed);
+        }
+        ~ExclusiveClientLockWindow() {
+            const int64_t start = service_.client_lock_hold_start_ns_.load(
+                std::memory_order_relaxed);
+            service_.client_lock_last_hold_start_ns_.store(
+                start, std::memory_order_relaxed);
+            service_.client_lock_last_hold_end_ns_.store(
+                std::chrono::steady_clock::now().time_since_epoch().count(),
+                std::memory_order_relaxed);
+            service_.client_lock_hold_start_ns_.store(
+                kNoClientLockHold, std::memory_order_relaxed);
+        }
+        ExclusiveClientLockWindow(const ExclusiveClientLockWindow&) = delete;
+        ExclusiveClientLockWindow& operator=(const ExclusiveClientLockWindow&) =
+            delete;
+
+       private:
+        MasterService& service_;
+    };
+
+    // The recorded hold windows as one snapshot.
+    ExclusiveClientLockHolds ReadExclusiveClientLockHolds() const;
+
     const std::chrono::seconds nof_heartbeat_interval_sec_;
     const std::chrono::milliseconds nof_heartbeat_probe_timeout_ms_;
     const uint32_t nof_heartbeat_failures_threshold_;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -94,6 +94,23 @@ static constexpr double DEFAULT_NOF_EVICTION_RATIO = 0.05;
 static constexpr double DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO = 0.90;
 static constexpr int64_t DEFAULT_MASTER_VIEW_LEASE_TTL_SEC = 5;  // in seconds
 static constexpr int64_t DEFAULT_CLIENT_LIVE_TTL_SEC = 10;       // in seconds
+// Client mass-expiry circuit breaker, armed by default. The rule it applies
+// and the reasoning behind it are written out in one place,
+// MasterService::ClientMonitorFunc. It is armed by default because expiring a
+// client the master only suspects of being dead is unrecoverable, so it gets a
+// named off switch rather than a sentinel value in another flag.
+static constexpr bool DEFAULT_CLIENT_MASS_EXPIRY_GUARD = true;
+// Upper bound on how long the breaker may defer one episode. Past this the
+// master expires the clients, so the breaker cannot defer forever. 0 disables
+// deferral.
+static constexpr int64_t DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC =
+    60;  // in seconds
+// Grace bounds the master accepts. A negative value is not a shorter grace,
+// it is a silently disabled breaker, so the command-line validator and the
+// config-file path both reject one through this predicate.
+inline constexpr bool IsValidClientMassExpiryGraceSec(int64_t grace_sec) {
+    return grace_sec >= 0;
+}
 static constexpr int64_t DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC = 10;
 static constexpr uint32_t DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS = 1000;
 static constexpr uint32_t DEFAULT_NOF_HEARTBEAT_FAILURES_THRESHOLD = 3;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -286,6 +286,28 @@ DEFINE_int64(
     "Seconds a client stays considered alive after the last heartbeat. "
     "If this TTL elapses without a refresh, the master treats the "
     "client as disconnected and may unmount its segments");
+DEFINE_bool(
+    client_mass_expiry_guard, mooncake::DEFAULT_CLIENT_MASS_EXPIRY_GUARD,
+    "Arm the client mass-expiry circuit breaker: hold back an expiry the "
+    "master cannot rule out being its own stall, rather than unmounting the "
+    "clients' segments and erasing their keys. The rule and the cases it "
+    "covers are written out at MasterService::ClientMonitorFunc in "
+    "master_service.cpp. false leaves the master with no stall detection at "
+    "all");
+DEFINE_int64(
+    client_mass_expiry_grace_sec,
+    mooncake::DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC,
+    "Upper bound, in seconds, on how long the client mass-expiry circuit "
+    "breaker may hold back one episode, after which the clients are expired. "
+    "0 leaves the master with no stall detection at all");
+DEFINE_validator(client_mass_expiry_grace_sec, [](const char* flagname,
+                                                  int64_t value) {
+    if (!mooncake::IsValidClientMassExpiryGraceSec(value)) {
+        LOG(ERROR) << flagname << " must be >= 0; got " << value;
+        return false;
+    }
+    return true;
+});
 DEFINE_int64(nof_heartbeat_interval_sec,
              mooncake::DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC,
              "How often master probes each mounted NoF segment");
@@ -505,6 +527,12 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetInt64("client_live_ttl_sec",
                             &master_config.client_live_ttl_sec,
                             FLAGS_client_ttl);
+    default_config.GetBool("client_mass_expiry_guard",
+                           &master_config.client_mass_expiry_guard,
+                           FLAGS_client_mass_expiry_guard);
+    default_config.GetInt64("client_mass_expiry_grace_sec",
+                            &master_config.client_mass_expiry_grace_sec,
+                            FLAGS_client_mass_expiry_grace_sec);
     default_config.GetInt64("nof_heartbeat_interval_sec",
                             &master_config.nof_heartbeat_interval_sec,
                             FLAGS_nof_heartbeat_interval_sec);
@@ -1078,6 +1106,18 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.client_live_ttl_sec = FLAGS_client_ttl;
     }
+    if ((google::GetCommandLineFlagInfo("client_mass_expiry_guard", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.client_mass_expiry_guard = FLAGS_client_mass_expiry_guard;
+    }
+    if ((google::GetCommandLineFlagInfo("client_mass_expiry_grace_sec",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.client_mass_expiry_grace_sec =
+            FLAGS_client_mass_expiry_grace_sec;
+    }
     if ((google::GetCommandLineFlagInfo("nof_heartbeat_interval_sec", &info) &&
          !info.is_default) ||
         !conf_set) {
@@ -1431,6 +1471,19 @@ int main(int argc, char* argv[]) {
         InitMasterConf(default_config, master_config);
     }
     LoadConfigFromCmdline(master_config, !conf_path.empty());
+    // The DEFINE_validators above only run for values that arrive as command
+    // line flags, so a config file reaches MasterService unvalidated. Apply
+    // the same predicate here, loudly: a negative grace is not a shorter one,
+    // it silently leaves the master with no stall detection.
+    if (!mooncake::IsValidClientMassExpiryGraceSec(
+            master_config.client_mass_expiry_grace_sec)) {
+        LOG(WARNING) << "action=config_clamped"
+                     << ", key=client_mass_expiry_grace_sec"
+                     << ", value=" << master_config.client_mass_expiry_grace_sec
+                     << ", clamped_to=0"
+                     << ", reason=must_be_non_negative";
+        master_config.client_mass_expiry_grace_sec = 0;
+    }
     ResolveRpcAddressFromInterfaceOrDie(master_config);
 
     // Fall back to environment variables for pod identity (K8s Downward API)
@@ -1551,6 +1604,10 @@ int main(int argc, char* argv[]) {
         << ", ha_backend_connstring=" << ha_backend_connstring
         << ", etcd_endpoints=" << master_config.etcd_endpoints
         << ", client_ttl=" << master_config.client_live_ttl_sec
+        << ", client_mass_expiry_guard="
+        << master_config.client_mass_expiry_guard
+        << ", client_mass_expiry_grace_sec="
+        << master_config.client_mass_expiry_grace_sec
         << ", rpc_thread_num=" << master_config.rpc_thread_num
         << ", rpc_port=" << master_config.rpc_port
         << ", rpc_address=" << master_config.rpc_address

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -63,6 +63,14 @@ MasterMetricManager::MasterMetricManager()
       // Initialize cluster metrics
       active_clients_("master_active_clients",
                       "Total number of active clients"),
+      client_expiry_deferred_(
+          "master_client_expiry_deferred_total",
+          "Total number of client-monitor ticks whose client mass expiry was "
+          "deferred because the master could not rule out its own stall"),
+      client_expiry_deferred_clients_(
+          "master_client_expiry_deferred_clients",
+          "Number of clients whose expiry is being deferred right now because "
+          "the master cannot rule out its own stall"),
 
       // Initialize Request Counters
       put_start_requests_("master_put_start_requests_total",
@@ -508,12 +516,14 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     key_count_.update(0);
     soft_pin_key_count_.update(0);
     active_clients_.update(0);
+    client_expiry_deferred_clients_.update(0);
     mem_cache_nums_.update(0);
     file_cache_nums_.update(0);
     put_start_discarded_staging_size_.update(0);
     promotion_in_flight_metric_.update(0);
 
     // Update Counters (use inc(0) to mark as changed)
+    client_expiry_deferred_.inc(0);
     promotion_admitted_.inc(0);
     promotion_completed_.inc(0);
     promotion_completed_bytes_.inc(0);
@@ -892,6 +902,26 @@ void MasterMetricManager::dec_active_clients(int64_t val) {
 
 int64_t MasterMetricManager::get_active_clients() {
     return active_clients_.value();
+}
+
+void MasterMetricManager::inc_client_expiry_deferred() {
+    client_expiry_deferred_.inc();
+}
+
+int64_t MasterMetricManager::get_client_expiry_deferred() {
+    return client_expiry_deferred_.value();
+}
+
+void MasterMetricManager::inc_client_expiry_deferred_clients(int64_t val) {
+    client_expiry_deferred_clients_.inc(val);
+}
+
+void MasterMetricManager::dec_client_expiry_deferred_clients(int64_t val) {
+    client_expiry_deferred_clients_.dec(val);
+}
+
+int64_t MasterMetricManager::get_client_expiry_deferred_clients() {
+    return client_expiry_deferred_clients_.value();
 }
 
 // Store-observed cache reuse metrics
@@ -1836,6 +1866,8 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(key_count_);
     serialize_metric(soft_pin_key_count_);
     serialize_metric(active_clients_);
+    serialize_metric(client_expiry_deferred_);
+    serialize_metric(client_expiry_deferred_clients_);
 
     // Serialize Histogram
     serialize_metric(value_size_distribution_);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -198,6 +198,9 @@ MasterService::MasterService(const MasterServiceConfig& config)
           config.nof_eviction_high_watermark_ratio),
       view_version_(config.view_version),
       client_live_ttl_sec_(config.client_live_ttl_sec),
+      client_mass_expiry_guard_(config.client_mass_expiry_guard),
+      client_mass_expiry_grace_(
+          std::chrono::seconds(config.client_mass_expiry_grace_sec)),
       nof_heartbeat_interval_sec_(
           std::chrono::seconds(config.nof_heartbeat_interval_sec)),
       nof_heartbeat_probe_timeout_ms_(
@@ -1028,6 +1031,7 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
     -> tl::expected<void, ErrorCode> {
     {
         std::unique_lock<std::shared_mutex> client_lock(client_mutex_);
+        ExclusiveClientLockWindow lock_window(*this);
         std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
         for (const auto& segment : segments) {
             if (!segment.host_id.empty()) {
@@ -1368,6 +1372,7 @@ void MasterService::UpdateClientHostId(const UUID& client_id,
     }
 
     std::unique_lock<std::shared_mutex> lock(client_mutex_);
+    ExclusiveClientLockWindow lock_window(*this);
     auto it = client_host_id_.find(client_id);
     if (it == client_host_id_.end() || it->second != host_id) {
         client_host_id_[client_id] = host_id;
@@ -9981,6 +9986,7 @@ void MasterService::ResetStateAfterFailedRestoreAttempt() {
 
     {
         std::unique_lock<std::shared_mutex> lock(client_mutex_);
+        ExclusiveClientLockWindow lock_window(*this);
         ok_client_.clear();
     }
     PodUUID pod_uuid;
@@ -11482,32 +11488,366 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
             << ", total_freed_size=" << total_freed_size;
 }
 
+ExclusiveClientLockHolds MasterService::ReadExclusiveClientLockHolds() const {
+    using Duration = std::chrono::steady_clock::duration;
+    using TimePoint = std::chrono::steady_clock::time_point;
+    ExclusiveClientLockHolds holds;
+    const int64_t in_progress =
+        client_lock_hold_start_ns_.load(std::memory_order_relaxed);
+    if (in_progress != kNoClientLockHold) {
+        holds.in_progress_start = TimePoint{Duration{in_progress}};
+    }
+    const int64_t last_start =
+        client_lock_last_hold_start_ns_.load(std::memory_order_relaxed);
+    const int64_t last_end =
+        client_lock_last_hold_end_ns_.load(std::memory_order_relaxed);
+    if (last_start != kNoClientLockHold && last_end != kNoClientLockHold) {
+        const TimePoint start{Duration{last_start}};
+        if (last_end < last_start) {
+            // A release wrote its start but not yet its end, so the hold it
+            // belongs to has no known end. Read it as still running, which is
+            // the reading that errs towards deferring.
+            if (!holds.in_progress_start.has_value() ||
+                start < *holds.in_progress_start) {
+                holds.in_progress_start = start;
+            }
+        } else {
+            holds.last_completed =
+                std::make_pair(start, TimePoint{Duration{last_end}});
+        }
+    }
+    return holds;
+}
+
+ClientMassExpiryDecision EvaluateClientMassExpiry(
+    const ClientMassExpiryInputs& inputs) {
+    ClientMassExpiryDecision decision;
+    decision.silent_for = inputs.now - inputs.last_ping_batch_at;
+    if (inputs.expired_count == 0 || !inputs.guard_enabled ||
+        inputs.grace <= std::chrono::seconds(0)) {
+        return decision;
+    }
+
+    // The window a hold has to overlap to be this tick's explanation:
+    // [last_ping_batch_at, now]. It opens at the last tick that popped a
+    // heartbeat, because a hold that released before that heartbeat is
+    // refuted by it -- the master demonstrably went back to serving pings
+    // afterwards, so it can no longer be what kept these candidates from
+    // being heard, and they are genuinely gone. It runs to now, because a
+    // hold in progress at this instant is stopping heartbeats at this
+    // instant whatever it did earlier (Overlaps takes any in_progress_start
+    // <= now).
+    decision.exclusive_hold_overlap =
+        inputs.holds.Overlaps(inputs.last_ping_batch_at, inputs.now);
+    decision.master_silent =
+        inputs.last_ping_batch_at < inputs.newest_expired_deadline;
+    decision.is_mass_expiry =
+        decision.exclusive_hold_overlap ||
+        (decision.master_silent &&
+         inputs.tracked_clients >= kMinTrackedClientsForSilenceEvidence);
+    if (!decision.is_mass_expiry) {
+        return decision;
+    }
+
+    decision.deferred_for =
+        inputs.now - inputs.episode_since.value_or(inputs.now);
+    // Compare the raw durations. Rounding to whole seconds first would make
+    // the effective bound [grace, grace + 1 s) instead of grace.
+    if (decision.deferred_for < inputs.grace) {
+        decision.defer = true;
+    } else {
+        decision.grace_exceeded = true;
+    }
+    return decision;
+}
+
+namespace {
+
+// This client monitor's contribution to master_client_expiry_deferred_clients.
+// The gauge is process-global while a monitor is per MasterService, so the
+// contribution is added and taken back as a delta rather than assigned: two
+// instances in one process then compose instead of overwriting each other. The
+// destructor takes the contribution back, so every exit from the monitor loop
+// -- including the one the destructor's join waits for -- leaves the gauge at
+// 0 rather than asserting a deferral that is no longer in progress.
+class DeferredClientsGaugeContribution {
+   public:
+    DeferredClientsGaugeContribution() = default;
+    ~DeferredClientsGaugeContribution() { Publish(0); }
+    DeferredClientsGaugeContribution(const DeferredClientsGaugeContribution&) =
+        delete;
+    DeferredClientsGaugeContribution& operator=(
+        const DeferredClientsGaugeContribution&) = delete;
+
+    void Publish(int64_t clients) {
+        if (clients == published_) {
+            return;
+        }
+        if (clients > published_) {
+            MasterMetricManager::instance().inc_client_expiry_deferred_clients(
+                clients - published_);
+        } else {
+            MasterMetricManager::instance().dec_client_expiry_deferred_clients(
+                published_ - clients);
+        }
+        published_ = clients;
+    }
+
+   private:
+    int64_t published_ = 0;
+};
+
+}  // namespace
+
 void MasterService::ClientMonitorFunc() {
+    // Both of these turn the circuit breaker off without saying so anywhere
+    // else, so say it once here: a master that will not hold back a suspected
+    // mass expiry is one bad tick away from erasing the whole cluster's cache
+    // index.
+    if (!client_mass_expiry_guard_ ||
+        client_mass_expiry_grace_ <= std::chrono::seconds(0)) {
+        LOG(WARNING) << "action=client_mass_expiry_guard_disabled"
+                     << ", client_mass_expiry_guard="
+                     << client_mass_expiry_guard_
+                     << ", client_mass_expiry_grace_sec="
+                     << client_mass_expiry_grace_.count()
+                     << ", effect=expiring_without_stall_detection";
+    }
+
     std::unordered_map<UUID, std::chrono::steady_clock::time_point,
                        boost::hash<UUID>>
         client_ttl;
+    // When the run of deferred expiries in progress began, or nullopt when no
+    // episode is in progress. Bounds one episode by
+    // client_mass_expiry_grace_.
+    std::optional<std::chrono::steady_clock::time_point> mass_expiry_since;
+    DeferredClientsGaugeContribution deferred_clients_gauge;
+    // The last tick that popped at least one ping, i.e. the last time the
+    // master is known to have processed a heartbeat. Seeded with the loop's
+    // first tick so a master that has only just started does not read its own
+    // empty queue as silence.
+    auto last_ping_batch_at = std::chrono::steady_clock::now();
     while (client_monitor_running_) {
         auto now = std::chrono::steady_clock::now();
 
-        // Update the client ttl
+        // Update the client ttl. A client's deadline is stamped by the tick
+        // that popped that client's ping, so it is that tick's time plus the
+        // ttl.
         PodUUID pod_client_id;
+        bool popped_ping = false;
         while (client_ping_queue_.pop(pod_client_id)) {
+            popped_ping = true;
             UUID client_id = {pod_client_id.first, pod_client_id.second};
             client_ttl[client_id] =
                 now + std::chrono::seconds(client_live_ttl_sec_);
         }
+        if (popped_ping) {
+            last_ping_batch_at = now;
+        }
 
-        // Find out expired clients
+        // Find out expired clients. Collect them without touching client_ttl,
+        // because the circuit breaker below may decide not to expire them.
         std::vector<UUID> expired_clients;
-        for (auto it = client_ttl.begin(); it != client_ttl.end();) {
-            if (it->second < now) {
-                LOG(INFO) << "client_id=" << it->first
-                          << ", action=client_expired";
-                expired_clients.push_back(it->first);
-                it = client_ttl.erase(it);
-            } else {
-                ++it;
+        auto newest_expired_deadline =
+            std::chrono::steady_clock::time_point::min();
+        for (const auto& [client_id, deadline] : client_ttl) {
+            if (deadline < now) {
+                expired_clients.push_back(client_id);
+                newest_expired_deadline =
+                    std::max(newest_expired_deadline, deadline);
             }
+        }
+
+        // Client mass-expiry circuit breaker.
+        //
+        // Expiring a client unmounts its segments and erases its keys, and
+        // nothing in the master undoes that: one bad tick costs the whole
+        // cluster its cache index, and only a snapshot or a standby that
+        // still holds the metadata can bring it back. So before acting, the
+        // monitor has to tell "my clients died" from "I failed to process
+        // their heartbeats" -- and it cannot do that from the absence of
+        // heartbeats, which looks identical either way. It measures the cause
+        // instead.
+        //
+        // Primary condition: an exclusive client_mutex_ hold overlapped
+        // [last_ping_batch_at, now], the stretch over which this master has
+        // no heartbeat of its own to show. A completed hold therefore counts
+        // only while no heartbeat has been popped since it released: once one
+        // has, the master is demonstrably serving pings again, that hold is
+        // refuted as an explanation, and candidates still overdue are
+        // genuinely gone. A hold in progress counts unconditionally, since it
+        // is stopping heartbeats at this instant. Ping's whole body is a
+        // shared-lock read of ok_client_ and a push onto a lock-free queue, so
+        // an exclusive holder of client_mutex_ is the one thing that stops the
+        // handler running at all -- and the master knows when it holds that
+        // lock, because every site that takes it exclusively records its
+        // window (see ExclusiveClientLockWindow). This is evidence about the
+        // master, not about the clients, so no tick boundary and no number of
+        // candidates can shake it. The monitor's own expiry branch below takes
+        // the same lock exclusively and is deliberately not instrumented: a
+        // previous tick's expiry work must not come back as evidence that the
+        // master was stalling.
+        //
+        // That left edge moves with the heartbeat stream, and it has to. A
+        // pinned edge -- the candidate's own last pop, newest_expired_deadline
+        // minus the ttl -- never advances while now does, so a routine
+        // few-millisecond hold that happens to land inside a dying client's
+        // last ttl window defers that client for the whole grace while every
+        // other client's heartbeats flow. Following the stream never widens
+        // the window either: the candidate's last pop is by definition at or
+        // before last_ping_batch_at, and the two coincide exactly when the
+        // newest candidate is the last client the master heard from, which is
+        // the single-client case and the whole-fleet case -- the two cases
+        // that need the protection most. Nor can the edge be a wall-clock
+        // recency bound on the hold: a hold can release and leave the master
+        // starved for many more ticks (the UnmountSegment ->
+        // ClearInvalidHandles sweep holds snapshot_mutex_ across all shards,
+        // observed at 8.5-9.6 s with 14M keys), and through that no heartbeat
+        // is popped, so last_ping_batch_at does not advance and the released
+        // hold stays evidence. A "holds within the last tick or two" rule ages
+        // that evidence out mid-stall and erases the keys.
+        //
+        // Secondary condition: the master has processed no ping at all since
+        // the newest candidate went overdue, and it tracks at least
+        // kMinTrackedClientsForSilenceEvidence clients. An exclusive hold is
+        // not the only way to starve heartbeats -- io threads all blocked on
+        // snapshot_mutex_ or on shard locks starve Ping too, and no hold is
+        // recorded for that -- so the silence is kept as weaker evidence. It
+        // needs the client count, because silence only says something about
+        // the master when there was somebody else who could have spoken for
+        // it: with one tracked client, "nobody pinged" and "that client died"
+        // are the same sentence, and reading it as a stall would hold back
+        // every store restart in a single-client cluster for the whole grace.
+        //
+        // The two are OR-ed, so the breaker errs towards deferring. That is
+        // the bounded direction: being wrong this way costs
+        // client_mass_expiry_grace_sec of stale segments, being wrong the
+        // other way costs the whole cluster its cache index.
+        //
+        // What the rule does, case by case:
+        //
+        //   one client, it dies, master healthy               expire now
+        //     -- no hold overlapped, and one tracked client is not evidence.
+        //   one client, a ReMountSegment stall                 defer
+        //     -- the remount's hold overlaps the window.
+        //   a client dies, then a short mount holds the lock   expire now
+        //     -- the hold released and heartbeats were popped after it, so it
+        //        does not explain a client still overdue. A left edge pinned
+        //        to the candidate's own last pop would defer the death for
+        //        the whole grace instead.
+        //   many clients, one stall, candidates split          defer
+        //     -- the hold overlaps every affected tick's window, because a
+        //        stall that blocks Ping pops no heartbeat and so cannot move
+        //        the window's left edge past itself. How the candidates split
+        //        across ticks is irrelevant, which is the whole point of
+        //        judging the cause, and it holds whether the tick carries a
+        //        majority of the clients or a single one.
+        //   many clients, healthy master, a majority die       expire now
+        //     -- the survivors' pings land after the candidates' deadlines,
+        //        so the master is not silent, and nothing was holding.
+        //   many clients, healthy master, all of them die      defer, then
+        //                                                      expire at the
+        //                                                      grace bound
+        //     -- silence with nobody left to speak for the master is exactly
+        //        what a total stall looks like, and no reading of the
+        //        heartbeat stream can separate the two. The cost is bounded
+        //        and it falls on segments whose owners are all gone.
+        //   one client, starvation with no client_mutex_ hold  keys erased
+        //     -- the residual gap. No hold is recorded and one tracked client
+        //        is not evidence, so the breaker has nothing to go on. Closing
+        //        it needs a liveness signal off the data path, which this
+        //        change does not build.
+        //
+        // Deferring is doing nothing at all: client_ttl keeps its entry, no
+        // unmount is prepared and no stale-handle sweep runs, and no deadline
+        // is refreshed by hand. Recovery needs no machinery either -- the loop
+        // above drains client_ping_queue_ every tick, so a client whose
+        // heartbeat arrives during the deferral has its TTL refreshed and
+        // stops being a candidate on its own, which is also what keeps the
+        // grace a bound on the whole episode rather than on the interval
+        // between refreshes.
+        const bool episode_was_open = mass_expiry_since.has_value();
+        const ClientMassExpiryDecision decision = EvaluateClientMassExpiry({
+            .guard_enabled = client_mass_expiry_guard_,
+            .grace = client_mass_expiry_grace_,
+            .expired_count = expired_clients.size(),
+            // client_ttl is this thread's own map, so reading its size needs
+            // no lock -- and the breaker must not take one, since it runs
+            // ahead of the locked section it exists to survive.
+            .tracked_clients = client_ttl.size(),
+            .holds = ReadExclusiveClientLockHolds(),
+            .now = now,
+            .last_ping_batch_at = last_ping_batch_at,
+            .newest_expired_deadline = newest_expired_deadline,
+            .episode_since = mass_expiry_since,
+        });
+
+        if (decision.is_mass_expiry) {
+            if (!mass_expiry_since.has_value()) {
+                mass_expiry_since = now;
+            }
+        } else {
+            mass_expiry_since.reset();
+        }
+        if (!decision.defer) {
+            deferred_clients_gauge.Publish(0);
+        }
+
+        if (decision.is_mass_expiry) {
+            const auto deferred_for_sec =
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    decision.deferred_for);
+            const auto silent_for_sec =
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    decision.silent_for);
+            if (decision.defer) {
+                MasterMetricManager::instance().inc_client_expiry_deferred();
+                deferred_clients_gauge.Publish(
+                    static_cast<int64_t>(expired_clients.size()));
+                // The first tick of an episode is news. The ticks after it are
+                // the same news once a second, so they go out at INFO and a
+                // 60 s episode does not bury the log in sixty warnings.
+                std::ostringstream line;
+                line << "action=client_mass_expiry_deferred"
+                     << ", expired_count=" << expired_clients.size()
+                     << ", tracked_clients=" << client_ttl.size()
+                     << ", exclusive_hold_overlap="
+                     << decision.exclusive_hold_overlap
+                     << ", master_silent=" << decision.master_silent
+                     << ", silent_for_sec=" << silent_for_sec.count()
+                     << ", deferred_for_sec=" << deferred_for_sec.count()
+                     << ", grace_sec=" << client_mass_expiry_grace_.count()
+                     << ", reason=master_stall_suspected";
+                if (episode_was_open) {
+                    LOG(INFO) << line.str();
+                } else {
+                    LOG(WARNING) << line.str();
+                }
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(kClientMonitorSleepMs));
+                continue;
+            }
+            // The grace bound is reached, so the breaker stops judging and the
+            // expiry goes ahead. mass_expiry_since stays set for as long as
+            // the conditions hold, which keeps the next tick from opening a
+            // fresh episode and deferring the same clients again. This is the
+            // master about to do the unrecoverable thing the breaker exists to
+            // avoid, so it is an error, not a warning.
+            LOG(ERROR) << "action=client_mass_expiry_grace_exceeded"
+                       << ", expired_count=" << expired_clients.size()
+                       << ", tracked_clients=" << client_ttl.size()
+                       << ", exclusive_hold_overlap="
+                       << decision.exclusive_hold_overlap
+                       << ", master_silent=" << decision.master_silent
+                       << ", silent_for_sec=" << silent_for_sec.count()
+                       << ", deferred_for_sec=" << deferred_for_sec.count()
+                       << ", grace_sec=" << client_mass_expiry_grace_.count()
+                       << ", reason=expiring_after_grace";
+        }
+
+        for (const auto& client_id : expired_clients) {
+            LOG(INFO) << "client_id=" << client_id << ", action=client_expired";
+            client_ttl.erase(client_id);
         }
 
         // Update the client status to NEED_REMOUNT

--- a/mooncake-store/tests/master_service_config_test.cpp
+++ b/mooncake-store/tests/master_service_config_test.cpp
@@ -46,4 +46,55 @@ TEST(MasterServiceConfigTest, OplogBatchMaxEntriesBuilderOverrideRespected) {
     EXPECT_EQ(17u, config.oplog_batch_max_entries);
 }
 
+TEST(MasterServiceConfigTest, ClientMassExpiryGuardIsArmedByDefault) {
+    MasterConfig master_config;
+    EXPECT_TRUE(master_config.client_mass_expiry_guard);
+    EXPECT_EQ(DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC,
+              master_config.client_mass_expiry_grace_sec);
+
+    MasterServiceConfig service_config;
+    EXPECT_TRUE(service_config.client_mass_expiry_guard);
+    EXPECT_EQ(DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC,
+              service_config.client_mass_expiry_grace_sec);
+}
+
+TEST(MasterServiceConfigTest, ClientMassExpiryBuilderOverridesAreRespected) {
+    auto config = MasterServiceConfig::builder()
+                      .set_client_mass_expiry_guard(false)
+                      .set_client_mass_expiry_grace_sec(7)
+                      .build();
+
+    EXPECT_FALSE(config.client_mass_expiry_guard);
+    EXPECT_EQ(7, config.client_mass_expiry_grace_sec);
+}
+
+// Every layer between the master's own config and the one MasterService is
+// constructed with has to carry these, or an operator's flag reaches a
+// serving master silently unchanged.
+TEST(MasterServiceConfigTest, ClientMassExpiryPropagatesToServingConfig) {
+    MasterConfig master_config{};
+    master_config.client_mass_expiry_guard = false;
+    master_config.client_mass_expiry_grace_sec = 11;
+    MasterServiceSupervisorConfig supervisor_config(master_config);
+
+    WrappedMasterServiceConfig wrapped_config(supervisor_config, 1);
+    MasterServiceConfig service_config(wrapped_config);
+
+    EXPECT_FALSE(supervisor_config.client_mass_expiry_guard);
+    EXPECT_EQ(11, supervisor_config.client_mass_expiry_grace_sec);
+    EXPECT_FALSE(wrapped_config.client_mass_expiry_guard);
+    EXPECT_EQ(11, wrapped_config.client_mass_expiry_grace_sec);
+    EXPECT_FALSE(service_config.client_mass_expiry_guard);
+    EXPECT_EQ(11, service_config.client_mass_expiry_grace_sec);
+}
+
+// The command-line validator and the config-file path share this predicate,
+// so a grace that arrives from a yaml file cannot skip the check the flag gets.
+TEST(MasterServiceConfigTest, ClientMassExpiryGraceRejectsNegativeValues) {
+    EXPECT_TRUE(IsValidClientMassExpiryGraceSec(0));
+    EXPECT_TRUE(
+        IsValidClientMassExpiryGraceSec(DEFAULT_CLIENT_MASS_EXPIRY_GRACE_SEC));
+    EXPECT_FALSE(IsValidClientMassExpiryGraceSec(-1));
+}
+
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -3396,6 +3396,817 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
     service_->RemoveAll();
 }
 
+// ---------------------------------------------------------------------------
+// Client mass-expiry circuit breaker (ClientMonitorFunc)
+//
+// Expiring a client unmounts its segments and erases its keys, and nothing in
+// the master undoes that: only a snapshot or a standby that still holds the
+// metadata can bring the index back. The breaker holds back an expiry the
+// master cannot rule out being its own stall, and it decides that from the
+// cause -- an exclusive client_mutex_ hold overlapping [last_ping_batch_at,
+// now], the stretch the master has no heartbeat of its own to show for --
+// rather than from the absence of heartbeats, which looks the same whether the
+// master failed to serve them or nobody sent any. A hold that released before
+// the last heartbeat was popped is refuted by that heartbeat and explains
+// nothing, which is what keeps a routine mount from deferring a genuine death.
+//
+// ClientMassExpiryDecisionTest covers the rule's boundary cases as a table
+// over the pure decision function, with no sleeping. The MasterServiceTest
+// cases below drive real monitor ticks, real locks and real keys, because the
+// wiring between the two -- which window is measured, when the episode latch
+// opens and closes, what the gauge holds -- is what a pure test cannot see.
+// ---------------------------------------------------------------------------
+
+namespace {
+constexpr int64_t kBreakerClientTtlSec = 1;
+constexpr size_t kBreakerSegmentSize = 1024 * 1024 * 16;
+
+// One tick of a healthy master with one client just gone overdue, as the
+// starting point every table case varies one reading of.
+ClientMassExpiryInputs BaseBreakerInputs() {
+    using namespace std::chrono;
+    const auto now = steady_clock::time_point{} + hours(1);
+    ClientMassExpiryInputs inputs;
+    inputs.guard_enabled = true;
+    inputs.grace = seconds(60);
+    inputs.expired_count = 1;
+    inputs.tracked_clients = 1;
+    inputs.now = now;
+    inputs.newest_expired_deadline = now - seconds(1);
+    // The pop that stamped that deadline, one 10 s ttl before it, and nothing
+    // popped since. This is the value that makes master_silent unavoidably
+    // true for the newest candidate, and it is why silence on its own cannot
+    // decide anything. It is also the left edge of the hold window, so in this
+    // base tick the window is the whole ttl the heartbeat could have arrived
+    // in -- the single-client case, where the pinned edge and the moving one
+    // coincide.
+    inputs.last_ping_batch_at = now - seconds(11);
+    return inputs;
+}
+}  // namespace
+
+TEST(ClientMassExpiryDecisionTest, CaseTable) {
+    using namespace std::chrono;
+    const auto base = BaseBreakerInputs();
+    const auto now = base.now;
+
+    // A completed hold window, given as seconds before now.
+    auto hold = [&](int64_t start_ago, int64_t end_ago) {
+        ExclusiveClientLockHolds holds;
+        holds.last_completed =
+            std::make_pair(now - seconds(start_ago), now - seconds(end_ago));
+        return holds;
+    };
+    // The same, in milliseconds: the cases that separate a hold's release from
+    // the last heartbeat pop turn on sub-second ordering, because that is the
+    // scale a routine mount's hold and a 1 s monitor tick live on.
+    auto hold_ms = [&](int64_t start_ago_ms, int64_t end_ago_ms) {
+        ExclusiveClientLockHolds holds;
+        holds.last_completed = std::make_pair(now - milliseconds(start_ago_ms),
+                                              now - milliseconds(end_ago_ms));
+        return holds;
+    };
+    auto hold_in_progress = [&](int64_t start_ago) {
+        ExclusiveClientLockHolds holds;
+        holds.in_progress_start = now - seconds(start_ago);
+        return holds;
+    };
+
+    struct Case {
+        const char* name;
+        ClientMassExpiryInputs inputs;
+        bool want_is_mass_expiry;
+        // Pinned per case as well as the verdict, so a row says which
+        // condition carried it instead of leaving that to be inferred.
+        bool want_hold_overlap;
+        bool want_master_silent;
+        const char* why;
+    };
+
+    std::vector<Case> cases;
+    auto add = [&](const char* name, bool want, bool want_hold_overlap,
+                   bool want_master_silent, const char* why,
+                   const std::function<void(ClientMassExpiryInputs&)>& tweak) {
+        ClientMassExpiryInputs inputs = base;
+        tweak(inputs);
+        cases.push_back(
+            {name, inputs, want, want_hold_overlap, want_master_silent, why});
+    };
+
+    add("one client, it dies, master healthy", false, false, true,
+        "one tracked client is not evidence about the master, and nothing was "
+        "holding client_mutex_",
+        [](ClientMassExpiryInputs&) {});
+    add("one client, a stall that has already released", true, true, true,
+        "the hold released, but no heartbeat has been popped since, so "
+        "nothing refutes it as the explanation",
+        [&](ClientMassExpiryInputs& in) { in.holds = hold(9, 2); });
+    add("one client, a stall still in progress", true, true, true,
+        "a hold running now is stopping heartbeats now",
+        [&](ClientMassExpiryInputs& in) { in.holds = hold_in_progress(0); });
+    add("one client, a hold the last heartbeat outlived", false, false, true,
+        "a heartbeat was popped after that hold released, so the master was "
+        "serving again and the hold explains nothing",
+        [&](ClientMassExpiryInputs& in) { in.holds = hold(20, 12); });
+    add("13 clients, one dies, a short mount hold lands in its last ttl", false,
+        false, false,
+        "the hold released and heartbeats were popped after it, so it cannot "
+        "explain a client that is still overdue -- this is the case a pinned "
+        "left edge deferred for the whole grace",
+        [&](ClientMassExpiryInputs& in) {
+            in.tracked_clients = 13;
+            // 100 ms of somebody else's mount, 2 s ago, then the survivors'
+            // heartbeats.
+            in.holds = hold_ms(2000, 1900);
+            in.last_ping_batch_at = now;
+        });
+    add("13 clients, a stall that released after the last heartbeat", true,
+        true, false,
+        "no heartbeat has been popped since the hold released, so the recovery "
+        "gap is still the master's and the hold carries the verdict on its own",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 6;
+            in.tracked_clients = 13;
+            in.holds = hold_ms(9000, 400);
+            in.last_ping_batch_at = now - milliseconds(500);
+        });
+    add("13 clients, one stall, 6 of them overdue this tick", true, true, true,
+        "the hold decides it, so how the deadlines split across ticks does "
+        "not matter",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 6;
+            in.tracked_clients = 13;
+            in.holds = hold(9, 2);
+        });
+    add("13 clients, one stall, 1 of them overdue this tick", true, true, false,
+        "a lone candidate inside a real stall is still the master's fault",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 1;
+            in.tracked_clients = 13;
+            in.holds = hold_ms(9000, 400);
+            in.last_ping_batch_at = now - milliseconds(500);
+        });
+    add("13 clients, a hold still in progress, a heartbeat popped this tick",
+        true, true, false,
+        "a hold running now stops heartbeats now, whatever was popped before "
+        "it started",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 6;
+            in.tracked_clients = 13;
+            in.holds = hold_in_progress(0);
+            in.last_ping_batch_at = now;
+        });
+    add("13 clients, healthy master, a majority genuinely die", false, false,
+        false,
+        "the survivors' heartbeats land after the candidates' deadlines, so "
+        "the master can vouch for itself",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 7;
+            in.tracked_clients = 13;
+            in.last_ping_batch_at = now;
+        });
+    add("13 clients, healthy master, the whole fleet goes silent", true, false,
+        true,
+        "with nobody left to speak for the master, silence and a total stall "
+        "are the same reading",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 13;
+            in.tracked_clients = 13;
+        });
+    add("2 clients, one dies, the other keeps pinging", false, false, false,
+        "not silent and nothing holding", [&](ClientMassExpiryInputs& in) {
+            in.tracked_clients = 2;
+            in.last_ping_batch_at = now;
+        });
+    add("guard disarmed", false, false, false,
+        "the operator asked for no stall detection",
+        [&](ClientMassExpiryInputs& in) {
+            in.guard_enabled = false;
+            in.holds = hold_in_progress(0);
+        });
+    add("zero grace", false, false, false,
+        "a zero grace is also no stall detection",
+        [&](ClientMassExpiryInputs& in) {
+            in.grace = seconds(0);
+            in.holds = hold_in_progress(0);
+        });
+    add("no candidates", false, false, false, "nothing to decide about",
+        [&](ClientMassExpiryInputs& in) {
+            in.expired_count = 0;
+            in.holds = hold_in_progress(0);
+        });
+
+    for (const auto& c : cases) {
+        const auto decision = EvaluateClientMassExpiry(c.inputs);
+        EXPECT_EQ(c.want_is_mass_expiry, decision.is_mass_expiry)
+            << "case: " << c.name << " -- " << c.why;
+        EXPECT_EQ(c.want_hold_overlap, decision.exclusive_hold_overlap)
+            << "case: " << c.name << " -- " << c.why;
+        EXPECT_EQ(c.want_master_silent, decision.master_silent)
+            << "case: " << c.name << " -- " << c.why;
+        // Nothing is ever both deferred and expired.
+        EXPECT_FALSE(decision.defer && decision.grace_exceeded)
+            << "case: " << c.name;
+        if (!c.want_is_mass_expiry) {
+            EXPECT_FALSE(decision.defer) << "case: " << c.name;
+            EXPECT_FALSE(decision.grace_exceeded) << "case: " << c.name;
+        }
+    }
+
+    // kMinTrackedClientsForSilenceEvidence is the whole difference between
+    // "one client, it dies, master healthy" and "the whole fleet
+    // goes silent", so pin it rather than leaving it implied.
+    EXPECT_EQ(2u, kMinTrackedClientsForSilenceEvidence);
+}
+
+TEST(ClientMassExpiryDecisionTest, GraceBoundIsCheckedOnRawDurations) {
+    using namespace std::chrono;
+    auto inputs = BaseBreakerInputs();
+    inputs.grace = seconds(60);
+    inputs.holds.in_progress_start = inputs.now;
+
+    // Inside the bound, at a fraction of a second below it.
+    inputs.episode_since = inputs.now - milliseconds(59500);
+    auto decision = EvaluateClientMassExpiry(inputs);
+    EXPECT_TRUE(decision.defer);
+    EXPECT_FALSE(decision.grace_exceeded);
+
+    // Exactly at the bound: the deferral is over.
+    inputs.episode_since = inputs.now - seconds(60);
+    decision = EvaluateClientMassExpiry(inputs);
+    EXPECT_FALSE(decision.defer);
+    EXPECT_TRUE(decision.grace_exceeded);
+
+    // Just past it, by less than the second a rounded comparison would lose.
+    inputs.episode_since = inputs.now - milliseconds(60100);
+    decision = EvaluateClientMassExpiry(inputs);
+    EXPECT_FALSE(decision.defer);
+    EXPECT_TRUE(decision.grace_exceeded);
+
+    // A fresh episode is opened at now, so its clock starts at zero.
+    inputs.episode_since = std::nullopt;
+    decision = EvaluateClientMassExpiry(inputs);
+    EXPECT_TRUE(decision.defer);
+    EXPECT_EQ(steady_clock::duration::zero(), decision.deferred_for);
+}
+
+TEST(ClientMassExpiryDecisionTest, GraceClockRunsFromTheEpisodeStart) {
+    using namespace std::chrono;
+    auto inputs = BaseBreakerInputs();
+    inputs.grace = seconds(60);
+    inputs.holds.in_progress_start = inputs.now;
+    inputs.episode_since = inputs.now - seconds(40);
+
+    // The candidate set growing must not move the clock: a rule that restarted
+    // it on every change would defer without bound for as long as clients keep
+    // lapsing one at a time.
+    for (size_t expired : {size_t{1}, size_t{5}, size_t{13}}) {
+        inputs.expired_count = expired;
+        inputs.tracked_clients = 13;
+        const auto decision = EvaluateClientMassExpiry(inputs);
+        EXPECT_TRUE(decision.defer);
+        EXPECT_EQ(seconds(40), duration_cast<seconds>(decision.deferred_for))
+            << "expired_count=" << expired << " moved the episode clock";
+    }
+}
+
+TEST(ClientMassExpiryDecisionTest, HoldOverlapIsInclusiveAtBothEdges) {
+    using namespace std::chrono;
+    const auto now = steady_clock::time_point{} + hours(1);
+    const auto window_start = now - seconds(10);
+
+    ExclusiveClientLockHolds ends_at_window_start;
+    ends_at_window_start.last_completed =
+        std::make_pair(now - seconds(20), window_start);
+    EXPECT_TRUE(ends_at_window_start.Overlaps(window_start, now));
+
+    ExclusiveClientLockHolds ends_just_before;
+    ends_just_before.last_completed =
+        std::make_pair(now - seconds(20), window_start - milliseconds(1));
+    EXPECT_FALSE(ends_just_before.Overlaps(window_start, now));
+
+    ExclusiveClientLockHolds starts_at_window_end;
+    starts_at_window_end.in_progress_start = now;
+    EXPECT_TRUE(starts_at_window_end.Overlaps(window_start, now));
+
+    ExclusiveClientLockHolds nothing_recorded;
+    EXPECT_FALSE(nothing_recorded.Overlaps(window_start, now));
+}
+
+// A genuinely single-client fleet whose only client dies on a healthy master.
+// This is the case the rule has to get right for a single-store cluster to be
+// operable at all: nothing is holding client_mutex_, so the master has no
+// reason to suspect itself, and the expiry must happen at once. Deferring it
+// would hold every store restart in such a cluster for the whole grace.
+TEST_F(MasterServiceTest, SingleClientFleetExpiresAtOnce) {
+    auto service_config = MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(kBreakerClientTtlSec)
+                              .set_client_mass_expiry_grace_sec(60)
+                              .build();
+    auto service = std::make_unique<MasterService>(service_config);
+
+    auto client =
+        RegisterClientWithSegment(*service, "breaker_lone_death",
+                                  kDefaultSegmentBase, kBreakerSegmentSize);
+    const std::string key =
+        PutObjectOnSegment(*service, client.client_id, client.segment_name);
+
+    // Let a monitor tick pop the registration heartbeat and put the
+    // registration's own ReMountSegment hold behind the window that tick
+    // stamps, so this measures a healthy master rather than the test's setup.
+    {
+        HeartbeatThread heartbeat(*service, client.client_id);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    }
+
+    const int64_t deferred_before =
+        MasterMetricManager::instance().get_client_expiry_deferred();
+
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(8),
+                        [&] { return !KeyIsVisible(*service, key); }))
+        << "a single-client cluster's only client was never expired, so its "
+           "store restarts wait out the whole grace";
+
+    ExpectKeyGoneFromReadApis(*service, key);
+    EXPECT_EQ(ClientStatus::NEED_REMOUNT,
+              ObserveClientStatus(*service, client.client_id));
+    EXPECT_EQ(deferred_before,
+              MasterMetricManager::instance().get_client_expiry_deferred())
+        << "silence with one tracked client was read as evidence about the "
+           "master";
+    EXPECT_EQ(
+        0,
+        MasterMetricManager::instance().get_client_expiry_deferred_clients());
+}
+
+// The same single-client fleet, but with an exclusive client_mutex_ hold
+// across the window its heartbeat could have arrived in -- a ReMountSegment
+// stall, in miniature. Together with the test above this is the pair that
+// pins the rule: the cluster's own client count decides nothing, the hold
+// does.
+TEST_F(MasterServiceTest, SingleClientFleetStallIsDeferred) {
+    auto service_config = MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(kBreakerClientTtlSec)
+                              .set_client_mass_expiry_grace_sec(60)
+                              .build();
+    auto service = std::make_unique<MasterService>(service_config);
+
+    auto client =
+        RegisterClientWithSegment(*service, "breaker_lone_stall",
+                                  kDefaultSegmentBase, kBreakerSegmentSize);
+    const std::string key =
+        PutObjectOnSegment(*service, client.client_id, client.segment_name);
+
+    const int64_t deferred_before =
+        MasterMetricManager::instance().get_client_expiry_deferred();
+
+    // The breaker's gate runs ahead of the monitor's own locked section, so it
+    // reaches a verdict while the hold is still in place. Only metrics may be
+    // read inside the hold: anything touching client state would queue behind
+    // it.
+    bool deferred_during_stall = false;
+    int64_t gauge_during_stall = 0;
+    WhileHoldingClientLockExclusively(*service, [&] {
+        deferred_during_stall = WaitFor(std::chrono::seconds(8), [&] {
+            return MasterMetricManager::instance()
+                       .get_client_expiry_deferred() > deferred_before;
+        });
+        gauge_during_stall = MasterMetricManager::instance()
+                                 .get_client_expiry_deferred_clients();
+    });
+    ASSERT_TRUE(deferred_during_stall)
+        << "the stall was not recognised, so a single-client cluster loses its "
+           "cache to any long exclusive section";
+    EXPECT_GT(gauge_during_stall, 0)
+        << "the gauge does not report the clients being held back";
+
+    EXPECT_TRUE(KeyIsVisible(*service, key))
+        << "the deferred expiry still erased the client's keys";
+    EXPECT_EQ(ClientStatus::OK,
+              ObserveClientStatus(*service, client.client_id));
+}
+
+// Two or more tracked clients all going silent with nothing holding
+// client_mutex_ is the one place the weaker, silence-based evidence is used.
+// A total stall of the io threads looks exactly like this and records no hold,
+// which is why the reading is kept; the price is that a fleet that really did
+// all die is held for the grace bound before being expired.
+TEST_F(MasterServiceTest, WholeFleetSilenceIsDeferredWithoutAHold) {
+    auto service_config = MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(kBreakerClientTtlSec)
+                              .set_client_mass_expiry_grace_sec(60)
+                              .build();
+    auto service = std::make_unique<MasterService>(service_config);
+
+    std::vector<RegisteredClientContext> clients;
+    std::vector<std::unique_ptr<HeartbeatThread>> heartbeats;
+    for (int i = 0; i < 4; ++i) {
+        clients.push_back(RegisterClientWithSegment(
+            *service, "breaker_silence_" + std::to_string(i),
+            kDefaultSegmentBase + static_cast<size_t>(i) * kBreakerSegmentSize,
+            kBreakerSegmentSize));
+    }
+    const std::string key = PutObjectOnSegment(*service, clients[0].client_id,
+                                               clients[0].segment_name);
+    for (const auto& client : clients) {
+        heartbeats.push_back(
+            std::make_unique<HeartbeatThread>(*service, client.client_id));
+    }
+    // Push every registration hold behind the window the next tick stamps, so
+    // the deferral below can only come from the silence.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+    const int64_t deferred_before =
+        MasterMetricManager::instance().get_client_expiry_deferred();
+    heartbeats.clear();
+
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(8),
+                        [&] {
+                            return MasterMetricManager::instance()
+                                       .get_client_expiry_deferred() >
+                                   deferred_before;
+                        }))
+        << "a whole fleet falling silent was expired without the master "
+           "checking whether it was serving anybody";
+
+    EXPECT_TRUE(KeyIsVisible(*service, key));
+    for (const auto& client : clients) {
+        EXPECT_EQ(ClientStatus::OK,
+                  ObserveClientStatus(*service, client.client_id));
+    }
+}
+
+// A majority of a healthy master's clients genuinely dying while the rest keep
+// pinging. The master has processed heartbeats after the casualties' deadlines
+// lapsed, so it can vouch for itself and the casualties really are gone: this
+// must expire at once. It is the regression test for a rule that deferred on
+// the share of clients expiring, which fired here precisely because the master
+// was demonstrably healthy.
+TEST_F(MasterServiceTest, MajorityGenuineDeathOnHealthyMasterExpiresAtOnce) {
+    constexpr int kCasualties = 3;
+    constexpr int kSurvivors = 2;
+    auto service_config = MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(kBreakerClientTtlSec)
+                              .set_client_mass_expiry_grace_sec(60)
+                              .build();
+    auto service = std::make_unique<MasterService>(service_config);
+
+    std::vector<RegisteredClientContext> clients;
+    for (int i = 0; i < kCasualties + kSurvivors; ++i) {
+        clients.push_back(RegisterClientWithSegment(
+            *service, "breaker_majority_" + std::to_string(i),
+            kDefaultSegmentBase + static_cast<size_t>(i) * kBreakerSegmentSize,
+            kBreakerSegmentSize));
+    }
+    std::vector<std::string> casualty_keys;
+    for (int i = 0; i < kCasualties; ++i) {
+        casualty_keys.push_back(PutObjectOnSegment(
+            *service, clients[i].client_id, clients[i].segment_name));
+    }
+
+    std::vector<std::unique_ptr<HeartbeatThread>> heartbeats;
+    for (const auto& client : clients) {
+        heartbeats.push_back(
+            std::make_unique<HeartbeatThread>(*service, client.client_id));
+    }
+    // Everybody alive for a tick, so the casualties' deadlines are stamped by
+    // a tick that has all the registration holds behind it.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+    const int64_t deferred_before =
+        MasterMetricManager::instance().get_client_expiry_deferred();
+    heartbeats.erase(heartbeats.begin(), heartbeats.begin() + kCasualties);
+
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(8),
+                        [&] {
+                            return std::none_of(
+                                casualty_keys.begin(), casualty_keys.end(),
+                                [&](const std::string& key) {
+                                    return KeyIsVisible(*service, key);
+                                });
+                        }))
+        << "a majority genuinely dying on a healthy master was deferred, "
+           "which is what losing a rack looks like";
+
+    EXPECT_EQ(deferred_before,
+              MasterMetricManager::instance().get_client_expiry_deferred())
+        << "the breaker fired although the master had served heartbeats after "
+           "the casualties' deadlines";
+    for (int i = kCasualties; i < kCasualties + kSurvivors; ++i) {
+        EXPECT_EQ(ClientStatus::OK,
+                  ObserveClientStatus(*service, clients[i].client_id));
+    }
+    heartbeats.clear();
+}
+
+// One stall whose expiries split across two monitor ticks. A client's deadline
+// is stamped by the tick that popped its heartbeat and clients ping on their
+// own timers, so the clients of one stalled master do not all fall due in the
+// same tick: 6 can fall due one tick and 7 the next. A rule that looked at the
+// share of clients expiring failed on the tick carrying 6, and unmounted their
+// segments and erased their keys -- the incident in miniature.
+//
+// The stall is a real exclusive client_mutex_ hold, held across the tick that
+// acts on the early group's deadlines. No witness client pings through it,
+// because a hold that stops Ping stops every client's heartbeat: whether the
+// master also reads itself as silent in the deferred tick depends on where the
+// last pop fell relative to the early deadlines, so this case asserts nothing
+// about that and the hold is what it is built on. The deterministic separation
+// of the two conditions is ClientMassExpiryDecisionTest.CaseTable, on the
+// sub-second ordering between a hold's release and the last heartbeat pop.
+// What this case adds is that the deferral covers a minority of the tracked
+// fleet -- the gauge names how many clients are held back, so the split is
+// read off the master itself -- and that the same split on an unguarded master
+// erases exactly those clients' keys.
+TEST_F(MasterServiceTest, ClientMassExpirySplitAcrossTicksIsDeferred) {
+    constexpr int kSplitEarlyClients = 6;
+    constexpr int kSplitLateClients = 7;
+    constexpr int64_t kSplitTtlSec = 4;
+    // The late group registers this much after the early group, so its
+    // deadlines lapse well after the early group's and the tick under test
+    // carries only the early group. The gap is the ttl, not a tick, because a
+    // deadline is stamped by the tick that popped the heartbeat and is acted
+    // on by the tick after it lapses: the two groups have to be further apart
+    // than that pair of roundings, or the hold below cannot sit between them.
+    const auto kSplitStagger = std::chrono::seconds(4);
+    // The hold spans the tick that acts on the early group's deadlines (arm +
+    // 5 s, acted on at arm + 5 s or 6 s) and releases before the late group's
+    // (arm + 9 s), so the episode the master sees is the minority one.
+    const auto kSplitHoldUntil = std::chrono::milliseconds(6600);
+
+    struct ArmResult {
+        std::vector<ClientStatus> early_status;
+        std::vector<ClientStatus> late_status;
+        std::vector<bool> early_keys_present;
+        int64_t deferred_delta = 0;
+        int64_t gauge_during_stall = 0;
+        bool deferred_during_stall = false;
+    };
+
+    auto run_arm = [&](bool guard, const std::string& tag) {
+        auto service_config = MasterServiceConfig::builder()
+                                  .set_client_live_ttl_sec(kSplitTtlSec)
+                                  .set_client_mass_expiry_guard(guard)
+                                  .set_client_mass_expiry_grace_sec(60)
+                                  .build();
+        auto service = std::make_unique<MasterService>(service_config);
+
+        const auto arm_started = std::chrono::steady_clock::now();
+        std::vector<RegisteredClientContext> early;
+        std::vector<std::string> early_keys;
+        for (int i = 0; i < kSplitEarlyClients; ++i) {
+            early.push_back(RegisterClientWithSegment(
+                *service, tag + "_early_" + std::to_string(i),
+                kDefaultSegmentBase +
+                    static_cast<size_t>(i) * kBreakerSegmentSize,
+                kBreakerSegmentSize));
+            early_keys.push_back(PutObjectOnSegment(
+                *service, early.back().client_id, early.back().segment_name));
+        }
+
+        const int64_t deferred_before =
+            MasterMetricManager::instance().get_client_expiry_deferred();
+
+        std::this_thread::sleep_for(kSplitStagger);
+
+        std::vector<RegisteredClientContext> late;
+        for (int i = 0; i < kSplitLateClients; ++i) {
+            late.push_back(RegisterClientWithSegment(
+                *service, tag + "_late_" + std::to_string(i),
+                kDefaultSegmentBase +
+                    static_cast<size_t>(kSplitEarlyClients + i) *
+                        kBreakerSegmentSize,
+                kBreakerSegmentSize));
+        }
+
+        ArmResult result;
+        // The stall. The breaker's gate runs ahead of the monitor's own locked
+        // section, so it reaches a verdict while the hold is still in place;
+        // an unguarded monitor instead blocks inside that section and does its
+        // expiry the moment the hold releases. Only metrics may be read in
+        // here -- anything touching client state would queue behind the hold.
+        const auto release_at = arm_started + kSplitHoldUntil;
+        WhileHoldingClientLockExclusively(*service, [&] {
+            const auto budget =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    release_at - std::chrono::steady_clock::now());
+            result.deferred_during_stall = WaitFor(budget, [&] {
+                return MasterMetricManager::instance()
+                           .get_client_expiry_deferred() > deferred_before;
+            });
+            result.gauge_during_stall =
+                MasterMetricManager::instance()
+                    .get_client_expiry_deferred_clients();
+            // Both arms hold for the same span, so both are sampled with the
+            // late group still inside its ttl.
+            std::this_thread::sleep_until(release_at);
+        });
+        result.deferred_delta =
+            MasterMetricManager::instance().get_client_expiry_deferred() -
+            deferred_before;
+
+        if (!guard) {
+            // The expiry the released hold lets through, and the sweep that
+            // erases the keys with it. Bounded well short of the late group's
+            // deadline, so a slow sweep cannot turn into a second episode.
+            WaitFor(std::chrono::milliseconds(800), [&] {
+                return !KeyIsVisible(*service, early_keys.front());
+            });
+        }
+        for (const auto& key : early_keys) {
+            result.early_keys_present.push_back(KeyIsVisible(*service, key));
+        }
+        for (const auto& client : early) {
+            result.early_status.push_back(
+                ObserveClientStatus(*service, client.client_id));
+        }
+        for (const auto& client : late) {
+            result.late_status.push_back(
+                ObserveClientStatus(*service, client.client_id));
+        }
+        return result;
+    };
+
+    // Sequentially, not concurrently: the deferral counter and the gauge are
+    // process-global, and this case reads both as exact numbers.
+    const ArmResult guarded = run_arm(true, "split_guarded");
+    const ArmResult unguarded = run_arm(false, "split_unguarded");
+
+    EXPECT_TRUE(guarded.deferred_during_stall)
+        << "the stall was not recognised, so a minority-sized tick inside it "
+           "was expired";
+    EXPECT_GT(guarded.gauge_during_stall, 0)
+        << "the gauge does not report the clients being held back";
+    EXPECT_LT(guarded.gauge_during_stall,
+              kSplitEarlyClients + kSplitLateClients)
+        << "the whole fleet was overdue in the deferred tick, so the episode "
+           "was not the minority one a share-of-clients rule misreads";
+    for (int i = 0; i < kSplitEarlyClients; ++i) {
+        EXPECT_EQ(ClientStatus::OK, guarded.early_status[i])
+            << "the early group was expired although an exclusive "
+               "client_mutex_ hold overlapped the window their heartbeats "
+               "could have arrived in";
+        EXPECT_TRUE(guarded.early_keys_present[i])
+            << "the deferred expiry still erased the early group's keys";
+    }
+    for (int i = 0; i < kSplitLateClients; ++i) {
+        EXPECT_EQ(ClientStatus::OK, guarded.late_status[i]);
+    }
+
+    EXPECT_EQ(0, unguarded.deferred_delta)
+        << "the guard was off, so nothing may be held back";
+    for (int i = 0; i < kSplitEarlyClients; ++i) {
+        EXPECT_EQ(ClientStatus::NEED_REMOUNT, unguarded.early_status[i])
+            << "the split did not happen, so this test proves nothing";
+        EXPECT_FALSE(unguarded.early_keys_present[i])
+            << "an expired client's keys survived, so key loss is not what "
+               "this test is measuring";
+    }
+    for (int i = 0; i < kSplitLateClients; ++i) {
+        EXPECT_EQ(ClientStatus::OK, unguarded.late_status[i])
+            << "the whole fleet expired at once, so the episode was not the "
+               "minority one a share-of-clients rule misreads";
+    }
+}
+
+// A deferral in progress that the clients themselves end. Recovery is the
+// monitor's own queue drain and nothing else: a heartbeat arriving refreshes
+// that client's ttl, which takes it out of the candidate set, which closes the
+// episode. Nothing is expired, the counter stops moving and the gauge returns
+// to 0.
+TEST_F(MasterServiceTest, HeartbeatsResumingEndTheDeferral) {
+    auto service_config = MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(kBreakerClientTtlSec)
+                              .set_client_mass_expiry_grace_sec(60)
+                              .build();
+    auto service = std::make_unique<MasterService>(service_config);
+
+    auto client = RegisterClientWithSegment(
+        *service, "breaker_recovery", kDefaultSegmentBase, kBreakerSegmentSize);
+    const std::string key =
+        PutObjectOnSegment(*service, client.client_id, client.segment_name);
+
+    const int64_t deferred_before =
+        MasterMetricManager::instance().get_client_expiry_deferred();
+    bool deferred_during_stall = false;
+    WhileHoldingClientLockExclusively(*service, [&] {
+        deferred_during_stall = WaitFor(std::chrono::seconds(8), [&] {
+            return MasterMetricManager::instance()
+                       .get_client_expiry_deferred() > deferred_before;
+        });
+    });
+    ASSERT_TRUE(deferred_during_stall)
+        << "nothing was deferred, so there is no recovery to observe";
+
+    HeartbeatThread heartbeat(*service, client.client_id);
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(6), [&] {
+        return MasterMetricManager::instance()
+                   .get_client_expiry_deferred_clients() == 0;
+    })) << "the episode never closed although the client resumed pinging";
+
+    const int64_t deferred_at_recovery =
+        MasterMetricManager::instance().get_client_expiry_deferred();
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    EXPECT_EQ(deferred_at_recovery,
+              MasterMetricManager::instance().get_client_expiry_deferred())
+        << "the breaker kept deferring a client that is pinging again";
+    EXPECT_TRUE(KeyIsVisible(*service, key));
+    EXPECT_EQ(ClientStatus::OK,
+              ObserveClientStatus(*service, client.client_id));
+}
+
+// The breaker must not be able to defer without bound. One episode whose
+// candidate set grows on several consecutive ticks -- clients registered in
+// three staggered groups, all of them then silent -- still has to end, and end
+// on the clock the episode started on rather than on the last change to its
+// candidate set. The exact arithmetic is pinned by
+// ClientMassExpiryDecisionTest.GraceClockRunsFromTheEpisodeStart; what this
+// case adds is that the monitor holds the latch across those changes.
+TEST_F(MasterServiceTest, GraceBoundEndsAnEpisodeWithAGrowingCandidateSet) {
+    constexpr int64_t kGraceSec = 3;
+    // The ttl has to outlast the whole stagger, because every group's
+    // registration heartbeat is proof that the master is serving: with a ttl
+    // shorter than the gap, each group's arrival expires the group before it
+    // instead of joining its episode. Five seconds against a 2.4 s stagger
+    // puts all six deadlines after the last heartbeat this master ever pops,
+    // which is the one episode with a growing candidate set.
+    constexpr int64_t kGrowingSetTtlSec = 5;
+    auto service_config = MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(kGrowingSetTtlSec)
+                              .set_client_mass_expiry_grace_sec(kGraceSec)
+                              .build();
+    auto service = std::make_unique<MasterService>(service_config);
+
+    std::vector<RegisteredClientContext> clients;
+    std::vector<std::string> keys;
+    auto register_group = [&](int group) {
+        for (int i = 0; i < 2; ++i) {
+            const int index = group * 2 + i;
+            clients.push_back(RegisterClientWithSegment(
+                *service, "breaker_grace_" + std::to_string(index),
+                kDefaultSegmentBase +
+                    static_cast<size_t>(index) * kBreakerSegmentSize,
+                kBreakerSegmentSize));
+            keys.push_back(PutObjectOnSegment(*service,
+                                              clients.back().client_id,
+                                              clients.back().segment_name));
+        }
+    };
+    // Three groups a tick and a bit apart, so their deadlines lapse on
+    // different ticks and the candidate set grows inside one episode.
+    register_group(0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    register_group(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    register_group(2);
+
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(8), [&] {
+        return MasterMetricManager::instance()
+                   .get_client_expiry_deferred_clients() > 0;
+    })) << "the episode never opened";
+    const auto episode_seen_at = std::chrono::steady_clock::now();
+    const int64_t deferred_clients_at_open =
+        MasterMetricManager::instance().get_client_expiry_deferred_clients();
+
+    // The first group is the one that opened the episode, so its expiry is
+    // what the episode's own grace clock has to produce. The later groups lapse
+    // inside the episode, which is the candidate-set change under test.
+    int64_t most_deferred_clients = deferred_clients_at_open;
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(8), [&] {
+        most_deferred_clients = std::max(
+            most_deferred_clients, MasterMetricManager::instance()
+                                       .get_client_expiry_deferred_clients());
+        return !KeyIsVisible(*service, keys[0]) &&
+               !KeyIsVisible(*service, keys[1]);
+    })) << "the episode never ended, so the breaker can defer without bound";
+    const auto expired_after =
+        std::chrono::steady_clock::now() - episode_seen_at;
+
+    EXPECT_GT(most_deferred_clients, deferred_clients_at_open)
+        << "the candidate set never grew, so this case does not exercise the "
+           "latch it is about";
+    EXPECT_LT(expired_after,
+              std::chrono::seconds(kGraceSec) + std::chrono::milliseconds(2000))
+        << "the episode outlived its grace bound by more than a monitor tick, "
+           "which is what a clock restarted on every candidate-set change "
+           "looks like";
+    ASSERT_TRUE(WaitFor(std::chrono::seconds(6), [&] {
+        return std::none_of(keys.begin(), keys.end(),
+                            [&](const std::string& key) {
+                                return KeyIsVisible(*service, key);
+                            });
+    })) << "some of the episode's clients were never expired";
+    // Every exit from the deferring state hands the gauge back, the
+    // grace-exceeded one included.
+    EXPECT_EQ(
+        0, MasterMetricManager::instance().get_client_expiry_deferred_clients())
+        << "the gauge still claims clients are being held back after the "
+           "episode expired";
+    for (const auto& key : keys) {
+        ExpectKeyGoneFromReadApis(*service, key);
+    }
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {

--- a/mooncake-store/tests/master_service_test_fixture.h
+++ b/mooncake-store/tests/master_service_test_fixture.h
@@ -13,13 +13,18 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
+#include <shared_mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace mooncake::test {
@@ -48,6 +53,30 @@ class MasterServiceTest : public ::testing::Test {
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
     static constexpr size_t kDefaultSegmentSize = 1024 * 1024 * 16;
     static constexpr uint64_t kStrictTenantQuotaBytes = 4 * 1024 * 1024;
+
+    // A key whose owning client was expired. That path erases the object
+    // outright rather than leaving it with replicas that are merely unready,
+    // which is what separates this from ExpectKeyHiddenFromReadApis.
+    void ExpectKeyGoneFromReadApis(MasterService& service,
+                                   const std::string& key) {
+        auto get = service.GetReplicaList(key, TenantId::Default());
+        ASSERT_FALSE(get.has_value());
+        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get.error());
+
+        auto exists = service.ExistKey(key, TenantId::Default());
+        ASSERT_TRUE(exists.has_value());
+        EXPECT_FALSE(*exists);
+
+        auto batch_exists = service.BatchExistKey({key}, TenantId::Default());
+        ASSERT_EQ(1u, batch_exists.size());
+        ASSERT_TRUE(batch_exists[0].has_value());
+        EXPECT_FALSE(*batch_exists[0]);
+
+        auto all_keys = service.GetAllKeys(TenantId::Default());
+        ASSERT_TRUE(all_keys.has_value());
+        EXPECT_EQ(all_keys->end(),
+                  std::find(all_keys->begin(), all_keys->end(), key));
+    }
 
     void PauseReplicaCleanup(MasterService& service) {
         service.replica_cleanup_worker_.Stop();
@@ -301,6 +330,100 @@ class MasterServiceTest : public ::testing::Test {
         auto mount_result = service.MountSegment(segment, client_id);
         EXPECT_TRUE(mount_result.has_value());
         return {.segment_id = segment.id, .client_id = client_id};
+    }
+
+    struct RegisteredClientContext {
+        UUID segment_id;
+        UUID client_id;
+        std::string segment_name;
+    };
+
+    // Mount a segment and then drive the same client through ReMountSegment.
+    // ReMountSegment is the only insert into ok_client_, so a client that only
+    // mounts is never something ClientMonitorFunc can expire, and a test that
+    // skips this step measures nothing.
+    RegisteredClientContext RegisterClientWithSegment(
+        MasterService& service, const std::string& name, size_t base,
+        size_t size = kDefaultSegmentSize) const {
+        Segment segment = MakeSegment(name, base, size);
+        UUID client_id = generate_uuid();
+        auto mount_result = service.MountSegment(segment, client_id);
+        EXPECT_TRUE(mount_result.has_value());
+        std::vector<Segment> segments{segment};
+        auto remount_result = service.ReMountSegment(segments, client_id);
+        EXPECT_TRUE(remount_result.has_value());
+        auto ping_result = service.Ping(client_id);
+        EXPECT_TRUE(ping_result.has_value());
+        return {.segment_id = segment.id,
+                .client_id = client_id,
+                .segment_name = segment.name};
+    }
+
+    // ClientStatus as the master sees it now. Ping is the only read of it, and
+    // it also refreshes the client's TTL, so call this once per assertion and
+    // never inside a wait loop that is supposed to let a client go silent.
+    ClientStatus ObserveClientStatus(MasterService& service,
+                                     const UUID& client_id) const {
+        auto ping_result = service.Ping(client_id);
+        EXPECT_TRUE(ping_result.has_value());
+        if (!ping_result.has_value()) {
+            return ClientStatus::UNDEFINED;
+        }
+        return ping_result.value().client_status;
+    }
+
+    // Runs fn under a real exclusive client_mutex_ hold, recorded the way
+    // every production site records one. The breaker judges on the recorded
+    // window, so a test that only takes the mutex proves nothing about it.
+    template <typename Fn>
+    void WhileHoldingClientLockExclusively(MasterService& service, Fn&& fn) {
+        std::unique_lock<std::shared_mutex> lock(service.client_mutex_);
+        MasterService::ExclusiveClientLockWindow window(service);
+        fn();
+    }
+
+    // Keeps one client's heartbeat arriving on its own thread, the way a live
+    // store does, so the test thread can wait while the master stays
+    // demonstrably able to serve Ping.
+    class HeartbeatThread {
+       public:
+        HeartbeatThread(MasterService& service, UUID client_id)
+            : thread_([this, &service, client_id] {
+                  while (!stop_.load()) {
+                      (void)service.Ping(client_id);
+                      std::this_thread::sleep_for(
+                          std::chrono::milliseconds(100));
+                  }
+              }) {}
+        ~HeartbeatThread() {
+            stop_.store(true);
+            thread_.join();
+        }
+
+       private:
+        std::atomic<bool> stop_{false};
+        std::thread thread_;
+    };
+
+    // Polls instead of sleeping a fixed span, so a test costs what the master
+    // actually takes rather than the worst case. Returns whether the
+    // condition ever held.
+    static bool WaitFor(std::chrono::milliseconds timeout,
+                        const std::function<bool()>& condition) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (condition()) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        return condition();
+    }
+
+    // Whether a key is still readable. Unlike Ping this touches no client
+    // state, so it is safe to poll while a client is meant to be going silent.
+    static bool KeyIsVisible(MasterService& service, const std::string& key) {
+        return service.GetReplicaList(key, TenantId::Default()).has_value();
     }
 
     std::string PutObjectOnSegment(MasterService& service,


### PR DESCRIPTION
## Description

## The failure mode

`ClientMonitorFunc` expires a client whose heartbeat deadline has passed, and expiry
is irreversible: the client's segments are unmounted and every key they held is
erased from the index. The monitor decides this from the **absence** of heartbeats,
which looks exactly the same whether the clients died or the master stopped serving
`Ping`.

So any stall in the master longer than `client_ttl` (default 10 s) makes it expire
**every client at once** and destroy the whole cluster's cache index. A transient
control-plane stall becomes permanent, cluster-wide data loss.

We hit this in production and reproduced all of it. `Ping`'s body is a shared-lock
read of `ok_client_` plus a push onto a lock-free queue, so an exclusive
`client_mutex_` holder is the one thing that can stop the handler running at all —
and because coro_rpc runs a non-coroutine handler inline on the io thread, io
threads blocked on that lock stop reading pings off their connections entirely. We
measured `master_ping_requests_total` completely flat for nine consecutive seconds
while one such hold ran.

## Why this is an operational problem, not just a rare edge case

**The trigger sits on the rollout path.** `ReMountSegment` is the only way into
`ok_client_`, so *every* store client start goes through it — a deploy, a rolling
update, a scale-out, an eviction, a node reboot, a DaemonSet update. The operations
run most often are the ones that can wipe the cluster's cache.

**And the penalty is charged in exactly the currency operators are trying to save.**
The loss is the cache, and re-warming a cache is far more expensive than the pod
boot that preceded it, so a fleet roll turns into a roll followed by a long cold
period. The joining node's own cache also comes online late, because its segments
are not usable until its remount returns. The rational response is to avoid
restarting store pods at all — which is the opposite of fast, frequent, safe
deploys, and it blocks the ordinary capacity work of scaling a cell out and back in.

For scale: on our rig, the metadata scan in `ReMountSegment` took 0.72 s at 1M
keys, 9.76 s at 14M and 13.2 s at 18M, against a 10 s `client_ttl` — a threshold at
roughly 14.2M keys. One of our production deployments holds 14.6M, so it sits above
the threshold in steady state; a single store pod restart there expires all of its
clients.

#3533 removed the largest scan on that path, and it helped. But the exposure is
structural rather than tied to that one scan: **any** exclusive `client_mutex_` hold
that outlasts `client_ttl` reproduces the same irreversible outcome. There is also
an inconsistency between the two defaults — `client_ttl` is 10 s while the client's
own RPC wait is coro_rpc's 30 s default, so the master gives up on a client well
before that client gives up on the master.

What this PR adds is the property that makes the join path safe to keep optimizing:
a regression there becomes a bounded deferral instead of a cluster-wide cache loss.

## What the change does

A circuit breaker in `ClientMonitorFunc`. When a tick's expiry candidates cannot be
distinguished from the master's own stall, it holds them back — a true no-op, with
no unmount prepared and no sweep started — bounded by
`client_mass_expiry_grace_sec`. Recovery needs no machinery: the next queue drain
refreshes the deadlines and the episode closes itself.

The judgement is a pure function, `EvaluateClientMassExpiry`, over one tick's
readings, which is what lets its boundary cases be a table-driven test with no
sleeping.

**It judges the cause, not the symptom.** The primary condition is that an exclusive
`client_mutex_` hold overlapped `[last_ping_batch_at, now]`, the stretch over which
this master has no heartbeat of its own to show. Every site taking that lock
exclusively records its hold window into relaxed atomics; the monitor's own expiry
branch deliberately does not, so a previous tick's expiry cannot come back as
evidence that the master was stalling.

Two things about that window are load-bearing:

- A completed hold counts **only while no heartbeat has been popped since it
  released**. Once one has, the master is demonstrably serving `Ping` again, that
  hold is refuted as an explanation, and a candidate still overdue is genuinely
  gone — so an ordinary single-client death is not deferred.
- The edge follows the heartbeat stream and **not the wall clock**. After a hold
  releases, the master can stay starved for many more ticks; through that no
  heartbeat is popped, so the released hold stays evidence. A window of "holds
  within the last tick or two" would age out mid-stall and erase the cache.

A secondary condition covers a total stall with no hold recorded: the master's own
silence, gated on there being at least two tracked clients — with exactly one
client, hearing nothing says only that that client stopped, which is the client's
own problem and must be acted on at once.

We tried symptom-based rules first — "too many clients expired in one tick" — and
they were defeated twice by the same thing: a deadline is stamped by the tick that
popped that client's heartbeat, so a stall's expiries spread across consecutive
ticks and each tick's share falls under any threshold. That is why the rule is
cause-based, and it is worth not simplifying back.

## The behaviour change a reviewer should weigh

A genuine simultaneous death of every client is deferred up to the grace bound
before being expired. This is inherent, not an oversight: a fleet that has vanished
and a master that has totally stalled produce identical heartbeat streams — none —
so no rule can separate them. The cost is bounded and observable
(`master_client_expiry_deferred_total`, and a `LOG(ERROR)` when the grace is
exceeded), and it buys the difference between a bounded delay and an unrecoverable
cache wipe.

Two gaps stay open and are stated in the code:

1. A single-client deployment starved by something other than a `client_mutex_`
   hold — all io threads busy on shard locks, say — records no hold, and one tracked
   client is not silence evidence, so that deployment's keys still go. Closing it
   needs a liveness signal off the data path.
2. The whole-fleet case above.

The guard is on by default and `client_mass_expiry_guard=false` restores the
previous behaviour exactly.

## Verification

Reproduced and gated on a 13-client deployment with the master under the same 8-CPU
and 60 GiB limits it runs with in production.

- **The stall, at 18M keys.** A joining client's remount held the lock for 13.8 s
  against a 10 s TTL. With the breaker: **zero** expiries, key count held at
  18,000,000, active clients never fell below the 12 long-lived ones, and the
  episode closed itself three ticks later when the hold released. Without it, all
  13 expire in one tick and the sweep erases the keys.
- **No false positive on an ordinary death.** One client killed while the others
  keep pinging expires after one TTL (10.66 s), with zero deferral ticks. Under a
  pinned window instead of `last_ping_batch_at`, the same case was deferred for the
  full 60 s grace — which is what motivated that edge.
- **Single-client deployment, both directions.** A lone death expires 1.4 s after
  `SIGKILL`; a genuine stall defers on hold evidence alone and preserves its keys.

Unit tests on this branch, built and run against `8715bb7c`: `master_service_test`
**80/80**, `master_service_config_test` **9/9**, the breaker's own 11 cases
(7 wall-clock, 4 pure) **11/11**, and `master_service_group_test` **13/13**, which
is the other consumer of the fixture header these tests extend. The tests were also
checked for discriminating power rather than just for passing — deleting the primary
condition fails only the stall and tick-split cases, and pinning the window's left
edge fails only the ordinary-death case.

Happy to split the breaker and its tests differently, or to trim the reasoning at
`ClientMonitorFunc`, if that suits review better — the comments are there mainly so
the rule is not later simplified back into a count of expiring clients, which does
not work.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Built against `8715bb7c` and run in a container with the master's production
resource limits (8 CPU, 60 GiB).

**Test commands:**
```bash
cmake -B build -DBUILD_UNIT_TESTS=ON
ninja -C build master_service_test master_service_config_test \
                master_service_group_test mooncake_master
./build/mooncake-store/tests/master_service_test
./build/mooncake-store/tests/master_service_config_test
./build/mooncake-store/tests/master_service_group_test
# the breaker's own cases
./build/mooncake-store/tests/master_service_test \
    --gtest_filter='*ClientMassExpiry*:*ClientExpiry*'
```

**Test results:**
- [x] Unit tests pass — `master_service_test` 80/80 (207 s),
      `master_service_config_test` 9/9, `master_service_group_test` 13/13,
      breaker subset 11/11 (46 s). Zero warnings in the build.
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done — the three gates described above, on a 13-client
      deployment against a master under production limits: the 18M-key stall,
      the ordinary single-client death, and both single-client directions.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` — clang-format
      20.1.0 reports zero replacements on every file touched
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass —
      not run; happy to do so if the hooks are expected to be green before review
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] **For changes >500 LOC: I have filed an RFC issue** — not filed. The diff is
      1637 insertions, of which 985 are tests and the test fixture and ~660 are
      production code, a large part of that the reasoning comments at
      `ClientMonitorFunc`. Please say if you would rather have an RFC issue first
      and I will open one and hold this PR behind it.

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code was used throughout, under human direction: to reproduce the failure on
a rig, to implement the breaker and its tests, and to run the verification above.
Two earlier symptom-based designs it produced were rejected during review after
being shown defeatable, which is why the rule is cause-based. The human submitter
has reviewed every line and is responsible for defending the change.