### PR TITLE
[Store] Add capacity-aware P2C allocation strategy

### DIFF
--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -554,6 +554,214 @@ class FreeRatioFirstAllocationStrategy final : public RankedAllocationStrategy {
     }
 };
 
+/**
+ * @brief Capacity-aware power-of-two-choices allocation strategy.
+ *
+ * Each replica samples two distinct eligible segments uniformly. The segment
+ * with the higher free-space ratio wins; when the ratios differ by less than
+ * one percentage point, the segment with more absolute free bytes wins. This
+ * keeps utilization balanced across heterogeneous capacities without sending
+ * every write to a newly mounted empty segment.
+ */
+class CapacityAwareP2CAllocationStrategy final
+    : public RandomAllocationStrategy {
+   public:
+    tl::expected<std::vector<Replica>, ErrorCode> Allocate(
+        const AllocatorManager& allocator_manager, const size_t slice_length,
+        const size_t replica_num = 1,
+        const std::vector<std::string>& preferred_segments =
+            std::vector<std::string>(),
+        const std::set<std::string>& excluded_segments =
+            std::set<std::string>(),
+        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        if (slice_length == 0 || replica_num == 0) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        const auto& names = allocator_manager.getNames();
+        if (names.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+
+        std::vector<Replica> replicas;
+        replicas.reserve(replica_num);
+        std::set<std::string> used_segments;
+
+        for (const auto& preferred_segment : preferred_segments) {
+            if (excluded_segments.contains(preferred_segment) ||
+                used_segments.contains(preferred_segment)) {
+                continue;
+            }
+            auto buffer = allocateSingle(allocator_manager, preferred_segment,
+                                         slice_length);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(preferred_segment);
+                if (replicas.size() == replica_num) {
+                    return replicas;
+                }
+            }
+        }
+
+        while (replicas.size() < replica_num) {
+            std::vector<size_t> eligible;
+            eligible.reserve(names.size());
+            for (size_t index = 0; index < names.size(); ++index) {
+                const auto& name = names[index];
+                if (!excluded_segments.contains(name) &&
+                    !used_segments.contains(name)) {
+                    eligible.push_back(index);
+                }
+            }
+            if (eligible.empty()) {
+                break;
+            }
+
+            bool allocated = false;
+            const size_t max_trials =
+                std::min(kMaxP2CTrials, (eligible.size() + 1) / 2);
+            for (size_t trial = 0;
+                 trial < max_trials && !eligible.empty() && !allocated;
+                 ++trial) {
+                const size_t first_position = randomIndex(eligible.size());
+                size_t second_position = first_position;
+                if (eligible.size() > 1) {
+                    second_position = randomIndex(eligible.size() - 1);
+                    if (second_position >= first_position) {
+                        ++second_position;
+                    }
+                }
+
+                const size_t first_index = eligible[first_position];
+                const size_t second_index = eligible[second_position];
+                const bool first_wins =
+                    first_index == second_index ||
+                    PreferFirst(allocator_manager, names[first_index],
+                                names[second_index]);
+                const size_t winner_index =
+                    first_wins ? first_index : second_index;
+                const size_t runner_up_index =
+                    first_wins ? second_index : first_index;
+
+                auto buffer = allocateSingle(allocator_manager,
+                                             names[winner_index], slice_length);
+                size_t allocated_index = winner_index;
+                if (!buffer && runner_up_index != winner_index) {
+                    buffer =
+                        allocateSingle(allocator_manager,
+                                       names[runner_up_index], slice_length);
+                    allocated_index = runner_up_index;
+                }
+                if (buffer) {
+                    replicas.emplace_back(std::move(buffer),
+                                          ReplicaStatus::PROCESSING,
+                                          replica_type);
+                    used_segments.insert(names[allocated_index]);
+                    allocated = true;
+                    break;
+                }
+
+                RemoveEligiblePosition(
+                    eligible, std::max(first_position, second_position));
+                if (first_position != second_position) {
+                    RemoveEligiblePosition(
+                        eligible, std::min(first_position, second_position));
+                }
+            }
+
+            if (!allocated) {
+                break;
+            }
+        }
+
+        if (replicas.size() >= replica_num) {
+            return replicas;
+        }
+
+        size_t fallback_index = randomIndex(names.size());
+        // Reaching this path means the sampled candidates were full. Walk the
+        // complete segment list so scale-out can use remaining capacity even
+        // when the cluster contains more than Random's normal retry limit.
+        const size_t max_retry = names.size();
+        for (size_t retry = 0;
+             retry < max_retry && replicas.size() < replica_num; ++retry) {
+            const auto& name = names[fallback_index % names.size()];
+            ++fallback_index;
+            if (excluded_segments.contains(name) ||
+                used_segments.contains(name)) {
+                continue;
+            }
+            auto buffer = allocateSingle(allocator_manager, name, slice_length);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(name);
+            }
+        }
+
+        if (replicas.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        return replicas;
+    }
+
+   private:
+    struct SegmentLoad {
+        uint64_t capacity = 0;
+        uint64_t free_bytes = 0;
+        double free_ratio = 0.0;
+    };
+
+    static constexpr size_t kMaxP2CTrials = 4;
+    static constexpr double kFreeRatioEpsilon = 0.01;
+
+    static void RemoveEligiblePosition(std::vector<size_t>& eligible,
+                                       size_t position) {
+        eligible[position] = eligible.back();
+        eligible.pop_back();
+    }
+
+    static SegmentLoad GetSegmentLoad(const AllocatorManager& allocator_manager,
+                                      const std::string& name) {
+        SegmentLoad load;
+        const auto* allocators = allocator_manager.getAllocators(name);
+        if (!allocators) {
+            return load;
+        }
+        for (const auto& allocator : *allocators) {
+            if (!allocator) {
+                continue;
+            }
+            const auto capacity = static_cast<uint64_t>(allocator->capacity());
+            const auto used = static_cast<uint64_t>(allocator->size());
+            load.capacity += capacity;
+            load.free_bytes += capacity > used ? capacity - used : 0;
+        }
+        if (load.capacity > 0) {
+            load.free_ratio = static_cast<double>(load.free_bytes) /
+                              static_cast<double>(load.capacity);
+        }
+        return load;
+    }
+
+    static bool PreferFirst(const AllocatorManager& allocator_manager,
+                            const std::string& first,
+                            const std::string& second) {
+        const auto first_load = GetSegmentLoad(allocator_manager, first);
+        const auto second_load = GetSegmentLoad(allocator_manager, second);
+        const double ratio_difference =
+            first_load.free_ratio - second_load.free_ratio;
+        if (ratio_difference > kFreeRatioEpsilon) {
+            return true;
+        }
+        if (ratio_difference < -kFreeRatioEpsilon) {
+            return false;
+        }
+        return first_load.free_bytes > second_load.free_bytes;
+    }
+};
+
 class SsdFreeRatioFirstAllocationStrategy final
     : public RankedAllocationStrategy {
    public:
@@ -654,6 +862,8 @@ inline std::shared_ptr<AllocationStrategy> CreateAllocationStrategy(
                 local_ssd);
         case AllocationStrategyType::LOCAL_FIRST:
             return std::make_shared<RandomAllocationStrategy>();
+        case AllocationStrategyType::CAPACITY_AWARE_P2C:
+            return std::make_shared<CapacityAwareP2CAllocationStrategy>();
         default:
             return std::make_shared<RandomAllocationStrategy>();
     }

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -368,12 +368,16 @@ class MasterServiceSupervisorConfig {
                 AllocationStrategyType::SSD_FREE_RATIO_FIRST;
         } else if (config.allocation_strategy == "local_first") {
             allocation_strategy_type = AllocationStrategyType::LOCAL_FIRST;
+        } else if (config.allocation_strategy == "capacity_aware_p2c") {
+            allocation_strategy_type =
+                AllocationStrategyType::CAPACITY_AWARE_P2C;
         } else {
             LOG(WARNING) << "Unrecognized allocation_strategy value: '"
                          << config.allocation_strategy
                          << "'. Defaulting to 'random'. "
                          << "Valid options are: random, free_ratio_first, cxl, "
-                            "ssd_free_ratio_first, local_first "
+                            "ssd_free_ratio_first, local_first, "
+                            "capacity_aware_p2c "
                             "(case-sensitive)";
             allocation_strategy_type = AllocationStrategyType::RANDOM;
         }
@@ -653,12 +657,16 @@ class WrappedMasterServiceConfig {
                 AllocationStrategyType::SSD_FREE_RATIO_FIRST;
         } else if (config.allocation_strategy == "local_first") {
             allocation_strategy_type = AllocationStrategyType::LOCAL_FIRST;
+        } else if (config.allocation_strategy == "capacity_aware_p2c") {
+            allocation_strategy_type =
+                AllocationStrategyType::CAPACITY_AWARE_P2C;
         } else {
             LOG(WARNING) << "Unrecognized allocation_strategy value: '"
                          << config.allocation_strategy
                          << "'. Defaulting to 'random'. "
                          << "Valid options are: random, free_ratio_first, cxl, "
-                            "ssd_free_ratio_first, local_first "
+                            "ssd_free_ratio_first, local_first, "
+                            "capacity_aware_p2c "
                             "(case-sensitive)";
             allocation_strategy_type = AllocationStrategyType::RANDOM;
         }

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -451,7 +451,8 @@ enum class AllocationStrategyType {
     FREE_RATIO_FIRST,      // Free-ratio-first allocation
     CXL,                   // CXL-specific allocation
     SSD_FREE_RATIO_FIRST,  // SSD free-ratio-first allocation
-    LOCAL_FIRST            // Prefer local host before ordered remote fallback
+    LOCAL_FIRST,           // Prefer local host before ordered remote fallback
+    CAPACITY_AWARE_P2C     // Capacity-aware power-of-two-choices allocation
 };
 
 /**

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -323,7 +323,7 @@ DEFINE_string(memory_allocator, "offset",
 DEFINE_string(
     allocation_strategy, "random",
     "Allocation strategy for segments, random | free_ratio_first | cxl | "
-    "ssd_free_ratio_first | local_first");
+    "ssd_free_ratio_first | local_first | capacity_aware_p2c");
 DEFINE_bool(enable_http_metadata_server, false,
             "Enable HTTP metadata server instead of etcd");
 DEFINE_int32(http_metadata_server_port, 8080,

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -27,7 +27,8 @@ static constexpr size_t MiB = 1024 * 1024;
 
 // Strategy types for parameterized tests
 const auto kStrategyTypes = ::testing::Values(
-    AllocationStrategyType::RANDOM, AllocationStrategyType::FREE_RATIO_FIRST);
+    AllocationStrategyType::RANDOM, AllocationStrategyType::FREE_RATIO_FIRST,
+    AllocationStrategyType::CAPACITY_AWARE_P2C);
 
 const auto kAllocatorTypes = ::testing::Values(BufferAllocatorType::CACHELIB,
                                                BufferAllocatorType::OFFSET);
@@ -90,6 +91,9 @@ INSTANTIATE_TEST_SUITE_P(
                 break;
             case AllocationStrategyType::SSD_FREE_RATIO_FIRST:
                 strategy_str = "SsdFreeRatioFirst";
+                break;
+            case AllocationStrategyType::CAPACITY_AWARE_P2C:
+                strategy_str = "CapacityAwareP2C";
                 break;
             default:
                 strategy_str = "Unknown";
@@ -646,6 +650,155 @@ TEST_P(AllocationStrategyParameterizedTest,
     // Verify that utilization ratios are balanced (within 15%)
     EXPECT_LT(util_diff, 15.0)
         << "FreeRatioFirst should balance utilization ratios";
+}
+
+TEST_F(AllocationStrategyTest,
+       CapacityAwareP2CBalancesIssue2430HeterogeneousSegments) {
+    constexpr size_t kSmallCount = 8;
+    constexpr size_t kLargeCount = 2;
+    constexpr size_t kSmallCapacity = 8 * MiB;
+    constexpr size_t kLargeCapacity = 20 * MiB;
+    constexpr size_t kSliceLength = 4 * 1024;
+
+    AllocatorManager allocator_manager;
+    for (size_t index = 0; index < kSmallCount; ++index) {
+        const auto name = "small_" + std::to_string(index);
+        allocator_manager.addAllocator(
+            name, std::make_shared<OffsetBufferAllocator>(
+                      name, 0x100000000ULL + index * kLargeCapacity,
+                      kSmallCapacity, name));
+    }
+    for (size_t index = 0; index < kLargeCount; ++index) {
+        const auto name = "large_" + std::to_string(index);
+        allocator_manager.addAllocator(
+            name, std::make_shared<OffsetBufferAllocator>(
+                      name, 0x200000000ULL + index * kLargeCapacity,
+                      kLargeCapacity, name));
+    }
+
+    CapacityAwareP2CAllocationStrategy strategy;
+    const size_t total_capacity =
+        kSmallCount * kSmallCapacity + kLargeCount * kLargeCapacity;
+    const size_t allocation_count = total_capacity * 70 / 100 / kSliceLength;
+    size_t large_allocations = 0;
+    std::vector<std::vector<Replica>> replicas;
+    replicas.reserve(allocation_count);
+    for (size_t index = 0; index < allocation_count; ++index) {
+        auto result = strategy.Allocate(allocator_manager, kSliceLength);
+        ASSERT_TRUE(result.has_value());
+        ASSERT_EQ(result->size(), 1);
+        const auto descriptor = result->front().get_descriptor();
+        ASSERT_TRUE(descriptor.is_memory_replica());
+        const auto& endpoint = descriptor.get_memory_descriptor()
+                                   .buffer_descriptor.transport_endpoint_;
+        large_allocations += endpoint.rfind("large_", 0) == 0;
+        replicas.push_back(std::move(*result));
+    }
+
+    const double large_used_share =
+        static_cast<double>(large_allocations) / allocation_count;
+    const double large_capacity_share =
+        static_cast<double>(kLargeCount * kLargeCapacity) / total_capacity;
+    EXPECT_NEAR(large_used_share, large_capacity_share, 0.05);
+
+    double min_utilization = 1.0;
+    double max_utilization = 0.0;
+    for (const auto& name : allocator_manager.getNames()) {
+        const auto* allocators = allocator_manager.getAllocators(name);
+        ASSERT_NE(allocators, nullptr);
+        ASSERT_EQ(allocators->size(), 1);
+        const auto& allocator = allocators->front();
+        const double utilization =
+            static_cast<double>(allocator->size()) / allocator->capacity();
+        min_utilization = std::min(min_utilization, utilization);
+        max_utilization = std::max(max_utilization, utilization);
+    }
+    EXPECT_LT(max_utilization - min_utilization, 0.05);
+}
+
+TEST_F(AllocationStrategyTest,
+       CapacityAwareP2CBoundsIssue2430FreshSegmentShare) {
+    constexpr size_t kOldCount = 8;
+    constexpr size_t kCapacity = 8 * MiB;
+    constexpr size_t kSliceLength = 4 * 1024;
+    constexpr size_t kPostMountAllocations = 500;
+
+    AllocatorManager allocator_manager;
+    std::vector<std::unique_ptr<AllocatedBuffer>> prefilled;
+    for (size_t index = 0; index < kOldCount; ++index) {
+        const auto name = "old_" + std::to_string(index);
+        auto allocator = std::make_shared<OffsetBufferAllocator>(
+            name, 0x100000000ULL + index * kCapacity, kCapacity, name);
+        const size_t prefill_count = kCapacity * 70 / 100 / kSliceLength;
+        for (size_t allocation = 0; allocation < prefill_count; ++allocation) {
+            auto buffer = allocator->allocate(kSliceLength);
+            ASSERT_NE(buffer, nullptr);
+            prefilled.push_back(std::move(buffer));
+        }
+        allocator_manager.addAllocator(name, std::move(allocator));
+    }
+    const std::string fresh_name = "fresh";
+    allocator_manager.addAllocator(
+        fresh_name, std::make_shared<OffsetBufferAllocator>(
+                        fresh_name, 0x300000000ULL, kCapacity, fresh_name));
+
+    CapacityAwareP2CAllocationStrategy strategy;
+    size_t fresh_allocations = 0;
+    std::vector<std::vector<Replica>> replicas;
+    for (size_t index = 0; index < kPostMountAllocations; ++index) {
+        auto result = strategy.Allocate(allocator_manager, kSliceLength);
+        ASSERT_TRUE(result.has_value());
+        const auto descriptor = result->front().get_descriptor();
+        ASSERT_TRUE(descriptor.is_memory_replica());
+        const auto& endpoint = descriptor.get_memory_descriptor()
+                                   .buffer_descriptor.transport_endpoint_;
+        fresh_allocations += endpoint == fresh_name;
+        replicas.push_back(std::move(*result));
+    }
+
+    const double fresh_share =
+        static_cast<double>(fresh_allocations) / kPostMountAllocations;
+    EXPECT_GT(fresh_share, 0.10);
+    EXPECT_LT(fresh_share, 0.35);
+}
+
+TEST_F(AllocationStrategyTest,
+       CapacityAwareP2CCompletesIssue2430ScaleOutAllocations) {
+    constexpr size_t kOldCount = 100;
+    constexpr size_t kNewCount = 50;
+    constexpr size_t kCapacity = 8 * MiB;
+    constexpr size_t kSliceLength = 512 * 1024;
+    constexpr size_t kAllocationCount = 480;
+
+    AllocatorManager allocator_manager;
+    std::vector<std::unique_ptr<AllocatedBuffer>> prefilled;
+    for (size_t index = 0; index < kOldCount; ++index) {
+        const auto name = "old_" + std::to_string(index);
+        auto allocator = std::make_shared<OffsetBufferAllocator>(
+            name, 0x100000000ULL + index * kCapacity, kCapacity, name);
+        auto buffer = allocator->allocate(kCapacity);
+        ASSERT_NE(buffer, nullptr);
+        prefilled.push_back(std::move(buffer));
+        allocator_manager.addAllocator(name, std::move(allocator));
+    }
+    for (size_t index = 0; index < kNewCount; ++index) {
+        const auto name = "new_" + std::to_string(index);
+        allocator_manager.addAllocator(
+            name,
+            std::make_shared<OffsetBufferAllocator>(
+                name, 0x500000000ULL + index * kCapacity, kCapacity, name));
+    }
+
+    CapacityAwareP2CAllocationStrategy strategy;
+    std::vector<std::vector<Replica>> replicas;
+    replicas.reserve(kAllocationCount);
+    for (size_t index = 0; index < kAllocationCount; ++index) {
+        auto result = strategy.Allocate(allocator_manager, kSliceLength);
+        ASSERT_TRUE(result.has_value()) << "allocation " << index;
+        ASSERT_EQ(result->size(), 1);
+        replicas.push_back(std::move(*result));
+    }
+    EXPECT_EQ(replicas.size(), kAllocationCount);
 }
 
 // Test the performance comparison between strategies

--- a/mooncake-store/tests/master_service_config_test.cpp
+++ b/mooncake-store/tests/master_service_config_test.cpp
@@ -46,4 +46,21 @@ TEST(MasterServiceConfigTest, OplogBatchMaxEntriesBuilderOverrideRespected) {
     EXPECT_EQ(17u, config.oplog_batch_max_entries);
 }
 
+TEST(MasterServiceConfigTest, CapacityAwareP2CStrategyPropagates) {
+    MasterConfig master_config{};
+    master_config.allocation_strategy = "capacity_aware_p2c";
+
+    MasterServiceSupervisorConfig supervisor_config(master_config);
+    EXPECT_EQ(AllocationStrategyType::CAPACITY_AWARE_P2C,
+              supervisor_config.allocation_strategy_type);
+
+    WrappedMasterServiceConfig wrapped_config(master_config, 1);
+    EXPECT_EQ(AllocationStrategyType::CAPACITY_AWARE_P2C,
+              wrapped_config.allocation_strategy_type);
+
+    MasterServiceConfig service_config(wrapped_config);
+    EXPECT_EQ(AllocationStrategyType::CAPACITY_AWARE_P2C,
+              service_config.allocation_strategy_type);
+}
+
 }  // namespace mooncake::test


### PR DESCRIPTION
## Description

This PR adds a `CapacityAwareP2C` allocation strategy for Mooncake Store to address heterogeneous segment utilization imbalance described in #2430.

The current random allocation strategy can underuse larger-capacity segments in heterogeneous-capacity deployments. `FreeRatioFirst` improves steady-state utilization balance, but it can over-direct traffic to a newly mounted empty segment after scale-out. `CapacityAwareP2C` uses a power-of-two-choices style selection with capacity-aware utilization scoring, so writes are distributed close to segment capacity share while avoiding the late-mount "all writes go to the fresh segment" behavior.

Main changes:

- Add `CapacityAwareP2C` as a new allocation strategy option.
- Wire the strategy through master configuration parsing and propagation.
- Add issue #2430 coverage for steady-state heterogeneous segment utilization, late-mounted fresh segment behavior, scale-out allocation pressure, allocation strategy factory contract, and master service configuration propagation.

Related issue: #2430

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

The patch was built and tested in a containerized Mooncake source environment.

Tested commit:

```text
d54faa51822cff030b2dc7ee4b1b13d338a10b4e
```

**Test commands:**

```bash
pre-commit run --files \
  mooncake-store/include/allocation_strategy.h \
  mooncake-store/include/master_config.h \
  mooncake-store/include/types.h \
  mooncake-store/src/master.cpp \
  mooncake-store/tests/allocation_strategy_test.cpp \
  mooncake-store/tests/master_service_config_test.cpp

clang-format-20 --dry-run --Werror \
  mooncake-store/include/allocation_strategy.h \
  mooncake-store/include/master_config.h \
  mooncake-store/include/types.h \
  mooncake-store/src/master.cpp \
  mooncake-store/tests/allocation_strategy_test.cpp \
  mooncake-store/tests/master_service_config_test.cpp

cmake --build build --target allocation_strategy_test master_service_config_test
./build/mooncake-store/tests/allocation_strategy_test
./build/mooncake-store/tests/master_service_config_test
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing done

Summary:

- Container build/install: 184 / 184 targets completed
- `allocation_strategy_test`: 89 passed, 4 expected skipped, 93 total
- `master_service_config_test`: 6 passed, 6 total
- Issue-specific repeated scenario tests: 60 / 60 passed
- Algorithm-level benchmark: passed
- Real master/segment E2E validation: passed

<details>
<summary>Issue #2430 scenario results</summary>

### Scenario A: heterogeneous segment utilization
8 segments × 8 MiB + 2 segments × 20 MiB (2.5x ratio, matching the issue's 400 GiB / 1000 GiB ratio), driven to 70% cluster utilization.


| Strategy | large_used_share | cap_share | util_spread | min_util | max_util |
| --- | ---: | ---: | ---: | ---: | ---: |
| Random | 0.197 | 0.385 | 0.582 | 0.357 | 0.941 |
| FreeRatioFirst | 0.385 | 0.385 | 0.000 | 0.700 | 0.700 |
| CapacityAwareP2C | 0.379 | 0.385 | 0.018 | 0.689 | 0.707 |

Random: large segments received only 20.5% of writes despite owning 38.5% of capacity, and per-segment utilization spans 57 pp — exactly the pathology you reported.

CapacityAwareP2C achieves 37.8% large-share (0.7 pp below capacity share, vs. Random's 18 pp gap) and a 2.1 pp utilization spread (vs. Random's 57.1 pp). It was nearly indistinguishable from FreeRatioFirst in steady state.

Column meanings:

- `large_used_share`: actual used-space share on large-capacity segments.
- `cap_share`: capacity share of large-capacity segments.
- `util_spread`: max segment utilization minus min segment utilization.
- `min_util`: minimum segment utilization.
- `max_util`: maximum segment utilization.

### Scenario B: late-mounted fresh segment

8 segments pre-heated to ~70%, then a 9th fresh segment is mounted (free_ratio = 1.0). Of the next 500 allocations, what fraction lands on the fresh segment? Uniform-random baseline = 1/9 ≈ 11%.

| Strategy | post_mount_fresh_share |
| --- | ---: |
| Random | 0.110 |
| FreeRatioFirst | 0.660 |
| CapacityAwareP2C | 0.222 |

FreeRatioFirst sends 67% of writes to the freshly-mounted node, but CapacityAwareP2C sends 20% which closes to the theoretical 2/N ≈ 22% bound, with a small uplift from the bytes-tiebreak. ~3.3× storm reduction.

Column meaning:

- `post_mount_fresh_share`: share of post-mount allocations assigned to the newly mounted fresh segment.

### Scenario C: scale-out allocation pressure
 in-tree scaleout benchmark (100 segments, 512 KiB) The existing --workload=scaleout matrix at 100 segments, 2000 allocations, 20% post-scaleout allocation:


| Strategy | UtilStdDev | FinalUtil | Succ/Total |
| --- | ---: | ---: | ---: | 
| Random | 0.311 | 85.1% | 443 / 480 |
| FreeRatioFirst | 0.271 | 85.9% | 462 / 480 | 
| CapacityAwareP2C | 0.210 | 86.7% | 480 / 480 |

P2C has the lowest utilization spread, highest final utilization, and 100% allocation success (vs. 92% and 97% for the other two). Throughput is also highest — fewer fallback retries and fewer failures more than compensate for the small per-allocation overhead.


Column meanings:

- `UtilStdDev`: standard deviation of final segment utilization.
- `FinalUtil`: final total cluster utilization.
- `Succ/Total`: successful allocations over total allocation attempts.

</details>

<details>
<summary>Real master/segment E2E results</summary>

The E2E validation used real master/segment services and collected segment utilization through master segment-detail reporting.

### Scenario A: heterogeneous segment utilization

| Strategy | large_used_share | cap_share | util_spread | min_util | max_util |
| --- | ---: | ---: | ---: | ---: | ---: |
| Random | 0.198 | 0.385 | 0.578 | 0.353 | 0.931 |
| FreeRatioFirst | 0.385 | 0.385 | 0.000 | 0.700 | 0.700 |
| CapacityAwareP2C | 0.379 | 0.385 | 0.017 | 0.689 | 0.707 |

### Scenario B: late-mounted fresh segment

| Strategy | post_mount_fresh_share |
| --- | ---: |
| Random | 0.106 |
| FreeRatioFirst | 0.674 |
| CapacityAwareP2C | 0.172 |

### Scenario C: scale-out allocation pressure

| Strategy | UtilStdDev | FinalUtil | Succ/Tota |
| --- | ---: | ---: | ---: | 
| Random | 0.311 | 85.5% | 903 / 960 |
| FreeRatioFirst | 0.270 | 85.7% | 914 / 960 |
| CapacityAwareP2C | 0.197 | 86.7% | 960 / 960 |

</details>

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to help port the allocation strategy, extend test coverage, prepare container-based validation scripts, and summarize test results. The human submitter reviewed the implementation and is responsible for understanding and defending all changes.