### PR TITLE
[Bugfix][Store][TransferEngine] Fix standalone Ascend multi-NPU routing

### DIFF
--- a/mooncake-store/include/client_buffer.h
+++ b/mooncake-store/include/client_buffer.h
@@ -117,7 +117,8 @@ class BufferHandle {
  * @param handle The buffer handle to split
  * @return Vector of slices covering the entire buffer
  */
-std::vector<Slice> split_into_slices(BufferHandle& handle);
+std::vector<Slice> split_into_slices(BufferHandle& handle,
+                                     int32_t device_id = -1);
 
 /**
  * @brief Split a buffer into slices of maximum kMaxSliceSize
@@ -125,7 +126,8 @@ std::vector<Slice> split_into_slices(BufferHandle& handle);
  * @param length The length of the buffer to split
  * @return Vector of slices covering the entire buffer
  */
-std::vector<Slice> split_into_slices(void* buffer, size_t length);
+std::vector<Slice> split_into_slices(void* buffer, size_t length,
+                                     int32_t device_id = -1);
 
 /**
  * @brief Calculate the total size of a replica descriptor
@@ -142,6 +144,7 @@ uint64_t calculate_total_size(const Replica::Descriptor& replica);
  * @return 0 on success, non-zero on error
  */
 int allocateSlices(std::vector<Slice>& slices,
-                   const Replica::Descriptor& replica, void* buffer_ptr);
+                   const Replica::Descriptor& replica, void* buffer_ptr,
+                   int32_t device_id = -1);
 
 }  // namespace mooncake

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -424,7 +424,7 @@ class RealClient : public PyClient {
     // Allocator-backed buffer acquire: allocates + fills, keeps handle alive.
     // Returns (dummy_addr, size).
     tl::expected<std::tuple<uint64_t, size_t>, ErrorCode> acquire_buffer_dummy(
-        const std::string &key, const UUID &client_id);
+        const std::string &key, int32_t device_id, const UUID &client_id);
 
     // Allocator-backed buffer release: frees the handle held by acquire.
     tl::expected<void, ErrorCode> release_buffer_dummy(uint64_t dummy_addr,
@@ -434,14 +434,15 @@ class RealClient : public PyClient {
     // Returns vector of (dummy_addr, size) per key.
     std::vector<tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>>
     batch_acquire_buffer_dummy(const std::vector<std::string> &keys,
-                               const UUID &client_id);
+                               int32_t device_id, const UUID &client_id);
 
     tl::expected<std::tuple<uint64_t, size_t>, ErrorCode> allocate_buffer_dummy(
         size_t size, const UUID &client_id);
 
     tl::expected<void, ErrorCode> put_dummy_helper(
         const std::string &key, std::span<const char> value,
-        const ReplicateConfig &config, const UUID &client_id);
+        const ReplicateConfig &config, int32_t device_id,
+        const UUID &client_id);
 
     tl::expected<void, ErrorCode> upsert_dummy_helper(
         const std::string &key, std::span<const char> value,
@@ -469,11 +470,13 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> put_batch_dummy_helper(
         const std::vector<std::string> &keys,
         const std::vector<std::span<const char>> &values,
-        const ReplicateConfig &config, const UUID &client_id);
+        const ReplicateConfig &config, int32_t device_id,
+        const UUID &client_id);
 
     tl::expected<void, ErrorCode> put_parts_dummy_helper(
         const std::string &key, std::vector<std::span<const char>> values,
-        const ReplicateConfig &config, const UUID &client_id);
+        const ReplicateConfig &config, int32_t device_id,
+        const UUID &client_id);
 
     async_simple::coro::Lazy<std::vector<tl::expected<int64_t, ErrorCode>>>
     batch_get_into_dummy_helper(const std::vector<std::string> &keys,
@@ -616,7 +619,8 @@ class RealClient : public PyClient {
         const std::string &key, std::span<const char> value,
         const ReplicateConfig &config = ReplicateConfig{},
         const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator =
-            nullptr);
+            nullptr,
+        int32_t device_id = kInvalidPhysicalDeviceId);
 
     tl::expected<void, ErrorCode> register_buffer_internal(void *buffer,
                                                            size_t size);
@@ -722,7 +726,8 @@ class RealClient : public PyClient {
     std::vector<tl::expected<void, ErrorCode>> batch_put_from_internal(
         const std::vector<std::string> &keys,
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
-        const ReplicateConfig &config = ReplicateConfig{});
+        const ReplicateConfig &config = ReplicateConfig{},
+        int32_t device_id = kInvalidPhysicalDeviceId);
 
     std::vector<tl::expected<void, ErrorCode>>
     batch_put_from_multi_buffers_internal(
@@ -737,14 +742,16 @@ class RealClient : public PyClient {
         const std::vector<std::span<const char>> &values,
         const ReplicateConfig &config = ReplicateConfig{},
         const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator =
-            nullptr);
+            nullptr,
+        int32_t device_id = kInvalidPhysicalDeviceId);
 
     tl::expected<void, ErrorCode> put_batch_internal(
         const std::vector<std::string> &keys,
         const std::vector<std::span<const char>> &values,
         const ReplicateConfig &config = ReplicateConfig{},
         const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator =
-            nullptr);
+            nullptr,
+        int32_t device_id = kInvalidPhysicalDeviceId);
 
     tl::expected<void, ErrorCode> remove_internal(const std::string &key,
                                                   bool force = false);
@@ -769,12 +776,14 @@ class RealClient : public PyClient {
     std::shared_ptr<BufferHandle> get_buffer_internal(
         const std::string &key,
         const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator =
-            nullptr);
+            nullptr,
+        int32_t device_id = kInvalidPhysicalDeviceId);
 
     std::vector<std::shared_ptr<BufferHandle>> batch_get_buffer_internal(
         const std::vector<std::string> &keys,
         const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator =
-            nullptr);
+            nullptr,
+        int32_t device_id = kInvalidPhysicalDeviceId);
 
     std::map<std::string, std::vector<Replica::Descriptor>>
     batch_get_replica_desc(const std::vector<std::string> &keys);

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -421,6 +421,8 @@ struct SerializationError {
 struct Slice {
     void* ptr{nullptr};
     size_t size{0};
+    // Physical accelerator id carried across standalone-client async work.
+    int32_t device_id{-1};
 };
 
 const static uint64_t kMinSliceSize = facebook::cachelib::Slab::kMinAllocSize;

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -123,20 +123,21 @@ size_t BufferHandle::size() const {
 }
 
 // Utility functions for buffer and slice management
-std::vector<Slice> split_into_slices(BufferHandle& handle) {
+std::vector<Slice> split_into_slices(BufferHandle& handle, int32_t device_id) {
     auto base = static_cast<uint8_t*>(handle.ptr());
     auto length = handle.size();
-    return split_into_slices(base, length);
+    return split_into_slices(base, length, device_id);
 }
 
-std::vector<Slice> split_into_slices(void* buffer, size_t length) {
+std::vector<Slice> split_into_slices(void* buffer, size_t length,
+                                     int32_t device_id) {
     std::vector<Slice> slices;
     auto base = static_cast<uint8_t*>(buffer);
     size_t offset = 0;
 
     while (offset < length) {
         size_t chunk_size = std::min(length - offset, kMaxSliceSize);
-        slices.push_back({base + offset, chunk_size});
+        slices.push_back({base + offset, chunk_size, device_id});
         offset += chunk_size;
     }
     return slices;
@@ -160,7 +161,8 @@ uint64_t calculate_total_size(const Replica::Descriptor& replica) {
 }
 
 int allocateSlices(std::vector<Slice>& slices,
-                   const Replica::Descriptor& replica, void* buffer_ptr) {
+                   const Replica::Descriptor& replica, void* buffer_ptr,
+                   int32_t device_id) {
     if (replica.is_disk_replica()) {
         // For disk-based replica, split into slices based on file size
         uint64_t offset = 0;
@@ -168,25 +170,26 @@ int allocateSlices(std::vector<Slice>& slices,
         while (offset < total_length) {
             auto chunk_size = std::min(total_length - offset, kMaxSliceSize);
             void* chunk_ptr = static_cast<char*>(buffer_ptr) + offset;
-            slices.emplace_back(Slice{chunk_ptr, chunk_size});
+            slices.emplace_back(Slice{chunk_ptr, chunk_size, device_id});
             offset += chunk_size;
         }
     } else if (replica.is_local_disk_replica()) {
         slices.emplace_back(
-            Slice{buffer_ptr, replica.get_local_disk_descriptor().object_size});
+            Slice{buffer_ptr, replica.get_local_disk_descriptor().object_size,
+                  device_id});
     } else if (replica.is_dfs_replica()) {
-        slices.emplace_back(
-            Slice{buffer_ptr, replica.get_dfs_descriptor().object_size});
+        slices.emplace_back(Slice{
+            buffer_ptr, replica.get_dfs_descriptor().object_size, device_id});
     } else if (replica.is_nof_replica()) {
         auto& handle = replica.get_nof_descriptor().buffer_descriptor;
         void* chunk_ptr = buffer_ptr;
-        slices.emplace_back(Slice{chunk_ptr, handle.size_});
+        slices.emplace_back(Slice{chunk_ptr, handle.size_, device_id});
     } else {
         // For memory-based replica, split into slices based on buffer
         // descriptors
         auto& handle = replica.get_memory_descriptor().buffer_descriptor;
         void* chunk_ptr = buffer_ptr;
-        slices.emplace_back(Slice{chunk_ptr, handle.size_});
+        slices.emplace_back(Slice{chunk_ptr, handle.size_, device_id});
     }
     return 0;
 }

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -1116,7 +1116,7 @@ int DummyClient::put(const std::string& key, std::span<const char> value,
                      const ReplicateConfig& config) {
     return invoke_observed_void_rpc<&RealClient::put_dummy_helper>(
         TransferOperationKind::kWrite, "put", value.size_bytes(), false, key,
-        value, config, client_id_);
+        value, config, device_id_, client_id_);
 }
 
 int DummyClient::put_batch(const std::vector<std::string>& keys,
@@ -1124,7 +1124,7 @@ int DummyClient::put_batch(const std::vector<std::string>& keys,
                            const ReplicateConfig& config) {
     return invoke_observed_void_rpc<&RealClient::put_batch_dummy_helper>(
         TransferOperationKind::kWrite, "put_batch", sum_value_sizes(values),
-        true, keys, values, config, client_id_);
+        true, keys, values, config, device_id_, client_id_);
 }
 
 int DummyClient::put_parts(const std::string& key,
@@ -1132,7 +1132,7 @@ int DummyClient::put_parts(const std::string& key,
                            const ReplicateConfig& config) {
     return invoke_observed_void_rpc<&RealClient::put_parts_dummy_helper>(
         TransferOperationKind::kWrite, "put_parts", sum_value_sizes(values),
-        false, key, values, config, client_id_);
+        false, key, values, config, device_id_, client_id_);
 }
 
 int DummyClient::upsert(const std::string& key, std::span<const char> value,
@@ -1295,8 +1295,9 @@ std::shared_ptr<BufferHandle> DummyClient::get_buffer(const std::string& key) {
     }
 
     // Fallback: allocator-backed buffer via shm
-    auto result = invoke_rpc<&RealClient::acquire_buffer_dummy,
-                             std::tuple<uint64_t, size_t>>(key, client_id_);
+    auto result =
+        invoke_rpc<&RealClient::acquire_buffer_dummy,
+                   std::tuple<uint64_t, size_t>>(key, device_id_, client_id_);
     if (!result.has_value()) {
         return nullptr;
     }
@@ -1360,8 +1361,8 @@ std::vector<std::shared_ptr<BufferHandle>> DummyClient::batch_get_buffer(
 
     auto alloc_results =
         invoke_batch_rpc<&RealClient::batch_acquire_buffer_dummy,
-                         std::tuple<uint64_t, size_t>>(miss_keys.size(),
-                                                       miss_keys, client_id_);
+                         std::tuple<uint64_t, size_t>>(
+            miss_keys.size(), miss_keys, device_id_, client_id_);
 
     for (size_t i = 0; i < miss_indices.size(); ++i) {
         if (!alloc_results[i].has_value()) continue;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1969,7 +1969,8 @@ void RealClient::stop_http_server() {
 tl::expected<void, ErrorCode> RealClient::put_internal(
     const std::string &key, std::span<const char> value,
     const ReplicateConfig &config,
-    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator) {
+    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator,
+    int32_t device_id) {
     if (config.prefer_alloc_in_same_node) {
         LOG(ERROR) << "prefer_alloc_in_same_node is not supported.";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -1995,7 +1996,7 @@ tl::expected<void, ErrorCode> RealClient::put_internal(
         return tl::unexpected(scatter_result.error());
     }
 
-    std::vector<Slice> slices = split_into_slices(buffer_handle);
+    std::vector<Slice> slices = split_into_slices(buffer_handle, device_id);
 
     auto put_result = client_->Put(key, slices, config);
     if (!put_result) {
@@ -2007,7 +2008,7 @@ tl::expected<void, ErrorCode> RealClient::put_internal(
 
 tl::expected<void, ErrorCode> RealClient::put_dummy_helper(
     const std::string &key, std::span<const char> value,
-    const ReplicateConfig &config, const UUID &client_id) {
+    const ReplicateConfig &config, int32_t device_id, const UUID &client_id) {
     std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
@@ -2016,7 +2017,8 @@ tl::expected<void, ErrorCode> RealClient::put_dummy_helper(
     }
     auto &context = it->second;
 
-    return put_internal(key, value, config, context.client_buffer_allocator);
+    return put_internal(key, value, config, context.client_buffer_allocator,
+                        device_id);
 }
 
 int RealClient::put(const std::string &key, std::span<const char> value,
@@ -2038,7 +2040,8 @@ tl::expected<void, ErrorCode> RealClient::put_batch_internal(
     const std::vector<std::string> &keys,
     const std::vector<std::span<const char>> &values,
     const ReplicateConfig &config,
-    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator) {
+    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator,
+    int32_t device_id) {
     if (config.prefer_alloc_in_same_node) {
         LOG(ERROR) << "prefer_alloc_in_same_node is not supported.";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -2077,7 +2080,7 @@ tl::expected<void, ErrorCode> RealClient::put_batch_internal(
         if (!scatter_result) {
             return tl::unexpected(scatter_result.error());
         }
-        auto slices = split_into_slices(buffer_handle);
+        auto slices = split_into_slices(buffer_handle, device_id);
         buffer_handles.emplace_back(std::move(*alloc_result));
         batched_slices.emplace(key, std::move(slices));
     }
@@ -2109,7 +2112,7 @@ tl::expected<void, ErrorCode> RealClient::put_batch_internal(
 tl::expected<void, ErrorCode> RealClient::put_batch_dummy_helper(
     const std::vector<std::string> &keys,
     const std::vector<std::span<const char>> &values,
-    const ReplicateConfig &config, const UUID &client_id) {
+    const ReplicateConfig &config, int32_t device_id, const UUID &client_id) {
     std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
@@ -2119,7 +2122,7 @@ tl::expected<void, ErrorCode> RealClient::put_batch_dummy_helper(
     auto &context = it->second;
 
     return put_batch_internal(keys, values, config,
-                              context.client_buffer_allocator);
+                              context.client_buffer_allocator, device_id);
 }
 
 int RealClient::put_batch(const std::vector<std::string> &keys,
@@ -2142,7 +2145,8 @@ int RealClient::put_batch(const std::vector<std::string> &keys,
 tl::expected<void, ErrorCode> RealClient::put_parts_internal(
     const std::string &key, const std::vector<std::span<const char>> &values,
     const ReplicateConfig &config,
-    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator) {
+    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator,
+    int32_t device_id) {
     if (config.prefer_alloc_in_same_node) {
         LOG(ERROR) << "prefer_alloc_in_same_node is not supported.";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -2190,7 +2194,7 @@ tl::expected<void, ErrorCode> RealClient::put_parts_internal(
     }
 
     // Split into slices
-    std::vector<Slice> slices = split_into_slices(buffer_handle);
+    std::vector<Slice> slices = split_into_slices(buffer_handle, device_id);
 
     // Perform the put operation - buffer_handle will be automatically released
     auto put_result = client_->Put(key, slices, config);
@@ -2205,7 +2209,7 @@ tl::expected<void, ErrorCode> RealClient::put_parts_internal(
 
 tl::expected<void, ErrorCode> RealClient::put_parts_dummy_helper(
     const std::string &key, std::vector<std::span<const char>> values,
-    const ReplicateConfig &config, const UUID &client_id) {
+    const ReplicateConfig &config, int32_t device_id, const UUID &client_id) {
     std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
@@ -2215,7 +2219,7 @@ tl::expected<void, ErrorCode> RealClient::put_parts_dummy_helper(
     auto &context = it->second;
 
     return put_parts_internal(key, values, config,
-                              context.client_buffer_allocator);
+                              context.client_buffer_allocator, device_id);
 }
 
 int RealClient::put_parts(const std::string &key,
@@ -2834,7 +2838,8 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
 // Implementation of get_buffer_internal method
 std::shared_ptr<BufferHandle> RealClient::get_buffer_internal(
     const std::string &key,
-    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator) {
+    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator,
+    int32_t device_id) {
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
         return nullptr;
@@ -2931,7 +2936,7 @@ std::shared_ptr<BufferHandle> RealClient::get_buffer_internal(
     }
 
     std::vector<Slice> slices;
-    allocateSlices(slices, replica, buffer_handle->ptr());
+    allocateSlices(slices, replica, buffer_handle->ptr(), device_id);
     auto filtered_qr = FilterQueryResult(query_result.value(), replica);
     auto get_result = client_->Get(key, filtered_qr, slices);
     if (!get_result) {
@@ -2987,7 +2992,7 @@ tl::expected<void, ErrorCode> RealClient::release_hot_cache(
 }
 
 tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>
-RealClient::acquire_buffer_dummy(const std::string &key,
+RealClient::acquire_buffer_dummy(const std::string &key, int32_t device_id,
                                  const UUID &client_id) {
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
@@ -2997,7 +3002,7 @@ RealClient::acquire_buffer_dummy(const std::string &key,
     auto &context = it->second;
 
     auto buffer_handle =
-        get_buffer_internal(key, context.client_buffer_allocator);
+        get_buffer_internal(key, context.client_buffer_allocator, device_id);
     if (!buffer_handle) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -3109,6 +3114,7 @@ tl::expected<void, ErrorCode> RealClient::batch_release_hot_cache(
 
 std::vector<tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>>
 RealClient::batch_acquire_buffer_dummy(const std::vector<std::string> &keys,
+                                       int32_t device_id,
                                        const UUID &client_id) {
     std::vector<tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>> results(
         keys.size(), tl::make_unexpected(ErrorCode::INTERNAL_ERROR));
@@ -3123,8 +3129,8 @@ RealClient::batch_acquire_buffer_dummy(const std::vector<std::string> &keys,
 
     // Use batch_get_buffer_internal with dummy's allocator
     lock.unlock();
-    auto handles =
-        batch_get_buffer_internal(keys, ctx_it->second.client_buffer_allocator);
+    auto handles = batch_get_buffer_internal(
+        keys, ctx_it->second.client_buffer_allocator, device_id);
     lock.lock();
 
     // Re-validate context after re-lock
@@ -3166,7 +3172,8 @@ RealClient::batch_acquire_buffer_dummy(const std::vector<std::string> &keys,
 std::vector<std::shared_ptr<BufferHandle>>
 RealClient::batch_get_buffer_internal(
     const std::vector<std::string> &keys,
-    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator) {
+    const std::shared_ptr<ClientBufferAllocator> &client_buffer_allocator,
+    int32_t device_id) {
     std::vector<std::shared_ptr<BufferHandle>> final_results(keys.size(),
                                                              nullptr);
 
@@ -3245,7 +3252,7 @@ RealClient::batch_get_buffer_internal(
         auto buffer_handle =
             std::make_unique<BufferHandle>(std::move(*alloc_result));
         std::vector<Slice> slices;
-        allocateSlices(slices, replica, buffer_handle->ptr());
+        allocateSlices(slices, replica, buffer_handle->ptr(), device_id);
 
         if (replica.is_local_disk_replica()) {
             // LOCAL_DISK: buffer is allocated and registered via
@@ -4155,12 +4162,14 @@ RealClient::batch_put_from_dummy_helper(
         return std::vector<tl::expected<void, ErrorCode>>(
             keys.size(), tl::unexpected(buffers_result.error()));
     }
-    return batch_put_from_internal(keys, buffers_result.value(), sizes, config);
+    return batch_put_from_internal(keys, buffers_result.value(), sizes, config,
+                                   device_id);
 }
 
 std::vector<tl::expected<void, ErrorCode>> RealClient::batch_put_from_internal(
     const std::vector<std::string> &keys, const std::vector<void *> &buffers,
-    const std::vector<size_t> &sizes, const ReplicateConfig &config) {
+    const std::vector<size_t> &sizes, const ReplicateConfig &config,
+    int32_t device_id) {
     if (config.prefer_alloc_in_same_node) {
         LOG(ERROR) << "prefer_alloc_in_same_node is not supported.";
         return std::vector<tl::expected<void, ErrorCode>>(
@@ -4186,7 +4195,7 @@ std::vector<tl::expected<void, ErrorCode>> RealClient::batch_put_from_internal(
         void *buffer = buffers[i];
         size_t size = sizes[i];
 
-        all_slices[key] = split_into_slices(buffer, size);
+        all_slices[key] = split_into_slices(buffer, size, device_id);
     }
 
     std::vector<std::vector<mooncake::Slice>> ordered_batched_slices;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -1088,6 +1088,7 @@ std::optional<TransferFuture> TransferSubmitter::submit_batch(
             request.target_id = seg;
             request.target_offset = handle.buffer_address_ + offset;
             request.length = slice.size;
+            request.device_id = slice.device_id;
             requests.emplace_back(request);
             offset += slice.size;
         }
@@ -1168,6 +1169,7 @@ TransferSubmitter::submit_batch_get_offload_object(
                     .target_id = seg,
                     .target_offset = pointers[i] + offset,
                     .length = slice.size,
+                    .device_id = slice.device_id,
                 });
             }
             offset += slice.size;
@@ -1290,6 +1292,7 @@ std::optional<TransferFuture> TransferSubmitter::submitTransferEngineOperation(
         request.target_id = seg;
         request.target_offset = base_address + offset;
         request.length = slice.size;
+        request.device_id = slice.device_id;
 
         offset += slice.size;
         requests.emplace_back(request);

--- a/mooncake-store/tests/client_buffer_test.cpp
+++ b/mooncake-store/tests/client_buffer_test.cpp
@@ -279,6 +279,37 @@ TEST_F(ClientBufferTest, SplitIntoSlicesPtrLength) {
     EXPECT_EQ(total_slice_size, alloc_size);
 }
 
+TEST_F(ClientBufferTest, SplitIntoSlicesPreservesDeviceId) {
+    constexpr size_t kLength = 1024;
+    constexpr int32_t kPhysicalDeviceId = 3;
+    std::vector<uint8_t> buffer(kLength);
+
+    auto slices =
+        split_into_slices(buffer.data(), buffer.size(), kPhysicalDeviceId);
+
+    ASSERT_FALSE(slices.empty());
+    for (const auto& slice : slices) {
+        EXPECT_EQ(slice.device_id, kPhysicalDeviceId);
+    }
+}
+
+TEST_F(ClientBufferTest, SplitBufferHandlePreservesDeviceId) {
+    constexpr size_t kBufferSize = 1024 * 1024;
+    constexpr size_t kAllocationSize = 1024;
+    constexpr int32_t kPhysicalDeviceId = 3;
+    auto allocator = ClientBufferAllocator::create(kBufferSize);
+    ASSERT_NE(allocator, nullptr);
+    auto handle = allocator->allocate(kAllocationSize);
+    ASSERT_TRUE(handle.has_value());
+
+    auto slices = split_into_slices(*handle, kPhysicalDeviceId);
+
+    ASSERT_FALSE(slices.empty());
+    for (const auto& slice : slices) {
+        EXPECT_EQ(slice.device_id, kPhysicalDeviceId);
+    }
+}
+
 // Test memory exhaustion scenario
 TEST_F(ClientBufferTest, MemoryExhaustion) {
     const size_t buffer_size =
@@ -367,6 +398,7 @@ TEST_F(ClientBufferTest, CalculateTotalSizeZeroSizeMemoryReplica) {
 TEST_F(ClientBufferTest, AllocateSlicesMemoryReplica) {
     const size_t buffer_size = 1024 * 1024;  // 1MB
     const size_t alloc_size = 4096;          // 4KB
+    constexpr int32_t kPhysicalDeviceId = 3;
 
     auto allocator = ClientBufferAllocator::create(buffer_size);
     ASSERT_NE(allocator, nullptr);
@@ -386,7 +418,8 @@ TEST_F(ClientBufferTest, AllocateSlicesMemoryReplica) {
     replica.status = ReplicaStatus::COMPLETE;
 
     std::vector<Slice> slices;
-    int result = allocateSlices(slices, replica, handle.ptr());
+    int result =
+        allocateSlices(slices, replica, handle.ptr(), kPhysicalDeviceId);
 
     EXPECT_EQ(result, 0);
     EXPECT_EQ(slices.size(), 1);
@@ -396,6 +429,7 @@ TEST_F(ClientBufferTest, AllocateSlicesMemoryReplica) {
 
     // Verify slice pointer matches buffer pointer
     EXPECT_EQ(slices[0].ptr, handle.ptr());
+    EXPECT_EQ(slices[0].device_id, kPhysicalDeviceId);
 }
 
 // Test allocateSlices function with disk replica

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/context_manager.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/context_manager.h
@@ -59,6 +59,9 @@ class ContextManager {
     // Returns false if physical id is not managed by this process.
     bool setCurrentContextByPhysicalId(int32_t physical_dev_id) const;
 
+    // Resolve a physical device id to the logical engine index.
+    int32_t logicalDeviceForPhysicalId(int32_t physical_dev_id) const;
+
     // Cleanup all contexts
     void finalize();
 

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -67,6 +67,10 @@ class Transport {
         SegmentID target_id;
         uint64_t target_offset;
         size_t length;
+        // Explicit local accelerator identity for asynchronous submissions.
+        // Ascend standalone clients pass a physical device id here so the
+        // transport need not consult thread-local ACL state.
+        int32_t device_id = -1;
         int advise_retry_cnt = 0;
         // Per-request transport pin, TENT only.
         int transport_hint = 0;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -35,9 +35,13 @@
 namespace mooncake {
 namespace {
 
-int32_t ResolveCurrentEngineId(bool agent_mode) {
+int32_t ResolveEngineId(bool agent_mode, int32_t physical_device_id) {
     if (!agent_mode) {
         return 0;
+    }
+    if (physical_device_id >= 0) {
+        return ContextManager::getInstance().logicalDeviceForPhysicalId(
+            physical_device_id);
     }
     int32_t current_device_id = 0;
     if (aclrtGetDevice(&current_device_id) != ACL_ERROR_NONE) {
@@ -263,9 +267,17 @@ Status AscendDirectTransport::submitTransfer(
             std::to_string(batch_id));
     }
 
-    const int32_t current_engine_id = ResolveCurrentEngineId(agent_mode_);
-    if (current_engine_id < 0) {
-        return Status::Context("aclrtGetDevice failed");
+    std::vector<int32_t> engine_ids;
+    engine_ids.reserve(entries.size());
+    for (const auto &request : entries) {
+        const int32_t engine_id =
+            ResolveEngineId(agent_mode_, request.device_id);
+        if (engine_id < 0) {
+            return Status::Context(request.device_id >= 0
+                                       ? "invalid physical device id"
+                                       : "aclrtGetDevice failed");
+        }
+        engine_ids.push_back(engine_id);
     }
 
     auto cur_task_size = batch_desc.task_list.size();
@@ -273,12 +285,13 @@ Status AscendDirectTransport::submitTransfer(
     std::vector<Slice *> slice_list;
     slice_list.reserve(entries.size());
 
+    size_t request_index = 0;
     for (auto &request : entries) {
         TransferTask &task = batch_desc.task_list[cur_task_size];
         ++cur_task_size;
         task.total_bytes = request.length;
         Slice *slice = getSliceCache().allocate();
-        InitializeSlice(request, current_engine_id, &task, slice);
+        InitializeSlice(request, engine_ids[request_index++], &task, slice);
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
         slice_list.push_back(slice);
@@ -291,14 +304,25 @@ Status AscendDirectTransport::submitTransfer(
 
 Status AscendDirectTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    const int32_t current_engine_id = ResolveCurrentEngineId(agent_mode_);
-    if (current_engine_id < 0) {
-        return Status::Context("aclrtGetDevice failed");
+    std::vector<int32_t> engine_ids;
+    engine_ids.reserve(task_list.size());
+    for (const auto *task : task_list) {
+        assert(task);
+        assert(task->request);
+        const int32_t engine_id =
+            ResolveEngineId(agent_mode_, task->request->device_id);
+        if (engine_id < 0) {
+            return Status::Context(task->request->device_id >= 0
+                                       ? "invalid physical device id"
+                                       : "aclrtGetDevice failed");
+        }
+        engine_ids.push_back(engine_id);
     }
 
     std::vector<Slice *> slice_list;
     slice_list.reserve(task_list.size());
 
+    size_t task_index = 0;
     for (auto index : task_list) {
         assert(index);
         auto &task = *index;
@@ -306,7 +330,7 @@ Status AscendDirectTransport::submitTransferTask(
         auto &request = *task.request;
         task.total_bytes = request.length;
         Slice *slice = getSliceCache().allocate();
-        InitializeSlice(request, current_engine_id, &task, slice);
+        InitializeSlice(request, engine_ids[task_index++], &task, slice);
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
         slice_list.push_back(slice);

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/context_manager.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/context_manager.cpp
@@ -192,6 +192,22 @@ bool ContextManager::setCurrentContextByPhysicalId(
     return true;
 }
 
+int32_t ContextManager::logicalDeviceForPhysicalId(
+    int32_t physical_dev_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!initialized_) {
+        LOG(ERROR) << "ContextManager not initialized";
+        return -1;
+    }
+    auto it = physical_to_logic_.find(physical_dev_id);
+    if (it == physical_to_logic_.end()) {
+        LOG(ERROR) << "Physical device id not managed by this process: "
+                   << physical_dev_id;
+        return -1;
+    }
+    return it->second;
+}
+
 void ContextManager::finalize() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!initialized_) {

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/slice_dispatcher.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/slice_dispatcher.cpp
@@ -64,12 +64,14 @@ DefaultSliceDispatcher::DefaultSliceDispatcher(
 
 void DefaultSliceDispatcher::enqueue(
     std::vector<Transport::Slice *> slice_list) {
-    std::map<
-        std::pair<Transport::SegmentID, Transport::TransferRequest::OpCode>,
-        std::vector<Transport::Slice *>>
+    std::map<std::tuple<int32_t, Transport::SegmentID,
+                        Transport::TransferRequest::OpCode>,
+             std::vector<Transport::Slice *>>
         seg_to_slices;
     for (auto slice : slice_list) {
-        seg_to_slices[{slice->target_id, slice->opcode}].push_back(slice);
+        seg_to_slices[{slice->ascend_direct.engine_id, slice->target_id,
+                       slice->opcode}]
+            .push_back(slice);
     }
     auto *executor = transfer_executor_;
     auto contexts = local_engine_contexts_;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
@@ -140,7 +140,17 @@ void TransferExecutorBase::ParseExecutorEnvIntoInitParams(InitParams& params) {
     }
     char* use_async = std::getenv("ASCEND_USE_ASYNC_TRANSFER");
     if (use_async) {
-        params.use_async_transfer = true;
+        auto use_async_opt = parseFromString<int32_t>(use_async);
+        if (!use_async_opt.has_value()) {
+            LOG(WARNING) << "ASCEND_USE_ASYNC_TRANSFER is not valid, value:"
+                         << use_async
+                         << ", keeping default:" << params.use_async_transfer;
+        } else {
+            params.use_async_transfer =
+                static_cast<bool>(use_async_opt.value());
+            LOG(INFO) << "Set use async transfer to:"
+                      << params.use_async_transfer;
+        }
     }
     char* auto_connect = std::getenv("ASCEND_AUTO_CONNECT");
     if (auto_connect) {

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -790,7 +790,8 @@ class AscendDirectTransportTest : public ::testing::Test {
     };
 
     TransferWaitResult runLocalCopy(AscendDirectTransport* transport, void* src,
-                                    void* dst, size_t len) {
+                                    void* dst, size_t len,
+                                    int32_t device_id = -1) {
         auto batch_id = transport->allocateBatchID(1);
         if (batch_id == 0) {
             return {false, false, {}};
@@ -802,6 +803,7 @@ class AscendDirectTransportTest : public ::testing::Test {
         req.target_id = 0;
         req.target_offset = reinterpret_cast<uint64_t>(dst);
         req.length = len;
+        req.device_id = device_id;
         requests.push_back(req);
         Status s = transport->submitTransfer(batch_id, requests);
         if (!s.ok()) {
@@ -1118,7 +1120,8 @@ TEST_F(AscendDirectTransportTest, DummyReal_RemoteTransfer_Async_Success) {
     globalConfig().ascend_agent_mode = false;
 }
 
-TEST_F(AscendDirectTransportTest, DummyReal_SubmitTransfer_UsesDeviceId) {
+TEST_F(AscendDirectTransportTest,
+       DummyReal_LegacyRequestUsesThreadContextDeviceId) {
     globalConfig().ascend_agent_mode = true;
     unsetenv("HCCL_INTRA_ROCE_ENABLE");
     auto transport = createTransport();
@@ -1136,8 +1139,40 @@ TEST_F(AscendDirectTransportTest, DummyReal_SubmitTransfer_UsesDeviceId) {
                                test_buffer_dst_, kTransferBufSize);
     ASSERT_TRUE(result.finished);
     EXPECT_GE(mock_acl::get_get_device_call_count(), 1)
-        << "submitTransfer in dummy-real mode must call aclrtGetDevice to get "
-           "current device_id for slice dispatch";
+        << "legacy requests without a device id must retain context-based "
+           "routing";
+
+    globalConfig().ascend_agent_mode = false;
+}
+
+TEST_F(AscendDirectTransportTest,
+       DummyReal_ExplicitDeviceIdDoesNotReadThreadContext) {
+    globalConfig().ascend_agent_mode = true;
+    ContextManager::getInstance().finalize();
+    constexpr int kEngineCount = 4;
+    constexpr int kPhysicalDeviceId = 2;
+    mock_acl::set_device_count(kEngineCount);
+    ASSERT_TRUE(ContextManager::getInstance().initialize());
+    unsetenv("HCCL_INTRA_ROCE_ENABLE");
+    auto transport = createTransport();
+    ASSERT_NE(transport, nullptr);
+
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_dst_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+    initTestData(kTransferBufSize);
+
+    const int get_device_calls_before = mock_acl::get_get_device_call_count();
+    auto result =
+        runLocalCopy(transport.get(), test_buffer_src_, test_buffer_dst_,
+                     kTransferBufSize, kPhysicalDeviceId);
+    ASSERT_TRUE(result.finished);
+    EXPECT_FALSE(result.failed);
+    EXPECT_EQ(mock_acl::get_get_device_call_count(), get_device_calls_before)
+        << "explicit request device id must replace thread-local ACL routing";
 
     globalConfig().ascend_agent_mode = false;
 }
@@ -1287,6 +1322,20 @@ TEST_F(AscendDirectTransportTest, Memory_RegisterAndUnregister) {
                                              "cpu:0", true, true),
               0);
     EXPECT_EQ(transport->unregisterLocalMemory(test_buffer_src_, true), 0);
+}
+
+TEST_F(AscendDirectTransportTest,
+       Config_AsyncTransferZeroKeepsBufferPoolCompatible) {
+    setenv("ASCEND_USE_ASYNC_TRANSFER", "0", 1);
+    setenv("ASCEND_BUFFER_POOL", "4:8", 1);
+
+    TransferExecutorBase::InitParams params;
+    TransferExecutorBase::ParseExecutorEnvIntoInitParams(params);
+
+    EXPECT_FALSE(params.use_async_transfer);
+    EXPECT_TRUE(params.use_buffer_pool);
+    unsetenv("ASCEND_USE_ASYNC_TRANSFER");
+    unsetenv("ASCEND_BUFFER_POOL");
 }
 
 TEST_F(AscendDirectTransportTest, Memory_RegisterStampsBufferDeviceId) {


### PR DESCRIPTION
## Description

Fixes #3972

This PR fixes an ACL context loss issue affecting Ascend multi-NPU transfers in the standalone Mooncake Store deployment.

### Affected deployment

```text
Application
  ↓
DummyClient
  ↓ IPC/RPC
standalone mooncake_client
  ↓
RealClient
  ↓
Mooncake Store
  ↓
Ascend Direct Transfer Engine worker
```

In Ascend agent mode, the standalone RealClient manages multiple local NPUs. The DummyClient knows which physical NPU is associated with a request, and the RealClient can set the corresponding ACL context on the RPC or shared-memory registration thread.

However, Store transfers are subsequently executed by internal worker threads. ACL contexts are thread-local and are not inherited when execution switches to another thread.

Previously, `AscendDirectTransport` called `aclrtGetDevice()` from the transfer worker to determine the local Ascend engine. When the worker had no current ACL context, the operation failed with errors such as:

```text
aclrtGetDevice failed
rtGetDevMsg execution failed, the context is a null pointer
Failed to submit all transfers, error code is Context
Failed to submit transfer operation
transfer_read_failed
TRANSFER_FAIL
```

This caused Store `put` and `get` operations to fail in deployments such as:

```text
SGLang
  ↓
HiCache
  ↓
MooncakeStorageBackend
  ↓
DummyClient
  ↓
standalone mooncake_client
  ↓
RealClient
  ↓
Mooncake Store / Transfer Engine
```

The embedded RealClient path is not affected because the application and Mooncake client run in the same process and normally retain the expected device context.

### Root cause

The physical NPU identity was available in DummyClient and was used while registering shared memory with the standalone RealClient, but it was not carried through the complete asynchronous Store transfer path.

The previous routing path was:

```text
DummyClient request
  ↓
RealClient RPC handler sets the ACL context
  ↓
Store operation
  ↓
Internal worker-thread switch
  ↓
ACL context is not inherited
  ↓
AscendDirectTransport calls aclrtGetDevice()
  ↓
The worker has a null ACL context
  ↓
The transfer returns Status::Context
```

The Transfer Engine therefore depended on thread-local ACL state as routing metadata, even though that state was not guaranteed to exist on the worker thread.

### Solution

This change carries the physical device identity explicitly with each transfer request:

```text
DummyClient
  │
  │ physical_device_id
  ▼
RPC request
  │
  │ device_id
  ▼
Store Slice
  │
  │ Slice.device_id
  ▼
TransferRequest
  │
  │ TransferRequest.device_id
  ▼
AscendDirectTransport
  │
  │ logicalDeviceForPhysicalId(device_id)
  ▼
Selected logical engine and ACL context
```

The implementation:

- propagates the DummyClient physical device ID through the relevant standalone RealClient RPC calls;
- stores the physical device ID in Store `Slice` objects;
- copies `Slice.device_id` into `TransferRequest.device_id`;
- resolves the logical engine from the explicit physical device ID in Ascend agent mode;
- routes each transfer to the engine corresponding to the request's NPU;
- separates dispatched slices by engine ID so requests for different NPUs are not grouped into the same engine batch;
- preserves the context-based fallback for legacy and embedded requests that do not provide an explicit device ID;
- adds regression coverage for Store slice propagation and explicit Ascend engine routing.

### Async-transfer environment variable

This PR also corrects the parsing of `ASCEND_USE_ASYNC_TRANSFER`.

Previously, the presence of this environment variable enabled asynchronous transfer regardless of its value. As a result, the following configuration was incorrectly treated as buffer-pool mode plus enabled asynchronous transfer:

```bash
export ASCEND_BUFFER_POOL=4:8
export ASCEND_USE_ASYNC_TRANSFER=0
```

This caused initialization to fail with:

```text
Buffer pool mode does not support async transfer.
```

After this change:

- `ASCEND_USE_ASYNC_TRANSFER=0` disables asynchronous transfer;
- `ASCEND_USE_ASYNC_TRANSFER=1` enables asynchronous transfer;
- buffer-pool mode can be used with explicitly disabled asynchronous transfer.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Manual integration testing was performed on an Ascend Linux environment using Mooncake v0.3.13.

### Test topology

```text
Python test process
  ↓
DummyClient
  ↓ IPC/RPC
standalone mooncake_client
  ↓
RealClient
  ↓
Mooncake Store
  ↓
Ascend Direct Transfer Engine workers
```

This topology reproduces the original context-loss scenario because the ACL context selected by the application or RPC handler is not automatically inherited by the Transfer Engine worker threads.

### Test command

```bash
python3.12 test.py
./run_multi_npu_safe.sh test_every_npu_safe.py
```

The test enumerated the visible NPUs and exercised Store transfers using the physical device ID associated with each DummyClient request.

### Test scenarios

| Scenario | Test procedure | Validation |
| --- | --- | --- |
| Single-NPU write | Select one NPU and write multiple objects through DummyClient and the standalone RealClient | Every `put` operation returns success |
| Single-NPU read | Read every object written on the selected NPU | Returned object length and payload match the original data |
| Per-NPU read/write | Repeat the `put` and `get` test for every visible physical NPU | Requests for every NPU complete successfully |
| Physical-to-logical routing | Submit requests carrying each physical device ID | Each request is routed to the corresponding logical Ascend engine |
| Context switching | Switch the application's current NPU between requests and issue `put` and `get` operations after every switch | Routing follows the device ID carried by the request instead of worker-thread ACL state |
| Multi-NPU concurrent writes | Submit writes concurrently from workers targeting different NPUs | All writes succeed without cross-device routing failures |
| Multi-NPU concurrent reads | Read objects concurrently across different NPUs | Every read returns the expected object and payload |
| Repeated transfers | Execute multiple `put` and `get` operations on every tested NPU | No intermittent context or engine-selection failure occurs |
| Buffer-pool configuration | Run with `ASCEND_BUFFER_POOL=4:8` and `ASCEND_USE_ASYNC_TRANSFER=0` | Transfer Engine initialization succeeds and asynchronous transfer remains disabled |

### Data validation

For every successfully written key, the test verified that:

- the `put` operation returned success;
- the `get` operation returned the expected object length;
- the returned payload was byte-for-byte identical to the written payload;
- concurrent requests targeting different NPUs returned their corresponding data;
- switching the current application context did not change the engine selected for an already constructed request.

### Context-routing validation

The test explicitly covered the original failure sequence:

1. The Python process selected a physical NPU.
2. DummyClient captured and sent the physical device ID to the standalone RealClient.
3. Store processing continued on internal worker threads.
4. The transfer request retained the physical device ID after the thread switch.
5. Ascend Direct mapped the physical device ID to the corresponding logical engine.
6. The transfer completed without requiring the worker thread to inherit the RPC handler's ACL context.

### Test results

| Test item | Result |
| --- | --- |
| Single-NPU `put` and `get` | Passed |
| Read/write on every visible NPU | Passed |
| Multi-NPU concurrent `put` and `get` | Passed |
| ACL context switching between requests | Passed |
| Physical-device-to-logical-engine routing | Passed |
| Object-length verification | Passed |
| Byte-for-byte payload verification | Passed |
| Repeated-transfer stability | Passed |
| Buffer pool with `ASCEND_USE_ASYNC_TRANSFER=0` | Passed |

After the fix, the test completed without the following errors:

```text
aclrtGetDevice failed
the context is a null pointer
Status::Context
Failed to submit all transfers
Failed to submit transfer operation
transfer_read_failed
TRANSFER_FAIL
```

The PR also includes C++ regression tests for execution by the project CI.

**Test status:**

- [x] Unit tests pass locally
- [ ] Integration tests pass in project CI
- [x] Manual multi-NPU integration testing completed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable because this change does not introduce a new public API)
- [x] I have added tests to prove my changes are effective
- [ ] For changes greater than 500 LOC, I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [ ] AI tools were used