### PR TITLE
[Docs] Clarify Store parallel tensor API selection and limits

### DIFF
--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -733,6 +733,55 @@ store.put("key-a", b"value-a", config)
 
 ---
 
+## Choosing a Parallel Tensor IO API
+
+Use the API that matches the object being stored. The single-axis TP methods
+and the manifest-backed weight snapshot API have different storage contracts.
+
+| Requirement | Public API | Contract |
+|---|---|---|
+| Store and retrieve a complete tensor | `put_tensor()` / `get_tensor()` | One ordinary Store tensor object. |
+| Split a full tensor and read a TP shard | `put_tensor_with_tp()` / `get_tensor_with_tp()` | Legacy single-axis TP tensor objects; batch and registered-buffer variants are also available. |
+| Save weights and restore into a different TP/DP/EP/PP placement | `begin_weight_snapshot()` and `WeightStore.load_manifest()` / `plan_load()` / `load()` | Immutable manifest-managed fragments, with framework-supplied placement and runtime bindings. |
+| Use `put/get_tensor_with_cp`, `*_with_dp`, `*_with_ep`, or `*_with_pp` | No such public convenience methods | DP/EP/PP weight placement is expressed through the manifest API; CP is not a supported axis. |
+| Supply an arbitrary parallel strategy through `*_with_config` | No such public tensor API | `ReplicateConfig` controls Store replication and placement policy, not tensor parallel topology. |
+
+For example, with an already initialized `MooncakeDistributedStore`, the
+legacy TP write accepts the **full** tensor and writes all shards. `tp_rank`
+on this write does not select a single shard to persist:
+
+```python
+import torch
+
+tensor = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+assert store.put_tensor_with_tp("tp-example", tensor, tp_size=2, split_dim=1) == 0
+shard = store.get_tensor_with_tp("tp-example", tp_rank=1, tp_size=2, split_dim=1)
+assert torch.equal(shard, tensor[:, 3:])
+```
+
+### Parallel configuration boundaries
+
+The model-weight API uses typed `ParallelTopology`, `WeightPlacementManifest`,
+and `WeightRuntimeBindingManifest` values supplied by the framework adapter.
+It does not provide a factory that generates a separate put/get method family
+for each axis, or accept an arbitrary strategy dictionary.
+
+- TP and EP can describe logical splits. EP splits the leading logical expert
+  dimension; TP names an explicit logical dimension.
+- DP describes replicas or ownership. PP describes framework-provided tensor
+  or layer ownership. Neither implies a tensor split dimension.
+- CP (context parallelism) is absent from the current topology and axis types.
+  A sequence-dimension slice through the TP API does not establish CP topology
+  support or CP-aware KV-cache resharding.
+- Combining supported axes still requires complete logical coverage and
+  compatible source/target tensor descriptors. The planner is copy-only; it
+  does not convert dtype, quantization, packing, or model semantics.
+
+See the [manifest contracts](../../design/reshard-manifest.md),
+[weight reshard planner](../../design/model-weight-reshard-planner.md), and
+[Store upload planning](../../design/model-weight-store-upload-planning.md)
+for the configuration and execution boundaries.
+
 ## Model Weight Snapshot API
 
 Heterogeneous model-weight snapshots use the manifest-backed Reshard API.
@@ -760,7 +809,8 @@ placement and runtime binding manifests.
 
 ### Breaking Change and Migration
 
-This release removes the public `*_with_parallelism` API family and the
+PR [#3772](https://github.com/kvcache-ai/Mooncake/pull/3772) removed the public
+`*_with_parallelism` API family and the
 associated `ParallelAxis`, `TensorParallelism`, and `ReadTarget` helper types.
 Applications that create heterogeneous model-weight snapshots migrate their
 write path to `begin_weight_snapshot()`, `write_tensor()`, and `commit()`.

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -733,13 +733,14 @@ store.put("key-a", b"value-a", config)
 
 ---
 
+(choosing-a-parallel-tensor-io-api)=
 ## Choosing a Parallel Tensor IO API
 
 Use the API that matches the object being stored. The single-axis TP methods
 and the manifest-backed weight snapshot API have different storage contracts.
 
 | Requirement | Public API | Contract |
-|---|---|---|
+| --- | --- | --- |
 | Store and retrieve a complete tensor | `put_tensor()` / `get_tensor()` | One ordinary Store tensor object. |
 | Split a full tensor and read a TP shard | `put_tensor_with_tp()` / `get_tensor_with_tp()` | Legacy single-axis TP tensor objects; batch and registered-buffer variants are also available. |
 | Save weights and restore into a different TP/DP/EP/PP placement | `begin_weight_snapshot()` and `WeightStore.load_manifest()` / `plan_load()` / `load()` | Immutable manifest-managed fragments, with framework-supplied placement and runtime bindings. |
@@ -753,7 +754,7 @@ on this write does not select a single shard to persist:
 ```python
 import torch
 
-tensor = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+tensor = torch.linspace(0, 23, 24, dtype=torch.float32).reshape(4, 6)
 assert store.put_tensor_with_tp("tp-example", tensor, tp_size=2, split_dim=1) == 0
 shard = store.get_tensor_with_tp("tp-example", tp_rank=1, tp_size=2, split_dim=1)
 assert torch.equal(shard, tensor[:, 3:])

--- a/docs/source/design/model-weight-reshard-planner.md
+++ b/docs/source/design/model-weight-reshard-planner.md
@@ -79,7 +79,7 @@ ordinary TP tensor objects, but there are no corresponding CP/DP/EP/PP method
 factories or `*_with_config` tensor methods. The former public
 `*_with_parallelism` family was removed by
 PR [#3772](https://github.com/kvcache-ai/Mooncake/pull/3772).
-See [Choosing a Parallel Tensor IO API](../api-reference/python/mooncake-store.md#choosing-a-parallel-tensor-io-api)
+See {ref}`Choosing a Parallel Tensor IO API <choosing-a-parallel-tensor-io-api>`
 for entry points and the distinction between parallel topology and Store
 replication configuration.
 

--- a/docs/source/design/model-weight-reshard-planner.md
+++ b/docs/source/design/model-weight-reshard-planner.md
@@ -66,6 +66,23 @@ when it exceeds the configured limit.
 All four axes are resolved by one logical-box plan, rather than by model-wide
 per-axis conversion passes.
 
+### Supported axes and Store API selection
+
+The current `ParallelTopology` and `ParallelRank` types contain TP, PP, EP, and
+DP only. CP (context parallelism) is not a supported axis, and `SplitAxis`
+accepts only TP and EP. N-D logical planning therefore does not imply support
+for arbitrary named parallel strategies or CP-aware KV-cache layouts.
+
+Store callers use the manifest-backed weight snapshot lifecycle for these
+multi-axis weight placements. Legacy `*_with_tp` methods remain available for
+ordinary TP tensor objects, but there are no corresponding CP/DP/EP/PP method
+factories or `*_with_config` tensor methods. The former public
+`*_with_parallelism` family was removed by
+PR [#3772](https://github.com/kvcache-ai/Mooncake/pull/3772).
+See [Choosing a Parallel Tensor IO API](../api-reference/python/mooncake-store.md#choosing-a-parallel-tensor-io-api)
+for entry points and the distinction between parallel topology and Store
+replication configuration.
+
 ## Validation
 
 Placement construction validates the complete participant set, tensor


### PR DESCRIPTION
## Description

Callers looking for CP/DP/EP/PP variants of `put/get_tensor_with_tp` need to distinguish ordinary tensor objects from manifest-backed model-weight snapshots. Add an API selection table and a TP example, document supported axis semantics and CP/config-factory limits, and link the API reference to the existing manifest, reshard planner, and upload documentation.

Anchor the removed `*_with_parallelism` API's migration to #3772. This documents the current public interface and does not restore removed APIs or add parallelism support.

Overlap check: #3772 already provides snapshot implementation and migration documentation; this change adds caller-facing selection and support boundaries. Open #3564 concerns KV-cache planning, while this PR documents the current tensor and model-weight APIs without claiming that proposal is available.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Reshard (`mooncake-reshard`)
- [x] Docs

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

**Test commands:**
```bash
cd docs
make clean SPHINXBUILD=.venv/bin/sphinx-build
make html SPHINXBUILD=.venv/bin/sphinx-build
cd ..
docs/.venv/bin/pre-commit run --files \
  docs/source/api-reference/python/mooncake-store.md \
  docs/source/design/model-weight-reshard-planner.md
git diff --check
```

**Test results:**
- [x] Documentation HTML build completes.
- [x] Changed-file pre-commit hooks pass.
- [x] Generated HTML sections and their local link targets/anchors checked.
- [ ] Unit tests pass (not run; documentation-only change).
- [ ] Integration tests pass (not run; the TP snippet was checked against the native binding and implementation, not executed against a Store service).

## Checklist

- [ ] Human submitter has reviewed every changed line and can defend the change end-to-end.
- [x] Agent reviewed the diff against current public bindings and Reshard contracts.
- [x] I have run pre-commit on the files changed in this PR and all hooks pass.
- [x] I have updated the documentation.
- C/C++ formatting, new runtime tests, and an RFC are not applicable to this documentation-only change.

## AI Assistance Disclosure

- [x] AI tools were used.

Codex inspected the current source and related PRs, drafted the documentation, and ran local documentation checks. This PR remains a draft pending human review; no human review is claimed.