### PR TITLE
[TransferEngine] Prefer THP for shared-segment mmap without a HugeTLB pool

### DIFF
--- a/mooncake-integration/shared_segment.py
+++ b/mooncake-integration/shared_segment.py
@@ -73,9 +73,12 @@ def create_shared_segment(
     1. ``tp_group`` is a deprecated alias of ``comm_group``. ``device_id``
     defaults to the rank's current accelerator.
 
-    ``mmap`` (default True) uses POSIX shm. Set ``mmap=False`` for the platform
-    VMM fabric path. ``host_register`` (default False) HostRegister's mmap pages
-    for ``device_id`` so ``tensors().data_ptr()`` is a device VA suitable for TE
+    ``mmap`` (default True) uses an unnamed memfd and asks the kernel for THP
+    (``MADV_HUGEPAGE``) so the span can be 2MiB pages without a HugeTLB pool;
+    4KiB pages if THP cannot allocate. Ranks share those pages through the
+    memfd. Set ``mmap=False`` for the platform VMM fabric path.
+    ``host_register`` (default False) HostRegister's mmap pages for
+    ``device_id`` so ``tensors().data_ptr()`` is a device VA suitable for TE
     ``location=\"npu\"`` ROCE D2rH; requires ``mmap=True``. Ascend VMM
     (``mmap=False``) also exposes NPU tensors: the host SVM VA is already
     device-accessible after ``MemSetAccess`` (owner ``MallocMem``, peer
@@ -127,9 +130,7 @@ def create_shared_segment(
     except RuntimeError as exc:
         create_error = str(exc)
 
-    _raise_if_any_rank_failed(
-        create_error, world_size, rank_id, comm_group, "create"
-    )
+    _raise_if_any_rank_failed(create_error, world_size, rank_id, comm_group, "create")
     if segment is None:
         raise SharedSegmentError("Shared segment create returned no segment")
 

--- a/mooncake-transfer-engine/include/shared_segment/shared_segment.h
+++ b/mooncake-transfer-engine/include/shared_segment/shared_segment.h
@@ -56,7 +56,9 @@ struct SharedSegmentOptions {
     uint32_t owner_rank = 0;
     // Accelerator that is granted access to the host pages (D2H/H2D).
     int32_t device_id = 0;
-    // true: POSIX shm_open + mmap on the same host.
+    // true: unnamed memfd + mmap. Prefer THP (MADV_HUGEPAGE) so the kernel
+    // can back the span with 2MiB pages; 4KiB pages if THP cannot allocate.
+    // Does not use the HugeTLB pool. Ranks share the pages through the memfd.
     // false: platform VMM with a fabric shareable handle.
     bool mmap = true;
     // When mmap is true: HostRegister the pages for device_id (Ascend).
@@ -80,9 +82,9 @@ class SharedSegment {
                          std::shared_ptr<SharedSegment>& segment,
                          std::string& out_blob);
 
-    // Whether this build can share memory across processes. mmap uses POSIX
-    // shm (always available). host_register additionally needs Ascend.
-    // VMM (mmap=false) needs a platform fabric backend.
+    // Whether this build can share memory across processes. mmap uses an
+    // anonymous memfd (always available). host_register additionally needs
+    // Ascend. VMM (mmap=false) needs a platform fabric backend.
     static bool Supported(bool mmap = true, bool host_register = false);
 
     // Phase two. `blobs` is indexed by rank. After success, `ready()` is true
@@ -94,7 +96,7 @@ class SharedSegment {
     uint64_t size() const { return size_; }
 
     // Address the accelerator sees, when the backend had to map the pages for
-    // it separately (POSIX shm plus HostRegister on Ascend). Zero when
+    // it separately (mmap plus HostRegister on Ascend). Zero when
     // `base_addr()` is already device-accessible.
     uintptr_t device_addr() const;
 

--- a/mooncake-transfer-engine/src/shared_segment/mmap_shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/mmap_shared_segment.cpp
@@ -12,17 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <glog/logging.h>
 
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
-#include <random>
 #include <string>
 #include <sys/mman.h>
-#include <sys/stat.h>
+#include <sys/syscall.h>
 #include <unistd.h>
+
+#ifdef __has_include
+#if __has_include(<linux/memfd.h>)
+#include <linux/memfd.h>
+#endif
+#endif
 
 #include "shared_segment_internal.h"
 
@@ -30,10 +40,13 @@
 #include <acl/acl.h>
 #endif
 
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
+
 namespace mooncake {
 namespace {
 constexpr uint16_t kMmapBackendId = 3;
-constexpr uint64_t kFallbackPageSize = 4096;
 // Matches the common PMD THP size when sysfs is unavailable.
 constexpr uint64_t kFallbackHugePageSize = 2ULL * 1024 * 1024;
 constexpr const char* kThpPmdSizePath =
@@ -41,16 +54,8 @@ constexpr const char* kThpPmdSizePath =
 constexpr const char* kShmemThpEnabledPath =
     "/sys/kernel/mm/transparent_hugepage/shmem_enabled";
 
-uint64_t BasePageSize() {
-    long page = sysconf(_SC_PAGESIZE);
-    if (page <= 0) {
-        return kFallbackPageSize;
-    }
-    return static_cast<uint64_t>(page);
-}
-
-// mmap uses shm_open (tmpfs/shmem), so only shmem THP matters. Sysfs looks like
-// "always within_size [advise] never deny force"; the active mode is bracketed.
+// memfd without MFD_HUGETLB is a tmpfs/shmem inode, so shmem THP applies.
+// Sysfs looks like "always within_size [advise] never deny force".
 bool ShmemThpEnabled() {
     static const bool kEnabled = []() -> bool {
         FILE* fp = std::fopen(kShmemThpEnabledPath, "r");
@@ -93,11 +98,7 @@ uint64_t HugePageSize() {
     return kSize;
 }
 
-// Hint only when shmem THP is on; failure must not abort the segment.
 void AdviseTransparentHugePages(void* addr, uint64_t size) {
-    if (!ShmemThpEnabled()) {
-        return;
-    }
 #ifdef MADV_HUGEPAGE
     if (addr == nullptr || size == 0) {
         return;
@@ -110,6 +111,132 @@ void AdviseTransparentHugePages(void* addr, uint64_t size) {
     (void)addr;
     (void)size;
 #endif
+}
+
+void AdviseDontFork(void* addr, uint64_t size) {
+#ifdef MADV_DONTFORK
+    if (addr == nullptr || size == 0) {
+        return;
+    }
+    if (madvise(addr, size, MADV_DONTFORK) != 0) {
+        LOG(WARNING) << "madvise(MADV_DONTFORK) failed for shared segment: "
+                     << std::strerror(errno);
+    }
+#else
+    (void)addr;
+    (void)size;
+#endif
+}
+
+int CreateAnonymousMemFd() {
+#ifdef __NR_memfd_create
+    return static_cast<int>(syscall(__NR_memfd_create, "mcss", MFD_CLOEXEC));
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+// Leave a PROT_NONE window whose address is aligned to the THP PMD size so a
+// later MAP_FIXED memfd map can use 2MiB pages. Falls back to an unaligned
+// reservation if the oversized mmap fails.
+void* ReserveAlignedWindow(uint64_t size, uint64_t align) {
+    if (align == 0 || (align & (align - 1)) != 0) {
+        align = HugePageSize();
+    }
+    const uint64_t span = size + align;
+    void* raw =
+        mmap(nullptr, span, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (raw != MAP_FAILED) {
+        const auto start = reinterpret_cast<uintptr_t>(raw);
+        const auto aligned = (start + static_cast<uintptr_t>(align) - 1) &
+                             ~(static_cast<uintptr_t>(align) - 1);
+        const auto end = aligned + size;
+        const auto raw_end = start + span;
+        if (aligned > start) {
+            (void)munmap(raw, aligned - start);
+        }
+        if (raw_end > end) {
+            (void)munmap(reinterpret_cast<void*>(end), raw_end - end);
+        }
+        return reinterpret_cast<void*>(aligned);
+    }
+    return mmap(nullptr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+}
+
+// Touch one byte per PMD so THP can back the range with 2MiB pages. If THP
+// cannot allocate, the kernel leaves 4KiB pages. Never uses the HugeTLB pool.
+void PrefaultAnonymousRange(void* addr, uint64_t size, uint64_t stride) {
+    if (addr == nullptr || size == 0 || stride == 0) {
+        return;
+    }
+    auto* bytes = static_cast<volatile uint8_t*>(addr);
+    for (uint64_t off = 0; off < size; off += stride) {
+        bytes[off] = 0;
+    }
+    bytes[size - 1] = 0;
+}
+
+Status MapMemFd(int fd, uint64_t size, void* hint, void*& addr) {
+    int map_flags = MAP_SHARED;
+    if (hint != nullptr) {
+        map_flags |= MAP_FIXED;
+    }
+    void* mapped = mmap(hint, size, PROT_READ | PROT_WRITE, map_flags, fd, 0);
+    if (mapped == MAP_FAILED) {
+        return Status::Memory(std::string("mmap failed: ") +
+                              std::strerror(errno));
+    }
+    addr = mapped;
+    return Status::OK();
+}
+
+// Unnamed memfd (no MFD_HUGETLB, no nr_hugepages). MADV_HUGEPAGE is applied
+// before any page is faulted so the kernel can use THP; otherwise 4KiB pages.
+Status CreateAndMapMemFd(uint64_t size, int& fd, void*& addr) {
+    fd = CreateAnonymousMemFd();
+    if (fd < 0) {
+        return Status::Memory(std::string("memfd_create failed: ") +
+                              std::strerror(errno));
+    }
+    if (ftruncate(fd, static_cast<off_t>(size)) != 0) {
+        const int err = errno;
+        close(fd);
+        fd = -1;
+        return Status::Memory(std::string("ftruncate failed: ") +
+                              std::strerror(err));
+    }
+    void* hint = ReserveAlignedWindow(size, HugePageSize());
+    if (hint == MAP_FAILED) {
+        hint = nullptr;
+    }
+    auto status = MapMemFd(fd, size, hint, addr);
+    if (!status.ok() && hint != nullptr) {
+        (void)munmap(hint, size);
+        hint = nullptr;
+        status = MapMemFd(fd, size, nullptr, addr);
+    }
+    if (!status.ok()) {
+        close(fd);
+        fd = -1;
+        return status;
+    }
+    AdviseTransparentHugePages(addr, size);
+    PrefaultAnonymousRange(addr, size, HugePageSize());
+    AdviseDontFork(addr, size);
+    return Status::OK();
+}
+
+std::string EncodeMemFdHandle(int fd) {
+    char name[64];
+    std::snprintf(name, sizeof(name), "/proc/%d/fd/%d",
+                  static_cast<int>(getpid()), fd);
+    return name;
+}
+
+bool IsMemFdHandle(const std::string& name) {
+    return name.rfind("/proc/", 0) == 0 &&
+           name.find("/fd/") != std::string::npos;
 }
 
 Status HostRegister(void* addr, uint64_t size, int32_t device_id,
@@ -157,28 +284,15 @@ void HostUnregister(void* addr, void* /*ascend_dev_ptr*/) {
 #endif
 }
 
-// POSIX shm names are limited to NAME_MAX and must start with a slash. The pid
-// separates owners that live on one host at the same time; the random suffix
-// covers pid reuse after a crash left a name behind.
-std::string MakeShmName() {
-    static thread_local std::mt19937_64 rng{std::random_device{}()};
-    char name[48];
-    std::snprintf(name, sizeof(name), "/mcss_%d_%016llx",
-                  static_cast<int>(getpid()),
-                  static_cast<unsigned long long>(rng()));
-    return name;
-}
-
 class MmapSharedSegmentBackend : public SharedSegmentBackend {
    public:
     ~MmapSharedSegmentBackend() override { Release(); }
 
     uint64_t Granularity(
         const SharedSegmentOptions& /*options*/) const override {
-        if (ShmemThpEnabled()) {
-            return HugePageSize();
-        }
-        return BasePageSize();
+        // Align length to the THP PMD size so MADV_HUGEPAGE can use 2MiB
+        // pages. 4KiB fallback still accepts a PMD-aligned length.
+        return HugePageSize();
     }
 
     Status CreateOwner(uint64_t size, const SharedSegmentOptions& options,
@@ -198,16 +312,13 @@ class MmapSharedSegmentBackend : public SharedSegmentBackend {
     }
 
    private:
-    Status MapShared(const std::string& shm_name, uint64_t size, bool create,
-                     void*& addr);
     Status RegisterMapped(const SharedSegmentOptions& options);
     void Release();
 
     void* addr_ = nullptr;
     uint64_t size_ = 0;
+    int memfd_ = -1;
     bool registered_ = false;
-    bool unlink_on_release_ = false;
-    std::string shm_name_;
     void* ascend_dev_ptr_ = nullptr;
 };
 
@@ -225,61 +336,28 @@ Status MmapSharedSegmentBackend::RegisterMapped(
     return Status::OK();
 }
 
-Status MmapSharedSegmentBackend::MapShared(const std::string& shm_name,
-                                           uint64_t size, bool create,
-                                           void*& addr) {
-    int flags = create ? (O_CREAT | O_EXCL | O_RDWR) : O_RDWR;
-    int fd = shm_open(shm_name.c_str(), flags, 0600);
-    if (fd < 0) {
-        return Status::Memory(std::string("shm_open failed: ") +
-                              std::strerror(errno));
-    }
-    if (create && ftruncate(fd, static_cast<off_t>(size)) != 0) {
-        const int err = errno;
-        close(fd);
-        shm_unlink(shm_name.c_str());
-        return Status::Memory(std::string("ftruncate failed: ") +
-                              std::strerror(err));
-    }
-
-    int map_flags = MAP_SHARED;
-    void* hint = addr;
-    if (hint != nullptr) {
-        map_flags |= MAP_FIXED;
-    }
-    void* mapped = mmap(hint, size, PROT_READ | PROT_WRITE, map_flags, fd, 0);
-    const int map_err = errno;
-    close(fd);
-    if (mapped == MAP_FAILED) {
-        if (create) {
-            shm_unlink(shm_name.c_str());
-        }
-        return Status::Memory(std::string("mmap failed: ") +
-                              std::strerror(map_err));
-    }
-    AdviseTransparentHugePages(mapped, size);
-    addr = mapped;
-    return Status::OK();
-}
-
 Status MmapSharedSegmentBackend::CreateOwner(
     uint64_t size, const SharedSegmentOptions& options, uintptr_t& base_addr,
     std::vector<uint8_t>& handle) {
-    const std::string name = MakeShmName();
+    int fd = -1;
     void* mapped = nullptr;
-    auto status = MapShared(name, size, /*create=*/true, mapped);
+    auto status = CreateAndMapMemFd(size, fd, mapped);
     if (!status.ok()) {
         return status;
     }
+    LOG(INFO) << "Shared segment mmap: unnamed memfd + THP hint (no HugeTLB), "
+              << "size " << size
+              << ", shmem_thp=" << (ShmemThpEnabled() ? "on" : "off");
+
     addr_ = mapped;
     size_ = size;
-    unlink_on_release_ = true;
-    shm_name_ = name;
+    memfd_ = fd;
     status = RegisterMapped(options);
     if (!status.ok()) {
         return status;
     }
     base_addr = reinterpret_cast<uintptr_t>(addr_);
+    const std::string name = EncodeMemFdHandle(memfd_);
     handle.assign(name.begin(), name.end());
     return Status::OK();
 }
@@ -287,8 +365,7 @@ Status MmapSharedSegmentBackend::CreateOwner(
 Status MmapSharedSegmentBackend::ReserveLocal(
     uint64_t size, const SharedSegmentOptions& /*options*/,
     uintptr_t& base_addr) {
-    void* reserved =
-        mmap(nullptr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void* reserved = ReserveAlignedWindow(size, HugePageSize());
     if (reserved == MAP_FAILED) {
         return Status::Memory(std::string("mmap reserve failed: ") +
                               std::strerror(errno));
@@ -315,18 +392,26 @@ Status MmapSharedSegmentBackend::ImportAndMap(
             "Shared segment owner handle has an unexpected length");
     }
     const std::string name(handle.begin(), handle.end());
-    if (name.empty() || name[0] != '/') {
+    if (!IsMemFdHandle(name)) {
         return Status::InvalidArgument(
-            "Shared segment owner handle is not a POSIX shm name");
+            "Shared segment owner handle is not a memfd /proc/<pid>/fd path");
+    }
+
+    int fd = open(name.c_str(), O_RDWR);
+    if (fd < 0) {
+        return Status::Memory(std::string("open memfd handle failed: ") +
+                              std::strerror(errno) + " (" + name + ")");
     }
 
     void* mapped = addr_;
-    auto status = MapShared(name, size, /*create=*/false, mapped);
+    auto status = MapMemFd(fd, size, mapped, mapped);
+    close(fd);
     if (!status.ok()) {
         return status;
     }
     addr_ = mapped;
-    shm_name_ = name;
+    AdviseTransparentHugePages(addr_, size);
+    AdviseDontFork(addr_, size);
     status = RegisterMapped(options);
     if (!status.ok()) {
         return status;
@@ -344,18 +429,17 @@ void MmapSharedSegmentBackend::Release() {
         (void)munmap(addr_, size_);
         addr_ = nullptr;
     }
-    if (unlink_on_release_ && !shm_name_.empty()) {
-        (void)shm_unlink(shm_name_.c_str());
-        unlink_on_release_ = false;
+    if (memfd_ >= 0) {
+        close(memfd_);
+        memfd_ = -1;
     }
-    shm_name_.clear();
     size_ = 0;
 }
 }  // namespace
 
 std::unique_ptr<SharedSegmentBackend> CreateMmapSharedSegmentBackend() {
-    // POSIX shm + mmap is always available. HostRegister is optional and is
-    // checked when SharedSegmentOptions::host_register is set.
+    // Anonymous memfd + mmap is always available. HostRegister is optional and
+    // is checked when SharedSegmentOptions::host_register is set.
     return std::make_unique<MmapSharedSegmentBackend>();
 }
 

--- a/mooncake-transfer-engine/src/shared_segment/shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/shared_segment.cpp
@@ -235,7 +235,7 @@ bool SharedSegment::Supported(bool mmap, bool host_register) {
         return false;
 #endif
     }
-    // mmap without HostRegister only needs POSIX shm.
+    // mmap without HostRegister only needs an anonymous memfd.
     return true;
 }
 

--- a/mooncake-transfer-engine/tests/shared_segment_test.cpp
+++ b/mooncake-transfer-engine/tests/shared_segment_test.cpp
@@ -15,10 +15,19 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
 
 #include "shared_segment/shared_segment.h"
 #include "shared_segment_internal.h"
+
+#if defined(USE_ASCEND_DIRECT)
+#include <acl/acl.h>
+#endif
 
 namespace mooncake {
 namespace {
@@ -239,9 +248,7 @@ TEST(SharedSegmentMmapTest, TwoRanksSharePagesInOneProcess) {
     std::shared_ptr<SharedSegment> peer;
     auto status = SharedSegment::Create("mmap-tp", kSegmentSize, owner_opts,
                                         owner, owner_blob);
-    if (!status.ok()) {
-        GTEST_SKIP() << "HostRegister unavailable: " << status.ToString();
-    }
+    ASSERT_TRUE(status.ok()) << status.ToString();
     ASSERT_TRUE(SharedSegment::Create("mmap-tp", kSegmentSize, peer_opts, peer,
                                       peer_blob)
                     .ok());
@@ -256,7 +263,7 @@ TEST(SharedSegmentMmapTest, TwoRanksSharePagesInOneProcess) {
     owner_bytes[4095] = 0xCD;
     EXPECT_EQ(peer_bytes[0], 0xAB);
     EXPECT_EQ(peer_bytes[4095], 0xCD);
-    // Rank-local VAs need not match.
+    // Rank-local virtual addresses need not match.
     EXPECT_NE(owner->base_addr(), peer->base_addr());
 }
 
@@ -272,7 +279,8 @@ TEST(SharedSegmentMmapTest, RejectsMixedBackendBlobs) {
     auto status = SharedSegment::Create("mmap-mix", kSegmentSize, mmap_opts,
                                         mmap_segment, mmap_blob);
     if (!status.ok()) {
-        GTEST_SKIP() << "HostRegister unavailable: " << status.ToString();
+        GTEST_SKIP() << "mmap shared segment unavailable: "
+                     << status.ToString();
     }
 
     // Forge a peer blob that claims a different backend id.
@@ -284,5 +292,152 @@ TEST(SharedSegmentMmapTest, RejectsMixedBackendBlobs) {
     ASSERT_TRUE(EncodeSegmentBlob(header, handle, forged).ok());
     EXPECT_TRUE(mmap_segment->Complete({forged}).IsInvalidArgument());
 }
+
+TEST(SharedSegmentMmapTest, OwnerHandleIsProcFd) {
+    if (!SharedSegment::Supported(/*mmap=*/true)) {
+        GTEST_SKIP() << "mmap shared segment unavailable";
+    }
+    SharedSegmentOptions options = KvOptions(0, 1);
+    options.mmap = true;
+
+    std::string blob;
+    std::shared_ptr<SharedSegment> segment;
+    auto status =
+        SharedSegment::Create("mmap-fd", kSegmentSize, options, segment, blob);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+
+    SegmentBlobHeader header{};
+    std::vector<uint8_t> handle;
+    ASSERT_TRUE(DecodeSegmentBlob(blob, header, handle).ok());
+    const std::string path(handle.begin(), handle.end());
+    int pid = -1;
+    int fd = -1;
+    ASSERT_EQ(std::sscanf(path.c_str(), "/proc/%d/fd/%d", &pid, &fd), 2);
+    EXPECT_EQ(pid, static_cast<int>(getpid()));
+    EXPECT_GE(fd, 0);
+}
+
+TEST(SharedSegmentMmapTest, TwoProcessesSharePages) {
+    if (!SharedSegment::Supported(/*mmap=*/true)) {
+        GTEST_SKIP() << "mmap shared segment unavailable";
+    }
+
+    int to_peer[2];
+    int to_owner[2];
+    ASSERT_EQ(pipe(to_peer), 0);
+    ASSERT_EQ(pipe(to_owner), 0);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(to_peer[1]);
+        close(to_owner[0]);
+        SharedSegmentOptions peer_opts = KvOptions(1, 2);
+        peer_opts.mmap = true;
+        std::string peer_blob;
+        std::shared_ptr<SharedSegment> peer;
+        auto status = SharedSegment::Create("mmap-fork", kSegmentSize,
+                                            peer_opts, peer, peer_blob);
+        if (!status.ok() ||
+            write(to_owner[1], peer_blob.data(), peer_blob.size()) !=
+                static_cast<ssize_t>(peer_blob.size())) {
+            _exit(2);
+        }
+        std::string owner_blob(kSegmentBlobBytes, '\0');
+        if (read(to_peer[0], owner_blob.data(), owner_blob.size()) !=
+            static_cast<ssize_t>(owner_blob.size())) {
+            _exit(3);
+        }
+        const std::vector<std::string> blobs = {owner_blob, peer_blob};
+        if (!peer->Complete(blobs).ok()) {
+            _exit(4);
+        }
+        uint8_t ready = 1;
+        if (write(to_owner[1], &ready, 1) != 1) {
+            _exit(5);
+        }
+        if (read(to_peer[0], &ready, 1) != 1) {
+            _exit(6);
+        }
+        auto* bytes = reinterpret_cast<uint8_t*>(peer->base_addr());
+        const int ok = (bytes[0] == 0xA5 && bytes[4095] == 0x5A) ? 0 : 7;
+        _exit(ok);
+    }
+
+    close(to_peer[0]);
+    close(to_owner[1]);
+    SharedSegmentOptions owner_opts = KvOptions(0, 2);
+    owner_opts.mmap = true;
+    std::string owner_blob;
+    std::shared_ptr<SharedSegment> owner;
+    auto status = SharedSegment::Create("mmap-fork", kSegmentSize, owner_opts,
+                                        owner, owner_blob);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    ASSERT_EQ(write(to_peer[1], owner_blob.data(), owner_blob.size()),
+              static_cast<ssize_t>(owner_blob.size()));
+
+    std::string peer_blob(kSegmentBlobBytes, '\0');
+    ASSERT_EQ(read(to_owner[0], peer_blob.data(), peer_blob.size()),
+              static_cast<ssize_t>(peer_blob.size()));
+    const std::vector<std::string> blobs = {owner_blob, peer_blob};
+    ASSERT_TRUE(owner->Complete(blobs).ok());
+
+    uint8_t ready = 0;
+    ASSERT_EQ(read(to_owner[0], &ready, 1), 1);
+    auto* bytes = reinterpret_cast<uint8_t*>(owner->base_addr());
+    bytes[0] = 0xA5;
+    bytes[4095] = 0x5A;
+    ASSERT_EQ(write(to_peer[1], &ready, 1), 1);
+
+    int wstatus = 0;
+    ASSERT_EQ(waitpid(child, &wstatus, 0), child);
+    ASSERT_TRUE(WIFEXITED(wstatus));
+    EXPECT_EQ(WEXITSTATUS(wstatus), 0);
+}
+
+#if defined(USE_ASCEND_DIRECT)
+TEST(SharedSegmentMmapTest, HostRegisterTwoRanksSharePages) {
+    if (!SharedSegment::Supported(/*mmap=*/true, /*host_register=*/true)) {
+        GTEST_SKIP() << "HostRegister unavailable in this build";
+    }
+    if (aclInit(nullptr) != ACL_ERROR_NONE ||
+        aclrtSetDevice(0) != ACL_ERROR_NONE) {
+        GTEST_SKIP() << "aclrtSetDevice(0) unavailable";
+    }
+    SharedSegmentOptions owner_opts = KvOptions(0, 2);
+    owner_opts.mmap = true;
+    owner_opts.host_register = true;
+    owner_opts.device_id = 0;
+    SharedSegmentOptions peer_opts = owner_opts;
+    peer_opts.rank_id = 1;
+
+    std::string owner_blob;
+    std::string peer_blob;
+    std::shared_ptr<SharedSegment> owner;
+    std::shared_ptr<SharedSegment> peer;
+    auto status = SharedSegment::Create("mmap-hr-tp", kSegmentSize, owner_opts,
+                                        owner, owner_blob);
+    if (!status.ok()) {
+        GTEST_SKIP() << "HostRegister create failed: " << status.ToString();
+    }
+    status = SharedSegment::Create("mmap-hr-tp", kSegmentSize, peer_opts, peer,
+                                   peer_blob);
+    if (!status.ok()) {
+        GTEST_SKIP() << "peer HostRegister failed: " << status.ToString();
+    }
+    const std::vector<std::string> blobs = {owner_blob, peer_blob};
+    ASSERT_TRUE(owner->Complete(blobs).ok()) << "owner complete";
+    ASSERT_TRUE(peer->Complete(blobs).ok()) << "peer complete";
+    ASSERT_NE(owner->device_addr(), 0u);
+    ASSERT_NE(peer->device_addr(), 0u);
+
+    auto* owner_bytes = reinterpret_cast<uint8_t*>(owner->base_addr());
+    auto* peer_bytes = reinterpret_cast<uint8_t*>(peer->base_addr());
+    owner_bytes[0] = 0x11;
+    owner_bytes[4095] = 0x22;
+    EXPECT_EQ(peer_bytes[0], 0x11);
+    EXPECT_EQ(peer_bytes[4095], 0x22);
+}
+#endif
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description

`create_shared_segment(mmap=True)` previously used POSIX shm (`shm_open` + a name in `/dev/shm`) and only applied `MADV_HUGEPAGE` after the mapping existed. That left large HostRegister MRs on 4KiB pages unless the kernel happened to collapse them.

This switches the mmap backend to an unnamed `memfd` (no `MFD_HUGETLB`, no `vm.nr_hugepages`) and asks for THP **before** the first fault:

1. Reserve a 2MiB-aligned `PROT_NONE` window
2. `mmap` the memfd there with `MAP_SHARED|MAP_FIXED`
3. `madvise(MADV_HUGEPAGE)` then prefault one byte per PMD
4. `madvise(MADV_DONTFORK)`

If THP cannot allocate, the kernel keeps 4KiB pages. TP ranks still share the same physical pages through `/proc/<pid>/fd/<n>`.

Relates to the original shared-segment work in #3285. No overlapping open PR for this mmap path.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Performance improvement
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# gtest (CI)
# mooncake-transfer-engine/tests/shared_segment_test.cpp
#   OwnerHandleIsProcFd, TwoProcessesSharePages, HostRegisterTwoRanksSharePages

# local Ascend HixlCS check (not in this PR): 32GiB slices, nr_hugepages=0
# register+transfer through 256GiB; two-rank share + transfer
```

**Test results:**
- [x] Unit tests added (proc-fd handle, fork share, HostRegister two ranks)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

On an Ascend host with THP `always` / shmem `advise` and `HugePages_Total=0`:

- smaps `ShmemPmdMapped` equaled the full mapping size (2MiB through 256GiB)
- HixlCS `RegisterMem(MEM_DEVICE)` + `TransferSync` succeeded for 1×–8×32GiB
- Two ranks shared one 32GiB segment and transferred correctly

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (`clang-format-20` on the rewritten mmap backend; `git-clang-format` was not available on the build host)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass (`mooncake-code-format` skipped: no `git-clang-format`)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (N/A; under 500 LOC excluding tests)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok 4.6 drafted the mmap rewrite and tests. The submitter reviewed the memfd/THP/madvise sequence and the sharing handle.


Made with [Cursor](https://cursor.com)