### PR TITLE
[Store] Fail KV benchmarks when a worker raises

### DIFF
--- a/mooncake-store/benchmarks/store_kv_bench.md
+++ b/mooncake-store/benchmarks/store_kv_bench.md
@@ -202,3 +202,8 @@ Each phase prints:
 - aggregated error counts
 
 An overall summary is printed after all phases complete.
+
+If a worker raises an exception, the benchmark waits for all workers to finish,
+reports the failed phase and lane, and exits with code `1`. This error path does
+not write a new summary or journal; any output files from an earlier run remain
+unchanged.

--- a/mooncake-store/benchmarks/store_kv_bench.py
+++ b/mooncake-store/benchmarks/store_kv_bench.py
@@ -965,11 +965,16 @@ class BenchmarkRunner:
         sessions = self._make_sessions()
         per_lane_stats: List[Optional[PhaseStats]] = [None] * self.lane_count
         threads: List[threading.Thread] = []
+        errors: List[Optional[BaseException]] = [None] * self.lane_count
 
         def runner(index: int, session: StoreSession) -> None:
             stats = PhaseStats(name=f"{phase_name}/lane{index}")
             stats.start_time = time.perf_counter()
-            worker_builder(session, index)(stats)
+            try:
+                worker_builder(session, index)(stats)
+            except BaseException as exc:
+                errors[index] = exc
+                return
             stats.end_time = time.perf_counter()
             per_lane_stats[index] = stats
 
@@ -984,6 +989,11 @@ class BenchmarkRunner:
 
         for thread in threads:
             thread.join()
+
+        # Join every lane before allowing the caller to release shared buffers.
+        for lane_id, error in enumerate(errors):
+            if error is not None:
+                raise RuntimeError(f"{phase_name} lane {lane_id} failed") from error
 
         merged = merge_stats(phase_name, [s for s in per_lane_stats if s is not None])
         log_phase_stats(merged)

--- a/mooncake-store/benchmarks/test_store_kv_bench.py
+++ b/mooncake-store/benchmarks/test_store_kv_bench.py
@@ -3,10 +3,13 @@ import importlib.util
 import json
 import os
 import sys
+import threading
 import types
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 
 class FakeBufferLease:
@@ -214,6 +217,103 @@ class StoreSessionMetadataTest(unittest.TestCase):
         summary = json.loads((output_dir / "summary.json").read_text())
         self.assertTrue(summary["ok"])
         self.assertEqual(summary["journal_records"], 5)
+
+
+class WorkerFailureTest(unittest.TestCase):
+    def setUp(self):
+        args = bench.build_parser().parse_args(["--scenario=metadata_smoke"])
+        self.runner = bench.BenchmarkRunner(args)
+        self.runner._sessions = [Mock()]
+        hook = patch.object(threading, "excepthook")
+        hook.start()
+        self.addCleanup(hook.stop)
+
+    def test_worker_and_builder_errors_reach_caller(self):
+        for during_build in (False, True):
+            for error in (ValueError("store failed"), SystemExit(0)):
+                with self.subTest(during_build=during_build, error=type(error)):
+
+                    def build(session, lane):
+                        if during_build:
+                            raise error
+
+                        def work(stats):
+                            raise error
+
+                        return work
+
+                    with self.assertRaisesRegex(
+                        RuntimeError, "probe.*lane 0"
+                    ) as caught:
+                        self.runner._run_threads("probe", build)
+                    self.assertIs(caught.exception.__cause__, error)
+
+    def test_failure_joins_every_lane_before_returning(self):
+        self.runner.lane_count = 2
+        self.runner._sessions = [Mock(), Mock()]
+        joined = []
+        finished = threading.Event()
+        original_join = threading.Thread.join
+
+        def join(thread, *args, **kwargs):
+            original_join(thread, *args, **kwargs)
+            joined.append(thread.name)
+
+        def build(session, lane):
+            def work(stats):
+                if lane == 0:
+                    raise RuntimeError("first lane failed")
+                finished.set()
+                stats.requests = 1
+
+            return work
+
+        with patch.object(threading.Thread, "join", join):
+            with self.assertRaises(RuntimeError):
+                self.runner._run_threads("probe", build)
+        self.assertEqual(joined, ["probe-lane0", "probe-lane1"])
+        self.assertTrue(finished.is_set())
+
+    def test_healthy_lanes_keep_their_statistics(self):
+        self.runner.lane_count = 2
+        self.runner._sessions = [Mock(), Mock()]
+
+        def build(session, lane):
+            def work(stats):
+                stats.requests = lane + 1
+                stats.successful_requests = lane + 1
+
+            return work
+
+        stats = self.runner._run_threads("probe", build)
+        self.assertEqual(stats.requests, 3)
+        self.assertEqual(stats.successful_requests, 3)
+        self.assertEqual(stats.failed_requests, 0)
+
+    def test_cli_fails_without_writing_success_and_closes_store(self):
+        for scenario, operation in (("metadata_smoke", "put"), ("verify_write", "get")):
+            with self.subTest(scenario=scenario), TemporaryDirectory() as directory:
+                store = Mock()
+                store.setup.return_value = 0
+                store.put.return_value = 0
+                getattr(store, operation).side_effect = RuntimeError("store failed")
+                argv = [
+                    "store_kv_bench.py",
+                    "--scenario",
+                    scenario,
+                    "--nr-objects=1",
+                    "--output-dir",
+                    directory,
+                ]
+                with (
+                    patch.object(bench, "MooncakeDistributedStore", return_value=store),
+                    patch.object(sys, "argv", argv),
+                    patch.object(bench.LOG, "exception") as log_error,
+                ):
+                    self.assertEqual(bench.main(), 1)
+                log_error.assert_called_once()
+                store.close.assert_called_once()
+                self.assertFalse((Path(directory) / "summary.json").exists())
 
 
 class ZcopyBufferPoolTest(unittest.TestCase):


### PR DESCRIPTION
## Description

A Store benchmark worker can raise an exception while the CLI still exits with code 0 and writes `"ok": true`. `_run_threads` loses the failed lane's statistics, so both `metadata_smoke` and the read-back phase of `verify_write` can report success without completing their work.

Capture worker failures, join every lane, then raise in the caller with the phase, lane, and original exception. Waiting for all lanes matters because they share the Store runtime and zero-copy buffers. The existing CLI error path now returns 1 and cleans up the runtime. The benchmark guide documents the output behavior on this path.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

```bash
python mooncake-store/benchmarks/test_store_kv_bench.py -v
pre-commit run --files mooncake-store/benchmarks/store_kv_bench.py mooncake-store/benchmarks/test_store_kv_bench.py mooncake-store/benchmarks/store_kv_bench.md
git diff --check
```

The new regression class reports 7 failures on the unmodified baseline; its healthy-lane control passes. With the fix, all 13 tests in the file pass. Coverage includes worker construction/execution failures, a worker exiting via `SystemExit`, joining all lanes before propagating the error, unchanged successful statistics, and CLI failure/cleanup without writing a new success report.

These are CPU tests with a fake Store on Windows/Python 3.12.13, not native Store, GPU, or RDMA integration tests. All applicable pre-commit hooks pass; C++, Rust, YAML, and CMake hooks have no matching changes.

- [x] Unit tests pass
- [ ] Integration tests pass (not run; fake Store coverage only)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run pre-commit on the changed files and all applicable hooks pass
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective

No C/C++ files changed; the RFC threshold does not apply.

## AI Assistance Disclosure

- [x] AI tools were used

Codex investigated the failure, drafted the implementation and tests, and ran the local checks. The submitter reviewed every changed line before submission.