### PR TITLE
[TransferEngine] Clamp RDMA QP atomic depths to device limits

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -255,6 +255,10 @@ class RdmaContext {
 
     uint8_t portNum() const { return port_; }
 
+    uint8_t maxDestRdAtomic() const { return max_dest_rd_atomic_; }
+
+    uint8_t maxRdAtomic() const { return max_rd_atomic_; }
+
     uint8_t numLagPorts() const { return num_lag_ports_; }
 
     int activeSpeed() const { return active_speed_; }
@@ -320,6 +324,8 @@ class RdmaContext {
 
     uint8_t port_ = 0;
     uint16_t lid_ = 0;
+    uint8_t max_dest_rd_atomic_ = 16;
+    uint8_t max_rd_atomic_ = 16;
     int gid_index_ = -1;
     int active_speed_ = -1;
     int active_width_ = 1;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -1549,6 +1549,34 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         if (attr.active_speed_ex) active_speed_ = attr.active_speed_ex;
 #endif
         active_width_ = attr.active_width;
+        // Divide the shared responder budget across roughly 16 active QPs.
+        // Ionic reports max_res_rd_atom=16 for the whole device: reserving 16
+        // per QP can make the second QP's RTR transition fail with EINVAL.
+        // This is a per-QP policy, not device-wide admission control; other
+        // processes and larger endpoint counts still share the same budget.
+        {
+            const uint32_t res = device_attr.max_res_rd_atom;
+            uint32_t per_qp = res == 0 ? 0 : std::max(1u, res / 16);
+            per_qp = std::min(per_qp, 16u);
+            per_qp = std::min(
+                per_qp, static_cast<uint32_t>(device_attr.max_qp_rd_atom));
+            max_dest_rd_atomic_ = static_cast<uint8_t>(per_qp);
+
+            // Use the same conservative depth for reads initiated locally,
+            // rather than retaining 16 when the responder depth is only 1.
+            max_rd_atomic_ = static_cast<uint8_t>(std::min(
+                per_qp,
+                static_cast<uint32_t>(device_attr.max_qp_init_rd_atom)));
+
+            LOG(INFO) << "RDMA " << device_name
+                      << " rd_atomic clamp: max_dest_rd_atomic="
+                      << static_cast<int>(max_dest_rd_atomic_)
+                      << ", max_rd_atomic=" << static_cast<int>(max_rd_atomic_)
+                      << " (device max_res_rd_atom=" << res
+                      << ", max_qp_rd_atom=" << device_attr.max_qp_rd_atom
+                      << ", max_qp_init_rd_atom="
+                      << device_attr.max_qp_init_rd_atom << ")";
+        }
         {
             std::lock_guard<std::mutex> guard(gid_lock_);
             gid_index_ = gid_index;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -1247,7 +1247,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     attr.ah_attr.port_num = context_.portNum();
     attr.dest_qp_num = peer_qp_num;
     attr.rq_psn = 0;
-    attr.max_dest_rd_atomic = 16;
+    attr.max_dest_rd_atomic = context_.maxDestRdAtomic();
     attr.min_rnr_timer = 12;  // 12 in previous implementation
     ret = ibv_modify_qp(qp, &attr,
                         IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_MIN_RNR_TIMER |
@@ -1282,7 +1282,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     attr.retry_cnt = kRetryCount;
     attr.rnr_retry = 7;  // or 7,RNR error
     attr.sq_psn = 0;
-    attr.max_rd_atomic = 16;
+    attr.max_rd_atomic = context_.maxRdAtomic();
     ret = ibv_modify_qp(qp, &attr,
                         IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
                             IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -60,6 +60,9 @@ struct FakeVerbsDevice {
     uint8_t active_speed = 0;
     uint8_t active_width = 0;
     uint32_t active_speed_ex = 0;
+    int max_res_rd_atom = 2048;
+    int max_qp_rd_atom = 16;
+    int max_qp_init_rd_atom = 16;
 };
 
 FakeVerbsDevice fake_verbs;
@@ -74,6 +77,9 @@ class FakeVerbsDeviceScope {
         fake_verbs.active_speed = 0;
         fake_verbs.active_width = 0;
         fake_verbs.active_speed_ex = 0;
+        fake_verbs.max_res_rd_atom = 2048;
+        fake_verbs.max_qp_rd_atom = 16;
+        fake_verbs.max_qp_init_rd_atom = 16;
     }
 
     ~FakeVerbsDeviceScope() { fake_verbs.enabled = false; }
@@ -137,6 +143,9 @@ int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr) {
     device_attr->max_sge = std::numeric_limits<int>::max();
     device_attr->max_cqe = std::numeric_limits<int>::max();
     device_attr->max_mr_size = std::numeric_limits<uint64_t>::max();
+    device_attr->max_res_rd_atom = fake_verbs.max_res_rd_atom;
+    device_attr->max_qp_rd_atom = fake_verbs.max_qp_rd_atom;
+    device_attr->max_qp_init_rd_atom = fake_verbs.max_qp_init_rd_atom;
     return 0;
 }
 
@@ -231,6 +240,42 @@ TEST_F(RdmaContextConstructionTest, RecordsNegotiatedPortSpeedAndWidth) {
     GTEST_SKIP() << "Requires Linux libibverbs symbol interposition";
 #endif
 }
+
+class RdmaAtomicLimitsTest
+    : public RdmaContextConstructionTest,
+      public ::testing::WithParamInterface<std::array<int, 5>> {};
+
+TEST_P(RdmaAtomicLimitsTest, RecordsDeviceCompatibleQpDepths) {
+#ifdef __linux__
+    FakeVerbsDeviceScope fake_device(/*num_comp_vectors=*/0);
+    const auto caps = GetParam();
+    fake_verbs.max_res_rd_atom = caps[0];
+    fake_verbs.max_qp_rd_atom = caps[1];
+    fake_verbs.max_qp_init_rd_atom = caps[2];
+
+    // Exercise openRdmaDevice(), then stop before allocating real resources.
+    EXPECT_EQ(context_->construct(1, 1, /*port=*/1, /*gid_index=*/0),
+              ERR_CONTEXT);
+    EXPECT_EQ(context_->maxDestRdAtomic(), caps[3]);
+    EXPECT_EQ(context_->maxRdAtomic(), caps[4]);
+    RdmaContextTestPeer::disableContextForTeardown(*context_);
+#else
+    GTEST_SKIP() << "Requires Linux libibverbs symbol interposition";
+#endif
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DeviceCaps, RdmaAtomicLimitsTest,
+    ::testing::Values(
+        std::array<int, 5>{16, 16, 16, 1, 1},      // Ionic shared budget
+        std::array<int, 5>{2048, 16, 16, 16, 16},  // Preserve larger NIC depths
+        std::array<int, 5>{64, 16, 16, 4, 4},      // Shared responder budget
+        std::array<int, 5>{2048, 2, 16, 2, 2},     // Per-QP responder cap
+        std::array<int, 5>{2048, 16, 4, 16, 4},    // Initiator cap
+        std::array<int, 5>{8, 16, 16, 1, 1},       // Small nonzero budget
+        std::array<int, 5>{0, 16, 16, 0, 0},       // No shared read resources
+        std::array<int, 5>{2048, 0, 16, 0, 0},     // No responder support
+        std::array<int, 5>{2048, 16, 0, 16, 0}));  // No initiator support
 
 // XDR's encoding (256) does not fit ibv_port_attr::active_speed (uint8_t),
 // which reads 0; rdma-core carries it in active_speed_ex. show_links must


### PR DESCRIPTION
## Description

Creating multiple RC QPs can fail on AMD Pensando Ionic devices with `Failed to modify QP to RTR ... Invalid argument`. These devices advertise `max_res_rd_atom=16` for the whole device, while Transfer Engine currently requests a responder depth of 16 for every QP. The first QP can exhaust that budget, preventing even the second QP of an endpoint from reaching RTR.

Select the responder and initiator depths from the queried device capabilities and use them in the RTR/RTS transitions:

- Share the responder capacity across a nominal budget of 16 QPs, with a minimum depth of 1 for nonzero capacity; cap the result at the existing default of 16 and `max_qp_rd_atom`.
- Bound the initiator depth by that selected depth and `max_qp_init_rd_atom`; preserve zero capabilities.
- Log the selected depths and device limits. Add nine regression cases covering Ionic, larger devices, per-QP limits, and zero capabilities.

On Ionic with all three capabilities equal to 16, this selects responder/initiator depths of 1/1 instead of 16/16. Devices with sufficient shared and per-QP capacity retain 16/16. Devices with smaller budgets may trade read concurrency for QP availability. This is a conservative per-QP allocation policy; it does not implement device-wide admission control across arbitrary endpoint/process counts or negotiate depths with heterogeneous peers.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Validation against upstream main `b9059252aa8db150ada8220241707d47e27ebb79` plus this patch, using `rocm/atom-dev:mooncake_v0.3.14-rc1` as the build environment:

```bash
cmake -S . -B /validation/build-cpu \
  -DCMAKE_BUILD_TYPE=Release -DWITH_TE=ON -DWITH_STORE=OFF \
  -DWITH_STORE_RUST=OFF -DUSE_TENT=OFF -DUSE_CUDA=OFF -DUSE_HIP=OFF \
  -DUSE_ETCD=OFF -DUSE_HTTP=OFF -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON
cmake --build /validation/build-cpu --target rdma_context_reprobe_test \
  rdma_endpoint_state_test rdma_endpoint_reestablish_test transfer_engine_validator -j 8
ctest --test-dir /validation/build-cpu --output-on-failure \
  -R '^(rdma_context_reprobe_test|rdma_endpoint_state_test)$'

bash scripts/code_format.sh --changed-lines --check --base upstream/main
pre-commit run --files \
  mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h \
  mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp \
  mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp \
  mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
```

- CPU Transfer Engine, validator, and the three listed test binaries built successfully.
- `rdma_endpoint_state_test`: 8 passed.
- `rdma_context_reprobe_test`: 18 passed, including all nine added cases; 1 existing XDR test skipped because the installed RDMA headers lack extended speed support.
- Changed-line clang-format 20.1.8 and all applicable pre-commit hooks passed.
- HIP Transfer Engine/validator build passed with `USE_HIP=ON`, `USE_HIP_DMABUF=ON`, `BUILD_UNIT_TESTS=OFF`, and `BUILD_EXAMPLES=ON` (otherwise the same configuration). CMake reported `HIP dmabuf MR registration enabled (hsa-runtime64 found)`.