### PR TITLE
[Store] Add device-DAX arena mode to offset_allocator_storage_backend

### DIFF
--- a/docs/source/deployment/ssd/ssd-offload.md
+++ b/docs/source/deployment/ssd/ssd-offload.md
@@ -211,6 +211,22 @@ Pre-allocates a single large file and manages offset-based allocation within it.
 
 Best for: high-concurrency scenarios with many small objects where restart durability is not required.
 
+#### Device-DAX / CXL memory arena
+
+Set `MOONCAKE_OFFSET_DAX_DEVICE_PATH` to place the arena on byte-addressable memory instead of a file: a device-DAX character device (`/dev/dax0.0`, backed by PMEM or CXL-attached memory), an fsdax file, or any regular file. The backend maps the first `MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES` bytes with `mmap(MAP_SHARED)` and copies records with `memcpy`. Device-DAX nodes do not support `read`/`write` syscalls, so this mode is the only way to use them. `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` is still required: it holds the metadata checkpoint when persistence is enabled.
+
+| Variable | Default | Description |
+|---|---|---|
+| `MOONCAKE_OFFSET_DAX_DEVICE_PATH` | unset | Path to map as the data arena. Unset keeps the file-based arena under `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`. |
+| `MOONCAKE_OFFSET_DAX_ALIGNMENT_BYTES` | `2097152` | Capacity is rounded down to a multiple of this. Device-DAX rejects mapping lengths that are not a multiple of the device alignment (2 MiB, or 1 GiB for some namespaces). |
+
+Notes:
+
+- The process needs read/write permission on the device node, and the device must already exist; no `ndctl`/`daxctl` provisioning is performed.
+- `MOONCAKE_OFFLOAD_USE_URING` is ignored for the DAX arena.
+- Device memory outlives the process, so `MOONCAKE_OFFSET_PERSIST_MODE=strict` or `relaxed` restores the arena after a restart. Sync uses `msync`, which does not flush CPU caches to persistent media; treat the arena as volatile across power loss.
+- The DAX arena is independent of the transfer engine's `cxl` protocol (`MC_CXL_DEV_PATH`). Do not point both at the same device range.
+
 ---
 
 ## Eviction

--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -99,6 +99,8 @@ struct OffsetAllocatorBackendEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_OFFSET_PERSIST_MODE);
     MC_DEFINE_ENV_VAR(int64_t, MOONCAKE_OFFSET_PERSIST_INTERVAL_SECONDS);
     MC_DEFINE_ENV_VAR(bool, MOONCAKE_OFFSET_RECORD_CRC);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_OFFSET_DAX_DEVICE_PATH);
+    MC_DEFINE_ENV_VAR(int64_t, MOONCAKE_OFFSET_DAX_ALIGNMENT_BYTES);
 };
 
 struct ReplicaSelectionEnvironmentVariables {

--- a/mooncake-store/include/config/offset_allocator_backend_config.h
+++ b/mooncake-store/include/config/offset_allocator_backend_config.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace mooncake {
 
@@ -61,6 +62,18 @@ struct OffsetAllocatorBackendConfig {
     // the CPU (future DMA/GDS writers): unchecksummed records are then
     // validated by checkpoint ordering (seq guard) alone.
     bool enable_record_crc = true;
+
+    // ---- Device-DAX / byte-addressable arena ----
+    // When non-empty, the data arena is an mmap(MAP_SHARED) of this path (a
+    // device-DAX chardev such as /dev/dax0.0, an fsdax file, or any regular
+    // file) instead of {storage_filepath}/kv_cache.data. The metadata
+    // checkpoint still lives under storage_filepath. See DaxFile.
+    std::string dax_device_path;
+
+    // Capacity is rounded down to a multiple of this when dax_device_path is
+    // set. Device-DAX rejects mmap lengths that are not a multiple of the
+    // device alignment (2 MiB, or 1 GiB for some namespaces).
+    int64_t dax_alignment_bytes = 2 * 1024 * 1024;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/dax_file.h
+++ b/mooncake-store/include/dax_file.h
@@ -1,0 +1,66 @@
+// Copyright 2026 KVCache.AI
+// StorageFile backed by a byte-addressable, mmap-able device.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "file_interface.h"
+
+namespace mooncake {
+
+/**
+ * @class DaxFile
+ * @brief StorageFile over an mmap(MAP_SHARED) of a byte-addressable device.
+ *
+ * Intended for Linux device-DAX character devices (/dev/daxX.Y backed by
+ * PMEM or CXL-attached memory), fsdax files, or any regular file. Device-DAX
+ * nodes reject read/write syscalls, so every I/O is a memcpy through the
+ * mapping. The mapping is treated as fast volatile memory: datasync() is an
+ * msync(), which does not flush CPU caches to persistent media.
+ */
+class DaxFile : public StorageFile {
+   public:
+    /**
+     * @brief Opens `path` O_RDWR and maps its first `size` bytes MAP_SHARED.
+     *
+     * Regular files smaller than `size` are grown with ftruncate so fsdax
+     * files and test fixtures work. Character devices report st_size == 0
+     * and are mapped as-is; device-DAX requires `size` to be a multiple of
+     * the device alignment (typically 2 MiB) or mmap fails with EINVAL.
+     */
+    static tl::expected<std::shared_ptr<DaxFile>, ErrorCode> Open(
+        const std::string &path, size_t size);
+
+    ~DaxFile() override;
+
+    tl::expected<void, ErrorCode> datasync() override;
+
+    // Sequential I/O is not offered: the only consumer
+    // (OffsetAllocatorStorageBackend) addresses records by offset.
+    tl::expected<size_t, ErrorCode> write(const std::string &buffer,
+                                          size_t length) override;
+    tl::expected<size_t, ErrorCode> write(std::span<const char> data,
+                                          size_t length) override;
+    tl::expected<size_t, ErrorCode> read(std::string &buffer,
+                                         size_t length) override;
+
+    tl::expected<size_t, ErrorCode> vector_write(const iovec *iov, int iovcnt,
+                                                 off_t offset) override;
+    tl::expected<size_t, ErrorCode> vector_read(const iovec *iov, int iovcnt,
+                                                off_t offset) override;
+
+    void *base() const { return base_; }
+    size_t size() const { return size_; }
+
+   private:
+    DaxFile(const std::string &path, int fd, void *base, size_t size);
+
+    bool InRange(off_t offset, size_t length) const;
+
+    void *base_;
+    size_t size_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -1474,6 +1474,11 @@ class OffsetAllocatorStorageBackend : public StorageBackendInterface {
     // Returns full path to data file: {storage_path_}/kv_cache.data
     std::string GetDataFilePath() const;
 
+    // Maps cfg_.dax_device_path as the data arena (see DaxFile), binding
+    // data_file_path_ and data_file_. Used instead of the file open paths
+    // whenever dax_device_path is set.
+    tl::expected<void, ErrorCode> OpenDaxDataFile();
+
     static constexpr size_t kNumShards =
         1024;  // Number of shards (must be power of 2 for bitwise optimization)
 
@@ -1656,6 +1661,7 @@ class OffsetAllocatorStorageBackend : public StorageBackendInterface {
     int64_t GetMetadataConsecutiveFailures() const {
         return metadata_consecutive_failures_.load(std::memory_order_relaxed);
     }
+    uint64_t GetCapacityForTest() const { return capacity_; }
 
    private:
 };

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     nvme_kv_object_layout.cpp
     transfer_task.cpp
     posix_file.cpp
+    dax_file.cpp
     client_buffer.cpp
     aligned_client_buffer.cpp
     real_client.cpp

--- a/mooncake-store/src/config/offset_allocator_backend_config.cpp
+++ b/mooncake-store/src/config/offset_allocator_backend_config.cpp
@@ -54,6 +54,12 @@ bool OffsetAllocatorBackendConfig::Validate() const {
             << "OffsetAllocatorBackendConfig: max_capacity_nodes must be >= 0";
         return false;
     }
+    if (dax_alignment_bytes <= 0 ||
+        (dax_alignment_bytes & (dax_alignment_bytes - 1)) != 0) {
+        LOG(ERROR) << "OffsetAllocatorBackendConfig: dax_alignment_bytes must "
+                      "be a positive power of two";
+        return false;
+    }
     return true;
 }
 
@@ -130,6 +136,13 @@ OffsetAllocatorBackendConfig OffsetAllocatorBackendConfig::FromEnvironment() {
         record_crc.has_value() && !*record_crc) {
         cfg.enable_record_crc = false;
     }
+
+    // Device-DAX / byte-addressable arena (see DaxFile).
+    cfg.dax_device_path = Environ::ReadOr(
+        Variables::MOONCAKE_OFFSET_DAX_DEVICE_PATH, cfg.dax_device_path);
+    cfg.dax_alignment_bytes =
+        Environ::ReadOr(Variables::MOONCAKE_OFFSET_DAX_ALIGNMENT_BYTES,
+                        cfg.dax_alignment_bytes);
 
     return cfg;
 }

--- a/mooncake-store/src/dax_file.cpp
+++ b/mooncake-store/src/dax_file.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 KVCache.AI
+
+#include "dax_file.h"
+
+#include <fcntl.h>
+#include <glog/logging.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+
+namespace mooncake {
+
+DaxFile::DaxFile(const std::string &path, int fd, void *base, size_t size)
+    : StorageFile(path, fd), base_(base), size_(size) {
+    // Never unlink the backing path on a failed write: for a character
+    // device that would remove the device node itself.
+    delete_on_write_fail_ = false;
+}
+
+tl::expected<std::shared_ptr<DaxFile>, ErrorCode> DaxFile::Open(
+    const std::string &path, size_t size) {
+    if (path.empty() || size == 0) {
+        LOG(ERROR) << "DaxFile: path must be non-empty and size > 0";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    int fd = ::open(path.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+        LOG(ERROR) << "DaxFile: failed to open " << path << ": "
+                   << strerror(errno);
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+
+    struct stat st{};
+    if (::fstat(fd, &st) != 0) {
+        LOG(ERROR) << "DaxFile: fstat failed on " << path << ": "
+                   << strerror(errno);
+        ::close(fd);
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+    if (S_ISREG(st.st_mode) && static_cast<uint64_t>(st.st_size) < size) {
+        if (::ftruncate(fd, static_cast<off_t>(size)) != 0) {
+            LOG(ERROR) << "DaxFile: failed to grow " << path << " to " << size
+                       << " bytes: " << strerror(errno);
+            ::close(fd);
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+    }
+
+    void *base =
+        ::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (base == MAP_FAILED) {
+        LOG(ERROR) << "DaxFile: mmap of " << size << " bytes from " << path
+                   << " failed: " << strerror(errno)
+                   << " (device-DAX requires the length to be a multiple of "
+                      "the device alignment, typically 2 MiB)";
+        ::close(fd);
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+
+    return std::shared_ptr<DaxFile>(new DaxFile(path, fd, base, size));
+}
+
+DaxFile::~DaxFile() {
+    if (base_ != nullptr && ::munmap(base_, size_) != 0) {
+        LOG(WARNING) << "DaxFile: munmap failed for " << filename_ << ": "
+                     << strerror(errno);
+    }
+    base_ = nullptr;
+    if (fd_ >= 0 && ::close(fd_) != 0) {
+        LOG(WARNING) << "DaxFile: failed to close " << filename_;
+    }
+    fd_ = -1;
+}
+
+tl::expected<void, ErrorCode> DaxFile::datasync() {
+    if (base_ == nullptr) {
+        return make_error<void>(ErrorCode::FILE_NOT_FOUND);
+    }
+    // ponytail: msync covers fsdax and regular files. Device-DAX chardevs
+    // have no fsync op, so the kernel answers EINVAL; there is no page cache
+    // to flush and stores already landed in device memory. Add CLWB+SFENCE
+    // here if crash-consistent PMEM durability is ever required.
+    if (::msync(base_, size_, MS_SYNC) != 0) {
+        if (errno == EINVAL) {
+            LOG_FIRST_N(INFO, 1) << "DaxFile: msync unsupported on "
+                                 << filename_ << "; treating as no-op";
+            return {};
+        }
+        LOG(ERROR) << "DaxFile: msync failed for " << filename_ << ": "
+                   << strerror(errno);
+        return make_error<void>(ErrorCode::FILE_WRITE_FAIL);
+    }
+    return {};
+}
+
+tl::expected<size_t, ErrorCode> DaxFile::write(const std::string &, size_t) {
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+tl::expected<size_t, ErrorCode> DaxFile::write(std::span<const char>, size_t) {
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+tl::expected<size_t, ErrorCode> DaxFile::read(std::string &, size_t) {
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+bool DaxFile::InRange(off_t offset, size_t length) const {
+    if (offset < 0) return false;
+    const auto start = static_cast<uint64_t>(offset);
+    return start <= size_ && length <= size_ - start;
+}
+
+tl::expected<size_t, ErrorCode> DaxFile::vector_write(const iovec *iov,
+                                                      int iovcnt,
+                                                      off_t offset) {
+    if (base_ == nullptr) {
+        return make_error<size_t>(ErrorCode::FILE_NOT_FOUND);
+    }
+    if (iov == nullptr || iovcnt < 0) {
+        return make_error<size_t>(ErrorCode::FILE_INVALID_BUFFER);
+    }
+    size_t total = 0;
+    for (int i = 0; i < iovcnt; ++i) total += iov[i].iov_len;
+    if (!InRange(offset, total)) {
+        LOG(ERROR) << "DaxFile: write of " << total << " bytes at offset "
+                   << offset << " exceeds mapping of " << size_ << " bytes";
+        return make_error<size_t>(ErrorCode::FILE_WRITE_FAIL);
+    }
+    char *dst = static_cast<char *>(base_) + offset;
+    for (int i = 0; i < iovcnt; ++i) {
+        if (iov[i].iov_len > 0) {
+            std::memcpy(dst, iov[i].iov_base, iov[i].iov_len);
+            dst += iov[i].iov_len;
+        }
+    }
+    return total;
+}
+
+tl::expected<size_t, ErrorCode> DaxFile::vector_read(const iovec *iov,
+                                                     int iovcnt, off_t offset) {
+    if (base_ == nullptr) {
+        return make_error<size_t>(ErrorCode::FILE_NOT_FOUND);
+    }
+    if (iov == nullptr || iovcnt < 0) {
+        return make_error<size_t>(ErrorCode::FILE_INVALID_BUFFER);
+    }
+    size_t total = 0;
+    for (int i = 0; i < iovcnt; ++i) total += iov[i].iov_len;
+    if (!InRange(offset, total)) {
+        LOG(ERROR) << "DaxFile: read of " << total << " bytes at offset "
+                   << offset << " exceeds mapping of " << size_ << " bytes";
+        return make_error<size_t>(ErrorCode::FILE_READ_FAIL);
+    }
+    const char *src = static_cast<const char *>(base_) + offset;
+    for (int i = 0; i < iovcnt; ++i) {
+        if (iov[i].iov_len > 0) {
+            std::memcpy(iov[i].iov_base, src, iov[i].iov_len);
+            src += iov[i].iov_len;
+        }
+    }
+    return total;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -28,6 +28,7 @@
 #include "common/timestamp.h"
 #include "common/file_util.h"
 #include "crc32c.h"
+#include "dax_file.h"
 #include "environ.h"
 
 #include <ylt/util/tl/expected.hpp>
@@ -3536,6 +3537,17 @@ OffsetAllocatorStorageBackend::OffsetAllocatorStorageBackend(
       storage_path_(file_storage_config_.storage_filepath),
       cfg_(offset_backend_config) {
     capacity_ = file_storage_config_.total_size_limit;
+    if (!cfg_.dax_device_path.empty() && cfg_.dax_alignment_bytes > 0) {
+        const auto align = static_cast<uint64_t>(cfg_.dax_alignment_bytes);
+        const uint64_t aligned = capacity_ / align * align;
+        if (aligned != capacity_) {
+            LOG(WARNING) << "OffsetAllocatorStorageBackend: rounding DAX "
+                            "arena capacity "
+                         << capacity_ << " down to " << aligned
+                         << " (multiple of " << align << " bytes)";
+            capacity_ = aligned;
+        }
+    }
 }
 
 OffsetAllocatorStorageBackend::~OffsetAllocatorStorageBackend() {
@@ -3583,6 +3595,20 @@ std::string OffsetAllocatorStorageBackend::GetDataFilePath() const {
 
 std::string OffsetAllocatorStorageBackend::GetMetaFilePath() const {
     return (std::filesystem::path(storage_path_) / "kv_cache.meta").string();
+}
+
+tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::OpenDaxDataFile() {
+    data_file_path_ = cfg_.dax_device_path;
+    auto dax = DaxFile::Open(data_file_path_, capacity_);
+    if (!dax) {
+        LOG(ERROR) << "Failed to map DAX data arena: " << data_file_path_;
+        return tl::make_unexpected(dax.error());
+    }
+    if (file_storage_config_.use_uring) {
+        LOG(INFO) << "use_uring ignored for DAX data arena " << data_file_path_;
+    }
+    data_file_ = std::move(*dax);
+    return {};
 }
 
 //-----------------------------------------------------------------------------
@@ -3738,39 +3764,48 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
             total_keys_.store(0, std::memory_order_relaxed);
         }
 
-        // Get data file path
-        data_file_path_ = GetDataFilePath();
-
-        // Open/truncate data file in read-write mode
-        int flags = O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC;
-        int raw_fd = open(data_file_path_.c_str(), flags, 0644);
-        if (raw_fd < 0) {
-            LOG(ERROR) << "Failed to open data file: " << data_file_path_;
-            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
-        }
-        FdGuard fd_guard(raw_fd);
-
-        // Use fallocate if available, otherwise ftruncate
-        if (fallocate(fd_guard.get(), 0, 0, capacity_) != 0) {
-            // Fallback to ftruncate
-            if (ftruncate(fd_guard.get(), capacity_) != 0) {
-                LOG(ERROR) << "Failed to preallocate file: " << data_file_path_
-                           << ", capacity: " << capacity_
-                           << ", error: " << strerror(errno);
-                return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        if (!cfg_.dax_device_path.empty()) {
+            // Byte-addressable arena: map the device, no file to create.
+            auto dax = OpenDaxDataFile();
+            if (!dax) {
+                return tl::make_unexpected(dax.error());
             }
-        }
+        } else {
+            // Get data file path
+            data_file_path_ = GetDataFilePath();
 
-        // Release fd to StorageFile (takes ownership and will close it)
+            // Open/truncate data file in read-write mode
+            int flags = O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC;
+            int raw_fd = open(data_file_path_.c_str(), flags, 0644);
+            if (raw_fd < 0) {
+                LOG(ERROR) << "Failed to open data file: " << data_file_path_;
+                return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+            }
+            FdGuard fd_guard(raw_fd);
+
+            // Use fallocate if available, otherwise ftruncate
+            if (fallocate(fd_guard.get(), 0, 0, capacity_) != 0) {
+                // Fallback to ftruncate
+                if (ftruncate(fd_guard.get(), capacity_) != 0) {
+                    LOG(ERROR)
+                        << "Failed to preallocate file: " << data_file_path_
+                        << ", capacity: " << capacity_
+                        << ", error: " << strerror(errno);
+                    return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+                }
+            }
+
+            // Release fd to StorageFile (takes ownership and will close it)
 #ifdef USE_URING
-        if (file_storage_config_.use_uring) {
-            data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, true);
-        } else
+            if (file_storage_config_.use_uring) {
+                data_file_ = std::make_shared<UringFile>(
+                    data_file_path_, fd_guard.release(), 32, true);
+            } else
 #endif
-        {
-            data_file_ = std::make_shared<PosixFile>(data_file_path_,
-                                                     fd_guard.release());
+            {
+                data_file_ = std::make_shared<PosixFile>(data_file_path_,
+                                                         fd_guard.release());
+            }
         }
         if (cfg_.persist_mode != OffsetPersistMode::kDisabled) {
             data_file_->SetDeleteOnWriteFail(false);
@@ -4515,49 +4550,61 @@ OffsetAllocatorStorageBackend::TryRecoverFromMetadata() {
             }
         }
 
-        // Open data file without truncation
-        data_file_path_ = GetDataFilePath();
-        int flags = O_CLOEXEC | O_RDWR;
-        int raw_fd = open(data_file_path_.c_str(), flags, 0644);
-        if (raw_fd < 0) {
-            const int open_errno = errno;
-            LOG(ERROR) << "Failed to open data file: " << data_file_path_
-                       << ": " << strerror(open_errno);
-            // The meta references data that is genuinely gone: nothing
-            // recoverable remains, so a fresh start is appropriate.
-            if (open_errno == ENOENT) {
+        if (!cfg_.dax_device_path.empty()) {
+            // Device memory outlives the process, so the persisted
+            // allocator state still describes the arena. Chardevs report
+            // st_size == 0, so there is no file-size check to run here.
+            if (!OpenDaxDataFile()) {
+                // A device that cannot be mapped right now may come back;
+                // do not wipe the checkpoint for it.
+                fallback_guard.disarm();
+                return RecoveryResult::kTransientError;
+            }
+        } else {
+            // Open data file without truncation
+            data_file_path_ = GetDataFilePath();
+            int flags = O_CLOEXEC | O_RDWR;
+            int raw_fd = open(data_file_path_.c_str(), flags, 0644);
+            if (raw_fd < 0) {
+                const int open_errno = errno;
+                LOG(ERROR) << "Failed to open data file: " << data_file_path_
+                           << ": " << strerror(open_errno);
+                // The meta references data that is genuinely gone: nothing
+                // recoverable remains, so a fresh start is appropriate.
+                if (open_errno == ENOENT) {
+                    return RecoveryResult::kCorrupt;
+                }
+                // Anything else (fd exhaustion, permissions, I/O error) may
+                // be transient -- do not wipe the persisted cache for it.
+                fallback_guard.disarm();
+                return RecoveryResult::kTransientError;
+            }
+            FdGuard fd_guard(raw_fd);
+
+            // Verify data file size matches capacity_
+            struct stat st;
+            if (fstat(fd_guard.get(), &st) != 0) {
+                LOG(ERROR) << "fstat failed on data file: " << strerror(errno);
+                fallback_guard.disarm();
+                return RecoveryResult::kTransientError;
+            }
+            if (static_cast<uint64_t>(st.st_size) != capacity_) {
+                LOG(WARNING) << "data file size mismatch: expected "
+                             << capacity_ << ", got " << st.st_size
+                             << " -- falling back to fresh start";
                 return RecoveryResult::kCorrupt;
             }
-            // Anything else (fd exhaustion, permissions, I/O error) may
-            // be transient -- do not wipe the persisted cache for it.
-            fallback_guard.disarm();
-            return RecoveryResult::kTransientError;
-        }
-        FdGuard fd_guard(raw_fd);
-
-        // Verify data file size matches capacity_
-        struct stat st;
-        if (fstat(fd_guard.get(), &st) != 0) {
-            LOG(ERROR) << "fstat failed on data file: " << strerror(errno);
-            fallback_guard.disarm();
-            return RecoveryResult::kTransientError;
-        }
-        if (static_cast<uint64_t>(st.st_size) != capacity_) {
-            LOG(WARNING) << "data file size mismatch: expected " << capacity_
-                         << ", got " << st.st_size
-                         << " -- falling back to fresh start";
-            return RecoveryResult::kCorrupt;
-        }
 
 #ifdef USE_URING
-        if (file_storage_config_.use_uring) {
-            data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, true);
-        } else
+            if (file_storage_config_.use_uring) {
+                data_file_ = std::make_shared<UringFile>(
+                    data_file_path_, fd_guard.release(), 32, true);
+            } else
 #endif
-        {
-            data_file_ = std::make_shared<PosixFile>(data_file_path_,
-                                                     fd_guard.release());
+            {
+                data_file_ = std::make_shared<PosixFile>(data_file_path_,
+                                                         fd_guard.release());
+            }
         }
         data_file_->SetDeleteOnWriteFail(false);
 
@@ -5465,7 +5512,9 @@ void OffsetAllocatorStorageBackend::RemoveAll() {
     // Rebinding the shared_ptr drops our ref; any in-flight
     // BatchLoad/BatchStore that pinned the old data_file_ keeps it alive until
     // its I/O completes — no use-after-free.
-    if (!data_file_path_.empty()) {
+    // A DAX arena keeps its mapping: the allocator rebuild below already
+    // makes every old record unreachable, and there is nothing to truncate.
+    if (!data_file_path_.empty() && cfg_.dax_device_path.empty()) {
         int fd = open(data_file_path_.c_str(),
                       O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC, 0644);
         if (fd >= 0) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -29,6 +29,7 @@
 #include "allocator.h"
 #include "common/timestamp.h"
 #include "common/file_util.h"
+#include "dax_file.h"
 #include "utils/common.h"
 
 namespace fs = std::filesystem;
@@ -1228,6 +1229,172 @@ TEST_F(StorageBackendTest, OffsetAllocatorStorageBackend_BasicPutGet) {
         std::string loaded(static_cast<char*>(it->second.ptr), it->second.size);
         EXPECT_EQ(loaded, expected_value);
     }
+}
+
+//-----------------------------------------------------------------------------
+// Device-DAX arena. A sparse regular file stands in for /dev/daxX.Y: the
+// backend takes the same open + mmap(MAP_SHARED) path either way, and a
+// regular file additionally lets the test read the bytes back through the
+// fd to prove write-through.
+
+namespace {
+
+std::string MakeFakeDaxDevice(const std::string& dir, size_t size) {
+    const std::string path = dir + "/fake_dax.dev";
+    std::ofstream(path, std::ios::binary).close();
+    fs::resize_file(path, size);
+    return path;
+}
+
+void OffloadOne(StorageBackendInterface& backend, const std::string& key,
+                const std::string& value) {
+    std::unordered_map<std::string, std::vector<Slice>> batch;
+    batch.emplace(key, std::vector<Slice>{Slice{const_cast<char*>(value.data()),
+                                                value.size()}});
+    auto res = backend.BatchOffload(
+        batch,
+        [](const std::vector<std::string>&,
+           std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(res.value(), 1);
+}
+
+std::string LoadOne(StorageBackendInterface& backend, const std::string& key,
+                    size_t size) {
+    std::string out(size, '\0');
+    std::unordered_map<std::string, Slice> slices;
+    slices.emplace(key, Slice{out.data(), out.size()});
+    EXPECT_TRUE(backend.BatchLoad(slices).has_value());
+    return out;
+}
+
+}  // namespace
+
+TEST_F(StorageBackendTest, DaxFile_RoundTripWriteThroughAndBounds) {
+    const size_t size = 64 * 1024;
+    const auto path = MakeFakeDaxDevice(data_path, size);
+    auto opened = DaxFile::Open(path, size);
+    ASSERT_TRUE(opened.has_value());
+    auto& file = *opened;
+
+    std::string payload = "dax-payload";
+    iovec wiov{payload.data(), payload.size()};
+    auto wr = file->vector_write(&wiov, 1, 4096);
+    ASSERT_TRUE(wr.has_value());
+    EXPECT_EQ(wr.value(), payload.size());
+
+    std::string out(payload.size(), '\0');
+    iovec riov{out.data(), out.size()};
+    ASSERT_TRUE(file->vector_read(&riov, 1, 4096).has_value());
+    EXPECT_EQ(out, payload);
+
+    // MAP_SHARED write-through: the bytes are visible via the fd path.
+    std::ifstream in(path, std::ios::binary);
+    in.seekg(4096);
+    std::string on_disk(payload.size(), '\0');
+    in.read(on_disk.data(), on_disk.size());
+    EXPECT_EQ(on_disk, payload);
+
+    // Out-of-range I/O is rejected rather than silently truncated.
+    EXPECT_FALSE(file->vector_write(&wiov, 1, size - 1).has_value());
+    EXPECT_FALSE(file->vector_read(&riov, 1, size).has_value());
+    EXPECT_FALSE(file->vector_write(&wiov, 1, -1).has_value());
+
+    // A zero-length mapping request is invalid; a missing path fails open.
+    EXPECT_FALSE(DaxFile::Open(path, 0).has_value());
+    EXPECT_FALSE(DaxFile::Open(data_path + "/missing.dev", size).has_value());
+}
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_DaxArenaPutGetRemoveAll) {
+    const auto path = MakeFakeDaxDevice(data_path, 8 * 1024 * 1024);
+
+    FileStorageConfig config;
+    config.storage_filepath = data_path;
+    config.storage_backend_type = StorageBackendType::kOffsetAllocator;
+    config.total_size_limit = 4 * 1024 * 1024;
+    config.total_keys_limit = 10000;
+    OffsetAllocatorBackendConfig dax_cfg;
+    dax_cfg.dax_device_path = path;
+    ASSERT_TRUE(dax_cfg.Validate());
+
+    OffsetAllocatorStorageBackend backend(config, dax_cfg);
+    ASSERT_TRUE(backend.Init());
+    // The arena is the mapped device: no kv_cache.data is created.
+    EXPECT_FALSE(fs::exists(data_path + "/kv_cache.data"));
+
+    const std::string key = "dax_key";
+    const std::string value(64 * 1024, 'x');
+    OffloadOne(backend, key, value);
+    EXPECT_TRUE(backend.IsExist(key).value());
+    EXPECT_EQ(LoadOne(backend, key, value.size()), value);
+
+    backend.RemoveAll();
+    EXPECT_FALSE(backend.IsExist(key).value());
+
+    // Still writable after RemoveAll on the same mapping.
+    const std::string value2(32 * 1024, 'y');
+    OffloadOne(backend, key, value2);
+    EXPECT_EQ(LoadOne(backend, key, value2.size()), value2);
+}
+
+TEST_F(StorageBackendTest, OffsetAllocatorStorageBackend_DaxCapacityAlignment) {
+    const auto path = MakeFakeDaxDevice(data_path, 8 * 1024 * 1024);
+    FileStorageConfig config;
+    config.storage_filepath = data_path;
+    config.storage_backend_type = StorageBackendType::kOffsetAllocator;
+    config.total_keys_limit = 10000;
+    OffsetAllocatorBackendConfig dax_cfg;
+    dax_cfg.dax_device_path = path;
+
+    // 5 MiB rounds down to the 2 MiB device alignment.
+    config.total_size_limit = 5 * 1024 * 1024;
+    {
+        OffsetAllocatorStorageBackend backend(config, dax_cfg);
+        EXPECT_EQ(backend.GetCapacityForTest(), 4u * 1024 * 1024);
+        ASSERT_TRUE(backend.Init());
+    }
+
+    // Below one alignment unit there is no arena at all.
+    config.total_size_limit = 1024 * 1024;
+    {
+        OffsetAllocatorStorageBackend backend(config, dax_cfg);
+        EXPECT_EQ(backend.GetCapacityForTest(), 0u);
+        EXPECT_FALSE(backend.Init().has_value());
+    }
+
+    // The alignment knob must be a power of two.
+    dax_cfg.dax_alignment_bytes = 3 * 1024 * 1024;
+    EXPECT_FALSE(dax_cfg.Validate());
+    dax_cfg.dax_alignment_bytes = 0;
+    EXPECT_FALSE(dax_cfg.Validate());
+}
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_DaxArenaRecoversAfterRestart) {
+    const auto path = MakeFakeDaxDevice(data_path, 8 * 1024 * 1024);
+    FileStorageConfig config;
+    config.storage_filepath = data_path;
+    config.storage_backend_type = StorageBackendType::kOffsetAllocator;
+    config.total_size_limit = 4 * 1024 * 1024;
+    config.total_keys_limit = 10000;
+    OffsetAllocatorBackendConfig dax_cfg;
+    dax_cfg.dax_device_path = path;
+    dax_cfg.persist_mode = OffsetPersistMode::kStrict;
+    ASSERT_TRUE(dax_cfg.Validate());
+
+    const std::string key = "survivor";
+    const std::string value(16 * 1024, 'z');
+    {
+        OffsetAllocatorStorageBackend backend(config, dax_cfg);
+        ASSERT_TRUE(backend.Init());
+        OffloadOne(backend, key, value);
+    }  // destructor writes the final checkpoint
+
+    OffsetAllocatorStorageBackend restarted(config, dax_cfg);
+    ASSERT_TRUE(restarted.Init());
+    ASSERT_TRUE(restarted.IsExist(key).value());
+    EXPECT_EQ(LoadOne(restarted, key, value.size()), value);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Adds a device-DAX / CXL memory arena mode to `offset_allocator_storage_backend`, so the client-side offload tier can live on byte-addressable memory (`/dev/daxX.Y` backed by PMEM or CXL-attached memory, an fsdax file, or any regular file) instead of a file on SSD.

Device-DAX character devices reject `read`/`write` syscalls and only support `mmap`, so the existing `PosixFile`/`UringFile` paths cannot use them. This change:

- Adds `DaxFile`, a `StorageFile` over an `mmap(MAP_SHARED)` of the device. `vector_read`/`vector_write` are bounds-checked `memcpy`s through the mapping; `datasync` is `msync`, with the device-DAX `EINVAL` (no fsync op, nothing to flush) treated as a no-op. It never unlinks its path on write failure, since that would remove a device node.
- Adds `OffsetAllocatorBackendConfig::dax_device_path` / `dax_alignment_bytes` (env `MOONCAKE_OFFSET_DAX_DEVICE_PATH`, `MOONCAKE_OFFSET_DAX_ALIGNMENT_BYTES`, default 2 MiB). When the path is set, `OffsetAllocatorStorageBackend` maps it as the arena in the fresh-start and recovery paths, skips the create/truncate/fallocate and `st_size` checks that only make sense for files, keeps the mapping across `RemoveAll`, and rounds capacity down to the device alignment (device-DAX fails `mmap` with `EINVAL` on misaligned lengths).
- Everything above the file layer is unchanged: offset allocator, sharded index, FIFO watermark eviction, `ScanMeta`, record CRC and checkpoint persistence. Because device memory outlives the process, `MOONCAKE_OFFSET_PERSIST_MODE=strict|relaxed` restores the arena after a restart.
- Documents the new mode in `docs/source/deployment/ssd/ssd-offload.md`.

The file-based arena is untouched when `MOONCAKE_OFFSET_DAX_DEVICE_PATH` is unset. This is independent of the transfer engine's `cxl` protocol (`MC_CXL_DEV_PATH`), which serves DAX memory as segment memory rather than as an offload tier.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

New tests in `mooncake-store/tests/storage_backend_test.cpp` use a sparse regular file as a stand-in device (same `open` + `mmap(MAP_SHARED)` path as a chardev, and the bytes can be read back through the fd to prove write-through):

- `DaxFile_RoundTripWriteThroughAndBounds`: write/read through the mapping, bytes visible via the file, out-of-range and negative offsets rejected, invalid open arguments rejected.
- `OffsetAllocatorStorageBackend_DaxArenaPutGetRemoveAll`: offload/load round trip on the DAX arena, no `kv_cache.data` created, `RemoveAll` then reuse.
- `OffsetAllocatorStorageBackend_DaxCapacityAlignment`: 5 MiB rounds down to 4 MiB, sub-alignment capacity fails `Init`, non-power-of-two alignment fails `Validate`.
- `OffsetAllocatorStorageBackend_DaxArenaRecoversAfterRestart`: strict persistence, destroy backend, re-`Init` on the same arena, key still loadable.

Not tested here: a real `/dev/dax` device (none available); the alignment and `msync` behaviour on real hardware follow the kernel semantics described in the code comments.

**Test commands:**
```bash
cmake -G Ninja -S . -B build -DUSE_ETCD=OFF -DUSE_HTTP=ON -DWITH_STORE_RUST=OFF
cmake --build build --target storage_backend_test
./build/mooncake-store/tests/storage_backend_test --gtest_filter='*Dax*:*OffsetAllocator*'
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass (`cmake-format` wanted to reflow pre-existing, unrelated comment blocks in `mooncake-store/src/CMakeLists.txt`; that rewrite is left out of this PR per `AGENTS.md`)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code (Claude Fable 5.1) was used to survey the existing offload backends, draft the `DaxFile` implementation, the backend branches, the tests and the docs, and to build and run the tests in the devcontainer image. The human submitter is responsible for reviewing and defending every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)