### PR TITLE
[TENT] Skip idle GPUs when synchronizing dest CUDA contexts

### DIFF
--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -16,6 +16,7 @@
 #include "tent/common/status.h"
 
 #include <bits/stdint-uintn.h>
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <numa.h>
 #include <glog/logging.h>
@@ -23,6 +24,34 @@
 
 namespace mooncake {
 namespace tent {
+namespace {
+
+// Driver-API probe: true iff this process already has a primary context on
+// `device`. Does not create one. Topology lists every visible GPU for NIC
+// affinity; cudaSetDevice on those names would allocate idle-card contexts
+// (Tone runs --gpus all without CUDA_VISIBLE_DEVICES).
+bool cudaPrimaryContextIsActive(int device) {
+    if (cuInit(0) != CUDA_SUCCESS) return false;
+    CUdevice cu_dev = 0;
+    if (cuDeviceGet(&cu_dev, device) != CUDA_SUCCESS) return false;
+    unsigned int flags = 0;
+    int active = 0;
+    if (cuDevicePrimaryCtxGetState(cu_dev, &flags, &active) != CUDA_SUCCESS) {
+        return false;
+    }
+    return active != 0;
+}
+
+// Bare cudaGetDevice() can implicitly create GPU 0 when this thread has no
+// current context. Only save/restore the caller's device when one exists.
+bool cudaHasCurrentContext() {
+    if (cuInit(0) != CUDA_SUCCESS) return false;
+    CUcontext ctx = nullptr;
+    return cuCtxGetCurrent(&ctx) == CUDA_SUCCESS && ctx != nullptr;
+}
+
+}  // namespace
+
 Status CudaPlatform::allocate(void** pptr, size_t size,
                               MemoryOptions& options) {
     LocationParser location(options.location);
@@ -99,11 +128,13 @@ Status CudaPlatform::synchronizeDevices(const Topology* topology) {
     }
 
     int saved = 0;
-    const bool have_saved = cudaGetDevice(&saved) == cudaSuccess;
+    const bool have_saved =
+        cudaHasCurrentContext() && cudaGetDevice(&saved) == cudaSuccess;
     if (!have_saved) (void)cudaGetLastError();
 
     for (int device : devices) {
         if (device >= device_count) continue;
+        if (!cudaPrimaryContextIsActive(device)) continue;
         err = cudaSetDevice(device);
         if (err != cudaSuccess) {
             LOG(WARNING) << "CudaPlatform::synchronizeDevices cudaSetDevice("

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -18,20 +18,30 @@
 #include <bits/stdint-uintn.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <numa.h>
 #include <glog/logging.h>
+#include <mutex>
+#include <numa.h>
 #include <vector>
 
 namespace mooncake {
 namespace tent {
 namespace {
 
+// cuInit is process-global and idempotent; still call it once so the driver
+// probe is not re-entered on every topology device.
+bool ensureCudaDriverInit() {
+    static std::once_flag flag;
+    static CUresult result = CUDA_ERROR_NOT_INITIALIZED;
+    std::call_once(flag, []() { result = cuInit(0); });
+    return result == CUDA_SUCCESS;
+}
+
 // Driver-API probe: true iff this process already has a primary context on
 // `device`. Does not create one. Topology lists every visible GPU for NIC
 // affinity; cudaSetDevice on those names would allocate idle-card contexts
-// (Tone runs --gpus all without CUDA_VISIBLE_DEVICES).
+// when the process can see more GPUs than this rank uses.
 bool cudaPrimaryContextIsActive(int device) {
-    if (cuInit(0) != CUDA_SUCCESS) return false;
+    if (!ensureCudaDriverInit()) return false;
     CUdevice cu_dev = 0;
     if (cuDeviceGet(&cu_dev, device) != CUDA_SUCCESS) return false;
     unsigned int flags = 0;
@@ -45,7 +55,7 @@ bool cudaPrimaryContextIsActive(int device) {
 // Bare cudaGetDevice() can implicitly create GPU 0 when this thread has no
 // current context. Only save/restore the caller's device when one exists.
 bool cudaHasCurrentContext() {
-    if (cuInit(0) != CUDA_SUCCESS) return false;
+    if (!ensureCudaDriverInit()) return false;
     CUcontext ctx = nullptr;
     return cuCtxGetCurrent(&ctx) == CUDA_SUCCESS && ctx != nullptr;
 }

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -19,6 +19,11 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#ifdef USE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -2289,6 +2294,58 @@ TEST(RdmaQuiesceTest, TransportQuiesceSyncsTopologyDevicesViaPlatform) {
     EXPECT_TRUE(transport.quiesce().ok());
     EXPECT_TRUE(Platform::getLoader().synchronizeDevices(topology.get()).ok());
 }
+
+#ifdef USE_CUDA
+TEST(RdmaQuiesceTest, SynchronizeDevicesDoesNotCreateIdlePrimaryContexts) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count < 2) {
+        GTEST_SKIP() << "need at least 2 CUDA devices";
+    }
+    ASSERT_EQ(cuInit(0), CUDA_SUCCESS);
+
+    auto primary_active = [](int device) {
+        CUdevice cu_dev = 0;
+        if (cuDeviceGet(&cu_dev, device) != CUDA_SUCCESS) return false;
+        unsigned int flags = 0;
+        int active = 0;
+        return cuDevicePrimaryCtxGetState(cu_dev, &flags, &active) ==
+                   CUDA_SUCCESS &&
+               active != 0;
+    };
+
+    int idle = -1;
+    for (int i = 1; i < device_count; ++i) {
+        if (!primary_active(i)) {
+            idle = i;
+            break;
+        }
+    }
+    if (idle < 0) {
+        GTEST_SKIP() << "need an idle GPU besides cuda:0";
+    }
+
+    // Rank-like: only cuda:0 is in use. Topology still lists every visible GPU
+    // (Tone --gpus all / no CUDA_VISIBLE_DEVICES on the real box).
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+    ASSERT_TRUE(primary_active(0));
+
+    auto topology = std::make_shared<Topology>();
+    for (int i = 0; i < device_count; ++i) {
+        Topology::MemEntry memory;
+        memory.name = "cuda:" + std::to_string(i);
+        memory.type = Topology::MEM_CUDA;
+        memory.numa_node = 0;
+        topology->mem_list_.push_back(std::move(memory));
+    }
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    EXPECT_TRUE(transport.quiesce().ok());
+    EXPECT_TRUE(Platform::getLoader().synchronizeDevices(topology.get()).ok());
+    EXPECT_TRUE(primary_active(0));
+    EXPECT_FALSE(primary_active(idle));
+}
+#endif
 
 TEST(RdmaQuiesceTest, WorkersQuiesceWithoutStartRejectsSubmit) {
     auto topology = std::make_shared<Topology>();

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -2324,8 +2324,7 @@ TEST(RdmaQuiesceTest, SynchronizeDevicesDoesNotCreateIdlePrimaryContexts) {
         GTEST_SKIP() << "need an idle GPU besides cuda:0";
     }
 
-    // Rank-like: only cuda:0 is in use. Topology still lists every visible GPU
-    // (Tone --gpus all / no CUDA_VISIBLE_DEVICES on the real box).
+    // Only cuda:0 is in use. Topology still lists every visible GPU.
     ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
     ASSERT_TRUE(primary_active(0));
 


### PR DESCRIPTION
## Description

`CudaPlatform::synchronizeDevices()` walks every CUDA device named in the
engine topology and calls `cudaSetDevice`. Topology lists every visible GPU
for NIC affinity, so a rank that only uses a subset still creates primary
contexts on idle cards. A bare `cudaGetDevice()` can also implicitly create
GPU 0 when the calling thread has no current context.

Skip devices whose primary context is not already active
(`cuDevicePrimaryCtxGetState`). Save/restore the caller's device only when
`cuCtxGetCurrent` is non-null.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake -G Ninja -S . -B build-tent \
  -DUSE_TENT=ON -DUSE_CUDA=ON -DUSE_HTTP=ON \
  -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF \
  -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF
cmake --build build-tent --target tent_rdma_transport_test
CUDA_VISIBLE_DEVICES=6,7 ./build-tent/mooncake-transfer-engine/tent/tests/tent_rdma_transport_test \
  --gtest_filter='RdmaQuiesceTest.*'
```

**Test results:**
- [x] Unit tests pass (`RdmaQuiesceTest` 6/6, including `SynchronizeDevicesDoesNotCreateIdlePrimaryContexts`)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: CUDA 13 container on an 8×H20 host; used idle GPUs 6–7 only. After `cudaSetDevice(0)`, quiesce/synchronize left the other visible GPU without a primary context. GPU memory on the unused cards was unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Cursor (Grok 4.6): ported the idle-GPU skip onto `CudaPlatform::synchronizeDevices`, added the regression test, built and ran `RdmaQuiesceTest`, drafted this PR. Human submitter reviewed the diff.

Made with [Cursor](https://cursor.com)