### PR TITLE
[TransferEngine] Add structured sparse object transfer facade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
     hooks:
       - id: codespell
         exclude: '^(extern/|FAST25-release/)'
-        args: ['--ignore-words-list=te,mooncake,KVCache,cann,hsa,crate']
+        args: ['--ignore-words-list=te,mooncake,KVCache,cann,hsa,crate,coo']
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/mooncake-reshard/python/mooncake/reshard/geometry.py
+++ b/mooncake-reshard/python/mooncake/reshard/geometry.py
@@ -11,6 +11,7 @@ from ._compat import _strict_zip
 
 
 _MAX_HIGH_DIMENSIONAL_PAIRWISE_COMPARISONS = 1_000_000
+Box = tuple[tuple[int, ...], tuple[int, ...]]
 
 
 class LogicalBox(Protocol):
@@ -31,6 +32,42 @@ class OverlapRegion(Protocol):
 
     @property
     def overlap_shape(self) -> tuple[int, ...]: ...
+
+
+def box_intersection(
+    left_offset: tuple[int, ...],
+    left_shape: tuple[int, ...],
+    right_offset: tuple[int, ...],
+    right_shape: tuple[int, ...],
+) -> Box | None:
+    """Return the half-open intersection of two logical boxes.
+
+    This is shared by dense and sparse planners.  The helper deliberately
+    operates on the resource-neutral ``LogicalBox`` representation instead of
+    importing a weight-specific fragment type.
+    """
+
+    if not (
+        left_offset
+        and len(left_offset) == len(left_shape) == len(right_offset) == len(right_shape)
+    ):
+        raise ValueError("logical boxes must have the same non-zero rank")
+    if any(item < 0 for item in left_offset + right_offset):
+        raise ValueError("logical box offsets must be non-negative")
+    if any(item <= 0 for item in left_shape + right_shape):
+        raise ValueError("logical box shapes must be positive")
+    begin = tuple(
+        max(left, right) for left, right in _strict_zip(left_offset, right_offset)
+    )
+    end = tuple(
+        min(left_begin + left_extent, right_begin + right_extent)
+        for left_begin, left_extent, right_begin, right_extent in _strict_zip(
+            left_offset, left_shape, right_offset, right_shape
+        )
+    )
+    if any(begin_dim >= end_dim for begin_dim, end_dim in _strict_zip(begin, end)):
+        return None
+    return begin, end
 
 
 def box_contains(
@@ -256,8 +293,10 @@ def regions_exactly_cover(
 
 
 __all__ = [
+    "Box",
     "LogicalBox",
     "OverlapRegion",
+    "box_intersection",
     "box_contains",
     "boxes_exactly_cover",
     "boxes_overlap",

--- a/mooncake-reshard/python/mooncake/reshard/sparse/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/sparse/__init__.py
@@ -1,0 +1,39 @@
+"""Address-free planning for COO sparse structured objects.
+
+The sparse planner operates on logical tensor boxes and compact COO tile
+indexes.  It deliberately has no dependency on Mooncake Store, transports,
+RPC clients, or framework objects.  Store integrations can consume the
+returned plans and decide how to execute the requested member ranges.
+"""
+
+from .planner import (
+    Box,
+    Placement,
+    placement_matches,
+    SparseObjectIndex,
+    SparseObjectPlan,
+    SparseObjectRegion,
+    SparseObjectStorePlanner,
+    canonical_source_placement,
+    is_canonical_source,
+    normalize_placement,
+    normalize_shape,
+    object_ref_key,
+    plan_sparse_object_target,
+)
+
+__all__ = [
+    "Box",
+    "Placement",
+    "placement_matches",
+    "SparseObjectIndex",
+    "SparseObjectPlan",
+    "SparseObjectRegion",
+    "SparseObjectStorePlanner",
+    "canonical_source_placement",
+    "is_canonical_source",
+    "normalize_placement",
+    "normalize_shape",
+    "object_ref_key",
+    "plan_sparse_object_target",
+]

--- a/mooncake-reshard/python/mooncake/reshard/sparse/planner.py
+++ b/mooncake-reshard/python/mooncake/reshard/sparse/planner.py
@@ -1,0 +1,963 @@
+"""Address-free planner for COO sparse structured objects.
+
+The contract is intentionally generic rather than tied to a framework or a
+specific model family.  It supports arbitrary-rank COO coordinates and named
+placement axes, and is independent from the dense ``TransferRegion`` planner:
+regions here are ranges in the ``indices``/``values`` members of a structured
+object and carry additive (``scatter_add``) semantics.
+
+The planner has no transport dependency.  Callers provide compact source tile
+indexes and logical source/target descriptors; the planner returns aligned
+member ranges plus boundary-filter metadata.  Store integrations own RPCs,
+buffer allocation, caching, and target-object materialization.
+
+For replicated source participants, ``canonical_source_placement`` provides a
+deterministic admission gate before the caller computes and publishes COO.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_left, bisect_right
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ..geometry import Box, box_intersection, boxes_exactly_cover
+from ..weight import RuntimeTensorOwner
+from ..weight._planner.geometry import _CandidateBoxIndex
+from ..weight.types import OwnershipAxis, TensorDescriptor
+
+
+# Reuse the canonical reshard owner-coordinate representation.  Sparse
+# placement rules remain sparse-specific, but the wire shape is shared with
+# dense weight manifests.
+Placement = RuntimeTensorOwner
+
+
+def _placement_map(placement: Placement) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for axis, ordinal in placement:
+        if not isinstance(axis, str) or not axis or axis in result:
+            raise ValueError(f"invalid placement axis: {placement!r}")
+        if type(ordinal) is not int or ordinal < 0:
+            raise ValueError(f"invalid placement ordinal: {placement!r}")
+        result[axis] = ordinal
+    return result
+
+
+def normalize_placement(placement: Placement) -> Placement:
+    """Return the canonical ordering for a named placement."""
+
+    return tuple(sorted(_placement_map(tuple(placement)).items()))
+
+
+def canonical_source_placement(source_placements: Iterable[Placement]) -> Placement:
+    """Choose a deterministic source owner for one logical object.
+
+    Replicated source participants (for example, non-EP weights visible on
+    every training EP rank) can call this before computing COO.  The owner is
+    selected from the advertised placements, so the rule is independent of
+    EP/TP names and remains deterministic across processes.  An empty
+    placement is a valid canonical owner when all participants are otherwise
+    indistinguishable.
+    """
+
+    normalized = {
+        normalize_placement(tuple(placement)) for placement in source_placements
+    }
+    if not normalized:
+        raise ValueError("at least one source placement is required")
+    return min(normalized)
+
+
+def is_canonical_source(
+    source_placement: Placement, source_placements: Iterable[Placement]
+) -> bool:
+    """Return whether ``source_placement`` should publish the object."""
+
+    canonical = canonical_source_placement(source_placements)
+    normalized = normalize_placement(tuple(source_placement))
+    return normalized == canonical
+
+
+def placement_matches(
+    tensor: TensorDescriptor, source: Placement, target: Placement
+) -> bool:
+    """Match source/target owners using the canonical weight descriptor.
+
+    Ownership is already part of Mooncake's weight reshard manifest.  Sparse
+    planning only adds COO range selection; it must not create a second EP/TP
+    placement language.  Split and replicated axes are handled by the logical
+    boxes, while an ``OwnershipAxis`` requires the same ordinal on both sides.
+    """
+
+    source_map = _placement_map(source)
+    target_map = _placement_map(target)
+    for axis in tensor.parallel_axes:
+        if not isinstance(axis, OwnershipAxis):
+            continue
+        if (
+            axis.kind not in source_map
+            or axis.kind not in target_map
+            or source_map[axis.kind] != target_map[axis.kind]
+        ):
+            return False
+    return True
+
+
+def object_ref_key(ref: object) -> str:
+    """Normalize a structured-object reference for range-cache keys."""
+
+    if isinstance(ref, Mapping):
+        key = ref.get("key")
+        if key is None:
+            key = ref.get("manifest_key")
+    else:
+        key = getattr(ref, "key", None)
+        if key is None:
+            # Mooncake's production RemoteBundleRef calls this field
+            # ``manifest_key``; the tiny demo double uses ``key``.
+            key = getattr(ref, "manifest_key", ref)
+    if not isinstance(key, str) or not key:
+        raise ValueError("sparse object reference must expose a non-empty string key")
+    return key
+
+
+def normalize_shape(
+    value: Sequence[int], name: str, *, positive: bool
+) -> tuple[int, ...]:
+    if isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must be a sequence of integers")
+    try:
+        result = tuple(value)
+    except TypeError as error:
+        raise ValueError(f"{name} must be a sequence of integers") from error
+    if not result or any(type(item) is not int for item in result):
+        raise ValueError(f"{name} must be a non-empty integer sequence")
+    if positive and any(item <= 0 for item in result):
+        raise ValueError(f"{name} must contain positive integers")
+    if not positive and any(item < 0 for item in result):
+        raise ValueError(f"{name} must contain non-negative integers")
+    return result
+
+
+def _normalize_box(value: Box, name: str) -> Box:
+    if isinstance(value, (str, bytes, bytearray)) or len(value) != 2:
+        raise ValueError(f"{name} must be (begin, end)")
+    begin = normalize_shape(value[0], f"{name}.begin", positive=False)
+    end = normalize_shape(value[1], f"{name}.end", positive=False)
+    if len(begin) != len(end) or any(a >= b for a, b in zip(begin, end)):
+        raise ValueError(f"{name} must be a non-empty box")
+    return begin, end
+
+
+def _member_dtype(member: Mapping[str, Any], name: str) -> str:
+    """Return a declared dtype without reimplementing store-integration types.
+
+    The integration layer is the authority for mapping framework dtypes to
+    transport/storage types.  The planner only checks that the structured
+    object carries a declaration and that duplicated declarations agree.
+    """
+
+    dtype = member.get("dtype")
+    if not isinstance(dtype, str) or not dtype:
+        raise ValueError(f"{name} member must declare a non-empty dtype")
+    return dtype
+
+
+def _merge_sorted_ranges(
+    ranges: Iterable[tuple[int, int]],
+) -> tuple[tuple[int, int], ...]:
+    """Coalesce ranges already ordered by their source COO entry offsets."""
+
+    merged: list[tuple[int, int]] = []
+    for start, end in ranges:
+        if type(start) is not int or type(end) is not int:
+            raise ValueError("COO ranges must contain integers")
+        if start < 0 or end < start:
+            raise ValueError(f"invalid COO range: {(start, end)}")
+        if start == end:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return tuple(merged)
+
+
+@dataclass(frozen=True)
+class SparseObjectIndex:
+    """Tile index for an object whose COO members are sorted by tile.
+
+    ``tile_coords[i]`` owns entries in ``tile_ptr[i]:tile_ptr[i + 1]``.  The
+    same entry range applies to both ``indices`` (``[nnz, ndim]``) and
+    ``values`` (``[nnz]``), making structured-object axis-0 slices safe.
+    """
+
+    object_ref: str
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    tile_shape: tuple[int, ...]
+    tile_coords: tuple[tuple[int, ...], ...]
+    tile_ptr: tuple[int, ...]
+    nnz: int
+    base_generation: int
+    delta_generation: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.object_ref, str) or not self.object_ref:
+            raise ValueError("object_ref must be a non-empty string")
+        if not isinstance(self.tensor_id, str) or not self.tensor_id:
+            raise ValueError("tensor_id must be a non-empty string")
+        shape = normalize_shape(self.global_shape, "global_shape", positive=True)
+        tile_shape = normalize_shape(self.tile_shape, "tile_shape", positive=True)
+        if len(shape) != len(tile_shape):
+            raise ValueError("global_shape and tile_shape rank differ")
+        coords = tuple(
+            normalize_shape(coord, "tile_coords", positive=False)
+            for coord in self.tile_coords
+        )
+        if any(len(coord) != len(shape) for coord in coords):
+            raise ValueError("tile_coords rank differs from global_shape")
+        if any(
+            coords[position] >= coords[position + 1]
+            for position in range(len(coords) - 1)
+        ):
+            raise ValueError("tile_coords must be strictly sorted by tile coordinate")
+        if any(
+            coord[dimension] * tile_shape[dimension] >= shape[dimension]
+            for coord in coords
+            for dimension in range(len(shape))
+        ):
+            raise ValueError("tile_coords contains a tile outside global_shape")
+        ptr = tuple(self.tile_ptr)
+        if (
+            not ptr
+            or len(ptr) != len(coords) + 1
+            or ptr[0] != 0
+            or any(type(item) is not int or item < 0 for item in ptr)
+            or any(ptr[i] > ptr[i + 1] for i in range(len(ptr) - 1))
+        ):
+            raise ValueError(
+                "tile_ptr must be monotonic and have num_tiles + 1 entries"
+            )
+        if type(self.nnz) is not int or self.nnz < 0 or ptr[-1] != self.nnz:
+            raise ValueError("tile_ptr does not cover nnz")
+        for name in ("base_generation", "delta_generation"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if self.delta_generation <= self.base_generation:
+            raise ValueError("delta_generation must be newer than base_generation")
+        object.__setattr__(self, "global_shape", shape)
+        object.__setattr__(self, "tile_shape", tile_shape)
+        object.__setattr__(self, "tile_coords", coords)
+        object.__setattr__(self, "tile_ptr", ptr)
+
+    @classmethod
+    def from_metadata(
+        cls,
+        *,
+        object_ref: object,
+        metadata: Mapping[str, Any],
+        tile_coords: Sequence[Sequence[int]],
+        tile_ptr: Sequence[int],
+    ) -> "SparseObjectIndex":
+        """Decode metadata after reading only the compact index members."""
+
+        if metadata.get("schema") != "mooncake.sparse_object":
+            raise ValueError("unsupported sparse structured-object schema")
+        if metadata.get("version") != 1:
+            raise ValueError("unsupported sparse structured-object version")
+        if metadata.get("coordinate_space") != "global":
+            raise ValueError("source sparse object must use global coordinates")
+        members = metadata.get("members")
+        if not isinstance(members, Mapping):
+            raise ValueError("sparse object metadata is missing members")
+        for member_name in ("indices", "values", "tile_coords", "tile_ptr"):
+            if not isinstance(members.get(member_name), Mapping):
+                raise ValueError(f"sparse object metadata is missing {member_name}")
+        indices_dtype = _member_dtype(members["indices"], "indices")
+        values_dtype = _member_dtype(members["values"], "values")
+        tile_coords_dtype = _member_dtype(members["tile_coords"], "tile_coords")
+        _member_dtype(members["tile_ptr"], "tile_ptr")
+        if tile_coords_dtype != indices_dtype:
+            raise ValueError("tile_coords member dtype must match indices member dtype")
+        for metadata_name, member_dtype in (
+            ("index_dtype", indices_dtype),
+            ("value_dtype", values_dtype),
+        ):
+            declared_dtype = metadata.get(metadata_name)
+            if declared_dtype != member_dtype:
+                raise ValueError(
+                    f"{metadata_name} does not match the corresponding member dtype"
+                )
+        shape = members["indices"].get("shape")
+        if (
+            not isinstance(shape, Sequence)
+            or len(shape) != 2
+            or type(shape[0]) is not int
+            or type(shape[1]) is not int
+            or shape[0] < 0
+            or shape[1] <= 0
+        ):
+            raise ValueError("indices member must have shape [nnz, ndim]")
+        values_shape = members["values"].get("shape")
+        if (
+            not isinstance(values_shape, Sequence)
+            or len(values_shape) != 1
+            or type(values_shape[0]) is not int
+            or values_shape[0] != shape[0]
+        ):
+            raise ValueError("values member must have shape [nnz]")
+        tile_coords_shape = members["tile_coords"].get("shape")
+        tile_ptr_shape = members["tile_ptr"].get("shape")
+        if (
+            not isinstance(tile_coords_shape, Sequence)
+            or len(tile_coords_shape) != 2
+            or type(tile_coords_shape[0]) is not int
+            or type(tile_coords_shape[1]) is not int
+            or tile_coords_shape[0] < 0
+            or tile_coords_shape[1] != shape[1]
+            or not isinstance(tile_ptr_shape, Sequence)
+            or len(tile_ptr_shape) != 1
+            or type(tile_ptr_shape[0]) is not int
+            or tile_ptr_shape[0] != tile_coords_shape[0] + 1
+        ):
+            raise ValueError("sparse tile index member shapes are inconsistent")
+        coordinate_rank = metadata.get("coordinate_rank", shape[1])
+        if type(coordinate_rank) is not int or coordinate_rank != shape[1]:
+            raise ValueError("coordinate_rank does not match indices member")
+        if "nnz" in metadata and (
+            type(metadata["nnz"]) is not int or metadata["nnz"] != shape[0]
+        ):
+            raise ValueError("nnz does not match indices member")
+        global_shape = normalize_shape(
+            metadata.get("global_shape", ()), "global_shape", positive=True
+        )
+        if len(global_shape) != shape[1]:
+            raise ValueError("indices rank does not match global_shape")
+        global_offset = normalize_shape(
+            metadata.get("global_offset", ()), "global_offset", positive=False
+        )
+        local_shape = normalize_shape(
+            metadata.get("local_shape", ()), "local_shape", positive=True
+        )
+        if len(global_offset) != len(global_shape) or len(local_shape) != len(
+            global_shape
+        ):
+            raise ValueError("source geometry rank differs from global_shape")
+        if any(
+            global_offset[dimension] + local_shape[dimension] > global_shape[dimension]
+            for dimension in range(len(global_shape))
+        ):
+            raise ValueError("source sparse object geometry exceeds global_shape")
+        tile_shape = normalize_shape(
+            metadata.get("tile_shape", ()), "tile_shape", positive=True
+        )
+        if len(tile_shape) != len(global_shape):
+            raise ValueError("tile_shape rank differs from global_shape")
+        for name in ("base_generation", "delta_generation"):
+            if type(metadata.get(name)) is not int or metadata[name] < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if metadata["delta_generation"] <= metadata["base_generation"]:
+            raise ValueError("delta_generation must be newer than base_generation")
+        tensor_id = metadata.get("tensor_id")
+        if not isinstance(tensor_id, str) or not tensor_id:
+            raise ValueError("sparse object metadata is missing tensor_id")
+        normalized_tile_coords = tuple(tuple(coord) for coord in tile_coords)
+        normalized_tile_ptr = tuple(tile_ptr)
+        if len(normalized_tile_coords) != tile_coords_shape[0]:
+            raise ValueError("tile_coords payload shape differs from metadata")
+        if len(normalized_tile_ptr) != tile_ptr_shape[0]:
+            raise ValueError("tile_ptr payload shape differs from metadata")
+        return cls(
+            object_ref=object_ref_key(object_ref),
+            tensor_id=tensor_id,
+            global_shape=global_shape,
+            tile_shape=tile_shape,
+            tile_coords=normalized_tile_coords,
+            tile_ptr=normalized_tile_ptr,
+            nnz=int(shape[0]),
+            base_generation=int(metadata.get("base_generation", -1)),
+            delta_generation=int(metadata.get("delta_generation", -1)),
+        )
+
+
+@dataclass(frozen=True)
+class SparseObjectRegion:
+    """One aligned range read and its target logical box."""
+
+    tensor_id: str
+    source_object_ref: str
+    source_global_box: Box
+    target_global_offset: tuple[int, ...]
+    target_local_shape: tuple[int, ...]
+    target_placement: Placement
+    indices_range: tuple[int, int]
+    values_range: tuple[int, int]
+    exact_coordinate_filter: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tensor_id, str) or not self.tensor_id:
+            raise ValueError("tensor_id must be a non-empty string")
+        if not isinstance(self.source_object_ref, str) or not self.source_object_ref:
+            raise ValueError("source_object_ref must be a non-empty string")
+        box = _normalize_box(self.source_global_box, "source_global_box")
+        offset = normalize_shape(
+            self.target_global_offset, "target_global_offset", positive=False
+        )
+        shape = normalize_shape(
+            self.target_local_shape, "target_local_shape", positive=True
+        )
+        if len(offset) != len(shape) or len(offset) != len(box[0]):
+            raise ValueError("target geometry rank differs from source box")
+        if self.indices_range != self.values_range:
+            raise ValueError("indices and values ranges must be identical")
+        start, end = self.indices_range
+        if type(start) is not int or type(end) is not int or start < 0 or end <= start:
+            raise ValueError("COO ranges must be non-empty")
+        object.__setattr__(self, "source_global_box", box)
+        object.__setattr__(self, "target_global_offset", offset)
+        object.__setattr__(self, "target_local_shape", shape)
+
+    @property
+    def target_global_box(self) -> Box:
+        end = tuple(
+            self.target_global_offset[d] + self.target_local_shape[d]
+            for d in range(len(self.target_global_offset))
+        )
+        return self.target_global_offset, end
+
+    @property
+    def source_member_ranges(self) -> dict[str, tuple[int, int]]:
+        return {"indices": self.indices_range, "values": self.values_range}
+
+    @property
+    def apply(self) -> str:
+        """The only valid consumer operation for a sparse delta."""
+
+        return "scatter_add"
+
+
+@dataclass(frozen=True)
+class SparseObjectPlan:
+    """All source ranges required to materialize one target object."""
+
+    tensor_id: str
+    target_placement: Placement
+    target_global_offset: tuple[int, ...]
+    target_local_shape: tuple[int, ...]
+    base_generation: int
+    delta_generation: int
+    regions: tuple[SparseObjectRegion, ...]
+
+    @property
+    def source_ranges(self) -> tuple[tuple[str, tuple[int, int]], ...]:
+        return tuple(
+            (region.source_object_ref, region.indices_range) for region in self.regions
+        )
+
+    @property
+    def range_request_count(self) -> int:
+        return len(self.regions)
+
+    @property
+    def apply(self) -> str:
+        return "scatter_add"
+
+
+class SparseObjectStorePlanner:
+    """Plan sparse COO range reads for arbitrary named-axis placement."""
+
+    def __init__(self) -> None:
+        # ``tile_coords`` is sorted by tile row/column when the structured
+        # object is committed.  Cache only tiny row/column-group indexes
+        # derived from that member; never cache the source COO payload here.
+        self._tile_row_cache: dict[
+            str, tuple[tuple[int, ...], tuple[tuple[int, int, tuple[int, ...]], ...]]
+        ] = {}
+        self._tile_col_cache: dict[
+            str,
+            tuple[tuple[int, ...], tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]],
+        ] = {}
+
+    @staticmethod
+    def _intersection(source: Any, target: Any) -> Box | None:
+        return box_intersection(
+            tuple(source.global_offset),
+            tuple(source.local_shape),
+            tuple(target.global_offset),
+            tuple(target.local_shape),
+        )
+
+    def select_source_fragments(
+        self,
+        *,
+        tensor_id: str,
+        target: Any,
+        source_fragments: Iterable[Any],
+        tensor: TensorDescriptor,
+    ) -> tuple[Any, ...]:
+        """Filter source inventory before any source-object index is read.
+
+        The source manifest can contain all tensors and all placements.  This
+        method is intentionally part of the address-free planner so Store
+        adapters do not duplicate placement and box-intersection rules.
+        """
+
+        if tensor.tensor_id != tensor_id:
+            raise ValueError("tensor descriptor does not match tensor_id")
+        self._validate_target_fragment(target, tensor=tensor)
+        target_placement = normalize_placement(tuple(target.target_placement))
+        groups: dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]] = {}
+        for source in source_fragments:
+            if source.tensor_id != tensor_id:
+                continue
+            self._validate_source_fragment(source, tensor=tensor)
+            geometry_key = (
+                tuple(source.global_offset),
+                tuple(source.local_shape),
+            )
+            groups.setdefault(geometry_key, []).append(source)
+        return self._select_from_groups(
+            target=target,
+            tensor=tensor,
+            target_placement=target_placement,
+            groups=groups,
+        )
+
+    def _select_from_groups(
+        self,
+        *,
+        target: Any,
+        tensor: TensorDescriptor,
+        target_placement: Placement,
+        groups: Mapping[tuple[tuple[int, ...], tuple[int, ...]], list[Any]],
+        candidate_index: _CandidateBoxIndex | None = None,
+    ) -> tuple[Any, ...]:
+        """Select one replica per intersecting source geometry."""
+
+        if not groups:
+            return ()
+        candidate_index = candidate_index or _CandidateBoxIndex.build(
+            tuple(tuple(group) for group in groups.values())
+        )
+        selected: list[Any] = []
+        for group in candidate_index.query(target):
+            eligible = [
+                source
+                for source in group
+                if placement_matches(
+                    tensor,
+                    normalize_placement(tuple(source.source_placement)),
+                    target_placement,
+                )
+                and self._intersection(source, target) is not None
+            ]
+            if eligible:
+                selected.append(min(eligible, key=self._source_sort_key))
+        return tuple(selected)
+
+    @staticmethod
+    def _source_sort_key(source: Any) -> tuple[Any, ...]:
+        """Stable representative order matching dense source selection."""
+
+        return (
+            normalize_placement(tuple(source.source_placement)),
+            object_ref_key(source.object_ref),
+        )
+
+    @staticmethod
+    def _validate_source_fragment(source: Any, *, tensor: TensorDescriptor) -> None:
+        """Validate source geometry without imposing a single-source layout."""
+
+        if not hasattr(source, "global_shape"):
+            raise ValueError("sparse source fragment is missing geometry")
+        SparseObjectStorePlanner._fragment_geometry(
+            source, tensor=tensor, label="source"
+        )
+        if not isinstance(source.source_placement, Sequence):
+            raise ValueError("sparse source fragment placement is invalid")
+        normalize_placement(tuple(source.source_placement))
+        object_ref_key(source.object_ref)
+
+    @staticmethod
+    def _validate_target_fragment(target: Any, *, tensor: TensorDescriptor) -> None:
+        SparseObjectStorePlanner._fragment_geometry(
+            target, tensor=tensor, label="target"
+        )
+
+    @staticmethod
+    def _fragment_geometry(
+        fragment: Any, *, tensor: TensorDescriptor, label: str
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        """Normalize and validate one source/target logical fragment."""
+
+        try:
+            declared_shape = getattr(fragment, "global_shape", tensor.global_shape)
+            shape = normalize_shape(
+                declared_shape, f"{label}.global_shape", positive=True
+            )
+            offset = normalize_shape(
+                fragment.global_offset, f"{label}.global_offset", positive=False
+            )
+            local = normalize_shape(
+                fragment.local_shape, f"{label}.local_shape", positive=True
+            )
+        except AttributeError as error:
+            raise ValueError(f"sparse {label} fragment is missing geometry") from error
+        if len(offset) != len(local) or len(offset) != len(shape):
+            raise ValueError(f"sparse {label} fragment geometry rank differs")
+        if shape != tuple(tensor.global_shape):
+            raise ValueError(
+                f"sparse {label} fragment for {tensor.tensor_id!r} has a different global shape"
+            )
+        if any(offset[d] + local[d] > shape[d] for d in range(len(shape))):
+            raise ValueError(f"sparse {label} fragment exceeds global tensor geometry")
+        return shape, offset, local
+
+    def _row_groups(
+        self, index: SparseObjectIndex
+    ) -> tuple[tuple[int, ...], tuple[tuple[int, int, tuple[int, ...]], ...]]:
+        """Return a cached 2-D tile-row index derived from ``tile_coords``.
+
+        Each group is ``(start, end, columns)`` in the sorted tile table.  The
+        auxiliary index is metadata-only and is built once per source object;
+        it lets a row-oriented target locate tiles with two binary searches
+        instead of scanning every tile in the object.
+        """
+
+        key = index.object_ref
+        cached = self._tile_row_cache.get(key)
+        if cached is not None:
+            return cached
+        rows: list[int] = []
+        groups: list[tuple[int, int, tuple[int, ...]]] = []
+        coords = index.tile_coords
+        position = 0
+        while position < len(coords):
+            row = coords[position][0]
+            end = position + 1
+            while end < len(coords) and coords[end][0] == row:
+                end += 1
+            rows.append(row)
+            groups.append(
+                (position, end, tuple(coords[item][1] for item in range(position, end)))
+            )
+            position = end
+        result = (tuple(rows), tuple(groups))
+        self._tile_row_cache[key] = result
+        return result
+
+    def _column_groups(
+        self, index: SparseObjectIndex
+    ) -> tuple[tuple[int, ...], tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]]:
+        """Return a cached column-group index for a 2-D COO tile table.
+
+        The committed tile table is row-major, so tiles belonging to one
+        column are not contiguous.  The compact secondary index stores the
+        sorted row coordinates and the corresponding tile-table positions for
+        each column.  A column-oriented target can therefore binary-search
+        rows without scanning unrelated columns or COO entries.
+        """
+
+        key = index.object_ref
+        cached = self._tile_col_cache.get(key)
+        if cached is not None:
+            return cached
+        by_column: dict[int, list[tuple[int, int]]] = {}
+        for position, (row, column) in enumerate(index.tile_coords):
+            by_column.setdefault(column, []).append((row, position))
+        columns: list[int] = []
+        groups: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+        for column in sorted(by_column):
+            rows_and_positions = by_column[column]
+            columns.append(column)
+            groups.append(
+                (
+                    tuple(row for row, _position in rows_and_positions),
+                    tuple(position for _row, position in rows_and_positions),
+                )
+            )
+        result = (tuple(columns), tuple(groups))
+        self._tile_col_cache[key] = result
+        return result
+
+    def _tile_ranges(
+        self, index: SparseObjectIndex, overlap: Box
+    ) -> tuple[tuple[int, int], ...]:
+        begin, end = overlap
+        if len(begin) != len(index.tile_shape):
+            raise ValueError("overlap rank differs from tile index")
+
+        # Two-dimensional tensor parallel boxes can be row slices or column
+        # slices. Keep both secondary indexes and use the cheaper candidate
+        # direction. This avoids an O(num_tiles) scan for every target while
+        # preserving the compact COO contract.
+        if len(begin) == 2:
+            row_begin = begin[0] // index.tile_shape[0]
+            row_end = (end[0] - 1) // index.tile_shape[0]
+            col_begin = begin[1] // index.tile_shape[1]
+            col_end = (end[1] - 1) // index.tile_shape[1]
+            rows, row_groups = self._row_groups(index)
+            row_group_begin = bisect_left(rows, row_begin)
+            row_group_end = bisect_right(rows, row_end)
+            columns, column_groups = self._column_groups(index)
+            column_group_begin = bisect_left(columns, col_begin)
+            column_group_end = bisect_right(columns, col_end)
+            # A row slice usually touches fewer row groups; a column slice
+            # usually touches fewer column groups.  Select the smaller outer
+            # loop in O(1), then use binary search for the other coordinate.
+            # The tile table is never walked twice just to choose a direction.
+            if (row_group_end - row_group_begin) <= (
+                column_group_end - column_group_begin
+            ):
+                positions: list[int] = []
+                for start, _stop, row_columns in row_groups[
+                    row_group_begin:row_group_end
+                ]:
+                    col_start = bisect_left(row_columns, col_begin)
+                    col_stop = bisect_right(row_columns, col_end)
+                    positions.extend(range(start + col_start, start + col_stop))
+            else:
+                positions = []
+                for rows_for_column, column_positions in column_groups[
+                    column_group_begin:column_group_end
+                ]:
+                    row_start = bisect_left(rows_for_column, row_begin)
+                    row_stop = bisect_right(rows_for_column, row_end)
+                    positions.extend(column_positions[row_start:row_stop])
+
+            # Column groups are not contiguous in the row-major tile table;
+            # sort before turning entry offsets into coalesced ranges.
+            ranges = [
+                (index.tile_ptr[position], index.tile_ptr[position + 1])
+                for position in sorted(set(positions))
+            ]
+            return _merge_sorted_ranges(ranges)
+
+        # Generic N-D fallback.  The object contract remains N-D, while the
+        # 2-D path above is the performance path used by sparse weights.
+        ranges: list[tuple[int, int]] = []
+        for tile, start, stop in zip(
+            index.tile_coords, index.tile_ptr[:-1], index.tile_ptr[1:]
+        ):
+            tile_begin = tuple(tile[d] * index.tile_shape[d] for d in range(len(tile)))
+            tile_end = tuple(
+                tile_begin[d] + index.tile_shape[d] for d in range(len(tile))
+            )
+            if all(
+                tile_begin[d] < end[d] and begin[d] < tile_end[d]
+                for d in range(len(tile))
+            ):
+                ranges.append((start, stop))
+        return _merge_sorted_ranges(ranges)
+
+    @staticmethod
+    def _needs_exact_filter(index: SparseObjectIndex, overlap: Box) -> bool:
+        begin, end = overlap
+        return any(
+            value % tile != 0
+            for coordinate in (begin, end)
+            for value, tile in zip(coordinate, index.tile_shape)
+        )
+
+    def plan_target(
+        self,
+        *,
+        tensor_id: str,
+        tensor: TensorDescriptor,
+        target: Any,
+        source_fragments: Iterable[Any],
+        source_indexes: Mapping[str, SparseObjectIndex],
+        base_generation: int,
+        delta_generation: int,
+    ) -> SparseObjectPlan:
+        """Plan one target without materializing ``indices`` or ``values``."""
+
+        self._validate_target_fragment(target, tensor=tensor)
+        candidates = self.select_source_fragments(
+            tensor_id=tensor_id,
+            target=target,
+            source_fragments=source_fragments,
+            tensor=tensor,
+        )
+        return self._plan_target_candidates(
+            tensor_id=tensor_id,
+            target=target,
+            candidates=candidates,
+            source_indexes=source_indexes,
+            base_generation=base_generation,
+            delta_generation=delta_generation,
+        )
+
+    def _plan_target_candidates(
+        self,
+        *,
+        tensor_id: str,
+        target: Any,
+        candidates: Iterable[Any],
+        source_indexes: Mapping[str, SparseObjectIndex],
+        base_generation: int,
+        delta_generation: int,
+    ) -> SparseObjectPlan:
+        regions: list[SparseObjectRegion] = []
+        target_offset = normalize_shape(
+            target.global_offset, "target.global_offset", positive=False
+        )
+        target_shape = normalize_shape(
+            target.local_shape, "target.local_shape", positive=True
+        )
+        target_placement = normalize_placement(tuple(target.target_placement))
+        overlap_boxes: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+        for source in candidates:
+            overlap = self._intersection(source, target)
+            if overlap is None:
+                continue
+            overlap_boxes.append(
+                (
+                    overlap[0],
+                    tuple(
+                        overlap[1][dimension] - overlap[0][dimension]
+                        for dimension in range(len(overlap[0]))
+                    ),
+                )
+            )
+            key = object_ref_key(source.object_ref)
+            try:
+                index = source_indexes[key]
+            except KeyError as error:
+                raise ValueError(
+                    f"missing sparse tile index for source object {key!r}"
+                ) from error
+            if index.tensor_id != tensor_id:
+                raise ValueError("tile index tensor_id does not match source fragment")
+            if (index.base_generation, index.delta_generation) != (
+                base_generation,
+                delta_generation,
+            ):
+                raise ValueError("tile index generation does not match manifest")
+            if tuple(index.global_shape) != tuple(source.global_shape):
+                raise ValueError(
+                    "tile index global_shape does not match source fragment"
+                )
+            for start, stop in self._tile_ranges(index, overlap):
+                regions.append(
+                    SparseObjectRegion(
+                        tensor_id=tensor_id,
+                        source_object_ref=key,
+                        source_global_box=overlap,
+                        target_global_offset=target_offset,
+                        target_local_shape=target_shape,
+                        target_placement=target_placement,
+                        indices_range=(start, stop),
+                        values_range=(start, stop),
+                        exact_coordinate_filter=self._needs_exact_filter(
+                            index, overlap
+                        ),
+                    )
+                )
+        if not boxes_exactly_cover(target_offset, target_shape, overlap_boxes):
+            raise ValueError(
+                f"target sparse fragment is not fully covered: {tensor_id}"
+            )
+        regions.sort(key=lambda item: (item.source_object_ref, item.indices_range))
+        return SparseObjectPlan(
+            tensor_id=tensor_id,
+            target_placement=target_placement,
+            target_global_offset=target_offset,
+            target_local_shape=target_shape,
+            base_generation=base_generation,
+            delta_generation=delta_generation,
+            regions=tuple(regions),
+        )
+
+    def plan_targets(
+        self,
+        *,
+        targets: Iterable[Any],
+        source_fragments: Iterable[Any],
+        tensors: Mapping[str, TensorDescriptor],
+        source_indexes: Mapping[str, SparseObjectIndex],
+        base_generation: int,
+        delta_generation: int,
+    ) -> tuple[SparseObjectPlan, ...]:
+        """Plan a target set while reusing the caller's index cache."""
+
+        grouped: dict[str, list[Any]] = {}
+        for source in source_fragments:
+            grouped.setdefault(source.tensor_id, []).append(source)
+        groups_by_tensor: dict[
+            str, dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]]
+        ] = {}
+        for tensor_id, items in grouped.items():
+            tensor = tensors.get(tensor_id)
+            if tensor is None:
+                continue
+            groups: dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]] = {}
+            for source in items:
+                self._validate_source_fragment(source, tensor=tensor)
+                groups.setdefault(
+                    (tuple(source.global_offset), tuple(source.local_shape)), []
+                ).append(source)
+            groups_by_tensor[tensor_id] = groups
+        candidate_indexes = {
+            tensor_id: _CandidateBoxIndex.build(
+                tuple(tuple(group) for group in groups.values())
+            )
+            for tensor_id, groups in groups_by_tensor.items()
+            if groups
+        }
+        plans: list[SparseObjectPlan] = []
+        for target in targets:
+            tensor_id = target.tensor_id
+            try:
+                tensor = tensors[tensor_id]
+            except KeyError as error:
+                raise ValueError(
+                    f"missing tensor descriptor for {tensor_id!r}"
+                ) from error
+            self._validate_target_fragment(target, tensor=tensor)
+            target_placement = normalize_placement(tuple(target.target_placement))
+            candidates = self._select_from_groups(
+                target=target,
+                tensor=tensor,
+                target_placement=target_placement,
+                groups=groups_by_tensor.get(tensor_id, {}),
+                candidate_index=candidate_indexes.get(tensor_id),
+            )
+            plans.append(
+                self._plan_target_candidates(
+                    tensor_id=tensor_id,
+                    target=target,
+                    candidates=candidates,
+                    source_indexes=source_indexes,
+                    base_generation=base_generation,
+                    delta_generation=delta_generation,
+                )
+            )
+        return tuple(plans)
+
+
+def plan_sparse_object_target(**kwargs: Any) -> SparseObjectPlan:
+    """Functional facade for planning one target sparse object."""
+
+    return SparseObjectStorePlanner().plan_target(**kwargs)
+
+
+__all__ = [
+    "Box",
+    "Placement",
+    "placement_matches",
+    "SparseObjectIndex",
+    "SparseObjectPlan",
+    "SparseObjectRegion",
+    "SparseObjectStorePlanner",
+    "canonical_source_placement",
+    "is_canonical_source",
+    "normalize_placement",
+    "normalize_shape",
+    "object_ref_key",
+    "plan_sparse_object_target",
+]

--- a/mooncake-reshard/python/mooncake/reshard/sparse/planner.py
+++ b/mooncake-reshard/python/mooncake/reshard/sparse/planner.py
@@ -203,6 +203,11 @@ class SparseObjectIndex:
     nnz: int
     base_generation: int
     delta_generation: int
+    # Keep the source object's declared geometry alongside the compact index.
+    # Older callers that construct an index directly may omit these fields;
+    # such indexes are interpreted as complete global objects.
+    global_offset: tuple[int, ...] | None = None
+    local_shape: tuple[int, ...] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.object_ref, str) or not self.object_ref:
@@ -213,6 +218,20 @@ class SparseObjectIndex:
         tile_shape = normalize_shape(self.tile_shape, "tile_shape", positive=True)
         if len(shape) != len(tile_shape):
             raise ValueError("global_shape and tile_shape rank differ")
+        offset = (
+            normalize_shape(self.global_offset, "global_offset", positive=False)
+            if self.global_offset is not None
+            else (0,) * len(shape)
+        )
+        local = (
+            normalize_shape(self.local_shape, "local_shape", positive=True)
+            if self.local_shape is not None
+            else shape
+        )
+        if len(offset) != len(shape) or len(local) != len(shape):
+            raise ValueError("source geometry rank differs from global_shape")
+        if any(offset[d] + local[d] > shape[d] for d in range(len(shape))):
+            raise ValueError("source geometry exceeds global_shape")
         coords = tuple(
             normalize_shape(coord, "tile_coords", positive=False)
             for coord in self.tile_coords
@@ -251,6 +270,8 @@ class SparseObjectIndex:
             raise ValueError("delta_generation must be newer than base_generation")
         object.__setattr__(self, "global_shape", shape)
         object.__setattr__(self, "tile_shape", tile_shape)
+        object.__setattr__(self, "global_offset", offset)
+        object.__setattr__(self, "local_shape", local)
         object.__setattr__(self, "tile_coords", coords)
         object.__setattr__(self, "tile_ptr", ptr)
 
@@ -381,6 +402,8 @@ class SparseObjectIndex:
             nnz=int(shape[0]),
             base_generation=int(metadata.get("base_generation", -1)),
             delta_generation=int(metadata.get("delta_generation", -1)),
+            global_offset=global_offset,
+            local_shape=local_shape,
         )
 
 
@@ -417,6 +440,7 @@ class SparseObjectRegion:
         start, end = self.indices_range
         if type(start) is not int or type(end) is not int or start < 0 or end <= start:
             raise ValueError("COO ranges must be non-empty")
+        normalize_placement(tuple(self.target_placement))
         object.__setattr__(self, "source_global_box", box)
         object.__setattr__(self, "target_global_offset", offset)
         object.__setattr__(self, "target_local_shape", shape)
@@ -451,6 +475,55 @@ class SparseObjectPlan:
     base_generation: int
     delta_generation: int
     regions: tuple[SparseObjectRegion, ...]
+    physical_node: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tensor_id, str) or not self.tensor_id:
+            raise ValueError("tensor_id must be a non-empty string")
+        target_offset = normalize_shape(
+            self.target_global_offset, "target_global_offset", positive=False
+        )
+        target_shape = normalize_shape(
+            self.target_local_shape, "target_local_shape", positive=True
+        )
+        if len(target_offset) != len(target_shape):
+            raise ValueError("target geometry rank differs")
+        normalize_placement(tuple(self.target_placement))
+        if (
+            type(self.base_generation) is not int
+            or type(self.delta_generation) is not int
+            or self.base_generation < 0
+            or self.delta_generation <= self.base_generation
+        ):
+            raise ValueError("invalid sparse plan generation")
+        if self.physical_node is not None and (
+            not isinstance(self.physical_node, str) or not self.physical_node
+        ):
+            raise ValueError("physical_node must be a non-empty string")
+        target_end = tuple(
+            target_offset[d] + target_shape[d] for d in range(len(target_offset))
+        )
+        for region in self.regions:
+            if region.tensor_id != self.tensor_id:
+                raise ValueError("region tensor_id does not match sparse plan")
+            if (
+                region.target_global_offset != target_offset
+                or region.target_local_shape != target_shape
+                or region.target_placement
+                != normalize_placement(tuple(self.target_placement))
+            ):
+                raise ValueError("region target geometry does not match sparse plan")
+            region_begin, region_end = region.target_global_box
+            if any(
+                region_begin[d] < target_offset[d] or region_end[d] > target_end[d]
+                for d in range(len(target_offset))
+            ):
+                raise ValueError("region lies outside sparse plan target geometry")
+        object.__setattr__(self, "target_global_offset", target_offset)
+        object.__setattr__(self, "target_local_shape", target_shape)
+        object.__setattr__(
+            self, "target_placement", normalize_placement(tuple(self.target_placement))
+        )
 
     @property
     def source_ranges(self) -> tuple[tuple[str, tuple[int, int]], ...]:
@@ -482,6 +555,17 @@ class SparseObjectStorePlanner:
             tuple[tuple[int, ...], tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]],
         ] = {}
 
+    def clear_index_cache(self, object_ref: object | None = None) -> None:
+        """Drop metadata-only tile lookup caches for one object or all objects."""
+
+        key = None if object_ref is None else object_ref_key(object_ref)
+        if key is None:
+            self._tile_row_cache.clear()
+            self._tile_col_cache.clear()
+        else:
+            self._tile_row_cache.pop(key, None)
+            self._tile_col_cache.pop(key, None)
+
     @staticmethod
     def _intersection(source: Any, target: Any) -> Box | None:
         return box_intersection(
@@ -498,18 +582,109 @@ class SparseObjectStorePlanner:
         target: Any,
         source_fragments: Iterable[Any],
         tensor: TensorDescriptor,
+        source_indexes: Mapping[str, SparseObjectIndex] | None = None,
+        base_generation: int | None = None,
+        delta_generation: int | None = None,
     ) -> tuple[Any, ...]:
-        """Filter source inventory before any source-object index is read.
+        """Filter source inventory before reading source-object indexes by default.
 
         The source manifest can contain all tensors and all placements.  This
         method is intentionally part of the address-free planner so Store
         adapters do not duplicate placement and box-intersection rules.
+
+        When compact indexes and an expected generation are supplied, stale
+        replicas are filtered before choosing the deterministic representative.
+        Store adapters should read indexes for all geometrically eligible
+        replicas before calling this mode.
         """
 
         if tensor.tensor_id != tensor_id:
             raise ValueError("tensor descriptor does not match tensor_id")
+        target_tensor_id = getattr(target, "tensor_id", tensor_id)
+        if target_tensor_id != tensor_id:
+            raise ValueError("target tensor_id does not match tensor_id")
+        if (source_indexes is None) != (
+            base_generation is None and delta_generation is None
+        ):
+            raise ValueError(
+                "source_indexes and expected generations must be provided together"
+            )
+        if source_indexes is not None:
+            if (
+                type(base_generation) is not int
+                or type(delta_generation) is not int
+                or base_generation < 0
+                or delta_generation <= base_generation
+            ):
+                raise ValueError("expected source generations must be integers")
         self._validate_target_fragment(target, tensor=tensor)
         target_placement = normalize_placement(tuple(target.target_placement))
+        groups = self._source_groups(
+            tensor_id=tensor_id,
+            source_fragments=source_fragments,
+            tensor=tensor,
+        )
+        if source_indexes is not None:
+            groups = self._filter_groups_by_generation(
+                groups,
+                target=target,
+                tensor=tensor,
+                target_placement=target_placement,
+                source_indexes=source_indexes,
+                tensor_id=tensor_id,
+                base_generation=base_generation,
+                delta_generation=delta_generation,
+            )
+        return self._select_from_groups(
+            target=target,
+            tensor=tensor,
+            target_placement=target_placement,
+            groups=groups,
+        )
+
+    def candidate_source_fragments(
+        self,
+        *,
+        tensor_id: str,
+        target: Any,
+        source_fragments: Iterable[Any],
+        tensor: TensorDescriptor,
+    ) -> tuple[Any, ...]:
+        """Return all eligible source replicas before representative selection."""
+
+        if tensor.tensor_id != tensor_id:
+            raise ValueError("tensor descriptor does not match tensor_id")
+        target_tensor_id = getattr(target, "tensor_id", tensor_id)
+        if target_tensor_id != tensor_id:
+            raise ValueError("target tensor_id does not match tensor_id")
+        self._validate_target_fragment(target, tensor=tensor)
+        target_placement = normalize_placement(tuple(target.target_placement))
+        groups = self._source_groups(
+            tensor_id=tensor_id,
+            source_fragments=source_fragments,
+            tensor=tensor,
+        )
+        candidates: list[Any] = []
+        for group in groups.values():
+            candidates.extend(
+                source
+                for source in group
+                if placement_matches(
+                    tensor,
+                    normalize_placement(tuple(source.source_placement)),
+                    target_placement,
+                )
+                and self._intersection(source, target) is not None
+            )
+        return tuple(candidates)
+
+    def _source_groups(
+        self,
+        *,
+        tensor_id: str,
+        source_fragments: Iterable[Any],
+        tensor: TensorDescriptor,
+    ) -> dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]]:
         groups: dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]] = {}
         for source in source_fragments:
             if source.tensor_id != tensor_id:
@@ -520,12 +695,7 @@ class SparseObjectStorePlanner:
                 tuple(source.local_shape),
             )
             groups.setdefault(geometry_key, []).append(source)
-        return self._select_from_groups(
-            target=target,
-            tensor=tensor,
-            target_placement=target_placement,
-            groups=groups,
-        )
+        return groups
 
     def _select_from_groups(
         self,
@@ -581,6 +751,74 @@ class SparseObjectStorePlanner:
             raise ValueError("sparse source fragment placement is invalid")
         normalize_placement(tuple(source.source_placement))
         object_ref_key(source.object_ref)
+
+    @staticmethod
+    def _validate_index_identity(
+        index: SparseObjectIndex,
+        *,
+        source: Any,
+        tensor_id: str,
+    ) -> None:
+        key = object_ref_key(source.object_ref)
+        if index.object_ref != key:
+            raise ValueError("tile index object_ref does not match source fragment")
+        if index.tensor_id != tensor_id:
+            raise ValueError("tile index tensor_id does not match source fragment")
+        if tuple(index.global_shape) != tuple(source.global_shape):
+            raise ValueError("tile index global_shape does not match source fragment")
+        if tuple(index.global_offset) != tuple(source.global_offset) or tuple(
+            index.local_shape
+        ) != tuple(source.local_shape):
+            raise ValueError(
+                "tile index source geometry (global_offset/local_shape) does not "
+                "match source fragment"
+            )
+
+    @classmethod
+    def _filter_groups_by_generation(
+        cls,
+        groups: Mapping[tuple[tuple[int, ...], tuple[int, ...]], list[Any]],
+        *,
+        target: Any,
+        tensor: TensorDescriptor,
+        target_placement: Placement,
+        source_indexes: Mapping[str, SparseObjectIndex],
+        tensor_id: str,
+        base_generation: int,
+        delta_generation: int,
+    ) -> dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]]:
+        filtered: dict[tuple[tuple[int, ...], tuple[int, ...]], list[Any]] = {}
+        for geometry_key, group in groups.items():
+            eligible: list[Any] = []
+            for source in group:
+                if (
+                    not placement_matches(
+                        tensor,
+                        normalize_placement(tuple(source.source_placement)),
+                        target_placement,
+                    )
+                    or cls._intersection(source, target) is None
+                ):
+                    continue
+                key = object_ref_key(source.object_ref)
+                index = source_indexes.get(key)
+                if index is None:
+                    raise ValueError(
+                        f"missing sparse tile index for source object {key!r}"
+                    )
+                cls._validate_index_identity(
+                    index,
+                    source=source,
+                    tensor_id=tensor_id,
+                )
+                if (
+                    index.base_generation == base_generation
+                    and index.delta_generation == delta_generation
+                ):
+                    eligible.append(source)
+            if eligible:
+                filtered[geometry_key] = eligible
+        return filtered
 
     @staticmethod
     def _validate_target_fragment(target: Any, *, tensor: TensorDescriptor) -> None:
@@ -776,12 +1014,17 @@ class SparseObjectStorePlanner:
     ) -> SparseObjectPlan:
         """Plan one target without materializing ``indices`` or ``values``."""
 
+        if getattr(target, "tensor_id", tensor_id) != tensor_id:
+            raise ValueError("target tensor_id does not match tensor_id")
         self._validate_target_fragment(target, tensor=tensor)
         candidates = self.select_source_fragments(
             tensor_id=tensor_id,
             target=target,
             source_fragments=source_fragments,
             tensor=tensor,
+            source_indexes=source_indexes,
+            base_generation=base_generation,
+            delta_generation=delta_generation,
         )
         return self._plan_target_candidates(
             tensor_id=tensor_id,
@@ -810,6 +1053,11 @@ class SparseObjectStorePlanner:
             target.local_shape, "target.local_shape", positive=True
         )
         target_placement = normalize_placement(tuple(target.target_placement))
+        physical_node = getattr(target, "physical_node", None)
+        if physical_node is not None and (
+            not isinstance(physical_node, str) or not physical_node
+        ):
+            raise ValueError("target.physical_node must be a non-empty string")
         overlap_boxes: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
         for source in candidates:
             overlap = self._intersection(source, target)
@@ -831,17 +1079,16 @@ class SparseObjectStorePlanner:
                 raise ValueError(
                     f"missing sparse tile index for source object {key!r}"
                 ) from error
-            if index.tensor_id != tensor_id:
-                raise ValueError("tile index tensor_id does not match source fragment")
+            self._validate_index_identity(
+                index,
+                source=source,
+                tensor_id=tensor_id,
+            )
             if (index.base_generation, index.delta_generation) != (
                 base_generation,
                 delta_generation,
             ):
                 raise ValueError("tile index generation does not match manifest")
-            if tuple(index.global_shape) != tuple(source.global_shape):
-                raise ValueError(
-                    "tile index global_shape does not match source fragment"
-                )
             for start, stop in self._tile_ranges(index, overlap):
                 regions.append(
                     SparseObjectRegion(
@@ -871,6 +1118,7 @@ class SparseObjectStorePlanner:
             base_generation=base_generation,
             delta_generation=delta_generation,
             regions=tuple(regions),
+            physical_node=physical_node,
         )
 
     def plan_targets(
@@ -902,13 +1150,6 @@ class SparseObjectStorePlanner:
                     (tuple(source.global_offset), tuple(source.local_shape)), []
                 ).append(source)
             groups_by_tensor[tensor_id] = groups
-        candidate_indexes = {
-            tensor_id: _CandidateBoxIndex.build(
-                tuple(tuple(group) for group in groups.values())
-            )
-            for tensor_id, groups in groups_by_tensor.items()
-            if groups
-        }
         plans: list[SparseObjectPlan] = []
         for target in targets:
             tensor_id = target.tensor_id
@@ -918,14 +1159,33 @@ class SparseObjectStorePlanner:
                 raise ValueError(
                     f"missing tensor descriptor for {tensor_id!r}"
                 ) from error
+            if getattr(target, "tensor_id", tensor_id) != tensor_id:
+                raise ValueError("target tensor_id does not match tensor_id")
             self._validate_target_fragment(target, tensor=tensor)
             target_placement = normalize_placement(tuple(target.target_placement))
+            filtered_groups = self._filter_groups_by_generation(
+                groups_by_tensor.get(tensor_id, {}),
+                target=target,
+                tensor=tensor,
+                target_placement=target_placement,
+                source_indexes=source_indexes,
+                tensor_id=tensor_id,
+                base_generation=base_generation,
+                delta_generation=delta_generation,
+            )
+            candidate_index = (
+                _CandidateBoxIndex.build(
+                    tuple(tuple(group) for group in filtered_groups.values())
+                )
+                if filtered_groups
+                else None
+            )
             candidates = self._select_from_groups(
                 target=target,
                 tensor=tensor,
                 target_placement=target_placement,
-                groups=groups_by_tensor.get(tensor_id, {}),
-                candidate_index=candidate_indexes.get(tensor_id),
+                groups=filtered_groups,
+                candidate_index=candidate_index,
             )
             plans.append(
                 self._plan_target_candidates(

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/geometry.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/geometry.py
@@ -8,6 +8,7 @@ from ..._typing import TypeAlias
 
 from ..._compat import _strict_zip
 from ...contracts import TensorId
+from ...geometry import box_intersection
 from ..types import TensorDescriptor
 from ..storage_manifest import StoredFragmentSnapshot
 from .fragments import (
@@ -226,29 +227,18 @@ def _overlap_box(
     source: GeometryFragment,
     target: GeometryFragment,
 ) -> Optional[tuple[tuple[int, ...], tuple[int, ...]]]:
-    overlap_offset = tuple(
-        max(source_begin, target_begin)
-        for source_begin, target_begin in _strict_zip(
-            source.global_offset, target.global_offset
-        )
+    overlap = box_intersection(
+        source.global_offset,
+        source.local_shape,
+        target.global_offset,
+        target.local_shape,
     )
-    overlap_end = tuple(
-        min(
-            source_begin + source_extent,
-            target_begin + target_extent,
-        )
-        for source_begin, source_extent, target_begin, target_extent in _strict_zip(
-            source.global_offset,
-            source.local_shape,
-            target.global_offset,
-            target.local_shape,
-        )
-    )
+    if overlap is None:
+        return None
+    overlap_offset, overlap_end = overlap
     overlap_shape = tuple(
         end - begin for begin, end in _strict_zip(overlap_offset, overlap_end)
     )
-    if any(extent <= 0 for extent in overlap_shape):
-        return None
     return overlap_offset, overlap_shape
 
 

--- a/mooncake-reshard/tests/test_sparse_planner.py
+++ b/mooncake-reshard/tests/test_sparse_planner.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from mooncake.reshard.sparse import (
+    SparseObjectIndex,
+    SparseObjectStorePlanner,
+)
+from mooncake.reshard.weight import ReplicatedAxis, SplitAxis, TensorDescriptor
+
+
+@dataclass(frozen=True)
+class _Source:
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    source_placement: tuple[tuple[str, int], ...]
+    object_ref: str
+
+
+@dataclass(frozen=True)
+class _Target:
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    target_placement: tuple[tuple[str, int], ...]
+
+
+def _tensor() -> TensorDescriptor:
+    return TensorDescriptor(
+        tensor_id="layer.weight",
+        global_shape=(8, 8),
+        dtype="float32",
+        itemsize=4,
+        shard_dims=(1,),
+        layout_fingerprint="test:layer.weight",
+        parallel_axes=(ReplicatedAxis("ep"), SplitAxis("tp", 1)),
+    )
+
+
+def _index(object_ref: str, columns: tuple[int, ...]) -> SparseObjectIndex:
+    return SparseObjectIndex(
+        object_ref=object_ref,
+        tensor_id="layer.weight",
+        global_shape=(8, 8),
+        tile_shape=(4, 4),
+        tile_coords=tuple((row, column) for row, column in columns),
+        tile_ptr=tuple(range(len(columns) + 1)),
+        nnz=len(columns),
+        base_generation=1,
+        delta_generation=2,
+    )
+
+
+def test_multiple_source_shards_are_kept_and_same_geometry_is_represented_once() -> (
+    None
+):
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    target = _Target("layer.weight", (8, 8), (0, 0), (8, 8), (("tp", 0),))
+    left = _Source("layer.weight", (8, 8), (0, 0), (8, 4), (), "left")
+    left_replica = _Source("layer.weight", (8, 8), (0, 0), (8, 4), (), "left-replica")
+    right = _Source("layer.weight", (8, 8), (0, 4), (8, 4), (), "right")
+    sources = (left_replica, right, left)
+    selected = planner.select_source_fragments(
+        tensor_id="layer.weight",
+        target=target,
+        source_fragments=sources,
+        tensor=tensor,
+    )
+    assert {(item.global_offset, item.local_shape) for item in selected} == {
+        ((0, 0), (8, 4)),
+        ((0, 4), (8, 4)),
+    }
+
+    plan = planner.plan_target(
+        tensor_id="layer.weight",
+        tensor=tensor,
+        target=target,
+        source_fragments=sources,
+        source_indexes={
+            "left": _index("left", ((0, 0), (1, 0))),
+            "left-replica": _index("left-replica", ((0, 0), (1, 0))),
+            "right": _index("right", ((0, 1), (1, 1))),
+        },
+        base_generation=1,
+        delta_generation=2,
+    )
+    assert {region.source_object_ref for region in plan.regions} == {
+        "left",
+        "right",
+    }
+
+
+def test_partial_source_geometry_is_valid_for_a_target_shard() -> None:
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    target = _Target("layer.weight", (8, 8), (0, 4), (8, 4), (("tp", 1),))
+    source = _Source("layer.weight", (8, 8), (0, 4), (8, 4), (), "right")
+    plan = planner.plan_target(
+        tensor_id="layer.weight",
+        tensor=tensor,
+        target=target,
+        source_fragments=(source,),
+        source_indexes={"right": _index("right", ((0, 1), (1, 1)))},
+        base_generation=1,
+        delta_generation=2,
+    )
+    assert plan.range_request_count == 1
+
+
+def test_target_coverage_rejects_gaps_and_overlaps() -> None:
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    target = _Target("layer.weight", (8, 8), (0, 0), (8, 8), ())
+    left = _Source("layer.weight", (8, 8), (0, 0), (8, 3), (), "left")
+    right = _Source("layer.weight", (8, 8), (0, 4), (8, 4), (), "right")
+    indexes = {
+        "left": _index("left", ((0, 0),)),
+        "right": _index("right", ((0, 1),)),
+    }
+    with pytest.raises(ValueError, match="not fully covered"):
+        planner.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(left, right),
+            source_indexes=indexes,
+            base_generation=1,
+            delta_generation=2,
+        )
+
+    overlapping_right = _Source(
+        "layer.weight", (8, 8), (0, 4), (8, 4), (), "overlapping-right"
+    )
+    overlapping_left = _Source(
+        "layer.weight", (8, 8), (0, 0), (8, 5), (), "overlapping-left"
+    )
+    overlapping_indexes = {
+        "overlapping-left": _index("overlapping-left", ((0, 0),)),
+        "overlapping-right": _index("overlapping-right", ((0, 1),)),
+    }
+    with pytest.raises(ValueError, match="not fully covered"):
+        planner.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(overlapping_left, overlapping_right),
+            source_indexes=overlapping_indexes,
+            base_generation=1,
+            delta_generation=2,
+        )
+
+
+def test_index_metadata_rejects_geometry_rank_mismatch() -> None:
+    metadata = {
+        "schema": "mooncake.sparse_object",
+        "version": 1,
+        "coordinate_space": "global",
+        "tensor_id": "layer.weight",
+        "global_shape": [8, 8],
+        "global_offset": [0],
+        "local_shape": [8, 8],
+        "tile_shape": [4, 4],
+        "base_generation": 1,
+        "delta_generation": 2,
+        "members": {
+            "indices": {"dtype": "uint32", "shape": [1, 2]},
+            "values": {"dtype": "float32", "shape": [1]},
+            "tile_coords": {"dtype": "uint32", "shape": [1, 2]},
+            "tile_ptr": {"dtype": "uint64", "shape": [2]},
+        },
+        "index_dtype": "uint32",
+        "value_dtype": "float32",
+    }
+    with pytest.raises(ValueError, match="geometry rank"):
+        SparseObjectIndex.from_metadata(
+            object_ref="object",
+            metadata=metadata,
+            tile_coords=((0, 0),),
+            tile_ptr=(0, 1),
+        )
+
+
+def test_index_metadata_rejects_inconsistent_index_dtype() -> None:
+    metadata = {
+        "schema": "mooncake.sparse_object",
+        "version": 1,
+        "coordinate_space": "global",
+        "tensor_id": "layer.weight",
+        "global_shape": [8, 8],
+        "global_offset": [0, 0],
+        "local_shape": [8, 8],
+        "tile_shape": [4, 4],
+        "base_generation": 1,
+        "delta_generation": 2,
+        "index_dtype": "float32",
+        "value_dtype": "float32",
+        "members": {
+            "indices": {"dtype": "float32", "shape": [1, 2]},
+            "values": {"dtype": "float32", "shape": [1]},
+            "tile_coords": {"dtype": "uint32", "shape": [1, 2]},
+            "tile_ptr": {"dtype": "uint64", "shape": [2]},
+        },
+    }
+    with pytest.raises(ValueError, match="tile_coords member dtype"):
+        SparseObjectIndex.from_metadata(
+            object_ref="object",
+            metadata=metadata,
+            tile_coords=((0, 0),),
+            tile_ptr=(0, 1),
+        )

--- a/mooncake-reshard/tests/test_sparse_planner.py
+++ b/mooncake-reshard/tests/test_sparse_planner.py
@@ -42,11 +42,19 @@ def _tensor() -> TensorDescriptor:
     )
 
 
-def _index(object_ref: str, columns: tuple[int, ...]) -> SparseObjectIndex:
+def _index(
+    object_ref: str,
+    columns: tuple[int, ...],
+    *,
+    global_offset: tuple[int, ...] = (0, 0),
+    local_shape: tuple[int, ...] = (8, 8),
+) -> SparseObjectIndex:
     return SparseObjectIndex(
         object_ref=object_ref,
         tensor_id="layer.weight",
         global_shape=(8, 8),
+        global_offset=global_offset,
+        local_shape=local_shape,
         tile_shape=(4, 4),
         tile_coords=tuple((row, column) for row, column in columns),
         tile_ptr=tuple(range(len(columns) + 1)),
@@ -83,9 +91,13 @@ def test_multiple_source_shards_are_kept_and_same_geometry_is_represented_once()
         target=target,
         source_fragments=sources,
         source_indexes={
-            "left": _index("left", ((0, 0), (1, 0))),
-            "left-replica": _index("left-replica", ((0, 0), (1, 0))),
-            "right": _index("right", ((0, 1), (1, 1))),
+            "left": _index("left", ((0, 0), (1, 0)), local_shape=(8, 4)),
+            "left-replica": _index(
+                "left-replica", ((0, 0), (1, 0)), local_shape=(8, 4)
+            ),
+            "right": _index(
+                "right", ((0, 1), (1, 1)), global_offset=(0, 4), local_shape=(8, 4)
+            ),
         },
         base_generation=1,
         delta_generation=2,
@@ -106,7 +118,11 @@ def test_partial_source_geometry_is_valid_for_a_target_shard() -> None:
         tensor=tensor,
         target=target,
         source_fragments=(source,),
-        source_indexes={"right": _index("right", ((0, 1), (1, 1)))},
+        source_indexes={
+            "right": _index(
+                "right", ((0, 1), (1, 1)), global_offset=(0, 4), local_shape=(8, 4)
+            )
+        },
         base_generation=1,
         delta_generation=2,
     )
@@ -120,8 +136,8 @@ def test_target_coverage_rejects_gaps_and_overlaps() -> None:
     left = _Source("layer.weight", (8, 8), (0, 0), (8, 3), (), "left")
     right = _Source("layer.weight", (8, 8), (0, 4), (8, 4), (), "right")
     indexes = {
-        "left": _index("left", ((0, 0),)),
-        "right": _index("right", ((0, 1),)),
+        "left": _index("left", ((0, 0),), local_shape=(8, 3)),
+        "right": _index("right", ((0, 1),), global_offset=(0, 4), local_shape=(8, 4)),
     }
     with pytest.raises(ValueError, match="not fully covered"):
         planner.plan_target(
@@ -141,8 +157,13 @@ def test_target_coverage_rejects_gaps_and_overlaps() -> None:
         "layer.weight", (8, 8), (0, 0), (8, 5), (), "overlapping-left"
     )
     overlapping_indexes = {
-        "overlapping-left": _index("overlapping-left", ((0, 0),)),
-        "overlapping-right": _index("overlapping-right", ((0, 1),)),
+        "overlapping-left": _index("overlapping-left", ((0, 0),), local_shape=(8, 5)),
+        "overlapping-right": _index(
+            "overlapping-right",
+            ((0, 1),),
+            global_offset=(0, 4),
+            local_shape=(8, 4),
+        ),
     }
     with pytest.raises(ValueError, match="not fully covered"):
         planner.plan_target(
@@ -214,3 +235,135 @@ def test_index_metadata_rejects_inconsistent_index_dtype() -> None:
             tile_coords=((0, 0),),
             tile_ptr=(0, 1),
         )
+
+
+def test_generation_filter_selects_current_replica_before_object_order() -> None:
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    target = _Target("layer.weight", (8, 8), (0, 0), (8, 8), ())
+    stale = _Source("layer.weight", (8, 8), (0, 0), (8, 8), (), "aaa-stale")
+    current = _Source("layer.weight", (8, 8), (0, 0), (8, 8), (), "zzz-current")
+    stale_index = SparseObjectIndex(
+        object_ref="aaa-stale",
+        tensor_id="layer.weight",
+        global_shape=(8, 8),
+        tile_shape=(4, 4),
+        tile_coords=((0, 0),),
+        tile_ptr=(0, 1),
+        nnz=1,
+        base_generation=0,
+        delta_generation=1,
+    )
+    current_index = _index("zzz-current", ((0, 0),))
+    selected = planner.select_source_fragments(
+        tensor_id="layer.weight",
+        target=target,
+        source_fragments=(stale, current),
+        tensor=tensor,
+        source_indexes={
+            "aaa-stale": stale_index,
+            "zzz-current": current_index,
+        },
+        base_generation=1,
+        delta_generation=2,
+    )
+    assert selected == (current,)
+
+
+def test_index_geometry_and_object_identity_are_checked() -> None:
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    target = _Target("layer.weight", (8, 8), (0, 0), (8, 8), ())
+    source = _Source("layer.weight", (8, 8), (0, 0), (8, 4), (), "source")
+    mismatched_geometry = SparseObjectIndex(
+        object_ref="source",
+        tensor_id="layer.weight",
+        global_shape=(8, 8),
+        tile_shape=(4, 4),
+        tile_coords=((0, 0),),
+        tile_ptr=(0, 1),
+        nnz=1,
+        base_generation=1,
+        delta_generation=2,
+        global_offset=(0, 4),
+        local_shape=(8, 4),
+    )
+    with pytest.raises(ValueError, match="global_offset"):
+        planner.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(source,),
+            source_indexes={"source": mismatched_geometry},
+            base_generation=1,
+            delta_generation=2,
+        )
+
+    wrong_object = _index("other", ((0, 0),), local_shape=(8, 4))
+    with pytest.raises(ValueError, match="object_ref"):
+        planner.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(source,),
+            source_indexes={"source": wrong_object},
+            base_generation=1,
+            delta_generation=2,
+        )
+
+
+def test_target_tensor_id_must_match_explicit_tensor_id() -> None:
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    target = _Target("other.weight", (8, 8), (0, 0), (8, 8), ())
+    with pytest.raises(ValueError, match="target tensor_id"):
+        planner.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(),
+            source_indexes={},
+            base_generation=1,
+            delta_generation=2,
+        )
+
+
+def test_plan_targets_filters_stale_replicas_per_target_geometry() -> None:
+    planner = SparseObjectStorePlanner()
+    tensor = _tensor()
+    left = _Source("layer.weight", (8, 8), (0, 0), (8, 4), (), "left")
+    right = _Source("layer.weight", (8, 8), (0, 4), (8, 4), (), "right")
+    stale_left = _Source("layer.weight", (8, 8), (0, 0), (8, 4), (), "stale-left")
+    targets = (
+        _Target("layer.weight", (8, 8), (0, 0), (8, 4), ()),
+        _Target("layer.weight", (8, 8), (0, 4), (8, 4), ()),
+    )
+    indexes = {
+        "left": _index("left", ((0, 0),), local_shape=(8, 4)),
+        "right": _index("right", ((0, 1),), global_offset=(0, 4), local_shape=(8, 4)),
+        "stale-left": SparseObjectIndex(
+            object_ref="stale-left",
+            tensor_id="layer.weight",
+            global_shape=(8, 8),
+            global_offset=(0, 0),
+            local_shape=(8, 4),
+            tile_shape=(4, 4),
+            tile_coords=((0, 0),),
+            tile_ptr=(0, 1),
+            nnz=1,
+            base_generation=0,
+            delta_generation=1,
+        ),
+    }
+    plans = planner.plan_targets(
+        targets=targets,
+        source_fragments=(stale_left, left, right),
+        tensors={"layer.weight": tensor},
+        source_indexes=indexes,
+        base_generation=1,
+        delta_generation=2,
+    )
+    assert tuple(plan.source_ranges for plan in plans) == (
+        (("left", (0, 1)),),
+        (("right", (0, 1)),),
+    )

--- a/mooncake-rl/sparse_object_store.py
+++ b/mooncake-rl/sparse_object_store.py
@@ -1,0 +1,1267 @@
+"""Mooncake Store facade for COO sparse structured objects."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from concurrent.futures import Future
+from dataclasses import dataclass
+import threading
+from typing import Any, Protocol
+
+from mooncake.reshard.sparse.planner import (
+    Box,
+    Placement,
+    SparseObjectIndex,
+    SparseObjectPlan,
+    SparseObjectRegion,
+    SparseObjectStorePlanner,
+    canonical_source_placement,
+    is_canonical_source,
+    normalize_placement,
+    normalize_shape,
+    object_ref_key,
+)
+from mooncake.reshard.weight import TensorDescriptor
+
+
+@dataclass(frozen=True)
+class StoredSparseObject:
+    """Reference and compact metadata returned by ``put_sparse_object``."""
+
+    ref: object
+    metadata: Mapping[str, Any]
+    index: SparseObjectIndex
+
+
+@dataclass(frozen=True)
+class StoredTargetSparseObject:
+    """Reference and metadata for a target-local sparse object."""
+
+    ref: object
+    metadata: Mapping[str, Any]
+    nnz: int
+
+
+class SparseGenerationError(RuntimeError):
+    """Base class for target-side sparse update fencing failures."""
+
+
+class StaleSparseGenerationError(SparseGenerationError):
+    """Raised when an update is older than the generation already applied."""
+
+
+class SparseGenerationMismatchError(SparseGenerationError):
+    """Raised when an incremental update does not extend the current base."""
+
+
+class SparseGenerationNotInitializedError(SparseGenerationError):
+    """Raised when a target has no controller-seeded current generation."""
+
+
+class SparseGenerationInProgressError(SparseGenerationError):
+    """Raised when the same target is already applying another update."""
+
+
+@dataclass(frozen=True)
+class _GenerationLease:
+    target_key: str
+    base_generation: int
+    delta_generation: int
+    update_key: str | None
+
+
+class SparseGenerationFence:
+    """Process-local generation fence for idempotent sparse target apply.
+
+    The shared control plane must persist the same ``target_key`` and current
+    generation for a multi-process deployment.  This helper deliberately keeps
+    that policy small and deterministic: an update must start at the current
+    generation, equal-generation retries are no-ops, and a newer update cannot
+    overlap an in-flight update for the same target.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._current: dict[str, int] = {}
+        self._applied_update_keys: dict[str, str | None] = {}
+        self._inflight: set[str] = set()
+
+    def current(self, target_key: str) -> int | None:
+        with self._lock:
+            return self._current.get(target_key)
+
+    def set_current(self, target_key: str, generation: int) -> None:
+        """Seed the generation of a full/dense target already in memory."""
+
+        if not isinstance(target_key, str) or not target_key:
+            raise ValueError("target_key must be a non-empty string")
+        if type(generation) is not int or generation < 0:
+            raise ValueError("generation must be a non-negative integer")
+        with self._lock:
+            if target_key in self._inflight:
+                raise SparseGenerationInProgressError(
+                    f"{target_key!r} already has an in-flight update"
+                )
+            current = self._current.get(target_key)
+            if current is not None and generation < current:
+                raise StaleSparseGenerationError(
+                    f"{target_key!r} is at generation {current}, "
+                    f"cannot reset it to {generation}"
+                )
+            self._current[target_key] = generation
+            self._applied_update_keys.pop(target_key, None)
+
+    def begin(
+        self,
+        target_key: str,
+        base_generation: int,
+        delta_generation: int,
+        update_key: str | None = None,
+    ) -> _GenerationLease | None:
+        if not isinstance(target_key, str) or not target_key:
+            raise ValueError("target_key must be a non-empty string")
+        if (
+            type(base_generation) is not int
+            or type(delta_generation) is not int
+            or base_generation < 0
+            or delta_generation <= base_generation
+        ):
+            raise ValueError("invalid sparse update generation")
+        if update_key is not None and (
+            not isinstance(update_key, str) or not update_key
+        ):
+            raise ValueError("update_key must be a non-empty string")
+        with self._lock:
+            current = self._current.get(target_key)
+            if current is None:
+                raise SparseGenerationNotInitializedError(
+                    f"{target_key!r} has no initialized generation"
+                )
+            if current is not None:
+                if delta_generation < current:
+                    raise StaleSparseGenerationError(
+                        f"{target_key!r} is at generation {current}, "
+                        f"update ends at {delta_generation}"
+                    )
+                if delta_generation == current and base_generation < current:
+                    applied_key = self._applied_update_keys.get(target_key)
+                    # An equal-generation retry is a no-op only when the
+                    # committed update identity is reproduced exactly.
+                    # Without an identity key we cannot distinguish a retry
+                    # from a different payload at the same generation.
+                    if (
+                        applied_key is None
+                        or update_key is None
+                        or applied_key != update_key
+                    ):
+                        raise SparseGenerationMismatchError(
+                            f"{target_key!r} already committed a different "
+                            f"update at generation {current}"
+                        )
+                    return None
+                if base_generation != current:
+                    raise SparseGenerationMismatchError(
+                        f"{target_key!r} is at generation {current}, "
+                        f"update starts at {base_generation}"
+                    )
+            if target_key in self._inflight:
+                raise SparseGenerationInProgressError(
+                    f"{target_key!r} already has an in-flight update"
+                )
+            self._inflight.add(target_key)
+            return _GenerationLease(
+                target_key, base_generation, delta_generation, update_key
+            )
+
+    def commit(self, lease: _GenerationLease) -> None:
+        with self._lock:
+            if lease.target_key not in self._inflight:
+                raise RuntimeError("sparse generation lease is not in flight")
+            self._inflight.remove(lease.target_key)
+            self._current[lease.target_key] = lease.delta_generation
+            self._applied_update_keys[lease.target_key] = lease.update_key
+
+    def abort(self, lease: _GenerationLease) -> None:
+        with self._lock:
+            self._inflight.discard(lease.target_key)
+
+
+class StructuredObjectBackend(Protocol):
+    """Subset of Mooncake structured-object APIs used by this facade."""
+
+    def put_structured_object(self, payload: object, **kwargs: Any) -> object: ...
+
+    def read_spec(self, ref: object) -> Any: ...
+
+    def materialize(self, spec: Any) -> Any: ...
+
+
+def _result_metadata_and_objects(
+    result: Any,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    """Accept ``StructuredObjectResult`` and simple test doubles alike."""
+
+    if hasattr(result, "metadata") and hasattr(result, "objects"):
+        return result.metadata, result.objects
+    if isinstance(result, Mapping):
+        metadata = result.get("metadata", {})
+        objects = result.get("objects", result)
+        if isinstance(metadata, Mapping) and isinstance(objects, Mapping):
+            return metadata, objects
+    raise TypeError(
+        "structured object materialize result must expose metadata and objects"
+    )
+
+
+class SparseObjectStore:
+    """Sparse object-store facade built on Mooncake structured objects.
+
+    The facade owns sparse-object encoding and compact index caching, while
+    the backend owns transport, manifests, leases, and copy/zero-copy policy.  A backend
+    can be a real ``MooncakeDistributedStore`` or a small test double.  The
+    optional ``payload_type`` is useful for tests and avoids importing the
+    Mooncake wheel until the first real PUT.
+    """
+
+    SCHEMA = "mooncake.sparse_object"
+    VERSION = 1
+
+    def __init__(
+        self,
+        backend: StructuredObjectBackend,
+        *,
+        payload_type: type | None = None,
+        planner: SparseObjectStorePlanner | None = None,
+    ) -> None:
+        self.backend = backend
+        self._payload_type = payload_type
+        self.planner = planner or SparseObjectStorePlanner()
+        self._index_cache: dict[str, SparseObjectIndex] = {}
+        self._metadata_cache: dict[str, Mapping[str, Any]] = {}
+        self._refs: dict[str, object] = {}
+        self._range_cache: dict[
+            tuple[str, int, int, str, tuple[int, int]],
+            Future[tuple[Any, Any]],
+        ] = {}
+        self._range_cache_limit = 4096
+        self._range_cache_lock = threading.Lock()
+
+    @staticmethod
+    def _payload_class(payload_type: type | None) -> type:
+        if payload_type is not None:
+            return payload_type
+        try:
+            from mooncake.structured_object_store import StructuredObjectPayload
+        except Exception as error:  # pragma: no cover - depends on installation
+            raise RuntimeError(
+                "Mooncake StructuredObjectPayload is unavailable; pass payload_type "
+                "when using a custom backend"
+            ) from error
+        return StructuredObjectPayload
+
+    @staticmethod
+    def _build_indexed_members(
+        indices: Any,
+        values: Any,
+        tile_shape: Sequence[int],
+        index_dtype: Any | None = None,
+    ) -> tuple[Any, Any, Any, Any]:
+        """Sort COO by tile and return aligned indices/values/index members."""
+
+        try:
+            import numpy as np
+        except ImportError as error:  # pragma: no cover - Mooncake depends on NumPy
+            raise RuntimeError("sparse object encoding requires NumPy") from error
+        indices = np.asarray(indices)
+        values = np.asarray(values)
+        if indices.ndim != 2 or indices.shape[1] == 0:
+            raise ValueError("indices must have shape [nnz, ndim]")
+        if indices.dtype.kind not in "iu":
+            raise ValueError("indices must use an integer dtype")
+        if values.ndim != 1 or len(values) != len(indices):
+            raise ValueError("values must have shape [nnz]")
+        normalized_tile_shape = normalize_shape(tile_shape, "tile_shape", positive=True)
+        ndim = indices.shape[1]
+        if len(normalized_tile_shape) != ndim:
+            raise ValueError("tile_shape rank differs from indices")
+        if len(indices) and np.any(indices < 0):
+            raise ValueError("indices must be non-negative global coordinates")
+        max_index = int(indices.max()) if len(indices) else 0
+        if index_dtype is None:
+            output_dtype = np.uint32 if max_index < 2**32 else np.uint64
+        else:
+            output_dtype = np.dtype(index_dtype)
+            if output_dtype.kind not in "iu":
+                raise ValueError("index_dtype must be an integer dtype")
+            if max_index >= 1 << (8 * output_dtype.itemsize):
+                raise ValueError("index_dtype cannot represent COO coordinates")
+        indices = np.ascontiguousarray(indices, dtype=output_dtype)
+        values = np.ascontiguousarray(values)
+        # Do tile arithmetic in a wide signed type.  The wire index may be
+        # uint16 (the ROLL contract), but tile_shape itself can exceed 65535
+        # and must not wrap before division.
+        tiles = indices.astype(np.int64, copy=False) // np.asarray(
+            normalized_tile_shape, dtype=np.int64
+        )
+        if len(indices):
+            keys = [indices[:, d] for d in reversed(range(ndim))]
+            keys.extend(tiles[:, d] for d in reversed(range(ndim)))
+            order = np.lexsort(tuple(keys))
+            indices = indices[order]
+            values = values[order]
+            tiles = tiles[order]
+            changes = np.empty(len(tiles), dtype=bool)
+            changes[0] = True
+            changes[1:] = np.any(tiles[1:] != tiles[:-1], axis=1)
+            first = np.flatnonzero(changes)
+            # Tile coordinates are bounded by the corresponding element
+            # coordinates, so the requested wire index dtype can represent
+            # them as well.  Persist them in the same dtype as `indices`;
+            # the division itself was intentionally performed in int64.
+            tile_coords = tiles[first].astype(output_dtype, copy=False)
+        else:
+            tile_coords = np.empty((0, ndim), dtype=output_dtype)
+            first = np.empty((0,), dtype=np.int64)
+        tile_ptr = np.concatenate(
+            (first, np.asarray([len(indices)], dtype=np.int64))
+        ).astype(np.uint64, copy=False)
+        return indices, values, tile_coords, tile_ptr
+
+    @staticmethod
+    def _member_spec(array: Any) -> dict[str, Any]:
+        return {"dtype": str(array.dtype), "shape": list(array.shape)}
+
+    @staticmethod
+    def _normalize_dtype(dtype: Any, name: str) -> str:
+        if isinstance(dtype, str):
+            normalized = dtype.strip().lower()
+            if normalized.startswith("torch."):
+                normalized = normalized[6:]
+            if normalized:
+                try:
+                    import numpy as np
+
+                    return np.dtype(normalized).name
+                except (TypeError, ValueError):
+                    # TensorDescriptor also carries framework dtypes such as
+                    # ``bfloat16`` and ``float8_e4m3fn`` that older NumPy
+                    # versions cannot parse.  Preserve those canonical names
+                    # for metadata-level equality checks.
+                    return normalized
+        try:
+            import numpy as np
+
+            return np.dtype(dtype).name
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"{name} must be a supported dtype") from error
+
+    @staticmethod
+    def _normalize_generation(generation: Sequence[int]) -> tuple[int, int]:
+        if (
+            not isinstance(generation, Sequence)
+            or isinstance(generation, (str, bytes, bytearray))
+            or len(generation) != 2
+            or type(generation[0]) is not int
+            or type(generation[1]) is not int
+            or generation[0] < 0
+            or generation[1] <= generation[0]
+        ):
+            raise ValueError("generation must be (base, delta) with delta newer")
+        return int(generation[0]), int(generation[1])
+
+    @staticmethod
+    def _normalize_geometry(
+        global_shape: Sequence[int],
+        global_offset: Sequence[int] | None,
+        local_shape: Sequence[int] | None,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        shape = normalize_shape(global_shape, "global_shape", positive=True)
+        ndim = len(shape)
+        offset = (
+            normalize_shape(global_offset, "global_offset", positive=False)
+            if global_offset is not None
+            else (0,) * ndim
+        )
+        local = (
+            normalize_shape(local_shape, "local_shape", positive=True)
+            if local_shape is not None
+            else shape
+        )
+        if len(offset) != ndim or len(local) != ndim:
+            raise ValueError("local geometry rank differs from global_shape")
+        if any(offset[d] + local[d] > shape[d] for d in range(ndim)):
+            raise ValueError("local geometry exceeds global_shape")
+        return shape, offset, local
+
+    def _put_indexed_sparse_object(
+        self,
+        *,
+        tensor_id: str,
+        global_shape: Sequence[int],
+        global_offset: Sequence[int] | None,
+        local_shape: Sequence[int] | None,
+        indices: Any,
+        values: Any,
+        generation: Sequence[int],
+        coordinate_space: str,
+        placement_field: str,
+        placement: Placement,
+        tile_shape: Sequence[int] | None,
+        partition: str,
+        index_dtype: Any | None = None,
+        metadata_extra: Mapping[str, Any] | None = None,
+        buffer_extra: Mapping[str, Any] | None = None,
+        **put_kwargs: Any,
+    ) -> tuple[object, Mapping[str, Any], SparseObjectIndex | None, int]:
+        """Validate, index, encode and commit either source or target COO.
+
+        Source and target sparse objects intentionally share one encoding path;
+        only coordinate space and placement metadata differ.
+        """
+
+        if not isinstance(tensor_id, str) or not tensor_id:
+            raise ValueError("tensor_id must be a non-empty string")
+        shape, offset, local = self._normalize_geometry(
+            global_shape, global_offset, local_shape
+        )
+        base_generation, delta_generation = self._normalize_generation(generation)
+        normalized_placement = normalize_placement(tuple(placement))
+        tile = (
+            tuple(tile_shape)
+            if tile_shape is not None
+            else tuple(
+                min(256, extent)
+                for extent in (shape if coordinate_space == "global" else local)
+            )
+        )
+        try:
+            import numpy as np
+        except ImportError as error:  # pragma: no cover - Mooncake depends on NumPy
+            raise RuntimeError("sparse object encoding requires NumPy") from error
+        raw_indices = np.asarray(indices)
+        raw_values = np.asarray(values)
+        ndim = len(shape)
+        if raw_indices.ndim != 2 or raw_indices.shape[1] != ndim:
+            raise ValueError("indices must have shape [nnz, len(global_shape)]")
+        if raw_values.ndim != 1 or len(raw_values) != len(raw_indices):
+            raise ValueError("values must have shape [nnz]")
+        if len(raw_indices):
+            if coordinate_space == "global":
+                lower = np.asarray(offset)
+                upper = lower + np.asarray(local)
+            else:
+                lower = np.zeros(ndim, dtype=raw_indices.dtype)
+                upper = np.asarray(local)
+            if np.any(raw_indices < lower) or np.any(raw_indices >= upper):
+                raise ValueError("COO indices are outside the declared geometry")
+        indexed_indices, indexed_values, tile_coords, tile_ptr = (
+            self._build_indexed_members(
+                raw_indices, raw_values, tile, index_dtype=index_dtype
+            )
+        )
+        buffers: dict[str, Any] = {
+            "indices": indexed_indices,
+            "values": indexed_values,
+            "tile_coords": tile_coords,
+            "tile_ptr": tile_ptr,
+        }
+        if buffer_extra:
+            for name, value in buffer_extra.items():
+                if not isinstance(name, str) or not name or name in buffers:
+                    raise ValueError(f"buffer_extra contains reserved name {name!r}")
+                buffers[name] = value
+
+        metadata: dict[str, Any] = {
+            "schema": self.SCHEMA,
+            "version": self.VERSION,
+            "tensor_id": tensor_id,
+            "global_shape": list(shape),
+            "global_offset": list(offset),
+            "local_shape": list(local),
+            "coordinate_space": coordinate_space,
+            "coordinate_rank": ndim,
+            "nnz": len(indexed_indices),
+            "index_dtype": str(indexed_indices.dtype),
+            "value_dtype": str(indexed_values.dtype),
+            "base_generation": base_generation,
+            "delta_generation": delta_generation,
+            "apply": "scatter_add",
+            "duplicate_semantics": (
+                "coalesced"
+                if metadata_extra is not None and metadata_extra.get("coalesced")
+                else "additive"
+            ),
+            placement_field: [list(item) for item in normalized_placement],
+            "tile_shape": list(tile),
+            "members": {
+                name: self._member_spec(value) for name, value in buffers.items()
+            },
+        }
+        if metadata_extra:
+            for key, value in metadata_extra.items():
+                if not isinstance(key, str) or key in metadata:
+                    raise ValueError(f"metadata_extra contains reserved key {key!r}")
+                metadata[key] = value
+        ref = self.put_structured_object(
+            metadata=metadata,
+            buffers=buffers,
+            partition=partition,
+            **put_kwargs,
+        )
+        key = object_ref_key(ref)
+        self._refs[key] = ref
+        index = None
+        if coordinate_space == "global":
+            index = SparseObjectIndex(
+                object_ref=key,
+                tensor_id=tensor_id,
+                global_shape=shape,
+                global_offset=offset,
+                local_shape=local,
+                tile_shape=tile,
+                tile_coords=tuple(
+                    tuple(int(item) for item in row) for row in tile_coords.tolist()
+                ),
+                tile_ptr=tuple(int(item) for item in tile_ptr.tolist()),
+                nnz=len(indexed_indices),
+                base_generation=base_generation,
+                delta_generation=delta_generation,
+            )
+            self._index_cache[key] = index
+            self._metadata_cache[key] = metadata
+        return ref, metadata, index, len(indexed_indices)
+
+    def put_structured_object(
+        self,
+        *,
+        metadata: Mapping[str, Any],
+        buffers: Mapping[str, Any],
+        partition: str = "default",
+        **put_kwargs: Any,
+    ) -> object:
+        """Commit a generic structured object through the configured backend.
+
+        Sparse source objects use :meth:`put_sparse_object` to add COO
+        validation and tile indexing.  Target-local objects (or other
+        structured payloads) can use this lower-level store entry point while
+        still sharing Mooncake's manifest/copy/lease handling.
+        """
+
+        payload_class = self._payload_class(self._payload_type)
+        payload = payload_class(metadata=metadata, buffers=buffers)
+        return self.backend.put_structured_object(
+            payload, partition=partition, **put_kwargs
+        )
+
+    def put_sparse_object(
+        self,
+        *,
+        tensor_id: str,
+        global_shape: Sequence[int],
+        indices: Any,
+        values: Any,
+        generation: tuple[int, int],
+        global_offset: Sequence[int] | None = None,
+        local_shape: Sequence[int] | None = None,
+        source_placement: Placement = (),
+        tile_shape: Sequence[int] | None = None,
+        index_dtype: Any | None = None,
+        logical_update_key: str | None = None,
+        placement_policy: str | None = None,
+        partition: str = "default",
+        **put_kwargs: Any,
+    ) -> StoredSparseObject:
+        """Encode and commit one global-coordinate sparse object."""
+        ref, metadata, index, _nnz = self._put_indexed_sparse_object(
+            tensor_id=tensor_id,
+            global_shape=global_shape,
+            global_offset=global_offset,
+            local_shape=local_shape,
+            indices=indices,
+            values=values,
+            generation=generation,
+            coordinate_space="global",
+            placement_field="source_placement",
+            placement=source_placement,
+            tile_shape=tile_shape,
+            partition=partition,
+            index_dtype=index_dtype,
+            metadata_extra={
+                key: value
+                for key, value in (
+                    ("logical_update_key", logical_update_key),
+                    ("placement_policy", placement_policy),
+                )
+                if value is not None
+            },
+            **put_kwargs,
+        )
+        assert index is not None
+        return StoredSparseObject(ref=ref, metadata=metadata, index=index)
+
+    def put_sparse_object_if_owner(
+        self,
+        *,
+        source_placement: Placement,
+        source_placements: Iterable[Placement],
+        **put_kwargs: Any,
+    ) -> StoredSparseObject | None:
+        """Publish a replicated source object from one deterministic owner.
+
+        The admission decision is made next to object publication so all
+        framework adapters share the same de-duplication rule.  Non-owners
+        return ``None`` before COO encoding or transport allocation.
+        """
+
+        placements = tuple(source_placements)
+        if not is_canonical_source(source_placement, placements):
+            return None
+        return self.put_sparse_object(source_placement=source_placement, **put_kwargs)
+
+    @staticmethod
+    def should_publish_source(
+        source_placement: Placement, source_placements: Iterable[Placement]
+    ) -> bool:
+        """Return the deterministic admission decision for a source rank."""
+
+        return is_canonical_source(source_placement, source_placements)
+
+    def put_target_sparse_object(
+        self,
+        *,
+        tensor_id: str,
+        global_shape: Sequence[int],
+        global_offset: Sequence[int],
+        local_shape: Sequence[int],
+        indices: Any,
+        values: Any,
+        generation: tuple[int, int],
+        target_placement: Placement = (),
+        tile_shape: Sequence[int] | None = None,
+        logical_update_key: str | None = None,
+        placement_policy: str | None = None,
+        target_key: str | None = None,
+        partition: str = "default",
+        **put_kwargs: Any,
+    ) -> StoredTargetSparseObject:
+        """Commit a target-local COO object after sparse-aware materialization.
+
+        ``indices`` are local to ``global_offset``.  Keeping this encoding
+        operation in the Mooncake facade means a framework adapter does not
+        need to duplicate target metadata, tile indexing, or structured-object
+        publication logic.
+        """
+        ref, metadata, _index, nnz = self._put_indexed_sparse_object(
+            tensor_id=tensor_id,
+            global_shape=global_shape,
+            global_offset=global_offset,
+            local_shape=local_shape,
+            indices=indices,
+            values=values,
+            generation=generation,
+            coordinate_space="target_local",
+            placement_field="target_placement",
+            placement=target_placement,
+            tile_shape=tile_shape,
+            partition=partition,
+            metadata_extra={
+                key: value
+                for key, value in (
+                    ("logical_update_key", logical_update_key),
+                    ("placement_policy", placement_policy),
+                    ("target_key", target_key),
+                )
+                if value is not None
+            },
+            **put_kwargs,
+        )
+        return StoredTargetSparseObject(ref=ref, metadata=metadata, nnz=nnz)
+
+    @staticmethod
+    def _read_members(
+        backend: StructuredObjectBackend, spec: Any
+    ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+        result = backend.materialize(spec)
+        return _result_metadata_and_objects(result)
+
+    def read_index(self, ref: object) -> SparseObjectIndex:
+        """Read only ``tile_coords`` and ``tile_ptr`` from a source object."""
+
+        index, _metadata = self.read_index_with_metadata(ref)
+        return index
+
+    def read_index_with_metadata(
+        self, ref: object
+    ) -> tuple[SparseObjectIndex, Mapping[str, Any]]:
+        """Read the compact index and return its metadata without COO members.
+
+        Structured-object metadata is part of the manifest and is returned by
+        the same index-only materialization.  Keeping this method separate
+        lets a store-side planner inspect dtype/tile configuration without
+        issuing another request or materializing ``indices``/``values``.
+        """
+
+        key = object_ref_key(ref)
+        self._refs.setdefault(key, ref)
+        cached = self._index_cache.get(key)
+        if cached is not None:
+            return cached, self._metadata_cache[key]
+        spec = self.backend.read_spec(ref).select_members(("tile_coords", "tile_ptr"))
+        metadata, objects = self._read_members(self.backend, spec)
+        index = SparseObjectIndex.from_metadata(
+            object_ref=ref,
+            metadata=metadata,
+            tile_coords=objects["tile_coords"].tolist(),
+            tile_ptr=objects["tile_ptr"].tolist(),
+        )
+        self._index_cache[key] = index
+        self._metadata_cache[key] = metadata
+        return index, metadata
+
+    def read_coo_range(
+        self, ref: object, entry_range: tuple[int, int]
+    ) -> tuple[Any, Any]:
+        """Read aligned ``indices``/``values`` axis-0 ranges only."""
+
+        key = object_ref_key(ref)
+        start, end = entry_range
+        if type(start) is not int or type(end) is not int or start < 0 or end <= start:
+            raise ValueError("COO range must be non-empty")
+        # Explicit member selection is important: adding slices alone does
+        # not stop a structured-object backend from materializing unrelated
+        # tile-index members.
+        backend_ref = self._refs.get(key, ref)
+        spec = self.backend.read_spec(backend_ref).select_members(("indices", "values"))
+        spec = spec.slice_member("indices", axis=0, start=start, end=end)
+        spec = spec.slice_member("values", axis=0, start=start, end=end)
+        _metadata, objects = self._read_members(self.backend, spec)
+        return objects["indices"], objects["values"]
+
+    def read_coo_range_cached(
+        self,
+        ref: object,
+        entry_range: tuple[int, int],
+        *,
+        base_generation: int,
+        delta_generation: int,
+        physical_node: str | None,
+    ) -> tuple[Any, Any]:
+        """Read one COO range once per process-local physical-node namespace.
+
+        Multiple TP/EP target workers can share a ``SparseObjectStore`` service
+        in one process.  ``physical_node`` is a cache namespace, not a
+        cross-process coordination mechanism.  The first consumer owns the
+        Store/RDMA GET; later consumers receive the immutable range payload
+        from this process-local cache and perform their own boundary
+        filter/rebase.
+        """
+
+        if physical_node is None:
+            return self.read_coo_range(ref, entry_range)
+        if not isinstance(physical_node, str) or not physical_node:
+            raise ValueError("physical_node must be a non-empty string")
+        key = (
+            object_ref_key(ref),
+            base_generation,
+            delta_generation,
+            physical_node,
+            entry_range,
+        )
+        with self._range_cache_lock:
+            future = self._range_cache.get(key)
+            owns_read = future is None
+            if owns_read:
+                future = Future()
+                if len(self._range_cache) >= self._range_cache_limit:
+                    completed_key = next(
+                        (
+                            cached_key
+                            for cached_key, cached_future in self._range_cache.items()
+                            if cached_future.done()
+                        ),
+                        None,
+                    )
+                    if completed_key is not None:
+                        del self._range_cache[completed_key]
+                self._range_cache[key] = future
+        assert future is not None
+        if not owns_read:
+            return future.result()
+        try:
+            result = self.read_coo_range(ref, entry_range)
+        except Exception as error:
+            future.set_exception(error)
+            with self._range_cache_lock:
+                if self._range_cache.get(key) is future:
+                    del self._range_cache[key]
+            raise
+        # Cache consumers share this payload.  Make NumPy results immutable so
+        # one EP/TP worker cannot corrupt a later local consumer.
+        try:
+            result[0].setflags(write=False)
+            result[1].setflags(write=False)
+        except AttributeError:
+            pass
+        future.set_result(result)
+        return result
+
+    def clear_range_cache(
+        self,
+        *,
+        object_ref: object | None = None,
+        physical_node: str | None = None,
+        before_delta_generation: int | None = None,
+    ) -> None:
+        """Release cached range payloads after target fan-out completes."""
+
+        object_key = None if object_ref is None else object_ref_key(object_ref)
+        if physical_node is not None and (
+            not isinstance(physical_node, str) or not physical_node
+        ):
+            raise ValueError("physical_node must be a non-empty string")
+        if before_delta_generation is not None and (
+            type(before_delta_generation) is not int or before_delta_generation < 0
+        ):
+            raise ValueError("before_delta_generation must be non-negative")
+        with self._range_cache_lock:
+            remove = [
+                key
+                for key in self._range_cache
+                if (object_key is None or key[0] == object_key)
+                and (physical_node is None or key[3] == physical_node)
+                and (
+                    before_delta_generation is None or key[2] < before_delta_generation
+                )
+            ]
+            for key in remove:
+                del self._range_cache[key]
+
+    def clear_cache(
+        self,
+        *,
+        object_ref: object | None = None,
+        physical_node: str | None = None,
+        before_delta_generation: int | None = None,
+    ) -> None:
+        """Release metadata and range caches after an update fan-out."""
+
+        key = None if object_ref is None else object_ref_key(object_ref)
+        if key is None:
+            self._index_cache.clear()
+            self._metadata_cache.clear()
+        else:
+            self._index_cache.pop(key, None)
+            self._metadata_cache.pop(key, None)
+        self.planner.clear_index_cache(key)
+        self.clear_range_cache(
+            object_ref=key,
+            physical_node=physical_node,
+            before_delta_generation=before_delta_generation,
+        )
+
+    def _select_target_sources(
+        self,
+        *,
+        tensor_id: str,
+        tensor: TensorDescriptor,
+        target: Any,
+        source_fragments: Iterable[Any],
+        base_generation: int,
+        delta_generation: int,
+    ) -> tuple[tuple[Any, ...], dict[str, SparseObjectIndex]]:
+        """Read indexes for intersecting replicas, then select current sources."""
+
+        source_fragments = tuple(source_fragments)
+        possible_sources = self.planner.candidate_source_fragments(
+            tensor_id=tensor_id,
+            target=target,
+            source_fragments=source_fragments,
+            tensor=tensor,
+        )
+        source_indexes = {
+            object_ref_key(source.object_ref): self.read_index(source.object_ref)
+            for source in possible_sources
+        }
+        candidates = self.planner.select_source_fragments(
+            tensor_id=tensor_id,
+            target=target,
+            source_fragments=source_fragments,
+            tensor=tensor,
+            source_indexes=source_indexes,
+            base_generation=base_generation,
+            delta_generation=delta_generation,
+        )
+        return candidates, source_indexes
+
+    def plan_target(self, **kwargs: Any) -> SparseObjectPlan:
+        """Filter candidates, then read only indexes needed by this target."""
+
+        source_fragments = tuple(kwargs.pop("source_fragments"))
+        source_indexes = kwargs.pop("source_indexes", None)
+        if source_indexes is None:
+            _candidates, source_indexes = self._select_target_sources(
+                tensor_id=kwargs["tensor_id"],
+                tensor=kwargs["tensor"],
+                target=kwargs["target"],
+                source_fragments=source_fragments,
+                base_generation=kwargs["base_generation"],
+                delta_generation=kwargs["delta_generation"],
+            )
+        return self.planner.plan_target(
+            source_fragments=source_fragments,
+            source_indexes=source_indexes,
+            **kwargs,
+        )
+
+    def materialize_target(
+        self,
+        *,
+        tensor_id: str,
+        tensor: TensorDescriptor,
+        target: Any,
+        source_fragments: Iterable[Any],
+        base_generation: int,
+        delta_generation: int,
+    ) -> tuple[Any, Any, tuple[int, ...] | None]:
+        """Materialize one target payload after planner-side filtering.
+
+        This is the Store-facing operation used by a framework adapter.  It
+        keeps source candidate selection, compact-index reads, dtype/tile
+        consistency checks, boundary filtering and coordinate rebasing inside
+        Mooncake.
+        """
+
+        candidates, source_indexes = self._select_target_sources(
+            tensor_id=tensor_id,
+            tensor=tensor,
+            target=target,
+            source_fragments=tuple(source_fragments),
+            base_generation=base_generation,
+            delta_generation=delta_generation,
+        )
+        value_dtype: Any | None = None
+        tile_shape: tuple[int, ...] | None = None
+        for source in candidates:
+            _index, metadata = self.read_index_with_metadata(source.object_ref)
+            try:
+                source_dtype = metadata["members"]["values"]["dtype"]
+                source_tile_shape = tuple(int(item) for item in metadata["tile_shape"])
+            except (KeyError, TypeError, ValueError) as error:
+                raise ValueError("sparse source metadata is incomplete") from error
+            source_dtype = self._normalize_dtype(source_dtype, "source value dtype")
+            tensor_dtype = self._normalize_dtype(tensor.dtype, "tensor dtype")
+            if source_dtype != tensor_dtype:
+                raise ValueError(
+                    f"source COO value dtype {source_dtype} does not match "
+                    f"TensorDescriptor dtype {tensor_dtype}"
+                )
+            if value_dtype is not None and source_dtype != value_dtype:
+                raise ValueError("source COO value dtypes differ")
+            if tile_shape is not None and source_tile_shape != tile_shape:
+                raise ValueError("source objects use inconsistent tile_shape")
+            value_dtype = source_dtype
+            tile_shape = source_tile_shape
+        plan = self.planner.plan_target(
+            tensor_id=tensor_id,
+            tensor=tensor,
+            target=target,
+            source_fragments=candidates,
+            source_indexes=source_indexes,
+            base_generation=base_generation,
+            delta_generation=delta_generation,
+        )
+        indices, values = self.materialize_plan(plan, value_dtype=value_dtype)
+        return indices, values, tile_shape
+
+    def read_plan(
+        self, plan: SparseObjectPlan
+    ) -> tuple[tuple[SparseObjectRegion, Any, Any], ...]:
+        """Materialize only the COO ranges described by a store plan.
+
+        This low-level method exposes the selected ranges for callers that
+        need custom device handling.  Use :meth:`materialize_plan` when the
+        store should perform boundary filtering and target-local rebasing.
+        No unrelated structured members are materialized here.
+        """
+
+        return tuple(self._iter_plan(plan))
+
+    def _iter_plan(
+        self, plan: SparseObjectPlan
+    ) -> Iterable[tuple[SparseObjectRegion, Any, Any]]:
+        """Stream planned ranges for materialization without a read-all tuple."""
+
+        for region in plan.regions:
+            indices, values = self.read_coo_range_cached(
+                region.source_object_ref,
+                region.indices_range,
+                base_generation=plan.base_generation,
+                delta_generation=plan.delta_generation,
+                physical_node=plan.physical_node,
+            )
+            yield region, indices, values
+
+    def materialize_plan(
+        self, plan: SparseObjectPlan, *, value_dtype: Any | None = None
+    ) -> tuple[Any, Any]:
+        """Filter and rebase a plan into target-local COO arrays.
+
+        This is the store-side counterpart to ``read_plan``.  It keeps the
+        framework adapter from reimplementing boundary filtering or coordinate
+        rebasing; the adapter only applies the returned ``scatter_add``
+        payload to its local weight.  Duplicate coordinates are preserved,
+        matching COO additive semantics.
+        """
+
+        try:
+            import numpy as np
+        except ImportError as error:  # pragma: no cover - Mooncake depends on NumPy
+            raise RuntimeError(
+                "sparse object materialization requires NumPy"
+            ) from error
+
+        selected_indices: list[Any] = []
+        selected_values: list[Any] = []
+        ndim = len(plan.target_local_shape)
+        inferred_dtype = None
+        for region, indices, values in self._iter_plan(plan):
+            indices = np.asarray(indices)
+            values = np.asarray(values)
+            if indices.ndim != 2 or indices.shape[1] != ndim or values.ndim != 1:
+                raise ValueError("COO range shape does not match sparse object plan")
+            inferred_dtype = values.dtype
+            begin, end = region.source_global_box
+            if region.exact_coordinate_filter:
+                mask = np.all(
+                    (indices >= np.asarray(begin)) & (indices < np.asarray(end)),
+                    axis=1,
+                )
+            else:
+                mask = np.ones(len(indices), dtype=bool)
+            if not np.any(mask):
+                continue
+            local = indices[mask].astype(np.int64, copy=True)
+            local -= np.asarray(plan.target_global_offset, dtype=np.int64)
+            if np.any(local < 0) or np.any(
+                local >= np.asarray(plan.target_local_shape, dtype=np.int64)
+            ):
+                raise ValueError("COO range produced a coordinate outside target shape")
+            selected_indices.append(local)
+            selected_values.append(values[mask].copy())
+
+        if not selected_indices:
+            dtype = np.dtype(value_dtype or inferred_dtype or np.float32)
+            return np.empty((0, ndim), dtype=np.uint32), np.empty((0,), dtype=dtype)
+        indices_out = np.concatenate(selected_indices, axis=0)
+        values_out = np.concatenate(selected_values, axis=0)
+        order = np.lexsort(
+            tuple(indices_out[:, dimension] for dimension in reversed(range(ndim)))
+        )
+        max_coordinate = int(indices_out.max()) if indices_out.size else 0
+        index_dtype = np.uint32 if max_coordinate < 2**32 else np.uint64
+        return indices_out[order].astype(index_dtype, copy=False), values_out[order]
+
+    def apply_target_sparse_object(
+        self,
+        base: Any,
+        ref: object,
+        *,
+        inplace: bool = True,
+        generation_fence: SparseGenerationFence | None = None,
+        target_key: str | None = None,
+        expected_tensor_id: str | None = None,
+        expected_target_placement: Placement | None = None,
+        expected_generation: tuple[int, int] | None = None,
+        expected_update_key: str | None = None,
+        expected_target_key: str | None = None,
+    ) -> Any:
+        """Apply a target-local COO object in one additive update.
+
+        ROLL supplies the target weight.  Mooncake owns the structured-object
+        read and the additive COO operation.  The current facade materializes
+        COO members through the backend and uses host staging before a Torch
+        update; a registered destination fast path is a future optimization.
+        """
+
+        try:
+            import numpy as np
+        except ImportError as error:  # pragma: no cover
+            raise RuntimeError("sparse object application requires NumPy") from error
+        backend_ref = self._refs.get(object_ref_key(ref), ref)
+        spec = self.backend.read_spec(backend_ref).select_members(("indices", "values"))
+        metadata, objects = self._read_members(self.backend, spec)
+        if metadata.get("schema") != self.SCHEMA:
+            raise ValueError("unsupported sparse structured-object schema")
+        if metadata.get("version") != self.VERSION:
+            raise ValueError("unsupported sparse structured-object version")
+        if metadata.get("coordinate_space") != "target_local":
+            raise ValueError("target application requires target-local COO coordinates")
+        if metadata.get("apply") != "scatter_add":
+            raise ValueError("target sparse object does not use scatter_add semantics")
+        if (
+            expected_tensor_id is not None
+            and metadata.get("tensor_id") != expected_tensor_id
+        ):
+            raise ValueError("target sparse object tensor_id does not match target")
+        if expected_target_placement is not None:
+            declared_placement = metadata.get("target_placement")
+            expected_placement = [
+                list(item)
+                for item in normalize_placement(tuple(expected_target_placement))
+            ]
+            if declared_placement != expected_placement:
+                raise ValueError("target sparse object placement does not match target")
+        if expected_generation is not None:
+            if tuple(expected_generation) != (
+                metadata.get("base_generation"),
+                metadata.get("delta_generation"),
+            ):
+                raise ValueError(
+                    "target sparse object generation does not match target"
+                )
+        if (
+            expected_update_key is not None
+            and metadata.get("logical_update_key") != expected_update_key
+        ):
+            raise ValueError("target sparse object update key does not match target")
+        if (
+            expected_target_key is not None
+            and metadata.get("target_key") != expected_target_key
+        ):
+            raise ValueError("target sparse object target key does not match target")
+        expected_shape = tuple(int(item) for item in metadata.get("local_shape", ()))
+        if tuple(getattr(base, "shape", ())) != expected_shape:
+            raise ValueError(
+                f"target base shape {tuple(getattr(base, 'shape', ()))!r} "
+                f"does not match sparse object local_shape {expected_shape!r}"
+            )
+        indices = np.asarray(objects["indices"])
+        values = np.asarray(objects["values"])
+        if _is_torch_tensor(base):
+            base_dtype = self._normalize_dtype(str(base.dtype), "base dtype")
+            value_dtype = self._normalize_dtype(values.dtype, "target value dtype")
+            if base_dtype != value_dtype:
+                raise ValueError(
+                    f"target value dtype does not match base dtype: "
+                    f"{value_dtype} vs {base_dtype}"
+                )
+        elif np.asarray(base).dtype != values.dtype:
+            raise ValueError(
+                f"target value dtype does not match base dtype: {values.dtype} vs "
+                f"{np.asarray(base).dtype}"
+            )
+        if indices.ndim != 2 or values.ndim != 1 or len(indices) != len(values):
+            raise ValueError("target sparse object has misaligned COO members")
+        if indices.shape[1] != len(expected_shape):
+            raise ValueError("target sparse object coordinate rank differs from base")
+        if indices.dtype.kind not in "iu":
+            raise ValueError("target sparse object indices must be integral")
+        if len(indices):
+            upper = np.asarray(expected_shape, dtype=indices.dtype)
+            if np.any(indices < 0) or np.any(indices >= upper):
+                raise ValueError("target sparse object index exceeds local shape")
+        members = metadata.get("members")
+        if not isinstance(members, Mapping):
+            raise ValueError("target sparse object metadata is missing members")
+        declared_indices = members.get("indices")
+        declared_values = members.get("values")
+        if not isinstance(declared_indices, Mapping) or not isinstance(
+            declared_values, Mapping
+        ):
+            raise ValueError("target sparse object metadata is missing COO members")
+        if declared_indices.get("shape") != list(indices.shape) or declared_values.get(
+            "shape"
+        ) != list(values.shape):
+            raise ValueError("target sparse object member shape does not match payload")
+        if declared_indices.get("dtype") != str(indices.dtype) or declared_values.get(
+            "dtype"
+        ) != str(values.dtype):
+            raise ValueError("target sparse object member dtype does not match payload")
+        if (generation_fence is None) != (target_key is None):
+            raise ValueError(
+                "generation_fence and target_key must be provided together"
+            )
+        lease = None
+        if generation_fence is not None:
+            update_key = expected_update_key or metadata.get("logical_update_key")
+            lease = generation_fence.begin(
+                target_key,
+                int(metadata.get("base_generation", -1)),
+                int(metadata.get("delta_generation", -1)),
+                update_key=update_key,
+            )
+        if not inplace:
+            result = (
+                base.clone() if _is_torch_tensor(base) else np.array(base, copy=True)
+            )
+        else:
+            result = base
+        if lease is None and generation_fence is not None:
+            return result
+        try:
+            if len(indices):
+                if _is_torch_tensor(result):
+                    import torch
+
+                    index_tensor = torch.as_tensor(
+                        indices, dtype=torch.long, device=result.device
+                    )
+                    value_tensor = torch.as_tensor(values, device=result.device)
+                    result.index_put_(
+                        tuple(index_tensor.transpose(0, 1)),
+                        value_tensor,
+                        accumulate=True,
+                    )
+                else:
+                    np.add.at(
+                        result,
+                        tuple(indices.astype(np.int64, copy=False).T),
+                        values,
+                    )
+            if lease is not None:
+                generation_fence.commit(lease)
+            return result
+        except Exception:
+            if lease is not None:
+                generation_fence.abort(lease)
+            raise
+
+
+def _is_torch_tensor(value: Any) -> bool:
+    """Avoid importing torch on NumPy-only Mooncake installations."""
+
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - optional dependency
+        return False
+    return isinstance(value, torch.Tensor)
+
+
+def plan_sparse_object_target(**kwargs: Any) -> SparseObjectPlan:
+    """Functional facade for planning one target object."""
+
+    return SparseObjectStorePlanner().plan_target(**kwargs)
+
+
+__all__ = [
+    "Box",
+    "Placement",
+    "canonical_source_placement",
+    "is_canonical_source",
+    "SparseObjectIndex",
+    "SparseObjectStore",
+    "SparseObjectStorePlanner",
+    "SparseObjectPlan",
+    "SparseObjectRegion",
+    "SparseGenerationError",
+    "SparseGenerationFence",
+    "SparseGenerationInProgressError",
+    "SparseGenerationMismatchError",
+    "SparseGenerationNotInitializedError",
+    "StaleSparseGenerationError",
+    "StoredSparseObject",
+    "StoredTargetSparseObject",
+    "StructuredObjectBackend",
+    "object_ref_key",
+    "plan_sparse_object_target",
+]

--- a/mooncake-rl/test_sparse_object_store.py
+++ b/mooncake-rl/test_sparse_object_store.py
@@ -1,0 +1,923 @@
+"""Dependency-free smoke tests for ``sparse_object_store.py``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+import threading
+import time
+import unittest
+
+import numpy as np
+
+# Keep the smoke test runnable both from this directory and from the Mooncake
+# repository root; ``mooncake-rl`` is an integration directory, not a package.
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "mooncake-reshard" / "python"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sparse_object_store import (  # noqa: E402
+    SparseGenerationFence,
+    SparseGenerationMismatchError,
+    SparseGenerationNotInitializedError,
+    SparseObjectIndex,
+    SparseObjectStorePlanner,
+    SparseObjectStore,
+    StaleSparseGenerationError,
+    canonical_source_placement,
+    is_canonical_source,
+    object_ref_key,
+)
+from mooncake.reshard.weight import (  # noqa: E402
+    OwnershipAxis,
+    ReplicatedAxis,
+    SplitAxis,
+    TensorDescriptor,
+)
+
+
+@dataclass(frozen=True)
+class _Source:
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    source_placement: tuple[tuple[str, int], ...]
+    object_ref: str
+
+
+@dataclass(frozen=True)
+class _Target:
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    target_placement: tuple[tuple[str, int], ...]
+    physical_node: str | None = None
+
+
+def _tensor_descriptor(
+    tensor_id: str,
+    shape: tuple[int, ...],
+    *,
+    owned_by_ep: bool = False,
+) -> TensorDescriptor:
+    axes = (
+        (OwnershipAxis("ep"), SplitAxis("tp", 1))
+        if owned_by_ep and len(shape) > 1
+        else (ReplicatedAxis("ep"),)
+    )
+    return TensorDescriptor(
+        tensor_id=tensor_id,
+        global_shape=shape,
+        dtype="float32",
+        itemsize=4,
+        shard_dims=(1,) if owned_by_ep and len(shape) > 1 else (),
+        layout_fingerprint=f"test:{tensor_id}",
+        parallel_axes=axes,
+    )
+
+
+@dataclass(frozen=True)
+class _Ref:
+    key: str
+
+
+@dataclass(frozen=True)
+class _RemoteRef:
+    manifest_key: str
+
+
+@dataclass(frozen=True)
+class _Payload:
+    metadata: dict
+    buffers: dict
+
+
+@dataclass(frozen=True)
+class _Result:
+    metadata: dict
+    objects: dict
+
+
+class _Spec:
+    def __init__(self, backend, ref, names=None, slices=None):
+        self.backend = backend
+        self.ref = ref
+        self.names = names
+        self.slices = {} if slices is None else dict(slices)
+
+    def select_members(self, names):
+        return _Spec(self.backend, self.ref, tuple(names), self.slices)
+
+    def slice_member(self, name, axis, start, end, step=1):
+        assert axis == 0 and step == 1
+        slices = dict(self.slices)
+        slices[name] = (start, end)
+        return _Spec(self.backend, self.ref, self.names, slices)
+
+
+class _Backend:
+    def __init__(self):
+        self.objects = {}
+        self.materialize_members = []
+
+    def put_structured_object(self, payload, **kwargs):
+        del kwargs
+        ref = _Ref(f"obj-{len(self.objects)}")
+        self.objects[ref.key] = payload
+        return ref
+
+    def read_spec(self, ref):
+        return _Spec(self, ref)
+
+    def materialize(self, spec):
+        key = object_ref_key(spec.ref)
+        payload = self.objects[key]
+        names = list(payload.buffers) if spec.names is None else list(spec.names)
+        self.materialize_members.append((key, tuple(names), dict(spec.slices)))
+        objects = {}
+        for name in names:
+            value = payload.buffers[name]
+            if name in spec.slices:
+                start, end = spec.slices[name]
+                value = value[start:end]
+            objects[name] = value.copy()
+        return _Result(dict(payload.metadata), objects)
+
+
+class _BlockingBackend(_Backend):
+    def __init__(self):
+        super().__init__()
+        self.first_coo_read_started = threading.Event()
+        self.release_first_coo_read = threading.Event()
+        self.coo_read_count = 0
+
+    def materialize(self, spec):
+        if spec.names == ("indices", "values"):
+            self.coo_read_count += 1
+            if self.coo_read_count == 1:
+                self.first_coo_read_started.set()
+                if not self.release_first_coo_read.wait(timeout=5):
+                    raise TimeoutError("test did not release the first COO read")
+        return super().materialize(spec)
+
+
+class SparseObjectStorePlannerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.index = SparseObjectIndex(
+            object_ref="source-0",
+            tensor_id="layer.weight",
+            global_shape=(8, 12),
+            tile_shape=(4, 4),
+            tile_coords=((0, 0), (1, 2)),
+            tile_ptr=(0, 2, 3),
+            nnz=3,
+            base_generation=10,
+            delta_generation=11,
+        )
+        self.source = _Source(
+            "layer.weight", (8, 12), (0, 0), (8, 12), (("ep", 0),), "source-0"
+        )
+
+    def test_merges_adjacent_ranges_and_marks_boundary_filter(self) -> None:
+        target = _Target((0, 0), (8, 10), (("ep", 0), ("tp", 0)))
+        plan = SparseObjectStorePlanner().plan_target(
+            tensor_id="layer.weight",
+            tensor=_tensor_descriptor("layer.weight", (8, 12), owned_by_ep=True),
+            target=target,
+            source_fragments=(self.source,),
+            source_indexes={"source-0": self.index},
+            base_generation=10,
+            delta_generation=11,
+        )
+        self.assertEqual(plan.source_ranges, (("source-0", (0, 3)),))
+        self.assertTrue(plan.regions[0].exact_coordinate_filter)
+        self.assertEqual(plan.apply, "scatter_add")
+        self.assertEqual(plan.regions[0].apply, "scatter_add")
+
+    def test_2d_coo_tile_lookup_skips_unmatched_columns_and_rows(self) -> None:
+        # The 2-D fast path indexes COO tiles by row group and binary-searches
+        # columns.  Only the first two tiles intersect this target; the tile
+        # at tile column 20 and the tile in row group 3 must not enter the
+        # plan.
+        index = SparseObjectIndex(
+            object_ref="source-fast",
+            tensor_id="layer.fast",
+            global_shape=(20, 100),
+            tile_shape=(4, 4),
+            tile_coords=((0, 0), (0, 2), (0, 20), (3, 1)),
+            tile_ptr=(0, 1, 2, 3, 4),
+            nnz=4,
+            base_generation=1,
+            delta_generation=2,
+        )
+        source = _Source("layer.fast", (20, 100), (0, 0), (20, 100), (), "source-fast")
+        target = _Target((0, 0), (8, 12), ())
+        plan = SparseObjectStorePlanner().plan_target(
+            tensor_id="layer.fast",
+            tensor=_tensor_descriptor("layer.fast", (20, 100)),
+            target=target,
+            source_fragments=(source,),
+            source_indexes={"source-fast": index},
+            base_generation=1,
+            delta_generation=2,
+        )
+        self.assertEqual(plan.source_ranges, (("source-fast", (0, 2)),))
+
+        # A column-oriented target is also answered from the compact index.
+        # Every row group has several columns, but only tile column 5 is in
+        # the target box.  The returned ranges are the ten one-entry tiles in
+        # that column; no other column can contribute an entry.
+        tile_coords = tuple((row, column) for row in range(10) for column in range(8))
+        column_index = SparseObjectIndex(
+            object_ref="source-column",
+            tensor_id="layer.column",
+            global_shape=(40, 32),
+            tile_shape=(4, 4),
+            tile_coords=tile_coords,
+            tile_ptr=tuple(range(len(tile_coords) + 1)),
+            nnz=len(tile_coords),
+            base_generation=1,
+            delta_generation=2,
+        )
+        column_source = _Source(
+            "layer.column", (40, 32), (0, 0), (40, 32), (), "source-column"
+        )
+        column_target = _Target((0, 20), (40, 4), ())
+        column_plan = SparseObjectStorePlanner().plan_target(
+            tensor_id="layer.column",
+            tensor=_tensor_descriptor("layer.column", (40, 32)),
+            target=column_target,
+            source_fragments=(column_source,),
+            source_indexes={"source-column": column_index},
+            base_generation=1,
+            delta_generation=2,
+        )
+        self.assertEqual(
+            column_plan.source_ranges,
+            (
+                ("source-column", (5, 6)),
+                ("source-column", (13, 14)),
+                ("source-column", (21, 22)),
+                ("source-column", (29, 30)),
+                ("source-column", (37, 38)),
+                ("source-column", (45, 46)),
+                ("source-column", (53, 54)),
+                ("source-column", (61, 62)),
+                ("source-column", (69, 70)),
+                ("source-column", (77, 78)),
+            ),
+        )
+
+    def test_supports_n_dimensional_coordinate(self) -> None:
+        index = SparseObjectIndex(
+            "source-n-dim",
+            "tensor.n_dim",
+            (4, 4, 4),
+            (2, 2, 2),
+            ((0, 0, 0),),
+            (0, 1),
+            1,
+            1,
+            2,
+        )
+        source = _Source(
+            "tensor.n_dim", (4, 4, 4), (0, 0, 0), (4, 4, 4), (), "source-n-dim"
+        )
+        target = _Target((1, 1, 1), (2, 2, 2), (("stage", 0),))
+        plan = SparseObjectStorePlanner().plan_target(
+            tensor_id="tensor.n_dim",
+            tensor=_tensor_descriptor("tensor.n_dim", (4, 4, 4)),
+            target=target,
+            source_fragments=(source,),
+            source_indexes={"source-n-dim": index},
+            base_generation=1,
+            delta_generation=2,
+        )
+        self.assertEqual(plan.range_request_count, 1)
+
+    def test_named_owner_mapping_is_not_ep_tp_specific(self) -> None:
+        tensor = TensorDescriptor(
+            tensor_id="tensor.n_dim",
+            global_shape=(4, 4),
+            dtype="float32",
+            itemsize=4,
+            shard_dims=(),
+            layout_fingerprint="test:owner",
+            parallel_axes=(OwnershipAxis("pp"),),
+        )
+        from mooncake.reshard.sparse import placement_matches
+
+        self.assertTrue(placement_matches(tensor, (("pp", 0),), (("pp", 0),)))
+        self.assertFalse(placement_matches(tensor, (("pp", 0),), (("pp", 1),)))
+        self.assertFalse(placement_matches(tensor, (), ()))
+
+    def test_source_owner_admission_is_deterministic_for_replicas(self) -> None:
+        candidates = ((("ep", 1),), (("ep", 0),))
+        self.assertEqual(canonical_source_placement(candidates), (("ep", 0),))
+        self.assertTrue(is_canonical_source((("ep", 0),), candidates))
+        self.assertFalse(is_canonical_source((("ep", 1),), candidates))
+
+    def test_object_ref_key_accepts_mooncake_remote_bundle_ref(self) -> None:
+        self.assertEqual(object_ref_key(_RemoteRef("manifest-0")), "manifest-0")
+        self.assertEqual(object_ref_key({"manifest_key": "manifest-1"}), "manifest-1")
+        self.assertEqual(
+            object_ref_key({"key": None, "manifest_key": "manifest-2"}), "manifest-2"
+        )
+
+    def test_store_facade_reads_index_then_aligned_coo_ranges(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        stored = store.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(8, 12),
+            indices=np.asarray([[7, 9], [0, 0], [4, 8]], dtype=np.uint32),
+            values=np.asarray([0.7, 0.1, 0.4], dtype=np.float32),
+            generation=(10, 11),
+            tile_shape=(4, 4),
+        )
+        # PUT owns sorting/index construction; source reads only compact index
+        # members, then only the requested aligned COO range.
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        index, metadata = reader.read_index_with_metadata(stored.ref)
+        self.assertEqual(metadata["schema"], "mooncake.sparse_object")
+        self.assertEqual(metadata["coordinate_rank"], 2)
+        self.assertEqual(metadata["nnz"], 3)
+        self.assertIs(reader.read_index(stored.ref), index)
+        self.assertEqual(index.tile_coords, ((0, 0), (1, 2)))
+        indices, values = reader.read_coo_range(stored.ref, (0, 2))
+        self.assertEqual(indices.tolist(), [[0, 0], [4, 8]])
+        np.testing.assert_allclose(values, [0.1, 0.4])
+        self.assertEqual(
+            backend.materialize_members,
+            [
+                ("obj-0", ("tile_coords", "tile_ptr"), {}),
+                ("obj-0", ("indices", "values"), {"indices": (0, 2), "values": (0, 2)}),
+            ],
+        )
+        source = _Source(
+            "layer.weight", (8, 12), (0, 0), (8, 12), (("ep", 0),), stored.ref
+        )
+        target = _Target((0, 0), (8, 10), (("ep", 0), ("tp", 0)))
+        plan = reader.plan_target(
+            tensor_id="layer.weight",
+            tensor=_tensor_descriptor("layer.weight", (8, 12), owned_by_ep=True),
+            target=target,
+            source_fragments=(source,),
+            base_generation=10,
+            delta_generation=11,
+        )
+        chunks = reader.read_plan(plan)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0][0].source_object_ref, "obj-0")
+        materialized_indices, materialized_values = reader.materialize_plan(plan)
+        self.assertEqual(materialized_indices.tolist(), [[0, 0], [4, 8], [7, 9]])
+        np.testing.assert_allclose(materialized_values, [0.1, 0.4, 0.7])
+
+    def test_empty_coo_source_is_a_valid_noop_update(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 4),
+            indices=np.empty((0, 2), dtype=np.uint32),
+            values=np.empty((0,), dtype=np.float32),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        source = _Source("layer.weight", (4, 4), (0, 0), (4, 4), (), stored.ref)
+        target = _Target((0, 0), (4, 4), ())
+        plan = reader.plan_target(
+            tensor_id="layer.weight",
+            tensor=_tensor_descriptor("layer.weight", (4, 4)),
+            target=target,
+            source_fragments=(source,),
+            base_generation=1,
+            delta_generation=2,
+        )
+        self.assertEqual(plan.regions, ())
+        indices, values = reader.materialize_plan(plan)
+        self.assertEqual(indices.shape, (0, 2))
+        self.assertEqual(values.shape, (0,))
+
+    def test_store_facade_can_commit_non_source_structured_object(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        ref = store.put_structured_object(
+            metadata={"coordinate_space": "target_local"},
+            buffers={"indices": np.asarray([[0, 1]], dtype=np.uint32)},
+        )
+        self.assertEqual(ref.key, "obj-0")
+        result = backend.materialize(backend.read_spec(ref))
+        self.assertEqual(result.metadata["coordinate_space"], "target_local")
+        self.assertEqual(result.objects["indices"].tolist(), [[0, 1]])
+
+    def test_store_plan_filters_inventory_before_index_reads(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        selected = writer.put_sparse_object(
+            tensor_id="selected",
+            global_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        unrelated = writer.put_sparse_object(
+            tensor_id="unrelated",
+            global_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([2.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        source = _Source("selected", (4, 4), (0, 0), (4, 4), (), selected.ref)
+        unrelated_source = _Source(
+            "unrelated", (4, 4), (0, 0), (4, 4), (), unrelated.ref
+        )
+        target = _Target((0, 0), (4, 4), ())
+        plan = reader.plan_target(
+            tensor_id="selected",
+            tensor=_tensor_descriptor("selected", (4, 4)),
+            target=target,
+            source_fragments=(source, unrelated_source),
+            base_generation=1,
+            delta_generation=2,
+        )
+        self.assertEqual(plan.source_ranges, ((object_ref_key(selected.ref), (0, 1)),))
+        self.assertEqual(
+            [key for key, names, _slices in backend.materialize_members],
+            [object_ref_key(selected.ref)],
+        )
+
+    def test_store_plan_keeps_multiple_source_shards_and_selects_replicas(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        left = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 8),
+            global_offset=(0, 0),
+            local_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        right = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 8),
+            global_offset=(0, 4),
+            local_shape=(4, 4),
+            indices=np.asarray([[0, 4]], dtype=np.uint32),
+            values=np.asarray([2.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        left_replica = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 8),
+            global_offset=(0, 0),
+            local_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        target = _Target((0, 0), (4, 8), ())
+        tensor = _tensor_descriptor("layer.weight", (4, 8))
+        source_left = _Source("layer.weight", (4, 8), (0, 0), (4, 4), (), left.ref)
+        source_right = _Source("layer.weight", (4, 8), (0, 4), (4, 4), (), right.ref)
+        source_left_replica = _Source(
+            "layer.weight", (4, 8), (0, 0), (4, 4), (), left_replica.ref
+        )
+        selected = reader.planner.select_source_fragments(
+            tensor_id="layer.weight",
+            target=target,
+            source_fragments=(source_left_replica, source_right, source_left),
+            tensor=tensor,
+        )
+        self.assertEqual(
+            {(item.global_offset, item.local_shape) for item in selected},
+            {((0, 0), (4, 4)), ((0, 4), (4, 4))},
+        )
+        plan = reader.planner.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(source_left_replica, source_right, source_left),
+            source_indexes={
+                object_ref_key(left.ref): left.index,
+                object_ref_key(left_replica.ref): left_replica.index,
+                object_ref_key(right.ref): right.index,
+            },
+            base_generation=1,
+            delta_generation=2,
+        )
+        self.assertEqual(
+            {region.source_object_ref for region in plan.regions},
+            {object_ref_key(left.ref), object_ref_key(right.ref)},
+        )
+
+    def test_source_index_retains_geometry_and_rejects_inventory_mismatch(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(8, 8),
+            global_offset=(4, 0),
+            local_shape=(4, 8),
+            indices=np.asarray([[4, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        with self.assertRaisesRegex(ValueError, "source geometry"):
+            reader.plan_target(
+                tensor_id="layer.weight",
+                tensor=_tensor_descriptor("layer.weight", (8, 8)),
+                target=_Target((0, 0), (8, 8), ()),
+                source_fragments=(
+                    _Source("layer.weight", (8, 8), (0, 0), (8, 8), (), stored.ref),
+                ),
+                base_generation=1,
+                delta_generation=2,
+            )
+
+    def test_uint16_index_uses_wide_tile_arithmetic(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        stored = store.put_sparse_object(
+            tensor_id="large.tile",
+            global_shape=(70001, 256),
+            indices=np.asarray([[65535, 0]], dtype=np.uint16),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+            tile_shape=(70000, 256),
+            index_dtype=np.uint16,
+        )
+        payload = backend.objects[object_ref_key(stored.ref)]
+        self.assertEqual(payload.buffers["tile_coords"].tolist(), [[0, 0]])
+
+    def test_generation_must_be_initialized_before_first_apply(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        target = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(10, 11),
+        )
+        with self.assertRaises(SparseGenerationNotInitializedError):
+            store.apply_target_sparse_object(
+                np.zeros((2, 2), dtype=np.float32),
+                target.ref,
+                generation_fence=SparseGenerationFence(),
+                target_key="uninitialized",
+            )
+
+    def test_node_local_range_cache_deduplicates_raw_gets_by_generation(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 4),
+            indices=np.asarray([[0, 0], [3, 3]], dtype=np.uint32),
+            values=np.asarray([1.0, 2.0], dtype=np.float32),
+            generation=(1, 2),
+            tile_shape=(4, 4),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        source = _Source("layer.weight", (4, 4), (0, 0), (4, 4), (), stored.ref)
+        tensor = _tensor_descriptor("layer.weight", (4, 4))
+        targets = (
+            _Target((0, 0), (4, 4), (("ep", 0),), physical_node="node-a"),
+            _Target((0, 0), (4, 4), (("ep", 1),), physical_node="node-a"),
+            _Target((0, 0), (4, 4), (("ep", 2),), physical_node="node-b"),
+        )
+        for target in targets:
+            plan = reader.plan_target(
+                tensor_id="layer.weight",
+                tensor=tensor,
+                target=target,
+                source_fragments=(source,),
+                base_generation=1,
+                delta_generation=2,
+            )
+            reader.materialize_plan(plan)
+        coo_reads = [
+            event
+            for event in backend.materialize_members
+            if event[1] == ("indices", "values")
+        ]
+        self.assertEqual(len(coo_reads), 2)
+        reader.clear_range_cache(physical_node="node-a")
+        reader.materialize_plan(
+            reader.plan_target(
+                tensor_id="layer.weight",
+                tensor=tensor,
+                target=targets[0],
+                source_fragments=(source,),
+                base_generation=1,
+                delta_generation=2,
+            )
+        )
+        self.assertEqual(
+            len(
+                [
+                    event
+                    for event in backend.materialize_members
+                    if event[1] == ("indices", "values")
+                ]
+            ),
+            3,
+        )
+
+    def test_node_local_range_cache_coalesces_concurrent_identical_reads(self) -> None:
+        backend = _BlockingBackend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+            tile_shape=(4, 4),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        results = []
+        errors = []
+
+        def read_range():
+            try:
+                results.append(
+                    reader.read_coo_range_cached(
+                        stored.ref,
+                        (0, 1),
+                        base_generation=1,
+                        delta_generation=2,
+                        physical_node="node-a",
+                    )
+                )
+            except Exception as error:  # pragma: no cover - assertion below
+                errors.append(error)
+
+        first = threading.Thread(target=read_range)
+        second = threading.Thread(target=read_range)
+        first.start()
+        self.assertTrue(backend.first_coo_read_started.wait(timeout=2))
+        second.start()
+        time.sleep(0.05)
+        self.assertEqual(backend.coo_read_count, 1)
+        backend.release_first_coo_read.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(backend.coo_read_count, 1)
+
+    def test_node_local_range_cache_returns_immutable_payload(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        first = reader.read_coo_range_cached(
+            stored.ref,
+            (0, 1),
+            base_generation=1,
+            delta_generation=2,
+            physical_node="node-a",
+        )
+        self.assertFalse(first[0].flags.writeable)
+        self.assertFalse(first[1].flags.writeable)
+        with self.assertRaises(ValueError):
+            first[1][0] = 2.0
+        second = reader.read_coo_range_cached(
+            stored.ref,
+            (0, 1),
+            base_generation=1,
+            delta_generation=2,
+            physical_node="node-a",
+        )
+        np.testing.assert_allclose(second[1], [1.0])
+
+    def test_clear_cache_releases_index_and_range_entries(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(4, 4),
+            indices=np.asarray([[0, 0]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        reader.read_index(stored.ref)
+        reader.read_coo_range_cached(
+            stored.ref,
+            (0, 1),
+            base_generation=1,
+            delta_generation=2,
+            physical_node="node-a",
+        )
+        self.assertEqual(len(reader._index_cache), 1)
+        self.assertEqual(len(reader._range_cache), 1)
+
+        reader.clear_cache(object_ref=stored.ref)
+
+        self.assertEqual(reader._index_cache, {})
+        self.assertEqual(reader._metadata_cache, {})
+        self.assertEqual(reader._range_cache, {})
+
+    def test_materialize_target_rejects_tensor_dtype_mismatch(self) -> None:
+        backend = _Backend()
+        writer = SparseObjectStore(backend, payload_type=_Payload)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            indices=np.asarray([[0, 1]], dtype=np.uint32),
+            values=np.asarray([1.0], dtype=np.float64),
+            generation=(1, 2),
+        )
+        reader = SparseObjectStore(backend, payload_type=_Payload)
+        with self.assertRaisesRegex(ValueError, "TensorDescriptor dtype"):
+            reader.materialize_target(
+                tensor_id="layer.weight",
+                tensor=_tensor_descriptor("layer.weight", (2, 2)),
+                target=_Target((0, 0), (2, 2), ()),
+                source_fragments=(
+                    _Source("layer.weight", (2, 2), (0, 0), (2, 2), (), stored.ref),
+                ),
+                base_generation=1,
+                delta_generation=2,
+            )
+
+    def test_target_apply_uses_batched_additive_update(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        target = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 3),
+            global_offset=(0, 0),
+            local_shape=(2, 3),
+            indices=np.asarray([[0, 1], [0, 1], [1, 2]], dtype=np.uint32),
+            values=np.asarray([1.0, 2.0, 4.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        base = np.zeros((2, 3), dtype=np.float32)
+        np.testing.assert_allclose(
+            store.apply_target_sparse_object(base, target.ref, inplace=False),
+            [[0.0, 3.0, 0.0], [0.0, 0.0, 4.0]],
+        )
+
+        try:
+            import torch
+        except ImportError:
+            return
+        torch_base = torch.zeros((2, 3), dtype=torch.float32)
+        torch_result = store.apply_target_sparse_object(
+            torch_base, target.ref, inplace=False
+        )
+        self.assertTrue(
+            torch.equal(torch_result, torch.tensor([[0.0, 3.0, 0.0], [0.0, 0.0, 4.0]]))
+        )
+
+    def test_target_apply_rejects_base_dtype_mismatch(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        target = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[0, 1]], dtype=np.uint32),
+            values=np.asarray([2.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        with self.assertRaisesRegex(ValueError, "value dtype does not match base"):
+            store.apply_target_sparse_object(
+                np.zeros((2, 2), dtype=np.float64), target.ref, inplace=False
+            )
+
+    def test_equal_generation_retry_without_update_key_is_rejected(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        target = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[0, 1]], dtype=np.uint32),
+            values=np.asarray([2.0], dtype=np.float32),
+            generation=(1, 2),
+        )
+        fence = SparseGenerationFence()
+        fence.set_current("worker-0", 1)
+        base = np.zeros((2, 2), dtype=np.float32)
+        store.apply_target_sparse_object(
+            base, target.ref, generation_fence=fence, target_key="worker-0"
+        )
+        with self.assertRaises(SparseGenerationMismatchError):
+            store.apply_target_sparse_object(
+                base, target.ref, generation_fence=fence, target_key="worker-0"
+            )
+
+    def test_target_apply_is_generation_fenced_and_identity_checked(self) -> None:
+        backend = _Backend()
+        store = SparseObjectStore(backend, payload_type=_Payload)
+        target = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[0, 1]], dtype=np.uint32),
+            values=np.asarray([2.0], dtype=np.float32),
+            generation=(10, 11),
+            target_placement=(("ep", 0), ("tp", 0)),
+            logical_update_key="layer.weight:10:11",
+            target_key="worker-0:layer.weight",
+        )
+        fence = SparseGenerationFence()
+        fence.set_current("worker-0:layer.weight", 10)
+        base = np.zeros((2, 2), dtype=np.float32)
+        store.apply_target_sparse_object(
+            base,
+            target.ref,
+            generation_fence=fence,
+            target_key="worker-0:layer.weight",
+            expected_tensor_id="layer.weight",
+            expected_target_placement=(("ep", 0), ("tp", 0)),
+            expected_generation=(10, 11),
+            expected_update_key="layer.weight:10:11",
+            expected_target_key="worker-0:layer.weight",
+        )
+        np.testing.assert_allclose(base, [[0.0, 2.0], [0.0, 0.0]])
+        different_key = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[1, 0]], dtype=np.uint32),
+            values=np.asarray([4.0], dtype=np.float32),
+            generation=(10, 11),
+            logical_update_key="layer.weight:other:10:11",
+        )
+        with self.assertRaises(SparseGenerationMismatchError):
+            store.apply_target_sparse_object(
+                base,
+                different_key.ref,
+                generation_fence=fence,
+                target_key="worker-0:layer.weight",
+            )
+        # Equal-generation retry is idempotent.
+        store.apply_target_sparse_object(
+            base,
+            target.ref,
+            generation_fence=fence,
+            target_key="worker-0:layer.weight",
+        )
+        np.testing.assert_allclose(base, [[0.0, 2.0], [0.0, 0.0]])
+
+        stale = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[1, 1]], dtype=np.uint32),
+            values=np.asarray([3.0], dtype=np.float32),
+            generation=(9, 10),
+        )
+        with self.assertRaises(StaleSparseGenerationError):
+            store.apply_target_sparse_object(
+                base,
+                stale.ref,
+                generation_fence=fence,
+                target_key="worker-0:layer.weight",
+            )
+        skipped = store.put_target_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(2, 2),
+            global_offset=(0, 0),
+            local_shape=(2, 2),
+            indices=np.asarray([[1, 1]], dtype=np.uint32),
+            values=np.asarray([3.0], dtype=np.float32),
+            generation=(12, 13),
+        )
+        with self.assertRaises(SparseGenerationMismatchError):
+            store.apply_target_sparse_object(
+                base,
+                skipped.ref,
+                generation_fence=fence,
+                target_key="worker-0:layer.weight",
+            )
+        np.testing.assert_allclose(base, [[0.0, 2.0], [0.0, 0.0]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-rl/test_sparse_object_store_mooncake.py
+++ b/mooncake-rl/test_sparse_object_store_mooncake.py
@@ -1,0 +1,154 @@
+"""Integration smoke test against Mooncake's current structured-object API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+for _path in (
+    _ROOT / "mooncake-reshard" / "python",
+    _ROOT / "mooncake-wheel",
+    _ROOT / "mooncake-rl",
+):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from mooncake.structured_object_store import (  # noqa: E402
+    MooncakeBundleTransfer,
+    StructuredObjectReadSpec,
+)
+from sparse_object_store import (  # noqa: E402
+    SparseObjectStore,
+    object_ref_key,
+)
+from mooncake.reshard.weight import (  # noqa: E402
+    OwnershipAxis,
+    SplitAxis,
+    TensorDescriptor,
+)
+
+
+class InMemoryBundleStore:
+    """Low-level structured-object store double for this test module."""
+
+    def __init__(self) -> None:
+        self._objects: dict[str, bytes] = {}
+
+    def put(self, key: str, value: object, config: object = None) -> int:
+        del config
+        self._objects[key] = bytes(value)
+        return 0
+
+    def get(self, key: str) -> bytes:
+        return self._objects[key]
+
+    def remove(self, key: str, force: bool = False) -> int:
+        del force
+        self._objects.pop(key, None)
+        return 0
+
+    def is_exist(self, key: str) -> int:
+        return int(key in self._objects)
+
+
+class TrackingBundleTransfer(MooncakeBundleTransfer):
+    """Record structured read specs while retaining the production layer."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.materialized_specs: list[StructuredObjectReadSpec] = []
+
+    def materialize(self, spec: StructuredObjectReadSpec):  # type: ignore[override]
+        self.materialized_specs.append(spec)
+        return super().materialize(spec)
+
+
+@dataclass(frozen=True)
+class _Source:
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    source_placement: tuple[tuple[str, int], ...]
+    object_ref: object
+
+
+@dataclass(frozen=True)
+class _Target:
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    target_placement: tuple[tuple[str, int], ...]
+
+
+class StructuredObjectIntegrationTest(unittest.TestCase):
+    def test_real_structured_object_member_slices(self) -> None:
+        low_level = InMemoryBundleStore()
+        writer_transfer = MooncakeBundleTransfer(low_level, key_prefix="integration")
+        writer = SparseObjectStore(writer_transfer)
+        stored = writer.put_sparse_object(
+            tensor_id="layer.weight",
+            global_shape=(8, 12),
+            global_offset=(0, 0),
+            local_shape=(8, 12),
+            source_placement=(("ep", 0),),
+            indices=np.asarray([[0, 0], [4, 8], [7, 9]], dtype=np.uint32),
+            values=np.asarray([0.1, 0.4, 0.7], dtype=np.float32),
+            generation=(1, 2),
+            tile_shape=(4, 4),
+        )
+
+        reader_transfer = TrackingBundleTransfer(low_level, key_prefix="integration")
+        reader = SparseObjectStore(reader_transfer)
+        source = _Source(
+            "layer.weight", (8, 12), (0, 0), (8, 12), (("ep", 0),), stored.ref
+        )
+        target = _Target(
+            "layer.weight", (8, 12), (0, 0), (4, 10), (("ep", 0), ("tp", 0))
+        )
+        tensor = TensorDescriptor(
+            tensor_id="layer.weight",
+            global_shape=(8, 12),
+            dtype="float32",
+            itemsize=4,
+            shard_dims=(1,),
+            layout_fingerprint="integration:layer.weight",
+            parallel_axes=(OwnershipAxis("ep"), SplitAxis("tp", 1)),
+        )
+        plan = reader.plan_target(
+            tensor_id="layer.weight",
+            tensor=tensor,
+            target=target,
+            source_fragments=(source,),
+            base_generation=1,
+            delta_generation=2,
+        )
+        indices, values = reader.materialize_plan(plan)
+        np.testing.assert_array_equal(indices, [[0, 0]])
+        np.testing.assert_allclose(values, [0.1])
+
+        source_key = object_ref_key(stored.ref)
+        source_specs = [
+            spec
+            for spec in reader_transfer.materialized_specs
+            if object_ref_key(spec.ref) == source_key
+        ]
+        self.assertEqual(
+            [spec.member_names for spec in source_specs],
+            [("tile_coords", "tile_ptr"), ("indices", "values")],
+        )
+        slices = dict(source_specs[-1].member_slices)
+        self.assertEqual(slices["indices"], slices["values"])
+        self.assertEqual(slices["indices"].start, 0)
+        self.assertEqual(slices["indices"].end, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds a framework-neutral prototype for transferring COO sparse updates as Mooncake structured objects.

The implementation keeps sparse planning separate from transport details. Source objects carry JSON metadata and named indices/values buffers; the facade uses the existing Mooncake Store structured-object and buffer APIs, whose data path is backed by the Transfer Engine transports.

The planner and facade provide:

- source-fragment selection by logical geometry and placement;
- compact tile indexes and aligned indices/values range reads;
- source identity, geometry, dtype, and generation validation;
- stale-replica filtering and generation fencing;
- target-boundary filtering, coordinate rebasing, and additive scatter-add materialization;
- process-local metadata/range cache management.

This PR is a prototype and does not integrate the structured-object path into the ScaleAligner/ROLL production update chain.

Related RFC: #3953

## Module

- [x] Transfer Engine (structured-object/buffer data path)
- [x] Reshard
- [x] Mooncake RL

## Type of Change

- [x] New feature

## How Has This Been Tested?

Test commands:

    PYTHONPATH=$PWD/mooncake-reshard/python:$PWD/mooncake-wheel:$PWD/mooncake-rl /root/sglang-venv/bin/python -m pytest -q mooncake-rl/test_sparse_object_store.py mooncake-reshard/tests/test_sparse_planner.py mooncake-rl/test_sparse_object_store_mooncake.py
    PYTHONPATH=$PWD/mooncake-reshard/python:$PWD/mooncake-wheel:$PWD/mooncake-rl /root/sglang-venv/bin/python -m pytest -q mooncake-reshard/tests --ignore=mooncake-reshard/tests/test_reshard_geometry.py --ignore=mooncake-reshard/tests/model_weight_store/test_snapshot_writer.py
    /root/sglang-venv/bin/python -m pre_commit run --files <changed-files>

Test results:

- 33 focused tests passed.
- 519 reshard tests passed when excluding the unrelated prebuilt-wheel compatibility test.
- pre-commit, ruff, ruff-format, compileall, and git diff checks passed.
- An independent real Mooncake Store/Transfer Engine validation passed for structured-object PUT, index-only reads, aligned COO range reads, target materialization, coordinate rebasing, and result verification.

The unfiltered reshard suite had one environment mismatch: the prebuilt local mooncake.store wheel does not expose begin_weight_snapshot, while the current source test expects that API. The affected test is outside this PR's sparse implementation.

## Scope and Limitations

- The planner and sparse facade are prototype APIs under mooncake-reshard and mooncake-rl.
- Caches are process-local; this PR does not provide cross-process or cross-node physical-object deduplication.
- The current Torch apply path uses host staging; it is not an end-to-end device-direct zero-copy path.
- ScaleAligner/ROLL production integration is intentionally not included.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my code and run the repository pre-commit hooks.
- [x] I have added tests to prove the changed behavior.
- [x] For changes over 500 LOC, I have filed the RFC issue referenced above.

## AI Assistance Disclosure

- [x] AI tools were used for implementation assistance, code review, test execution, and PR preparation. The human submitter is responsible for understanding and defending all changes.