### PR TITLE
[Store] Structure NvmeKvConnectorConfig environment settings

### DIFF
--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -123,6 +123,16 @@ struct TransferSubmitterEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MC_STORE_MEMCPY);
 };
 
+struct NvmeKvConnectorEnvironmentVariables {
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_DEVICE_PATH);
+    // Keep numeric values as strings because the existing NVMe parser accepts
+    // base prefixes, a leading plus, and leading whitespace.
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_NSID);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_QUEUE_DEPTH);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_TRANSPORT);
+};
+
 #undef MC_DEFINE_ENV_VAR
 
 }  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -79,6 +79,8 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     storage_backend.cpp
     nvme_kv_backend.cpp
     nvme_kv_connector.cpp
+    config/nvme_kv_connector_config.cpp
+    config/nvme_kv_u32_parser.cpp
     nvme_kv_executor_io_uring.cpp
     nvme_kv_executor_ioctl.cpp
     nvme_kv_executor_util.cpp

--- a/mooncake-store/src/config/nvme_kv_connector_config.cpp
+++ b/mooncake-store/src/config/nvme_kv_connector_config.cpp
@@ -1,0 +1,86 @@
+#include "nvme_kv_connector_config.h"
+
+#include <glog/logging.h>
+
+#include <optional>
+#include <string>
+
+#include "environ.h"
+#include "environment_variables.h"
+#include "nvme_kv_u32_parser.h"
+
+namespace mooncake {
+namespace {
+
+uint32_t ReadNvmeKvU32Or(const EnvironmentVariable<std::string>& variable,
+                         uint32_t fallback) {
+    const auto value = Environ::Read(variable);
+    if (!value.has_value()) {
+        return fallback;
+    }
+    return TryParseNvmeKvU32(value->c_str()).value_or(fallback);
+}
+
+tl::expected<NvmeKvTransport, ErrorCode> ReadTransport() {
+    const auto transport =
+        Environ::Read(
+            NvmeKvConnectorEnvironmentVariables::MOONCAKE_NVME_KV_TRANSPORT)
+            .value_or("");
+    if (transport.empty() || transport == "auto") {
+        return NvmeKvTransport::kAuto;
+    }
+    if (transport == "io_uring") {
+        return NvmeKvTransport::kIoUring;
+    }
+    if (transport == "ioctl") {
+        return NvmeKvTransport::kIoctl;
+    }
+    LOG(ERROR) << "Unknown MOONCAKE_NVME_KV_TRANSPORT: " << transport;
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+}  // namespace
+
+const char* NvmeKvTransportName(NvmeKvTransport transport) {
+    switch (transport) {
+        case NvmeKvTransport::kAuto:
+            return "auto";
+        case NvmeKvTransport::kIoUring:
+            return "io_uring";
+        case NvmeKvTransport::kIoctl:
+            return "ioctl";
+    }
+    return "unknown";
+}
+
+tl::expected<NvmeKvConnectorConfig, ErrorCode>
+NvmeKvConnectorConfig::FromEnvironment() {
+    NvmeKvConnectorConfig config;
+    config.device_path =
+        Environ::Read(
+            NvmeKvConnectorEnvironmentVariables::MOONCAKE_NVME_KV_DEVICE_PATH)
+            .value_or("");
+    if (config.device_path.empty()) {
+        LOG(ERROR) << "MOONCAKE_NVME_KV_DEVICE_PATH must not be empty";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    config.nsid = ReadNvmeKvU32Or(
+        NvmeKvConnectorEnvironmentVariables::MOONCAKE_NVME_KV_NSID,
+        config.nsid);
+    config.queue_depth = ReadNvmeKvU32Or(
+        NvmeKvConnectorEnvironmentVariables::MOONCAKE_NVME_KV_QUEUE_DEPTH,
+        config.queue_depth);
+    config.runtime_transfer_limit =
+        ReadNvmeKvU32Or(NvmeKvConnectorEnvironmentVariables::
+                            MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT,
+                        config.runtime_transfer_limit);
+    auto transport = ReadTransport();
+    if (!transport.has_value()) {
+        return tl::make_unexpected(transport.error());
+    }
+    config.transport = *transport;
+    return config;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/config/nvme_kv_connector_config.h
+++ b/mooncake-store/src/config/nvme_kv_connector_config.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "types.h"
+
+namespace mooncake {
+
+enum class NvmeKvTransport {
+    kAuto,
+    kIoUring,
+    kIoctl,
+};
+
+const char* NvmeKvTransportName(NvmeKvTransport transport);
+
+struct NvmeKvConnectorConfig {
+    std::string device_path;
+    uint32_t nsid = 1;
+    uint32_t queue_depth = 256;
+    uint32_t runtime_transfer_limit = 270336;
+    NvmeKvTransport transport = NvmeKvTransport::kAuto;
+
+    static tl::expected<NvmeKvConnectorConfig, ErrorCode> FromEnvironment();
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/config/nvme_kv_u32_parser.cpp
+++ b/mooncake-store/src/config/nvme_kv_u32_parser.cpp
@@ -1,0 +1,23 @@
+#include "nvme_kv_u32_parser.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+
+namespace mooncake {
+
+std::optional<uint32_t> TryParseNvmeKvU32(const char* value) {
+    if (value == nullptr) {
+        return std::nullopt;
+    }
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long parsed = std::strtoul(value, &end, 0);
+    if (errno != 0 || end == value || *end != '\0' ||
+        parsed > std::numeric_limits<uint32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<uint32_t>(parsed);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/config/nvme_kv_u32_parser.h
+++ b/mooncake-store/src/config/nvme_kv_u32_parser.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace mooncake {
+
+std::optional<uint32_t> TryParseNvmeKvU32(const char* value);
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_connector.cpp
+++ b/mooncake-store/src/nvme_kv_connector.cpp
@@ -2,10 +2,12 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <string_view>
 #include <utility>
 
 #include <glog/logging.h>
 
+#include "config/nvme_kv_connector_config.h"
 #include "nvme_kv_executor_util.h"
 #include "storage_backend.h"
 
@@ -15,48 +17,6 @@ namespace mooncake {
 std::unique_ptr<NvmeKvCommandExecutor> CreateNvmeKvStubExecutor(
     std::filesystem::path storage_path);
 #endif
-
-namespace {
-
-std::string GetEnvString(const char *name) {
-    const char *value = std::getenv(name);
-    return value == nullptr ? std::string() : std::string(value);
-}
-
-enum class RuntimeTransport {
-    kAuto,
-    kIoUring,
-    kIoctl,
-};
-
-const char *RuntimeTransportName(RuntimeTransport transport) {
-    switch (transport) {
-        case RuntimeTransport::kAuto:
-            return "auto";
-        case RuntimeTransport::kIoUring:
-            return "io_uring";
-        case RuntimeTransport::kIoctl:
-            return "ioctl";
-    }
-    return "unknown";
-}
-
-tl::expected<RuntimeTransport, ErrorCode> ParseRuntimeTransport() {
-    const auto transport = GetEnvString("MOONCAKE_NVME_KV_TRANSPORT");
-    if (transport.empty() || transport == "auto") {
-        return RuntimeTransport::kAuto;
-    }
-    if (transport == "io_uring") {
-        return RuntimeTransport::kIoUring;
-    }
-    if (transport == "ioctl") {
-        return RuntimeTransport::kIoctl;
-    }
-    LOG(ERROR) << "Unknown MOONCAKE_NVME_KV_TRANSPORT: " << transport;
-    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-}
-
-}  // namespace
 
 NvmeKvConnector::NvmeKvConnector(const FileStorageConfig &config)
     : storage_path_(
@@ -68,7 +28,8 @@ tl::expected<void, ErrorCode> NvmeKvConnector::Init() {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
 #ifdef MOONCAKE_ENABLE_NVME_KV_TEST_STUB
-    if (GetEnvString("MOONCAKE_NVME_KV_DRIVER") == "stub") {
+    const char *driver = std::getenv("MOONCAKE_NVME_KV_DRIVER");
+    if (driver != nullptr && std::string_view(driver) == "stub") {
         std::error_code ec;
         std::filesystem::create_directories(storage_path_, ec);
         if (ec) {
@@ -84,33 +45,23 @@ tl::expected<void, ErrorCode> NvmeKvConnector::Init() {
 }
 
 tl::expected<void, ErrorCode> NvmeKvConnector::InitRealExecutor() {
-    const auto device_path = GetEnvString("MOONCAKE_NVME_KV_DEVICE_PATH");
-    if (device_path.empty()) {
-        LOG(ERROR) << "MOONCAKE_NVME_KV_DEVICE_PATH must not be empty";
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    const uint32_t nsid = ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_NSID", 1);
-    const uint32_t queue_depth = ParseNvmeKvU32EnvOr(
-        "MOONCAKE_NVME_KV_QUEUE_DEPTH", kDefaultNvmeKvQueueDepth);
-    const uint32_t runtime_transfer_limit =
-        ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT",
-                            kDefaultNvmeKvRuntimeTransferLimit);
-    auto transport = ParseRuntimeTransport();
-    if (!transport) {
-        return tl::make_unexpected(transport.error());
+    auto config = NvmeKvConnectorConfig::FromEnvironment();
+    if (!config.has_value()) {
+        return tl::make_unexpected(config.error());
     }
 
     const auto create_executor =
-        [&](RuntimeTransport selected_transport) -> NvmeKvExecutorResult {
+        [&](NvmeKvTransport selected_transport) -> NvmeKvExecutorResult {
         switch (selected_transport) {
-            case RuntimeTransport::kIoUring:
+            case NvmeKvTransport::kIoUring:
                 return CreateNvmeKvIoUringExecutor(
-                    device_path, nsid, queue_depth, runtime_transfer_limit);
-            case RuntimeTransport::kIoctl:
-                return CreateNvmeKvIoctlExecutor(device_path, nsid, queue_depth,
-                                                 runtime_transfer_limit);
-            case RuntimeTransport::kAuto:
+                    config->device_path, config->nsid, config->queue_depth,
+                    config->runtime_transfer_limit);
+            case NvmeKvTransport::kIoctl:
+                return CreateNvmeKvIoctlExecutor(
+                    config->device_path, config->nsid, config->queue_depth,
+                    config->runtime_transfer_limit);
+            case NvmeKvTransport::kAuto:
                 break;
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -118,9 +69,9 @@ tl::expected<void, ErrorCode> NvmeKvConnector::InitRealExecutor() {
 
     NvmeKvExecutorResult executor_result =
         tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-    if (transport.value() == RuntimeTransport::kAuto) {
+    if (config->transport == NvmeKvTransport::kAuto) {
 #ifdef MOONCAKE_HAVE_NVME_URING_CMD
-        executor_result = create_executor(RuntimeTransport::kIoUring);
+        executor_result = create_executor(NvmeKvTransport::kIoUring);
         if (!executor_result) {
             LOG(WARNING) << "NVMe KV io_uring init failed, falling back to "
                             "ioctl: "
@@ -128,15 +79,15 @@ tl::expected<void, ErrorCode> NvmeKvConnector::InitRealExecutor() {
         }
 #endif
         if (!executor_result) {
-            executor_result = create_executor(RuntimeTransport::kIoctl);
+            executor_result = create_executor(NvmeKvTransport::kIoctl);
         }
     } else {
-        executor_result = create_executor(transport.value());
+        executor_result = create_executor(config->transport);
     }
 
     if (!executor_result) {
         LOG(ERROR) << "Failed to initialize NVMe KV "
-                   << RuntimeTransportName(transport.value()) << " executor";
+                   << NvmeKvTransportName(config->transport) << " executor";
         return tl::make_unexpected(executor_result.error());
     }
     executor_ = std::move(executor_result.value());

--- a/mooncake-store/src/nvme_kv_executor_util.cpp
+++ b/mooncake-store/src/nvme_kv_executor_util.cpp
@@ -2,10 +2,11 @@
 #include "nvme_kv_object_layout.h"
 
 #include <algorithm>
-#include <cerrno>
 #include <cstdlib>
 #include <iomanip>
 #include <limits>
+
+#include "config/nvme_kv_u32_parser.h"
 
 namespace mooncake {
 namespace {
@@ -30,17 +31,10 @@ uint32_t ReadLe32(const uint8_t *p) {
 
 uint32_t ParseNvmeKvU32EnvOr(const char *name, uint32_t fallback) {
     const char *value = std::getenv(name);
-    if (value == nullptr || value[0] == '\0') {
+    if (value == nullptr) {
         return fallback;
     }
-    char *end = nullptr;
-    errno = 0;
-    unsigned long parsed = std::strtoul(value, &end, 0);
-    if (errno != 0 || end == value || *end != '\0' ||
-        parsed > std::numeric_limits<uint32_t>::max()) {
-        return fallback;
-    }
-    return static_cast<uint32_t>(parsed);
+    return TryParseNvmeKvU32(value).value_or(fallback);
 }
 
 NvmeKvAlignedBuffer AllocateNvmeKvAlignedBuffer(size_t size) {

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -240,6 +240,7 @@ add_ha_test(batch_oplog_snapshot_promotion_test
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+add_store_test(nvme_kv_connector_config_test nvme_kv_connector_config_test.cpp)
 add_store_test(nvme_kv_storage_backend_test nvme_kv_storage_backend_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)
 add_store_test(file_per_key_config_test file_per_key_config_test.cpp)

--- a/mooncake-store/tests/nvme_kv_connector_config_test.cpp
+++ b/mooncake-store/tests/nvme_kv_connector_config_test.cpp
@@ -1,0 +1,208 @@
+#include "../src/config/nvme_kv_connector_config.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <string>
+
+namespace mooncake::test {
+namespace {
+
+class NvmeKvConnectorConfigTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("NvmeKvConnectorConfigTest");
+    }
+
+    static void TearDownTestSuite() { google::ShutdownGoogleLogging(); }
+
+    void SetUp() override {
+        original_logtostderr_ = FLAGS_logtostderr;
+        FLAGS_logtostderr = true;
+        for (size_t i = 0; i < kVariables.size(); ++i) {
+            if (const char* value = std::getenv(kVariables[i])) {
+                original_[i] = value;
+            }
+            ASSERT_EQ(unsetenv(kVariables[i]), 0);
+        }
+    }
+
+    void TearDown() override {
+        for (size_t i = 0; i < kVariables.size(); ++i) {
+            if (original_[i].has_value()) {
+                EXPECT_EQ(setenv(kVariables[i], original_[i]->c_str(), 1), 0);
+            } else {
+                EXPECT_EQ(unsetenv(kVariables[i]), 0);
+            }
+        }
+        FLAGS_logtostderr = original_logtostderr_;
+    }
+
+    void SetDevicePath() {
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_DEVICE_PATH", "/dev/nvme0n1", 1), 0);
+    }
+
+   private:
+    inline static constexpr std::array<const char*, 5> kVariables = {
+        "MOONCAKE_NVME_KV_DEVICE_PATH", "MOONCAKE_NVME_KV_NSID",
+        "MOONCAKE_NVME_KV_QUEUE_DEPTH",
+        "MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT",
+        "MOONCAKE_NVME_KV_TRANSPORT"};
+    std::array<std::optional<std::string>, kVariables.size()> original_;
+    bool original_logtostderr_ = false;
+};
+
+TEST_F(NvmeKvConnectorConfigTest, MissingDevicePathStopsBeforeTransport) {
+    ASSERT_EQ(setenv("MOONCAKE_NVME_KV_TRANSPORT", "invalid", 1), 0);
+
+    testing::internal::CaptureStderr();
+    const auto config = NvmeKvConnectorConfig::FromEnvironment();
+    const auto diagnostics = testing::internal::GetCapturedStderr();
+
+    ASSERT_FALSE(config.has_value());
+    EXPECT_EQ(config.error(), ErrorCode::INVALID_PARAMS);
+    EXPECT_NE(
+        diagnostics.find("MOONCAKE_NVME_KV_DEVICE_PATH must not be empty"),
+        std::string::npos);
+    EXPECT_EQ(diagnostics.find("Unknown MOONCAKE_NVME_KV_TRANSPORT"),
+              std::string::npos);
+}
+
+TEST_F(NvmeKvConnectorConfigTest, EmptyDevicePathIsRejected) {
+    ASSERT_EQ(setenv("MOONCAKE_NVME_KV_DEVICE_PATH", "", 1), 0);
+
+    testing::internal::CaptureStderr();
+    const auto config = NvmeKvConnectorConfig::FromEnvironment();
+    const auto diagnostics = testing::internal::GetCapturedStderr();
+
+    ASSERT_FALSE(config.has_value());
+    EXPECT_EQ(config.error(), ErrorCode::INVALID_PARAMS);
+    EXPECT_NE(
+        diagnostics.find("MOONCAKE_NVME_KV_DEVICE_PATH must not be empty"),
+        std::string::npos);
+}
+
+TEST_F(NvmeKvConnectorConfigTest, UnsetOptionalValuesKeepRealExecutorDefaults) {
+    SetDevicePath();
+
+    const auto config = NvmeKvConnectorConfig::FromEnvironment();
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->device_path, "/dev/nvme0n1");
+    EXPECT_EQ(config->nsid, 1u);
+    EXPECT_EQ(config->queue_depth, 256u);
+    EXPECT_EQ(config->runtime_transfer_limit, 270336u);
+    EXPECT_EQ(config->transport, NvmeKvTransport::kAuto);
+}
+
+TEST_F(NvmeKvConnectorConfigTest, PreservesLegacyUnsignedIntegerSyntax) {
+    struct Case {
+        const char* value;
+        uint32_t expected;
+    };
+    const Case cases[] = {{"0", 0u},
+                          {"+17", 17u},
+                          {" 17", 17u},
+                          {"010", 8u},
+                          {"0x10", 16u},
+                          {"-0", 0u},
+                          {"4294967295", std::numeric_limits<uint32_t>::max()}};
+    SetDevicePath();
+    for (const auto& entry : cases) {
+        SCOPED_TRACE(entry.value);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_NSID", entry.value, 1), 0);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_QUEUE_DEPTH", entry.value, 1), 0);
+        ASSERT_EQ(
+            setenv("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT", entry.value, 1),
+            0);
+
+        const auto config = NvmeKvConnectorConfig::FromEnvironment();
+
+        ASSERT_TRUE(config.has_value());
+        EXPECT_EQ(config->nsid, entry.expected);
+        EXPECT_EQ(config->queue_depth, entry.expected);
+        EXPECT_EQ(config->runtime_transfer_limit, entry.expected);
+    }
+}
+
+TEST_F(NvmeKvConnectorConfigTest, InvalidUnsignedIntegersKeepDefaultsSilently) {
+    const char* values[] = {"", "17 ", "17x", "-1", "0x", "4294967296", "abc"};
+    SetDevicePath();
+    for (const char* value : values) {
+        SCOPED_TRACE(value);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_NSID", value, 1), 0);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_QUEUE_DEPTH", value, 1), 0);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT", value, 1),
+                  0);
+
+        testing::internal::CaptureStderr();
+        const auto config = NvmeKvConnectorConfig::FromEnvironment();
+        const auto diagnostics = testing::internal::GetCapturedStderr();
+
+        ASSERT_TRUE(config.has_value());
+        EXPECT_EQ(config->nsid, 1u);
+        EXPECT_EQ(config->queue_depth, 256u);
+        EXPECT_EQ(config->runtime_transfer_limit, 270336u);
+        EXPECT_TRUE(diagnostics.empty()) << diagnostics;
+    }
+}
+
+TEST_F(NvmeKvConnectorConfigTest, AcceptsOnlyExistingTransportTokens) {
+    struct Case {
+        const char* value;
+        NvmeKvTransport expected;
+    };
+    const Case cases[] = {{"", NvmeKvTransport::kAuto},
+                          {"auto", NvmeKvTransport::kAuto},
+                          {"io_uring", NvmeKvTransport::kIoUring},
+                          {"ioctl", NvmeKvTransport::kIoctl}};
+    SetDevicePath();
+    for (const auto& entry : cases) {
+        SCOPED_TRACE(entry.value);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_TRANSPORT", entry.value, 1), 0);
+
+        const auto config = NvmeKvConnectorConfig::FromEnvironment();
+
+        ASSERT_TRUE(config.has_value());
+        EXPECT_EQ(config->transport, entry.expected);
+    }
+}
+
+TEST_F(NvmeKvConnectorConfigTest, InvalidTransportKeepsErrorAndDiagnostic) {
+    SetDevicePath();
+    for (const char* value : {"AUTO", "io-uring", " ioctl", "invalid"}) {
+        SCOPED_TRACE(value);
+        ASSERT_EQ(setenv("MOONCAKE_NVME_KV_TRANSPORT", value, 1), 0);
+
+        testing::internal::CaptureStderr();
+        const auto config = NvmeKvConnectorConfig::FromEnvironment();
+        const auto diagnostics = testing::internal::GetCapturedStderr();
+
+        ASSERT_FALSE(config.has_value());
+        EXPECT_EQ(config.error(), ErrorCode::INVALID_PARAMS);
+        EXPECT_NE(diagnostics.find(std::string("Unknown ") +
+                                   "MOONCAKE_NVME_KV_TRANSPORT: " + value),
+                  std::string::npos);
+    }
+}
+
+TEST_F(NvmeKvConnectorConfigTest, NewConfigsReadCurrentEnvironment) {
+    SetDevicePath();
+    ASSERT_EQ(setenv("MOONCAKE_NVME_KV_NSID", "1", 1), 0);
+    const auto first = NvmeKvConnectorConfig::FromEnvironment();
+    ASSERT_EQ(setenv("MOONCAKE_NVME_KV_NSID", "2", 1), 0);
+    const auto second = NvmeKvConnectorConfig::FromEnvironment();
+
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(first->nsid, 1u);
+    EXPECT_EQ(second->nsid, 2u);
+}
+
+}  // namespace
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

Move the real NVMe KV executor's environment loading into a private `NvmeKvConnectorConfig` and group its five environment-variable definitions in the common catalog. Keep the existing unsigned-integer parsing as a separate calculation helper shared by the config and the remaining NVMe KV runtime readers.

Preserve the existing defaults, base-prefixed integer syntax, leading whitespace and plus-sign handling, silent fallback for invalid integers, accepted transport values, diagnostics, and initialization order. The test-only stub driver still short-circuits before real-executor configuration is read, and the other NVMe KV runtime settings remain out of scope.

Part of #3809.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target nvme_kv_connector_config_test nvme_kv_storage_backend_test mooncake_store_client_objects -j32
ctest --test-dir build --output-on-failure -R '^(nvme_kv_connector_config|nvme_kv_storage_backend)_test$'
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

Both selected tests passed, and the Mooncake Store client objects build successfully. All applicable pre-commit hooks passed on the changed files.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped extract the config and parser, add and run tests, and review the changes.