### PR TITLE
[Store] Interleave the stale-handle sweep with concurrent RPCs

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2728,73 +2728,117 @@ void MasterService::ClearLocalDiskHandlesOwnedBy(const UUID& owner) {
 void MasterService::ClearStaleHandles(
     const std::function<bool(const Replica&)>& is_stale) {
     for (size_t i = 0; i < kNumShards; i++) {
-        MetadataShardAccessorRW shard(this, i);
-        for (auto tenant_it = shard->tenants.begin();
-             tenant_it != shard->tenants.end();) {
-            auto& tenant_state = tenant_it->second;
-            auto it = tenant_state.metadata.begin();
-            while (it != tenant_state.metadata.end()) {
-                const auto cleanup_plan =
-                    BuildStaleHandleCleanupPlan(it->second, is_stale);
-                if (!cleanup_plan.removed_ids.empty()) {
-                    if (enable_ha_) {
-                        if (enable_oplog_) {
-                            auto persist_result =
-                                PersistStaleHandleCleanupForHA(
-                                    "ClearStaleHandles", tenant_it->first,
-                                    it->first, it->second, cleanup_plan);
-                            if (!persist_result) {
-                                ++it;
-                                continue;
-                            }
-                            ++it;
-                            continue;
-                        }
-                    }
-                    if (CleanupStaleHandles(it->first, tenant_it->first,
-                                            tenant_state, it->second, is_stale,
-                                            &shard)) {
-                        it = EraseMetadata(tenant_state, it, tenant_it->first,
-                                           QuotaEraseMode::kFull, &shard);
-                    } else {
-                        ++it;
-                    }
-                } else if (!it->second.IsValid()) {
-                    if (enable_ha_) {
-                        if (enable_oplog_) {
-                            auto persist_result =
-                                AppendOpLogWithDurableFinalize(
-                                    OpType::REMOVE, tenant_it->first.value(),
-                                    it->first, {},
-                                    [this](const OpLogEntry& durable_entry) {
-                                        FinalizeMetadataEraseAfterDurable(
-                                            durable_entry,
-                                            QuotaEraseMode::kFull);
-                                    });
-                            if (!persist_result) {
-                                LOG(WARNING)
-                                    << "ClearStaleHandles(last replica)"
-                                    << ": REMOVE persist failed for key="
-                                    << it->first << ", err="
-                                    << static_cast<int>(persist_result.error());
-                                ++it;
-                                continue;
-                            }
-                            ++it;
-                            continue;
-                        }
-                    }
-                    it = EraseMetadata(tenant_state, it, tenant_it->first,
-                                       QuotaEraseMode::kFull, &shard);
-                } else {
-                    ++it;
+        // Pass 1 (read-only): collect the (tenant, key) pairs whose current
+        // state needs cleanup. The sweep used to hold the shard write lock
+        // for the whole shard and run the HA persist path inline per key,
+        // which blocked every RPC on that shard for minutes at large key
+        // counts (#3940). Candidates are committed one key at a time below,
+        // each under its own short write lock, so other work interleaves.
+        // Pass 1 (read-only, chunked): snapshot the shard's keys under one
+        // short read lock, then evaluate the stale predicate in bounded
+        // chunks, releasing the lock between chunks so writes interleave
+        // during the scan itself.
+        std::vector<std::pair<TenantId, std::string>> shard_keys;
+        {
+            MetadataShardAccessorRO shard(this, i);
+            for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+                for (const auto& [key, metadata] : tenant_state.metadata) {
+                    shard_keys.emplace_back(tenant_id, key);
                 }
             }
-            if (tenant_state.Empty()) {
-                tenant_it = shard->tenants.erase(tenant_it);
-            } else {
-                ++tenant_it;
+        }
+        constexpr size_t kScanChunkSize = 256;
+        std::vector<std::pair<TenantId, std::string>> candidates;
+        for (size_t start = 0; start < shard_keys.size();
+             start += kScanChunkSize) {
+            const size_t end =
+                std::min(start + kScanChunkSize, shard_keys.size());
+            std::this_thread::yield();
+            MetadataShardAccessorRO shard(this, i);
+            for (size_t k = start; k < end; ++k) {
+                const auto& [tenant_id, key] = shard_keys[k];
+                auto tenant_it = shard->tenants.find(tenant_id);
+                if (tenant_it == shard->tenants.end()) {
+                    continue;
+                }
+                auto it = tenant_it->second.metadata.find(key);
+                if (it == tenant_it->second.metadata.end()) {
+                    continue;
+                }
+                const auto cleanup_plan =
+                    BuildStaleHandleCleanupPlan(it->second, is_stale);
+                if (!cleanup_plan.removed_ids.empty() ||
+                    !it->second.IsValid()) {
+                    candidates.emplace_back(tenant_id, key);
+                }
             }
+        }
+
+        // Pass 2: commit each candidate under a fresh short write lock,
+        // re-verifying against the current state (it may have moved between
+        // the passes, so a candidate that is clean now is skipped).
+        for (const auto& [tenant_id, key] : candidates) {
+            MetadataShardAccessorRW shard(this, i);
+            auto tenant_it = shard->tenants.find(tenant_id);
+            if (tenant_it == shard->tenants.end()) {
+                continue;
+            }
+            auto& tenant_state = tenant_it->second;
+            auto it = tenant_state.metadata.find(key);
+            if (it == tenant_state.metadata.end()) {
+                continue;
+            }
+            const auto cleanup_plan =
+                BuildStaleHandleCleanupPlan(it->second, is_stale);
+            if (!cleanup_plan.removed_ids.empty()) {
+                if (enable_ha_) {
+                    if (enable_oplog_) {
+                        auto persist_result = PersistStaleHandleCleanupForHA(
+                            "ClearStaleHandles", tenant_it->first, it->first,
+                            it->second, cleanup_plan);
+                        if (!persist_result) {
+                            continue;
+                        }
+                        continue;
+                    }
+                }
+                if (CleanupStaleHandles(it->first, tenant_it->first,
+                                        tenant_state, it->second, is_stale,
+                                        &shard)) {
+                    EraseMetadata(tenant_state, it, tenant_it->first,
+                                  QuotaEraseMode::kFull, &shard);
+                }
+            } else if (!it->second.IsValid()) {
+                if (enable_ha_) {
+                    if (enable_oplog_) {
+                        auto persist_result = AppendOpLogWithDurableFinalize(
+                            OpType::REMOVE, tenant_it->first.value(), it->first,
+                            {}, [this](const OpLogEntry& durable_entry) {
+                                FinalizeMetadataEraseAfterDurable(
+                                    durable_entry, QuotaEraseMode::kFull);
+                            });
+                        if (!persist_result) {
+                            LOG(WARNING)
+                                << "ClearStaleHandles(last replica)"
+                                << ": REMOVE persist failed for key="
+                                << it->first << ", err="
+                                << static_cast<int>(persist_result.error());
+                            continue;
+                        }
+                        continue;
+                    }
+                }
+                EraseMetadata(tenant_state, it, tenant_it->first,
+                              QuotaEraseMode::kFull, &shard);
+            } else {
+                // Moved out of stale between the passes; leave it alone.
+                continue;
+            }
+            if (tenant_state.Empty()) {
+                shard->tenants.erase(tenant_it);
+            }
+            // Let a waiting writer win the lock between candidates.
+            std::this_thread::yield();
         }
     }
 }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -2506,6 +2506,73 @@ TEST_F(MasterServiceTest, DrainJobFailsAfterRetryBudgetExhausted) {
     EXPECT_EQ(segment_status.value(), SegmentStatus::OK);
 }
 
+// ===================== Stale Handle Sweep Tests =====================
+
+TEST_F(MasterServiceTest, StaleHandleSweepInterleavesConcurrentWrites) {
+    // #3940: the sweep used to hold each shard's write lock for the whole
+    // shard, so a concurrent write waited out the entire sweep. With a
+    // chunked scan and per-key commit locks, a write lands between them.
+    // The long sweep must not outlive the client TTL or the writer's client
+    // expires mid-test.
+    MasterService service(
+        MasterServiceConfig::builder().set_client_live_ttl_sec(3600).build());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(service);
+    const UUID client = context.client_id;
+    const TenantId tenant = TenantId::Default();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const auto writer_shard =
+        ShardIndexForTesting(service, tenant, "writer_key");
+    int seeded = 0;
+    for (int i = 0; seeded < 600; ++i) {
+        const std::string key = "sweep_" + std::to_string(i);
+        if (ShardIndexForTesting(service, tenant, key) != writer_shard) {
+            continue;
+        }
+        ASSERT_TRUE(
+            service.PutStart(client, key, tenant, 128, config).has_value());
+        ASSERT_TRUE(service.PutEnd(client, key, tenant, ReplicaType::MEMORY)
+                        .has_value());
+        ++seeded;
+    }
+
+    std::atomic<bool> sweep_started{false};
+    std::atomic<bool> sweep_done{false};
+    std::atomic<long long> sweep_ms{0};
+    std::thread sweeper([&] {
+        const auto start = std::chrono::steady_clock::now();
+        RunStaleHandleSweepForTesting(service, [&](const Replica& r) {
+            sweep_started = true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            return r.is_completed();
+        });
+        sweep_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - start)
+                       .count();
+        sweep_done = true;
+    });
+    while (!sweep_started.load()) {
+        std::this_thread::yield();
+    }
+    // Let the sweep get well into its first shard before writing.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    const auto start = std::chrono::steady_clock::now();
+    ASSERT_TRUE(service.PutStart(client, "writer_key", tenant, 128, config)
+                    .has_value());
+    const auto put_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - start)
+                            .count();
+    sweeper.join();
+
+    // 600 candidates x 10ms per evaluation across scan chunks plus commits
+    // makes the sweep several seconds long; a write that lands far earlier
+    // proves it interleaved instead of waiting out the whole sweep.
+    EXPECT_LT(put_ms, sweep_ms / 3)
+        << "write took " << put_ms << "ms of a " << sweep_ms << "ms sweep";
+}
+
 // ===================== Hard Pin Tests =====================
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_test_fixture.h
+++ b/mooncake-store/tests/master_service_test_fixture.h
@@ -49,6 +49,18 @@ class MasterServiceTest : public ::testing::Test {
     static constexpr size_t kDefaultSegmentSize = 1024 * 1024 * 16;
     static constexpr uint64_t kStrictTenantQuotaBytes = 4 * 1024 * 1024;
 
+    static void RunStaleHandleSweepForTesting(
+        MasterService& service,
+        const std::function<bool(const Replica&)>& is_stale) {
+        service.ClearStaleHandles(is_stale);
+    }
+
+    static size_t ShardIndexForTesting(MasterService& service,
+                                       const TenantId& tenant_id,
+                                       const std::string& key) {
+        return service.getShardIndex(tenant_id, key);
+    }
+
     void PauseReplicaCleanup(MasterService& service) {
         service.replica_cleanup_worker_.Stop();
     }


### PR DESCRIPTION
## Description

Fixes #3940. A lease-expiry cleanup ran `ClearStaleHandles` while holding each shard's write lock for the entire shard sweep — every tenant, every key, with the HA persist path inline per key. At tens of millions of keys the sweep blocked all RPC on that shard for minutes (the production trace in the issue: `Total=0.00` for Put/Get/Ping/FetchTasks, master alive, no re-election).

The sweep now works at a different lock cadence, with identical cleanup semantics:

- Per shard, the key set is snapshotted under one short read lock, then the stale predicate is evaluated in 256-key chunks, releasing the read lock between chunks.
- Each candidate is committed under its own short write lock, re-verified against current state (a candidate that moved out of stale between passes is skipped).
- A `yield` between candidates lets a waiting writer win the lock.

What gets cleaned, the HA persist path, and the tenant-empty erase rule are unchanged — only when the locks are held.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build-linux --target master_service_test master_service_ha_test
./mooncake-store/tests/master_service_test
./mooncake-store/tests/master_service_ha_test
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

New regression test `StaleHandleSweepInterleavesConcurrentWrites`: 600 keys seeded on the writer's shard, a 10ms slow stale predicate stretches the sweep to several seconds, and a `PutStart` issued mid-sweep must return in far less than the sweep's remaining time. It fails on current main (the write waits out the whole sweep: 13.6s of a 14.1s sweep in the measured red run) and passes here. In a Linux container (Ubuntu 22.04): `master_service_test` 70/70 and `master_service_ha_test` 95/95 pass.

The existing cleanup correctness coverage (the HA persist paths, tenant erase, quota accounting) is unchanged and green; the predicate is re-evaluated under the write lock before every commit, so a key whose state moved between passes is left alone.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code (clang-format) and run pre-commit on the touched files; all hooks pass
- [x] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (N/A)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Prepared with AI assistance (Kimi Code): the lock chain was traced on current main by reading, the fix and tests were drafted by the agent, and I reviewed the complete diff before submitting. The container runs and the red/green evidence above are the ones actually executed.