### PR TITLE
[Bugfix][Store] Interrupt in-flight snapshot children during shutdown

### DIFF
--- a/mooncake-store/include/master_snapshot_manager.h
+++ b/mooncake-store/include/master_snapshot_manager.h
@@ -45,9 +45,9 @@ struct MasterSnapshotManagerOptions {
  * timeout handling, payload upload, catalog publish, retention cleanup, and
  * snapshot metrics updates.
  *
- * This is a behavior-preserving refactor that moves snapshot orchestration
- * logic out of MasterService without changing snapshot format, restore
- * behavior, storage layout, flags, or locking semantics.
+ * Snapshot format, restore behavior, storage layout, flags, and locking
+ * semantics are unchanged; shutdown additionally interrupts an in-flight
+ * snapshot child so the manager can terminate promptly.
  */
 class MasterSnapshotManager {
     friend class test::MasterServiceSnapshotTestBase;  // Allow test access to
@@ -72,6 +72,8 @@ class MasterSnapshotManager {
     void WaitForSnapshotChild(pid_t pid, const std::string& snapshot_id,
                               int log_pipe_fd);
     void HandleChildTimeout(pid_t pid, const std::string& snapshot_id);
+    void TerminateSnapshotChild(pid_t pid, const std::string& snapshot_id,
+                                const char* reason);
     void HandleChildExit(pid_t pid, int status, const std::string& snapshot_id);
 
     tl::expected<void, SerializationError> PersistState(

--- a/mooncake-store/src/master_snapshot_manager.cpp
+++ b/mooncake-store/src/master_snapshot_manager.cpp
@@ -157,6 +157,12 @@ void MasterSnapshotManager::SnapshotThreadFunc() {
             close(log_pipe[1]);
         } else if (pid == 0) {
             // Child process
+            // The master installs handlers that only update parent-process
+            // shutdown state. A forked snapshot child must remain terminable
+            // by the timeout and shutdown paths below.
+            signal(SIGINT, SIG_DFL);
+            signal(SIGTERM, SIG_DFL);
+
             // Close read end, set write end for logging
             close(log_pipe[0]);
             g_snapshot_log_pipe_fd = log_pipe[1];
@@ -255,6 +261,12 @@ void MasterSnapshotManager::WaitForSnapshotChild(pid_t pid,
             return;
         } else if (result == 0) {
             // Child process is still running
+            if (!snapshot_running_) {
+                flush_child_logs();
+                TerminateSnapshotChild(pid, snapshot_id, "manager shutdown");
+                return;
+            }
+
             auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                                std::chrono::steady_clock::now() - start_time)
                                .count();
@@ -270,8 +282,11 @@ void MasterSnapshotManager::WaitForSnapshotChild(pid_t pid,
                 return;
             }
 
-            // Brief sleep before checking again
-            std::this_thread::sleep_for(std::chrono::seconds(2));
+            // Briefly wait before checking again, but wake promptly on Stop().
+            std::unique_lock<std::mutex> lock(snapshot_thread_mutex_);
+            snapshot_thread_cv_.wait_for(lock, std::chrono::seconds(2), [this] {
+                return !snapshot_running_.load();
+            });
         } else {
             // Child process has exited
             // Flush remaining logs from child
@@ -294,40 +309,60 @@ void MasterSnapshotManager::WaitForSnapshotChild(pid_t pid,
 
 void MasterSnapshotManager::HandleChildTimeout(pid_t pid,
                                                const std::string& snapshot_id) {
-    LOG(WARNING) << "[Snapshot] Child process timeout, snapshot_id="
-                 << snapshot_id << ", child_pid=" << pid
-                 << ", killing child process";
+    TerminateSnapshotChild(pid, snapshot_id, "snapshot timeout");
+}
+
+void MasterSnapshotManager::TerminateSnapshotChild(
+    pid_t pid, const std::string& snapshot_id, const char* reason) {
+    LOG(WARNING) << "[Snapshot] Terminating child process due to " << reason
+                 << ", snapshot_id=" << snapshot_id << ", child_pid=" << pid;
 
     // Try to gracefully terminate the child process
-    if (kill(pid, SIGTERM) == 0) {
-        // Wait a few seconds to see if it exits gracefully
-        std::this_thread::sleep_for(std::chrono::seconds(5));
-
-        // Check if it has exited
-        int status;
-        if (waitpid(pid, &status, WNOHANG) == 0) {
-            // Child process still not exited, force kill
-            LOG(WARNING) << "[Snapshot] Child process still running, force "
-                            "killing, snapshot_id="
-                         << snapshot_id << ", child_pid=" << pid;
-            kill(pid, SIGKILL);
-
-            // Wait for force termination to complete
-            waitpid(pid, &status, 0);
-            LOG(WARNING)
-                << "[Snapshot] Child process force killed, snapshot_id="
-                << snapshot_id << ", child_pid=" << pid;
-        } else {
-            LOG(INFO) << "[Snapshot] Child process terminated gracefully after "
-                         "SIGTERM, snapshot_id="
-                      << snapshot_id << ", child_pid=" << pid;
-        }
-    } else {
+    if (kill(pid, SIGTERM) == -1 && errno != ESRCH) {
         LOG(ERROR) << "[Snapshot] Failed to send SIGTERM to child process, "
                       "snapshot_id="
                    << snapshot_id << ", child_pid=" << pid
                    << ", error=" << strerror(errno);
     }
+
+    constexpr auto kTerminationGracePeriod = std::chrono::seconds(5);
+    constexpr auto kReapPollInterval = std::chrono::milliseconds(50);
+    const auto deadline =
+        std::chrono::steady_clock::now() + kTerminationGracePeriod;
+    int status;
+    while (std::chrono::steady_clock::now() < deadline) {
+        const pid_t result = waitpid(pid, &status, WNOHANG);
+        if (result == pid) {
+            LOG(INFO) << "[Snapshot] Child process terminated gracefully after "
+                         "SIGTERM, snapshot_id="
+                      << snapshot_id << ", child_pid=" << pid;
+            return;
+        }
+        if (result == -1 && errno != EINTR) {
+            if (errno != ECHILD) {
+                LOG(ERROR) << "[Snapshot] Failed to wait for child process, "
+                              "snapshot_id="
+                           << snapshot_id << ", child_pid=" << pid
+                           << ", error=" << strerror(errno);
+            }
+            return;
+        }
+        std::this_thread::sleep_for(kReapPollInterval);
+    }
+
+    LOG(WARNING) << "[Snapshot] Child process still running, force killing, "
+                    "snapshot_id="
+                 << snapshot_id << ", child_pid=" << pid;
+    if (kill(pid, SIGKILL) == -1 && errno != ESRCH) {
+        LOG(ERROR) << "[Snapshot] Failed to send SIGKILL to child process, "
+                      "snapshot_id="
+                   << snapshot_id << ", child_pid=" << pid
+                   << ", error=" << strerror(errno);
+    }
+    while (waitpid(pid, &status, 0) == -1 && errno == EINTR) {
+    }
+    LOG(WARNING) << "[Snapshot] Child process force killed, snapshot_id="
+                 << snapshot_id << ", child_pid=" << pid;
 }
 
 void MasterSnapshotManager::HandleChildExit(pid_t pid, int status,

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <future>
 #include <memory>
 #include <optional>
 #include <regex>
@@ -174,6 +175,17 @@ class SnapshotChildProcessTest : public ::testing::Test {
             auto temp_manager = CreateTempSnapshotManager();
             temp_manager->HandleChildTimeout(pid, snapshot_id);
         }
+    }
+
+    void CallWaitForSnapshotChild(MasterSnapshotManager& manager, pid_t pid,
+                                  const std::string& snapshot_id,
+                                  int log_pipe_fd) {
+        manager.snapshot_running_ = true;
+        manager.WaitForSnapshotChild(pid, snapshot_id, log_pipe_fd);
+    }
+
+    std::unique_ptr<MasterSnapshotManager> CreateSnapshotManagerForTest() {
+        return CreateTempSnapshotManager();
     }
 
     void CallCleanupOldSnapshot(int keep_count,
@@ -411,6 +423,43 @@ TEST_F(SnapshotChildProcessTest, HandleChildTimeout_KillsSleepingChild) {
     // result should be -1 (already reaped) or pid (just reaped)
     // It should NOT be 0 (still running)
     EXPECT_NE(result, 0) << "Child process should have been terminated";
+}
+
+TEST_F(SnapshotChildProcessTest, StopInterruptsRunningSnapshotChild) {
+    CreateDefaultService();
+    auto manager = CreateSnapshotManagerForTest();
+
+    int log_pipe[2];
+    ASSERT_EQ(pipe(log_pipe), 0);
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1) << "fork failed";
+    if (pid == 0) {
+        close(log_pipe[0]);
+        sleep(300);
+        _exit(0);
+    }
+    close(log_pipe[1]);
+
+    auto waiter = std::async(std::launch::async, [&] {
+        CallWaitForSnapshotChild(*manager, pid, "test_snapshot_stop",
+                                 log_pipe[0]);
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    manager->Stop();
+
+    const auto wait_status = waiter.wait_for(std::chrono::seconds(2));
+    if (wait_status != std::future_status::ready) {
+        // Keep a regression from leaving this test blocked until the manager's
+        // configured 60-second snapshot timeout.
+        kill(pid, SIGTERM);
+    }
+    EXPECT_EQ(wait_status, std::future_status::ready);
+    waiter.get();
+    close(log_pipe[0]);
+
+    int status;
+    EXPECT_EQ(waitpid(pid, &status, WNOHANG), -1)
+        << "Snapshot child should already be reaped";
 }
 
 // ========== CleanupOldSnapshot ==========


### PR DESCRIPTION
## Description

`MasterSnapshotManager::Stop()` stopped future snapshot scheduling, but it did
not interrupt a snapshot child that was already running. The manager destructor
then joined the snapshot thread while that thread remained in
`WaitForSnapshotChild()`. A standalone master shutting down during a slow or
stalled periodic snapshot could therefore block until the configured child
timeout (five minutes by default).

This change makes the child wait responsive to `Stop()` and bounds child
termination:

- replace the fixed two-second polling sleep with the manager's existing
  condition variable, preserving the normal polling interval while allowing
  shutdown to wake it immediately;
- terminate and reap an in-flight snapshot child when the manager stops;
- poll `waitpid()` during the existing five-second SIGTERM grace period so a
  responsive child is reaped promptly, then retain SIGKILL as the fallback;
- restore the default SIGINT/SIGTERM dispositions in the forked child. The
  standalone master installs handlers that only update parent-process state;
  inheriting those handlers otherwise prevents the child from terminating on
  SIGTERM.

### Trigger

1. Run a standalone master with periodic snapshots enabled.
2. Let a snapshot start and make the configured snapshot backend slow or
   unavailable so the child remains in progress.
3. stop the master (for example, during a pod termination or process restart).

Before this change, `MasterService::~MasterService()` called `Stop()` and later
joined the snapshot thread, but the in-flight child wait continued until the
snapshot completed or `snapshot_child_timeout_seconds` elapsed. With the
default configuration, that can delay shutdown by up to 300 seconds.

### Behavior

| Path | Before | After |
| --- | --- | --- |
| Normal snapshot | Child status polled every 2 seconds | Same 2-second polling interval |
| Shutdown with no snapshot in flight | Snapshot scheduler wakes immediately | Unchanged |
| Shutdown with a responsive child | Wait until completion or child timeout | Wake immediately, send SIGTERM, reap promptly |
| Unresponsive child | SIGTERM, fixed 5-second sleep, then SIGKILL | SIGTERM, poll for up to 5 seconds, then SIGKILL and reap |

The payload and publication order are unchanged: metadata, segments, task
state, and the manifest are uploaded before the snapshot descriptor/latest
marker is published. Cancelling before publication can leave unreferenced
partial objects, as the existing timeout path already can, but restore does not
select them. Cancelling after publication is safe because all snapshot payloads
and the manifest have already completed.

No steady-state transfer, allocation, snapshot serialization, or restore code
is changed. This path is used by standalone periodic snapshots; HA batch-OpLog
snapshot ownership is not changed.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The regression test forks a real child, runs the production wait path on a
separate thread, calls `Stop()`, and verifies both bounded completion and that
the child has already been reaped. The existing timeout test verifies the shared
termination helper, and the auto-snapshot test verifies that a normal child can
still serialize, publish, exit, and be reaped.

**Test commands:**

```bash
cmake --build build --target snapshot_child_process_test -j 4

build/mooncake-store/tests/snapshot_child_process_test

build/mooncake-store/tests/snapshot_child_process_test \
  --gtest_filter='SnapshotChildProcessTest.StopInterruptsRunningSnapshotChild' \
  --gtest_repeat=20 --gtest_break_on_failure

pre-commit run --files \
  mooncake-store/include/master_snapshot_manager.h \
  mooncake-store/src/master_snapshot_manager.cpp \
  mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
```

**Test results:**

- [x] Unit tests pass: all 26 `snapshot_child_process_test` tests passed.
- [x] Regression stress passes: 20/20 repeated stop/terminate/reap runs passed.
- [ ] Integration tests pass (not applicable; the affected lifecycle is covered
  with real fork, signals, and waitpid in the unit test).
- [x] Manual testing done: responsive children were reaped during the SIGTERM
  grace period; the SIGKILL fallback was also exercised with a child that
  ignored SIGTERM.
- [x] PR-scoped pre-commit passes, including clang-format 20 and codespell.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable; no user-facing API or
  configuration changes)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable (well below 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with this contribution.