### PR TITLE
[TENT] fix: TCP transport implicitly creates CUDA contexts

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/platform/cuda_utils.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/cuda_utils.h
@@ -1,0 +1,53 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_PLATFORM_CUDA_UTILS_H
+#define TENT_PLATFORM_CUDA_UTILS_H
+
+#include <cuda.h>
+
+#include <mutex>
+
+namespace mooncake {
+namespace tent {
+
+// cuInit() is idempotent and creates no context; the driver API does not
+// initialize itself lazily, so it must run before any driver query.
+inline bool ensureCudaDriverInit() {
+    static std::once_flag flag;
+    static CUresult result = CUDA_ERROR_NOT_INITIALIZED;
+    std::call_once(flag, []() { result = cuInit(0); });
+    return result == CUDA_SUCCESS;
+}
+
+// Device ordinal owning `ptr`, or -1 for host memory. Unlike the runtime
+// cudaPointerGetAttributes(), this never implicitly initializes the calling
+// thread's current device and its primary context (default GPU 0).
+inline int getCudaDeviceForPtr(const void* ptr) {
+    if (!ensureCudaDriverInit()) return -1;
+    unsigned int mem_type = 0;
+    CUresult res = cuPointerGetAttribute(
+        &mem_type, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)ptr);
+    if (res != CUDA_SUCCESS || mem_type != CU_MEMORYTYPE_DEVICE) return -1;
+    unsigned int dev_ordinal = 0;
+    res = cuPointerGetAttribute(
+        &dev_ordinal, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr);
+    if (res != CUDA_SUCCESS) return -1;
+    return static_cast<int>(dev_ordinal);
+}
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_PLATFORM_CUDA_UTILS_H

--- a/mooncake-transfer-engine/tent/plugins/cuda/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/plugins/cuda/CMakeLists.txt
@@ -14,7 +14,7 @@ set(TENT_CUDA_PLUGIN_SOURCES
 add_library(tent_cuda_plugin SHARED ${TENT_CUDA_PLUGIN_SOURCES})
 
 target_link_libraries(tent_cuda_plugin
-    PRIVATE CUDA::cudart tent_plugin
+    PRIVATE CUDA::cudart CUDA::cuda_driver tent_plugin
 )
 
 set_target_properties(tent_cuda_plugin PROPERTIES

--- a/mooncake-transfer-engine/tent/plugins/cuda/cuda_plugin.cpp
+++ b/mooncake-transfer-engine/tent/plugins/cuda/cuda_plugin.cpp
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 #include "tent/device_plugin.h"
+#include "tent/platform/cuda_utils.h"
 
 #include <cuda_runtime.h>
 #include <string.h>
 #include <stdio.h>
 #include <string>
 #include <glog/logging.h>
+
+using mooncake::tent::getCudaDeviceForPtr;
 
 struct cuda_plugin_ctx_t {
     // reserved
@@ -86,17 +89,18 @@ static int cuda_alloc(void* ctx_, void** pptr, size_t size, const char* loc) {
 static int cuda_free(void* ctx_, void* ptr, size_t size) {
     (void)ctx_;
     (void)size;
-    cudaPointerAttributes attrs;
-    CHECK_CUDA(cudaPointerGetAttributes(&attrs, ptr));
-    if (attrs.type == cudaMemoryTypeDevice) {
-        CHECK_CUDA(cudaFree(ptr));
-        return 0;
-    }
-    return -2;
+    if (getCudaDeviceForPtr(ptr) < 0) return -2;
+    CHECK_CUDA(cudaFree(ptr));
+    return 0;
 }
 
 static int cuda_memcpy_sync(void* ctx_, void* dst, void* src, size_t length) {
     (void)ctx_;
+    // Pin the owning device so the runtime does not default to GPU 0.
+    int dev = getCudaDeviceForPtr(src);
+    if (dev < 0) dev = getCudaDeviceForPtr(dst);
+    if (dev < 0) return -1;  // host-to-host; let the caller fall back
+    CHECK_CUDA(cudaSetDevice(dev));
     CHECK_CUDA(cudaMemcpy(dst, src, length, cudaMemcpyDefault));
     return 0;
 }
@@ -105,12 +109,11 @@ static int cuda_query_location(void* ctx_, void* addr, size_t size,
                                location_t* buf, size_t buf_count) {
     (void)ctx_;
     if (buf_count == 0) return -1;
-    cudaPointerAttributes attr{};
-    cudaError_t err = cudaPointerGetAttributes(&attr, addr);
-    if (err != cudaSuccess || attr.type != cudaMemoryTypeDevice) return 0;
+    int dev = getCudaDeviceForPtr(addr);
+    if (dev < 0) return 0;
     buf[0].start = addr;
     buf[0].length = size;
-    snprintf(buf[0].location, LOCATION_LEN, "cuda:%d", attr.device);
+    snprintf(buf[0].location, LOCATION_LEN, "cuda:%d", dev);
     return 1;
 }
 

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "tent/platform/cuda.h"
+#include "tent/platform/cuda_utils.h"
 #include "tent/common/status.h"
 
 #include <bits/stdint-uintn.h>
@@ -22,19 +23,11 @@
 #include <mutex>
 #include <numa.h>
 #include <vector>
+#include <cstring>
 
 namespace mooncake {
 namespace tent {
 namespace {
-
-// cuInit is process-global and idempotent; still call it once so the driver
-// probe is not re-entered on every topology device.
-bool ensureCudaDriverInit() {
-    static std::once_flag flag;
-    static CUresult result = CUDA_ERROR_NOT_INITIALIZED;
-    std::call_once(flag, []() { result = cuInit(0); });
-    return result == CUDA_SUCCESS;
-}
 
 // Driver-API probe: true iff this process already has a primary context on
 // `device`. Does not create one. Topology lists every visible GPU for NIC
@@ -82,15 +75,10 @@ Status CudaPlatform::allocate(void** pptr, size_t size,
 }
 
 Status CudaPlatform::free(void* ptr, size_t size) {
-    cudaPointerAttributes attributes;
-    CHECK_CUDA(cudaPointerGetAttributes(&attributes, ptr));
-    if (attributes.type == cudaMemoryTypeDevice) {
+    if (getCudaDeviceForPtr(ptr) >= 0) {
         CHECK_CUDA(cudaFree(ptr));
-    } else if (attributes.type == cudaMemoryTypeHost ||
-               attributes.type == cudaMemoryTypeUnregistered) {
-        numa_free(ptr, size);
     } else {
-        LOG(ERROR) << "Unknown memory type, " << ptr << " " << attributes.type;
+        numa_free(ptr, size);
     }
     return Status::OK();
 }
@@ -111,12 +99,30 @@ Status CudaPlatform::copy(void* dst, void* src, size_t length) {
     if (device_id == CUDAStreamPool::kCurrentDevice) {
         device_id = getPointerDeviceId(src);
     }
+    if (device_id == CUDAStreamPool::kCurrentDevice) {
+        // Host-to-host: plain memcpy. The stream pool would create a primary
+        // context on the thread's default device (GPU 0).
+        ::memcpy(dst, src, length);
+        return Status::OK();
+    }
 
+    // cudaMemcpyAsync() validates the stream against the current device's
+    // context; pin the buffer's device for the copy and restore the caller's
+    // binding only when the thread already had a context.
+    int saved_device = 0;
+    const bool have_saved =
+        cudaHasCurrentContext() && cudaGetDevice(&saved_device) == cudaSuccess;
+    if (!have_saved) (void)cudaGetLastError();
+
+    CHECK_CUDA(cudaSetDevice(device_id));
     CUDAStreamHandle stream;
     CHECK_STATUS(getStreamFromPool(stream, device_id));
     CHECK_CUDA(
         cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
     CHECK_CUDA(cudaStreamSynchronize(stream.get()));
+    if (have_saved) {
+        CHECK_CUDA(cudaSetDevice(saved_device));
+    }
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "tent/platform/cuda.h"
+#include "tent/platform/cuda_utils.h"
 #include "tent/common/status.h"
 #include "tent/common/utils/prefault.h"
 #include "tent/common/utils/random.h"
@@ -299,35 +300,17 @@ bool cudaAbiMatches() {
 MemoryType CudaPlatform::getMemoryType(void* addr) {
     if (!cudaDevicePresent()) return MTYPE_CPU;
     if (!cudaAbiMatches()) return MTYPE_UNKNOWN;
-    cudaPointerAttributes attributes{};
-    cudaError_t result = cudaPointerGetAttributes(&attributes, addr);
-    if (result != cudaSuccess) {
-        LOG(WARNING) << "cudaPointerGetAttributes: "
-                     << cudaGetErrorString(result);
-        return MTYPE_UNKNOWN;
-    }
-    if (attributes.type == cudaMemoryTypeDevice) return MTYPE_CUDA;
-    return MTYPE_CPU;
+    return getCudaDeviceForPtr(addr) >= 0 ? MTYPE_CUDA : MTYPE_CPU;
 }
 
 int CudaPlatform::getPointerDeviceId(void* addr) {
-    // Same guards as getMemoryType(): the cudaPointerAttributes layout changes
-    // across CUDA majors, so the struct must not be read on a runtime whose ABI
-    // does not match what we built against.
+    // Same guards as getMemoryType().
     if (!cudaDevicePresent() || !cudaAbiMatches()) {
         return CUDAStreamPool::kCurrentDevice;
     }
-    cudaPointerAttributes attributes{};
-    if (cudaPointerGetAttributes(&attributes, addr) != cudaSuccess) {
-        // Clear the latched error so it cannot surface at an unrelated
-        // cudaGetLastError() call site.
-        cudaGetLastError();
-        return CUDAStreamPool::kCurrentDevice;
-    }
-    if (attributes.type != cudaMemoryTypeDevice) {
-        return CUDAStreamPool::kCurrentDevice;
-    }
-    return attributes.device;
+    int device = getCudaDeviceForPtr(addr);
+    if (device < 0) return CUDAStreamPool::kCurrentDevice;
+    return device;
 }
 
 static inline uintptr_t alignPage(uintptr_t address) {
@@ -356,17 +339,11 @@ const std::vector<RangeLocation> CudaPlatform::getLocation(void* start,
         return entries;
     }
     if (cudaDevicePresent()) {
-        cudaPointerAttributes attributes{};
-        cudaError_t result = cudaPointerGetAttributes(&attributes, start);
-        if (result != cudaSuccess) {
-            LOG(WARNING) << "cudaPointerGetAttributes: "
-                         << cudaGetErrorString(result);
-            entries.push_back({(uint64_t)start, len, kWildcardLocation});
-            return entries;
-        }
-        if (attributes.type == cudaMemoryTypeDevice) {
+        // Unregistered pointers fall through to the NUMA probe below.
+        int cuda_dev = getCudaDeviceForPtr(start);
+        if (cuda_dev >= 0) {
             entries.push_back(
-                {(uint64_t)start, len, genCudaNodeName(attributes.device)});
+                {(uint64_t)start, len, genCudaNodeName(cuda_dev)});
             return entries;
         }
     }


### PR DESCRIPTION
## Description

TENT's TCP transport implicitly creates CUDA primary contexts in processes that never touched CUDA, or on GPUs the transfer never uses — several hundred MiB per process (~520 MiB on H200, ~414 MiB on A800). In per-rank deployments (`CUDA_VISIBLE_DEVICES=<rank>`), every rank's TCP traffic burns ~0.5 GB of GPU memory on its own card.

Three independent mechanisms, each verified on current `main` (2×A800, CUDA 12.9, TENT-enabled wheel, per-process nvidia-fd tracking at staged checkpoints):

1. **Host-to-host copies go through the CUDA stream pool.** `CudaPlatform::copy()` classifies both pointers as "current device", `CUDAStreamPool::acquire()` then calls `cudaGetDevice()` (device 0 on a fresh RPC worker thread) and `cudaStreamCreateWithFlags()` creates a primary context on GPU 0. This is reached on **every TCP WRITE** via the server-side `ControlService::onSendData()` (`control_plane.cpp:516` — no `MTYPE_CPU` fast path, unlike `sendData()`/`onRecvData()`) and on **every TCP READ** via `ControlClient::recvData()` (`control_plane.cpp:148`).
2. **Runtime-API pointer classification.** `cudaPointerGetAttributes()` on a thread with no prior `cudaSetDevice()` implicitly initializes the calling thread's current device (default GPU 0).
3. **`cudaMemcpyAsync()` validates the stream against the current device's context.** When a thread with no context (current device 0) copies through a stream belonging to another GPU, the runtime creates a primary context on GPU 0 — even though both buffer and stream live elsewhere. Confirmed with a minimal C-level repro (all other calls in the sequence are innocent).

### Fix

- New `tent/platform/cuda_utils.h`: `ensureCudaDriverInit()` (idempotent `cuInit`, creates no context — the driver API does not initialize itself lazily) and `getCudaDeviceForPtr()`, which classifies pointers via `cuPointerGetAttribute` and reads the driver's global pointer table without creating any context or implicitly initializing a device.
- `CudaPlatform::getMemoryType()` / `getPointerDeviceId()` / `getLocation()` / `free()` and the CUDA device plugin now classify pointers through the driver API.
- `CudaPlatform::copy()`: host-to-host copies use plain `::memcpy`; device-involved copies pin the buffer's device for the whole acquire/copy/synchronize sequence (restoring the caller's binding only when the thread already had a context), so a context is only ever created on the GPU that actually owns the buffer.

This supersedes #2330 (authored against a June tree; `copy()` has since been reworked by #3476 and the probe guards by #3261/#3945, so that diff no longer applies — and it did not cover mechanism 3 or the missing `cuInit`). It is the TENT counterpart of #2307, which fixed the classic (non-TENT) `TcpTransport`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:** two-process transfer over loopback TCP (`MC_USE_TENT=1`, tcp-only `MC_TENT_CONF`, GPU buffers allocated via ctypes `libcudart` so the test itself never pulls in torch), observing `nvidia-smi --query-compute-apps` plus per-process `/proc/<pid>/fd` nvidia-fd counts (driver init vs. context creation) at staged checkpoints; round-trip data-integrity checks in both directions. Also ran the exact repro script shared by @chestnut-Q in the #2307 discussion.

**Test results:** (2×A800-SXM4-80GB, CUDA 12.9, wheel built from this branch)

| Scenario (pure TCP, no torch) | Before | After |
|---|---|---|
| DRAM→DRAM WRITE | CPU-only **target** gets a 414 MiB context on GPU 0 | no context |
| DRAM→DRAM READ | CPU-only **initiator** gets a 414 MiB context on GPU 0 | no context |
| same + `CUDA_VISIBLE_DEVICES=1` | 414 MiB context on the rank's own GPU (the reported ~0.5 GB/card symptom) | no context; round-trip data verified |
| `cuda:1` → DRAM WRITE | initiator: contexts on GPU 0 **and** GPU 1; target polluted on GPU 0 | initiator: GPU 1 only (its own allocation); target clean; round-trip data verified |
| @chestnut-Q's repro script (#2307) | extra ~320 MiB on GPU 0 in the initiator (per their comment on #2330) | GPU 0 completely clean; only the initiator's own GPU 1 allocation remains; 50× WRITE completes |

- [x] Manual testing done (described above)
- [ ] Unit tests pass (deferred to CI)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format clean on all changed files)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) — N/A
- [ ] I have added tests to prove my changes are effective (manual repro matrix above; happy to add a unit test if maintainers prefer)
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (~100 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code assisted with root-cause analysis (fd-tracking repro, staged isolation, minimal C-level repro), implementing the fix, and running the verification matrix. The human submitter reviewed every changed line and can defend the change end-to-end.