### PR TITLE
[TENT] Let the admission drop probe past a depressed bandwidth estimate

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -118,6 +118,13 @@ class TentMetrics {
     // distinguishable from genuine MLU samples in the histogram above.
     void recordDeadlineInfeasible(TransportType tp);
 
+    // Record how an owner the admission queue dispatched as a probe -- past
+    // a drop predicate that called it infeasible (runtime_queue/
+    // mlu_probe_owners) -- ended: met its deadline, or missed it. The ratio
+    // says whether the drop threshold is over-conservative (probes mostly
+    // meet) or the link is genuinely full (probes mostly miss).
+    void recordDeadlineProbe(bool met_deadline);
+
     // Record a batch abandoned by lazyFreeBatch after repeated failed reclaim
     // attempts. Such a batch stays on the freelist without further retries and
     // is only reclaimed at engine teardown, so a nonzero value means resources
@@ -226,6 +233,8 @@ class TentMetrics {
                                                                   "operation"};
     static inline const std::array<std::string, 2> kTaskFailureLabels{
         "transport", "reason"};
+    static inline const std::array<std::string, 1> kOutcomeLabel{"outcome"};
+    static constexpr size_t kOutcomeDomain = 2;  // met, missed
 
     // Hot-path metrics record through pre-resolved label cells (see
     // cached_metric.h). Label domain sizes: TransportType has
@@ -290,6 +299,11 @@ class TentMetrics {
         "tent_deadline_infeasible_total",
         "Transfers whose deadline was already in the past at submit",
         kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicCounter<1> deadline_probe_total_{
+        "tent_deadline_probe_total",
+        "Owners the admission drop dispatched as probes, by whether they met "
+        "their deadline",
+        kOutcomeLabel, kOutcomeDomain};
     // Label-less: quarantine is a batch-lifecycle event, not a per-transport
     // one (a batch may hold SubBatches on several transports).
     ylt::metric::counter_t quarantined_batches_total_{

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -67,6 +67,41 @@ struct QueueLimits {
     // NowProvider (via setDegradationPolicy) or defaults to steady_clock.
     // 0 (default) disables promotion entirely.
     uint64_t promotion_slack_ns{0};
+    // Opt-in exploration for the drop above. The drop and the bandwidth
+    // estimate it divides by form a loop: dropping decides what is sent,
+    // and what is sent is all the estimate can learn from. On a link whose
+    // throughput needs enough work in flight, an estimate depressed by a
+    // spell of contention admits too little to ever measure more, and the
+    // queue settles below saturation for good. Per pickForDispatch call, up
+    // to this many owners the drop predicate would reject are dispatched
+    // anyway -- in EDF order, so the most urgent infeasible owner is probed
+    // first -- so the meter can see whether the NIC sustains more than the
+    // estimate says. A probe is dispatched like any other owner: it takes
+    // dispatch budget, counts toward the queue ahead, may still miss its
+    // deadline, and is not signalled through the degradation hook. It
+    // recurs on every pick for as long as the drop predicate fires, so on a
+    // link that genuinely is that slow it costs one late transfer per pick
+    // indefinitely, and its bytes raise the queue ahead of the owners behind
+    // it. 0 (default) = never probe. 1 is the value to use: the exploration the
+    // climb costs is set by how far the estimate has to move, not by the
+    // budget, so a larger budget only shortens the climb -- while, when the
+    // estimate is right, it dispatches that many more late transfers per
+    // pick and pushes that much more queue ahead onto the feasible owners
+    // behind them.
+    size_t mlu_probe_owners{0};
+    // Which rejected owners are worth probing. A depressed estimate
+    // misjudges owners just past the threshold: where it admits n owners a
+    // pick, the (n+1)-th -- the one a probe should test -- scores (n+1)/n
+    // times what the last owner scores at saturation, so at most twice
+    // that, and that saturated score is itself below theta or the drop would
+    // fire at line rate too. An owner far past the threshold -- a large
+    // transfer with a tight deadline -- is infeasible whatever the estimate
+    // says, and probing it buys a late transfer and no information. Only
+    // owners with MLU below mlu_local_threshold x this factor are probe
+    // candidates; the rest are dropped even with budget to spare. 2.0 covers
+    // every plateau a depressed estimate can produce. <= 1.0 removes the
+    // ceiling.
+    double mlu_probe_ceiling_factor{2.0};
 };
 
 struct QueueOwnerInput {
@@ -144,7 +179,17 @@ class LocalTransferAdmissionQueue {
                               DegradationHooks hooks,
                               NowProvider now_provider = nullptr);
 
-    Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status);
+    // How an owner that was dispatched as a probe (QueueLimits::
+    // mlu_probe_owners) ended: met its deadline, or did not (missed it, or
+    // ended in any terminal status other than COMPLETED). None for every
+    // other owner.
+    enum class ProbeOutcome { None, MetDeadline, MissedDeadline };
+
+    // `probe_outcome`, when given, receives the probe verdict for this owner
+    // so the caller can meter it; the queue keeps the same tally in
+    // probeStats().
+    Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status,
+                    ProbeOutcome* probe_outcome = nullptr);
 
     // Cancel an owner that has not entered the dispatch window. Idempotent for
     // an owner already canceled; dispatching owners must be canceled through
@@ -166,6 +211,16 @@ class LocalTransferAdmissionQueue {
     // Bytes of degradation-eligible owners currently Dispatching.
     size_t dispatchingBytes() const;
 
+    // Owners dispatched as probes (see QueueLimits::mlu_probe_owners) since
+    // construction, and how the completed ones fared against their deadline.
+    // met + missed <= dispatched: the rest are still in flight.
+    struct ProbeStats {
+        size_t dispatched{0};
+        size_t met_deadline{0};
+        size_t missed_deadline{0};
+    };
+    ProbeStats probeStats() const;
+
    private:
     enum class QueueState {
         Queued,
@@ -180,7 +235,12 @@ class LocalTransferAdmissionQueue {
         bool degradation_eligible{false};
         QueueState state{QueueState::Queued};
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
+        bool probe{false};  // dispatched past the drop predicate
     };
+
+    // now_provider_ when installed, else steady_clock; the clock the deadline
+    // predictor and the probe verdict share.
+    uint64_t clockNs() const;
 
     QueueLimits limits_;
     Status limits_status_;
@@ -196,6 +256,7 @@ class LocalTransferAdmissionQueue {
     // the queue-ahead term of the step-3 drop prediction. Owners on other
     // transports share the queue but not the provider's bandwidth.
     size_t dispatching_bytes_{0};
+    ProbeStats probe_stats_;
 
     // RFC #2519 step 3 degradation policy (all optional / opt-in).
     BandwidthProvider bandwidth_provider_;

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -238,6 +238,7 @@ void TentMetrics::registerMetrics() {
         &transport_attempt_failures_total_,
         &task_failures_total_,
         &deadline_infeasible_total_,
+        &deadline_probe_total_,
         &quarantined_batches_total_,
     };
 
@@ -313,6 +314,14 @@ void TentMetrics::recordDeadlineInfeasible(TransportType tp) {
         return;
     deadline_infeasible_total_.incCached(transportSlot(tp), [tp] {
         return std::array<std::string, 1>{transportTypeName(tp)};
+    });
+}
+
+void TentMetrics::recordDeadlineProbe(bool met_deadline) {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    deadline_probe_total_.incCached(met_deadline ? 0 : 1, [met_deadline] {
+        return std::array<std::string, 1>{met_deadline ? "met" : "missed"};
     });
 }
 
@@ -701,6 +710,8 @@ std::string TentMetrics::getJsonMetrics() {
             sumCounterValues(&transport_attempt_failures_total_);
         root[deadline_infeasible_total_.str_name()] =
             sumCounterValues(&deadline_infeasible_total_);
+        root[deadline_probe_total_.str_name()] =
+            sumCounterValues(&deadline_probe_total_);
         root[quarantined_batches_total_.str_name()] =
             static_cast<int64_t>(quarantined_batches_total_.value());
 
@@ -804,6 +815,7 @@ void TentMetrics::recordTransportAttemptFinished(TransportType, Request::OpCode,
                                                  TransferStatusEnum, double) {}
 void TentMetrics::recordDeadlineMLU(TransportType, double) {}
 void TentMetrics::recordDeadlineInfeasible(TransportType) {}
+void TentMetrics::recordDeadlineProbe(bool) {}
 void TentMetrics::recordBatchQuarantined() {}
 void TentMetrics::recordTaskFailure(TransportType, TaskFailureReason) {}
 void TentMetrics::recordInflightAttemptStarted(TransportType) {}

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -248,16 +248,7 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         limits_.deadline_aware && limits_.promotion_slack_ns > 0;
     const bool need_now = drop_enabled || promotion_enabled;
     const double bw_bps = drop_enabled ? bandwidth_provider_() : 0.0;
-    const uint64_t now_ns =
-        need_now
-            ? (now_provider_
-                   ? now_provider_()
-                   : static_cast<uint64_t>(
-                         std::chrono::duration_cast<std::chrono::nanoseconds>(
-                             std::chrono::steady_clock::now()
-                                 .time_since_epoch())
-                             .count()))
-            : 0;
+    const uint64_t now_ns = need_now ? clockNs() : 0;
 
     // Deadline proximity promotion: partition fifo_ so owners with critical
     // slack (deadline approaching within promotion_slack_ns) appear before
@@ -275,21 +266,26 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         });
     }
 
-    // True if the owner is predicted to miss its deadline hard enough to
-    // drop, by the same DeadlineMlu the RDMA workers order QP slots with.
-    // `bytes_ahead`: eligible bytes dispatched and still in flight,
-    // including what this call already picked. No deadline or no bandwidth
-    // (<= 0) means nothing to predict from, so never a drop -- not even
-    // past the deadline; DeadlineMlu yields 0 there too, the explicit
-    // checks just keep the rule readable here.
-    auto shouldDrop = [&](const QueueOwner& owner, size_t bytes_ahead) {
-        if (!drop_enabled || !owner.degradation_eligible) return false;
-        if (owner.request.deadline_ns == 0 || bw_bps <= 0.0) return false;
-        const double mlu =
-            DeadlineMlu(bytes_ahead, owner.request.length,
-                        owner.request.deadline_ns, now_ns, bw_bps);
-        return mlu >= limits_.mlu_local_threshold;
+    // Predicted MLU of a drop-eligible owner behind `bytes_ahead` (eligible
+    // bytes dispatched and still in flight, including what this call already
+    // picked), by the same DeadlineMlu the RDMA workers order QP slots with.
+    // -1 when there is nothing to predict from -- drop off, owner not
+    // eligible, no deadline, no bandwidth (<= 0) -- so never a drop then,
+    // not even past the deadline; DeadlineMlu yields 0 there too, the
+    // explicit checks just keep the rule readable here.
+    auto predictedMlu = [&](const QueueOwner& owner, size_t bytes_ahead) {
+        if (!drop_enabled || !owner.degradation_eligible) return -1.0;
+        if (owner.request.deadline_ns == 0 || bw_bps <= 0.0) return -1.0;
+        return DeadlineMlu(bytes_ahead, owner.request.length,
+                           owner.request.deadline_ns, now_ns, bw_bps);
     };
+    // An owner at or past the threshold is dropped; see
+    // QueueLimits::mlu_probe_ceiling_factor for the band above it that a
+    // probe may still take.
+    const double probe_ceiling =
+        limits_.mlu_probe_ceiling_factor > 1.0
+            ? limits_.mlu_local_threshold * limits_.mlu_probe_ceiling_factor
+            : std::numeric_limits<double>::infinity();
 
     auto dropOwner = [&](QueueOwnerId owner_id, QueueOwner& owner) {
         owner.state = QueueState::Terminal;
@@ -308,6 +304,7 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
+    size_t probes_used = 0;
     while (!fifo_.empty() && used_owners < max_owners) {
         auto owner_id = fifo_.front();
         auto owner_it = owners_.find(owner_id);
@@ -324,10 +321,20 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         // dispatched) and does not consume the dispatch budget. Because the
         // queue is EDF-ordered, later owners have looser deadlines, so we keep
         // scanning rather than stopping.
-        if (shouldDrop(owner_it->second, dispatching_bytes_)) {
-            fifo_.pop_front();
-            dropOwner(owner_id, owner_it->second);
-            continue;
+        // A probe is dispatched in the drop's place so the meter can learn
+        // what the NIC does with more in flight than the estimate admits;
+        // see QueueLimits::mlu_probe_owners and mlu_probe_ceiling_factor. It
+        // takes the normal path below and is budgeted like any other owner.
+        bool probe = false;
+        const double mlu = predictedMlu(owner_it->second, dispatching_bytes_);
+        if (drop_enabled && mlu >= limits_.mlu_local_threshold) {
+            if (probes_used < limits_.mlu_probe_owners && mlu < probe_ceiling) {
+                probe = true;
+            } else {
+                fifo_.pop_front();
+                dropOwner(owner_id, owner_it->second);
+                continue;
+            }
         }
 
         const auto& owner = owner_it->second;
@@ -338,6 +345,11 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         owner_it->second.state = QueueState::Dispatching;
         if (owner.degradation_eligible)
             dispatching_bytes_ += owner.request.length;
+        if (probe) {
+            ++probes_used;
+            ++probe_stats_.dispatched;
+            owner_it->second.probe = true;
+        }
         picked.push_back(owner_id);
         ++used_owners;
         used_bytes += owner.request.length;
@@ -345,8 +357,10 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     return picked;
 }
 
-Status LocalTransferAdmissionQueue::complete(
-    QueueOwnerId owner_id, TransferStatusEnum terminal_status) {
+Status LocalTransferAdmissionQueue::complete(QueueOwnerId owner_id,
+                                             TransferStatusEnum terminal_status,
+                                             ProbeOutcome* probe_outcome) {
+    if (probe_outcome) *probe_outcome = ProbeOutcome::None;
     if (owner_id == 0) {
         return Status::InvalidArgument("invalid queue owner id" LOC_MARK);
     }
@@ -366,6 +380,20 @@ Status LocalTransferAdmissionQueue::complete(
     owner.state = QueueState::Terminal;
     owner.terminal_status = terminal_status;
     if (owner.degradation_eligible) dispatching_bytes_ -= owner.request.length;
+    if (owner.probe) {
+        // The verdict the probe was dispatched to obtain: did the transfer the
+        // estimate called infeasible make it? Anything but a completion
+        // inside the window counts against the estimate having been wrong.
+        const bool met = terminal_status == TransferStatusEnum::COMPLETED &&
+                         clockNs() < owner.request.deadline_ns;
+        if (met)
+            ++probe_stats_.met_deadline;
+        else
+            ++probe_stats_.missed_deadline;
+        if (probe_outcome)
+            *probe_outcome =
+                met ? ProbeOutcome::MetDeadline : ProbeOutcome::MissedDeadline;
+    }
     --outstanding_owners_;
     outstanding_bytes_ -= owner.request.length;
     if (owner.kind == QueueOwnerKind::User) {
@@ -491,6 +519,19 @@ size_t LocalTransferAdmissionQueue::outstandingBytes() const {
 
 size_t LocalTransferAdmissionQueue::dispatchingBytes() const {
     return dispatching_bytes_;
+}
+
+LocalTransferAdmissionQueue::ProbeStats
+LocalTransferAdmissionQueue::probeStats() const {
+    return probe_stats_;
+}
+
+uint64_t LocalTransferAdmissionQueue::clockNs() const {
+    if (now_provider_) return now_provider_();
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -379,6 +379,10 @@ Status TransferEngineImpl::construct() {
         conf_->get("runtime_queue/mlu_local_threshold", 0.0);
     runtime_queue_config_.limits.promotion_slack_ns =
         conf_->get("runtime_queue/promotion_slack_ns", 0UL);
+    runtime_queue_config_.limits.mlu_probe_owners =
+        conf_->get("runtime_queue/mlu_probe_owners", 0UL);
+    runtime_queue_config_.limits.mlu_probe_ceiling_factor =
+        conf_->get("runtime_queue/mlu_probe_ceiling_factor", 2.0);
     runtime_queue_config_.max_dispatch_owners =
         conf_->get("runtime_queue/max_dispatch_owners", 64UL);
     runtime_queue_config_.max_dispatch_bytes =
@@ -2164,7 +2168,14 @@ Status TransferEngineImpl::finishQueuedOwner(
                 "runtime dispatch window accounting underflow" LOC_MARK);
         }
     }
-    CHECK_STATUS(runtime_queue_->complete(owner_id, terminal_status));
+    auto probe_outcome = LocalTransferAdmissionQueue::ProbeOutcome::None;
+    CHECK_STATUS(
+        runtime_queue_->complete(owner_id, terminal_status, &probe_outcome));
+    if (probe_outcome != LocalTransferAdmissionQueue::ProbeOutcome::None) {
+        TentMetrics::instance().recordDeadlineProbe(
+            probe_outcome ==
+            LocalTransferAdmissionQueue::ProbeOutcome::MetDeadline);
+    }
     if (queued.in_dispatch_window) {
         --dispatch_inflight_owners_;
         dispatch_inflight_bytes_ -= queued.byte_charge;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -345,6 +345,13 @@ target_include_directories(tent_device_selector_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_device_selector_test COMMAND tent_device_selector_test)
 
+add_executable(tent_admission_feedback_test admission_feedback_test.cpp)
+target_link_libraries(tent_admission_feedback_test PRIVATE gtest gtest_main
+                                                           tent_link_group)
+target_include_directories(tent_admission_feedback_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_admission_feedback_test COMMAND tent_admission_feedback_test)
+
 add_executable(tent_rdma_transport_test rdma_transport_test.cpp)
 target_link_libraries(tent_rdma_transport_test PRIVATE gtest gtest_main
                                                        tent_link_group ibverbs)

--- a/mooncake-transfer-engine/tent/tests/admission_feedback_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_feedback_test.cpp
@@ -46,13 +46,13 @@ constexpr size_t kOwnerBytes = 2'000'000;
 constexpr uint64_t kNow = 1'000'000'000;
 constexpr uint64_t kWindowNs = 10'000'000;  // 10 ms deadline window
 
-QueueOwnerInput eligibleOwner(size_t task_id) {
+QueueOwnerInput eligibleOwner(size_t task_id, uint64_t now_ns) {
     QueueOwnerInput owner;
     owner.owner_task_id = task_id;
     owner.request.opcode = Request::WRITE;
     owner.request.target_id = 1;
     owner.request.length = kOwnerBytes;
-    owner.request.deadline_ns = kNow + kWindowNs;
+    owner.request.deadline_ns = now_ns + kWindowNs;
     owner.degradation_eligible = true;
     return owner;
 }
@@ -87,11 +87,12 @@ std::unique_ptr<DeviceSelector> makeMeteredNic(double alpha) {
 // taught.
 class FeedbackLoop {
    public:
-    FeedbackLoop(double theta_local, double alpha)
+    FeedbackLoop(double theta_local, double alpha, size_t probe_owners = 0)
         : nic_(makeMeteredNic(alpha)), clock_(kNow) {
         QueueLimits limits{16, 1 << 30, 0, 0};
         limits.deadline_aware = true;
         limits.mlu_local_threshold = theta_local;
+        limits.mlu_probe_owners = probe_owners;
         queue_ = std::make_unique<LocalTransferAdmissionQueue>(limits);
         DegradationHooks hooks;
         hooks.on_local_decode_suggested = [this](const Request&) {
@@ -99,7 +100,7 @@ class FeedbackLoop {
         };
         queue_->setDegradationPolicy(
             [this] { return nic_->getAggregateTransmitBandwidth(); }, hooks,
-            [] { return kNow; });
+            [this] { return clock_; });  // one clock for queue and meter
     }
 
     struct Round {
@@ -110,21 +111,24 @@ class FeedbackLoop {
 
     // `served_cap` < N models the link being shared with traffic the queue
     // does not see: only that many of the admitted owners move at once.
-    Round run(int served_cap = kSaturatingOwners) {
+    // `offered` is how many owners arrive this round; more than the window
+    // can carry at line rate models demand past the link's limit.
+    Round run(int served_cap = kSaturatingOwners,
+              int offered = kSaturatingOwners) {
         const uint64_t token = ++token_;
+        if (token > 1) clock_ += 1'000'000;  // 1 ms idle between rounds
         std::vector<QueueOwnerInput> inputs;
-        for (int i = 0; i < kSaturatingOwners; ++i)
-            inputs.push_back(eligibleOwner(i));
+        for (int i = 0; i < offered; ++i)
+            inputs.push_back(eligibleOwner(i, clock_));
         QueueSubmit submit;
         submit.batch_token = token;
-        submit.batch_slots_left = kSaturatingOwners;
+        submit.batch_slots_left = offered;
         submit.owners = std::move(inputs);
         std::vector<QueueOwnerId> ids;
         EXPECT_EQ(queue_->tryAdmit(submit, ids).code(), Status::Code::kOk);
 
         std::vector<QueueOwnerId> dropped;
-        auto picked =
-            queue_->pickForDispatch(kSaturatingOwners, 1 << 30, &dropped);
+        auto picked = queue_->pickForDispatch(offered, 1 << 30, &dropped);
         const int n = static_cast<int>(picked.size());
         if (n > 0) serve(n, std::min(n, served_cap));
         for (auto id : picked)
@@ -138,6 +142,10 @@ class FeedbackLoop {
 
     double estimate() const { return nic_->getAggregateTransmitBandwidth(); }
     int dropsSignalled() const { return drops_signalled_; }
+    size_t probes() const { return queue_->probeStats().dispatched; }
+    LocalTransferAdmissionQueue::ProbeStats probeStats() const {
+        return queue_->probeStats();
+    }
 
    private:
     // Post `n` owners at once, let `concurrent` of them share the wire, and
@@ -158,7 +166,7 @@ class FeedbackLoop {
             nic_->noteCompleted(kDev, kOwnerBytes);
         }
         nic_->maybeSampleTransmit(kDev, poll_ts);
-        clock_ = poll_ts + 1'000'000;  // 1 ms idle before the next round
+        clock_ = poll_ts;  // complete() is judged at this instant
     }
 
     std::unique_ptr<DeviceSelector> nic_;
@@ -183,7 +191,8 @@ TEST(AdmissionFeedbackTest, CleanStartStaysSaturated) {
         auto r = loop.run();
         ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
         ASSERT_EQ(r.dropped, 0) << "round " << round;
-        ASSERT_NEAR(r.estimate_after, kLineRateBps, 1.0) << "round " << round;
+        ASSERT_NEAR(r.estimate_after, kLineRateBps, 1e-9 * kLineRateBps)
+            << "round " << round;
     }
     EXPECT_EQ(loop.dropsSignalled(), 0);
 }
@@ -232,6 +241,101 @@ TEST(AdmissionFeedbackTest, ShallowContentionRecovers) {
     EXPECT_NEAR(loop.estimate(), kLineRateBps, 0.02 * kLineRateBps);
 }
 
+// ---- the fix: one probe per pick ------------------------------------------
+
+// Same contention episode as above, one probe allowed per pick. When the
+// tenant leaves, the 5th owner is dispatched as a probe, 5 in flight teach
+// the meter a higher rate, and admission climbs back to 8 -- the probe
+// costing at most one otherwise-dropped owner per round on the way.
+TEST(AdmissionFeedbackTest, OneProbePerPickClimbsOutOfThePlateau) {
+    FeedbackLoop loop(/*theta=*/0.95, /*alpha=*/0.9, /*probe_owners=*/1);
+    for (int round = 0; round < 60; ++round) loop.run(/*served_cap=*/4);
+    ASSERT_NEAR(loop.estimate(), achievedBy(4), 0.02 * achievedBy(4));
+    const size_t probes_before = loop.probes();
+    const size_t missed_before = loop.probeStats().missed_deadline;
+
+    int recovered_at = -1;
+    size_t probes_at_50 = 0;
+    for (int round = 1; round <= 60; ++round) {
+        auto r = loop.run();
+        ASSERT_GE(r.admitted, 4) << "round " << round;
+        if (r.admitted == kSaturatingOwners && recovered_at < 0)
+            recovered_at = round;
+        if (recovered_at > 0)
+            ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
+        if (round == 50) probes_at_50 = loop.probes();
+    }
+    EXPECT_GT(recovered_at, 0);
+    EXPECT_LE(recovered_at, 40);
+    EXPECT_NEAR(loop.estimate(), kLineRateBps, 0.02 * kLineRateBps);
+    // At most one probe a round on the way up, none once saturated.
+    EXPECT_GT(loop.probes(), probes_before);
+    EXPECT_LE(loop.probes() - probes_before, 60u);
+    EXPECT_EQ(loop.probes(), probes_at_50);
+    // Every probe after the contention lifted made its deadline: the drop it
+    // replaced would have been wrong, which is what the verdict is for.
+    const auto stats = loop.probeStats();
+    EXPECT_EQ(stats.met_deadline + stats.missed_deadline, stats.dispatched);
+    EXPECT_EQ(stats.missed_deadline, missed_before);
+}
+
+// The same probe when the estimate is right: the tenant never leaves, 4 is
+// all the link will ever carry, and the meter keeps confirming it. The probe
+// has nothing to discover, but nothing tells it so: every pick dispatches a
+// 5th owner that the link takes the whole 10 ms window to finish -- one late
+// transfer per round, indefinitely, with the estimate never moving. This is
+// the price of exploration on a link that genuinely is that slow, and why
+// the budget is opt-in and best kept at 1.
+TEST(AdmissionFeedbackTest, ProbeOnACorrectEstimateIsPaidEveryRound) {
+    FeedbackLoop loop(/*theta=*/0.95, /*alpha=*/0.9, /*probe_owners=*/1);
+    for (int round = 0; round < 60; ++round) loop.run(/*served_cap=*/4);
+    ASSERT_NEAR(loop.estimate(), achievedBy(4), 0.02 * achievedBy(4));
+    const size_t probes_before = loop.probes();
+    const size_t missed_before = loop.probeStats().missed_deadline;
+
+    for (int round = 1; round <= 40; ++round) {
+        auto r = loop.run(/*served_cap=*/4);            // still only 4 can move
+        ASSERT_EQ(r.admitted, 5) << "round " << round;  // 4 + the probe
+        ASSERT_EQ(r.dropped, 3) << "round " << round;
+    }
+    EXPECT_EQ(loop.probes() - probes_before, 40u);  // one every round
+    // And every one of them took the whole window: the drop was right.
+    EXPECT_EQ(loop.probeStats().missed_deadline - missed_before, 40u);
+    EXPECT_NEAR(loop.estimate(), achievedBy(4), 0.02 * achievedBy(4));
+}
+
+// Demand grows past what the link can carry while the estimate sits, rightly,
+// at line rate: 11 owners a round, the 9th feasible (MLU 0.9), the 10th not
+// (1.0), the 11th not (1.1). The probe puts the 10th on the wire; ten in
+// flight still measure line rate, so the meter learns nothing, the estimate
+// does not move, and the probe recurs every round -- one transfer per pick
+// that finishes exactly at its window for no information in return. Without
+// the probe the same rounds drop two and admit nine at the same estimate.
+// The estimate equalling its line-rate seed is the observable fact a
+// seed-aware gate would use to skip this probe entirely.
+TEST(AdmissionFeedbackTest, AtLineRateOverloadTheProbeMeasuresNothing) {
+    constexpr int kOffered = 11;
+    FeedbackLoop with_probe(/*theta=*/0.95, /*alpha=*/0.9, /*probe_owners=*/1);
+    FeedbackLoop without(/*theta=*/0.95, /*alpha=*/0.9, /*probe_owners=*/0);
+
+    for (int round = 1; round <= 40; ++round) {
+        auto p = with_probe.run(kSaturatingOwners, kOffered);
+        ASSERT_EQ(p.admitted, 10) << "round " << round;  // 9 + the probe
+        ASSERT_EQ(p.dropped, 1) << "round " << round;
+        ASSERT_NEAR(p.estimate_after, kLineRateBps, 1e-9 * kLineRateBps)
+            << "round " << round;
+
+        auto q = without.run(kSaturatingOwners, kOffered);
+        ASSERT_EQ(q.admitted, 9) << "round " << round;
+        ASSERT_EQ(q.dropped, 2) << "round " << round;
+        ASSERT_NEAR(q.estimate_after, kLineRateBps, 1e-9 * kLineRateBps)
+            << "round " << round;
+    }
+    EXPECT_EQ(with_probe.probes(), 40u);  // one every round, never stops
+    EXPECT_EQ(with_probe.probeStats().missed_deadline, 40u);  // all late
+    EXPECT_EQ(without.probes(), 0u);
+}
+
 // ---- step 3: what the plateau depends on ---------------------------------
 
 // Whether the loop recovers from the 4-of-8 plateau within 100 rounds. The
@@ -263,10 +367,9 @@ TEST(AdmissionFeedbackTest, PlateauDoesNotDependOnLearningRate) {
 // (n+1)-th owner scores MLU = (n+1) * length / ((n/N) * line_rate * window)
 // and is admitted only below theta; with N * length / (line_rate * window)
 // = 16 MB / 20 MB = 0.8 here that is theta > 0.8 * (n+1) / n, so a 4-of-8
-// estimate admits a
-// 5th owner -- and climbs from there -- only when theta > 1.0. Loosening
-// theta buys recovery by dropping less in the first place, which is not a
-// fix for the loop but a different drop policy.
+// estimate admits a 5th owner -- and climbs from there -- only when
+// theta > 1.0. Loosening theta buys recovery by dropping less in the first
+// place, which is not a fix for the loop but a different drop policy.
 TEST(AdmissionFeedbackTest, PlateauDependsOnTheDropThreshold) {
     EXPECT_FALSE(recoversFromHalfPlateau(/*theta=*/0.8, /*alpha=*/0.9));
     EXPECT_FALSE(recoversFromHalfPlateau(/*theta=*/0.95, /*alpha=*/0.9));

--- a/mooncake-transfer-engine/tent/tests/admission_feedback_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_feedback_test.cpp
@@ -1,0 +1,281 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The admission queue's deadline drop and the DeviceSelector's transmit
+// estimate form a loop: the drop decides what is sent, what is sent is all
+// the meter can learn from, and the estimate is what the next drop is judged
+// against. These tests close that loop with the real queue and the real
+// meter over a queue-depth-bound link model -- a NIC that reaches line rate
+// only with enough work in flight -- and ask whether the loop returns to
+// saturation after the estimate has been depressed, and which parameters
+// that depends on.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tent/runtime/admission_queue.h"
+#include "tent/runtime/topology.h"
+#include "tent/transport/rdma/quota.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr int kDev = 0;
+constexpr double kLineRateBps = 2e9;  // 16 Gbps: 2 bytes per ns
+constexpr int kSaturatingOwners = 8;  // in flight to reach line rate
+constexpr size_t kOwnerBytes = 2'000'000;
+constexpr uint64_t kNow = 1'000'000'000;
+constexpr uint64_t kWindowNs = 10'000'000;  // 10 ms deadline window
+
+QueueOwnerInput eligibleOwner(size_t task_id) {
+    QueueOwnerInput owner;
+    owner.owner_task_id = task_id;
+    owner.request.opcode = Request::WRITE;
+    owner.request.target_id = 1;
+    owner.request.length = kOwnerBytes;
+    owner.request.deadline_ns = kNow + kWindowNs;
+    owner.degradation_eligible = true;
+    return owner;
+}
+
+// One RDMA NIC whose transmit meter samples whenever asked and follows each
+// sample with `alpha` weight on the old value, seeded at line rate.
+std::unique_ptr<DeviceSelector> makeMeteredNic(double alpha) {
+    auto topo = std::make_shared<Topology>();
+    Topology::NicEntry nic;
+    nic.name = "mlx5_0";
+    nic.type = Topology::NIC_RDMA;
+    nic.numa_node = 0;
+    topo->nic_list_.push_back(nic);
+    auto sel = std::make_unique<DeviceSelector>();
+    EXPECT_TRUE(sel->loadTopology(topo).ok());
+    DeviceSelector::SchedulingParams params;
+    params.transmit_bandwidth_learning_rate = alpha;
+    params.transmit_meter_interval_ns = 0;
+    sel->setSchedulingParams(params);
+    // 16 Gbps, above min_bandwidth_gbps so it seeds rather than falling
+    // back to the 400 Gbps default.
+    EXPECT_TRUE(sel->setDeviceBandwidth(kDev, 16.0).ok());  // 2 GB/s
+    return sel;
+}
+
+// The closed loop. Each round offers `kSaturatingOwners` equal, eligible
+// owners; whatever the queue dispatches is posted to the NIC together, served
+// at the rate that many in flight achieve (line rate times min(n, N) / N,
+// capped by an external `served_cap` when another tenant holds the link),
+// completed under one poll timestamp, and metered. The queue's bandwidth
+// provider reads the meter, so the next round is judged by what this one
+// taught.
+class FeedbackLoop {
+   public:
+    FeedbackLoop(double theta_local, double alpha)
+        : nic_(makeMeteredNic(alpha)), clock_(kNow) {
+        QueueLimits limits{16, 1 << 30, 0, 0};
+        limits.deadline_aware = true;
+        limits.mlu_local_threshold = theta_local;
+        queue_ = std::make_unique<LocalTransferAdmissionQueue>(limits);
+        DegradationHooks hooks;
+        hooks.on_local_decode_suggested = [this](const Request&) {
+            ++drops_signalled_;
+        };
+        queue_->setDegradationPolicy(
+            [this] { return nic_->getAggregateTransmitBandwidth(); }, hooks,
+            [] { return kNow; });
+    }
+
+    struct Round {
+        int admitted;
+        int dropped;
+        double estimate_after;
+    };
+
+    // `served_cap` < N models the link being shared with traffic the queue
+    // does not see: only that many of the admitted owners move at once.
+    Round run(int served_cap = kSaturatingOwners) {
+        const uint64_t token = ++token_;
+        std::vector<QueueOwnerInput> inputs;
+        for (int i = 0; i < kSaturatingOwners; ++i)
+            inputs.push_back(eligibleOwner(i));
+        QueueSubmit submit;
+        submit.batch_token = token;
+        submit.batch_slots_left = kSaturatingOwners;
+        submit.owners = std::move(inputs);
+        std::vector<QueueOwnerId> ids;
+        EXPECT_EQ(queue_->tryAdmit(submit, ids).code(), Status::Code::kOk);
+
+        std::vector<QueueOwnerId> dropped;
+        auto picked =
+            queue_->pickForDispatch(kSaturatingOwners, 1 << 30, &dropped);
+        const int n = static_cast<int>(picked.size());
+        if (n > 0) serve(n, std::min(n, served_cap));
+        for (auto id : picked)
+            EXPECT_EQ(
+                queue_->complete(id, TransferStatusEnum::COMPLETED).code(),
+                Status::Code::kOk);
+        EXPECT_EQ(queue_->retireBatch(token).code(), Status::Code::kOk);
+        return {n, static_cast<int>(dropped.size()),
+                nic_->getAggregateTransmitBandwidth()};
+    }
+
+    double estimate() const { return nic_->getAggregateTransmitBandwidth(); }
+    int dropsSignalled() const { return drops_signalled_; }
+
+   private:
+    // Post `n` owners at once, let `concurrent` of them share the wire, and
+    // reap everything in one poll pass -- the shape the RDMA workers give the
+    // meter. Busy time is the span; bytes are n * kOwnerBytes.
+    void serve(int n, int concurrent) {
+        const double achieved = kLineRateBps *
+                                std::min(concurrent, kSaturatingOwners) /
+                                kSaturatingOwners;
+        const uint64_t span_ns = static_cast<uint64_t>(
+            static_cast<double>(n) * kOwnerBytes / achieved * 1e9);
+        const uint64_t t0 = clock_;
+        for (int i = 0; i < n; ++i) nic_->notePosted(kDev, kOwnerBytes, t0);
+        nic_->maybeSampleTransmit(kDev, t0);
+        const uint64_t poll_ts = t0 + span_ns;
+        for (int i = 0; i < n; ++i) {
+            nic_->notePostEnded(kDev, kOwnerBytes, poll_ts);
+            nic_->noteCompleted(kDev, kOwnerBytes);
+        }
+        nic_->maybeSampleTransmit(kDev, poll_ts);
+        clock_ = poll_ts + 1'000'000;  // 1 ms idle before the next round
+    }
+
+    std::unique_ptr<DeviceSelector> nic_;
+    std::unique_ptr<LocalTransferAdmissionQueue> queue_;
+    uint64_t clock_;
+    uint64_t token_ = 0;
+    int drops_signalled_ = 0;
+};
+
+double achievedBy(int concurrent) {
+    return kLineRateBps * std::min(concurrent, kSaturatingOwners) /
+           kSaturatingOwners;
+}
+
+// ---- step 2: the real meter behaves as the model did --------------------
+
+// From the line-rate seed the meter measures line rate every round and the
+// queue never drops.
+TEST(AdmissionFeedbackTest, CleanStartStaysSaturated) {
+    FeedbackLoop loop(/*theta=*/0.95, /*alpha=*/0.9);
+    for (int round = 1; round <= 30; ++round) {
+        auto r = loop.run();
+        ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
+        ASSERT_EQ(r.dropped, 0) << "round " << round;
+        ASSERT_NEAR(r.estimate_after, kLineRateBps, 1.0) << "round " << round;
+    }
+    EXPECT_EQ(loop.dropsSignalled(), 0);
+}
+
+// Another tenant holds half the link for a while: only 4 of the 8 admitted
+// owners move at once, the meter learns 1 GB/s. Then the tenant leaves.
+// The queue now admits 4 (the 5th scores MLU 1.0 against 1 GB/s), those 4
+// achieve exactly 1 GB/s, and the meter has nothing to learn from that
+// would say otherwise: the loop stays on the plateau for good.
+TEST(AdmissionFeedbackTest, ContentionLeavesAPlateauTheLoopNeverLeaves) {
+    FeedbackLoop loop(/*theta=*/0.95, /*alpha=*/0.9);
+    for (int round = 0; round < 60; ++round) loop.run(/*served_cap=*/4);
+    ASSERT_NEAR(loop.estimate(), achievedBy(4), 0.02 * achievedBy(4));
+    const int signalled_during_contention = loop.dropsSignalled();
+
+    for (int round = 1; round <= 60; ++round) {
+        auto r = loop.run();  // contention gone: the link could do 2 GB/s
+        ASSERT_EQ(r.admitted, 4) << "round " << round;
+        ASSERT_EQ(r.dropped, 4) << "round " << round;
+    }
+    EXPECT_NEAR(loop.estimate(), achievedBy(4), 0.02 * achievedBy(4));
+    // Every drop after the contention lifted was a transfer the link could
+    // have carried, and each one was signalled for local recompute.
+    EXPECT_EQ(loop.dropsSignalled() - signalled_during_contention, 4 * 60);
+}
+
+// A shallower episode -- 6 of 8 moving -- leaves an estimate the survivors
+// can outrun: 7 are admitted, they achieve 1.75 GB/s, the estimate climbs,
+// and admission is back at 8.
+TEST(AdmissionFeedbackTest, ShallowContentionRecovers) {
+    FeedbackLoop loop(/*theta=*/0.95, /*alpha=*/0.9);
+    for (int round = 0; round < 60; ++round) loop.run(/*served_cap=*/6);
+    ASSERT_NEAR(loop.estimate(), achievedBy(6), 0.02 * achievedBy(6));
+
+    int recovered_at = -1;
+    for (int round = 1; round <= 60; ++round) {
+        auto r = loop.run();
+        ASSERT_GE(r.admitted, 7) << "round " << round;
+        if (r.admitted == kSaturatingOwners && recovered_at < 0)
+            recovered_at = round;
+        if (recovered_at > 0)
+            ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
+    }
+    EXPECT_GT(recovered_at, 0);
+    EXPECT_LE(recovered_at, 30);
+    EXPECT_NEAR(loop.estimate(), kLineRateBps, 0.02 * kLineRateBps);
+}
+
+// ---- step 3: what the plateau depends on ---------------------------------
+
+// Whether the loop recovers from the 4-of-8 plateau within 100 rounds. The
+// contention episode lasts until the estimate has settled within 1% of what
+// 4 achieve, however slowly this alpha gets there.
+bool recoversFromHalfPlateau(double theta, double alpha) {
+    FeedbackLoop loop(theta, alpha);
+    const double plateau = achievedBy(4);
+    for (int round = 0; round < 5000; ++round) {
+        loop.run(/*served_cap=*/4);
+        if (std::abs(loop.estimate() - plateau) <= 0.01 * plateau) break;
+    }
+    EXPECT_NEAR(loop.estimate(), plateau, 0.01 * plateau) << "alpha=" << alpha;
+    for (int round = 0; round < 100; ++round)
+        if (loop.run().admitted == kSaturatingOwners) return true;
+    return false;
+}
+
+// The smoothing rate only sets how fast the estimate moves; it does not
+// create or remove the fixed point. Every alpha stays stuck.
+TEST(AdmissionFeedbackTest, PlateauDoesNotDependOnLearningRate) {
+    for (double alpha : {0.0, 0.5, 0.9, 0.99}) {
+        EXPECT_FALSE(recoversFromHalfPlateau(/*theta=*/0.95, alpha))
+            << "alpha=" << alpha;
+    }
+}
+
+// The threshold sets the basin. At an estimate of n/N line rate the
+// (n+1)-th owner scores MLU = (n+1) * length / ((n/N) * line_rate * window)
+// and is admitted only below theta; with N * length / (line_rate * window)
+// = 16 MB / 20 MB = 0.8 here that is theta > 0.8 * (n+1) / n, so a 4-of-8
+// estimate admits a
+// 5th owner -- and climbs from there -- only when theta > 1.0. Loosening
+// theta buys recovery by dropping less in the first place, which is not a
+// fix for the loop but a different drop policy.
+TEST(AdmissionFeedbackTest, PlateauDependsOnTheDropThreshold) {
+    EXPECT_FALSE(recoversFromHalfPlateau(/*theta=*/0.8, /*alpha=*/0.9));
+    EXPECT_FALSE(recoversFromHalfPlateau(/*theta=*/0.95, /*alpha=*/0.9));
+    EXPECT_FALSE(recoversFromHalfPlateau(/*theta=*/0.99, /*alpha=*/0.9));
+    EXPECT_TRUE(recoversFromHalfPlateau(/*theta=*/1.05, /*alpha=*/0.9));
+    EXPECT_TRUE(recoversFromHalfPlateau(/*theta=*/1.2, /*alpha=*/0.9));
+    EXPECT_TRUE(recoversFromHalfPlateau(/*theta=*/1.5, /*alpha=*/0.9));
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -14,7 +14,9 @@
 
 #include "tent/runtime/admission_queue.h"
 
+#include <algorithm>
 #include <atomic>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -817,6 +819,159 @@ TEST(AdmissionQueueTest,
     EXPECT_EQ(queue.dispatchingBytes(), 0u);
     ASSERT_EQ(queue.retireBatch(1).code(), Status::Code::kOk);
     EXPECT_EQ(queue.dispatchingBytes(), 0u);
+}
+
+// --- RFC #2519 step 3: the drop / estimate feedback loop -----------------
+//
+// The drop decision, the traffic it lets through, and the bandwidth estimate
+// learned from that traffic form a loop: dropping shapes what is sent, what
+// is sent is the only thing the estimate can learn from, and the estimate
+// is what the next drop is judged against. RDMA throughput is queue-depth
+// bound, so a trickle admitted under a low estimate can genuinely achieve a
+// low rate and confirm the estimate. These tests drive the queue against a
+// model of such a link to see whether the loop returns to saturation or
+// settles on a plateau below it.
+//
+// Model: the link saturates at `line_rate` with `saturating_owners` in
+// flight and achieves a proportional fraction below that; the estimate
+// follows what was achieved with the transmit smoothing (alpha weights the
+// old value, as in DeviceSelector).
+struct QueueDepthBoundLink {
+    double line_rate;
+    int saturating_owners;
+    double alpha;
+    double rate;
+
+    double achieved(int concurrent) const {
+        return line_rate * std::min(concurrent, saturating_owners) /
+               saturating_owners;
+    }
+    void observe(int concurrent) {
+        rate = alpha * rate + (1.0 - alpha) * achieved(concurrent);
+    }
+};
+
+struct FeedbackRound {
+    int admitted;
+    int dropped;
+    double rate_after;
+};
+
+// One round: offer `owners` equal, eligible owners with the same deadline,
+// dispatch, complete whatever was admitted, retire the batch, and let the
+// link learn from the concurrency that round achieved.
+FeedbackRound runFeedbackRound(LocalTransferAdmissionQueue& queue,
+                               QueueDepthBoundLink& link, uint64_t token,
+                               int owners, size_t length,
+                               uint64_t deadline_ns) {
+    std::vector<QueueOwnerInput> inputs;
+    for (int i = 0; i < owners; ++i)
+        inputs.push_back(
+            makeDegradationEligibleOwnerWithDeadline(i, length, deadline_ns));
+    std::vector<QueueOwnerId> ids;
+    EXPECT_EQ(queue.tryAdmit(makeSubmit(token, owners, std::move(inputs)), ids)
+                  .code(),
+              Status::Code::kOk);
+
+    std::vector<QueueOwnerId> dropped;
+    auto picked = queue.pickForDispatch(owners, 1 << 30, &dropped);
+    for (auto id : picked)
+        EXPECT_EQ(queue.complete(id, TransferStatusEnum::COMPLETED).code(),
+                  Status::Code::kOk);
+    EXPECT_EQ(queue.retireBatch(token).code(), Status::Code::kOk);
+
+    link.observe(static_cast<int>(picked.size()));
+    return {static_cast<int>(picked.size()), static_cast<int>(dropped.size()),
+            link.rate};
+}
+
+// Shared scenario: 8 owners of 1 MB per round, a 10 ms window, theta 0.95,
+// a link that needs all 8 in flight to reach 1 GB/s (1 MB per ms). At line
+// rate the last owner scores MLU 0.8 and everything is admitted. The i-th
+// owner is judged behind the i-1 picked before it in the same call.
+constexpr double kLineRate = 1e9;
+constexpr int kSaturatingOwners = 8;
+constexpr size_t kOwnerBytes = 1'000'000;
+constexpr uint64_t kNow = 1'000'000'000;
+constexpr uint64_t kDeadline = kNow + 10'000'000;  // 10 ms window
+constexpr double kThetaLocal = 0.95;
+
+std::unique_ptr<LocalTransferAdmissionQueue> makeFeedbackQueue(
+    QueueDepthBoundLink& link, int& hook_calls) {
+    QueueLimits limits{16, 1 << 30, 0, 0};
+    limits.deadline_aware = true;
+    limits.mlu_local_threshold = kThetaLocal;
+    auto queue = std::make_unique<LocalTransferAdmissionQueue>(limits);
+    DegradationHooks hooks;
+    hooks.on_local_decode_suggested = [&](const Request&) { ++hook_calls; };
+    queue->setDegradationPolicy([&link] { return link.rate; }, hooks,
+                                [] { return kNow; });
+    return queue;
+}
+
+// From an optimistic seed nothing is dropped, the link stays saturated and
+// the estimate never moves: the loop does not starve itself from a clean
+// start.
+TEST(AdmissionQueueTest, Step3FeedbackCleanStartStaysSaturated) {
+    QueueDepthBoundLink link{kLineRate, kSaturatingOwners, 0.9, kLineRate};
+    int hook_calls = 0;
+    auto queue = makeFeedbackQueue(link, hook_calls);
+    for (uint64_t round = 1; round <= 30; ++round) {
+        auto r = runFeedbackRound(*queue, link, round, kSaturatingOwners,
+                                  kOwnerBytes, kDeadline);
+        ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
+        ASSERT_EQ(r.dropped, 0) << "round " << round;
+        ASSERT_DOUBLE_EQ(r.rate_after, kLineRate) << "round " << round;
+    }
+    EXPECT_EQ(hook_calls, 0);
+}
+
+// An estimate depressed to what 6 of 8 owners achieve drops one owner a
+// round, but the 7 that get through achieve more than the estimate says,
+// so it climbs back and admission returns to 8: the shallow basin recovers.
+TEST(AdmissionQueueTest, Step3FeedbackShallowDepressionRecovers) {
+    QueueDepthBoundLink link{kLineRate, kSaturatingOwners, 0.9, 0.0};
+    link.rate = link.achieved(6);  // 0.75 GB/s
+    int hook_calls = 0;
+    auto queue = makeFeedbackQueue(link, hook_calls);
+
+    int recovered_at = -1;
+    for (uint64_t round = 1; round <= 40; ++round) {
+        auto r = runFeedbackRound(*queue, link, round, kSaturatingOwners,
+                                  kOwnerBytes, kDeadline);
+        ASSERT_GE(r.admitted, 7) << "round " << round;  // never gets worse
+        if (r.admitted == kSaturatingOwners && recovered_at < 0)
+            recovered_at = static_cast<int>(round);
+        if (recovered_at > 0)
+            ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
+    }
+    EXPECT_GT(recovered_at, 0);
+    EXPECT_LE(recovered_at, 25);
+    EXPECT_NEAR(link.rate, kLineRate, 0.02 * kLineRate);
+    EXPECT_EQ(hook_calls, recovered_at - 1);  // one drop per round until then
+}
+
+// An estimate depressed to what 4 of 8 owners achieve is a fixed point: the
+// 5th owner scores MLU 1.0, so exactly 4 are admitted, 4 achieve exactly the
+// rate the estimate already holds, and nothing ever pulls it back up. This
+// pins the J21 finding under the queue-depth-bound model: the loop has a
+// self-sustaining plateau below saturation, and admission has no probe
+// (unlike selectMultiPath's probe_mode) to spend evidence on climbing out.
+// A probe mechanism must make this test's expectations flip.
+TEST(AdmissionQueueTest, Step3FeedbackDeepDepressionIsSelfSustaining) {
+    QueueDepthBoundLink link{kLineRate, kSaturatingOwners, 0.9, 0.0};
+    link.rate = link.achieved(4);  // 0.5 GB/s
+    int hook_calls = 0;
+    auto queue = makeFeedbackQueue(link, hook_calls);
+
+    for (uint64_t round = 1; round <= 50; ++round) {
+        auto r = runFeedbackRound(*queue, link, round, kSaturatingOwners,
+                                  kOwnerBytes, kDeadline);
+        ASSERT_EQ(r.admitted, 4) << "round " << round;
+        ASSERT_EQ(r.dropped, 4) << "round " << round;
+        ASSERT_DOUBLE_EQ(r.rate_after, link.achieved(4)) << "round " << round;
+    }
+    EXPECT_EQ(hook_calls, 4 * 50);
 }
 
 TEST(AdmissionQueueTest, Step3DropsAlreadyExpiredDeadline) {

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -897,10 +897,11 @@ constexpr uint64_t kDeadline = kNow + 10'000'000;  // 10 ms window
 constexpr double kThetaLocal = 0.95;
 
 std::unique_ptr<LocalTransferAdmissionQueue> makeFeedbackQueue(
-    QueueDepthBoundLink& link, int& hook_calls) {
+    QueueDepthBoundLink& link, int& hook_calls, size_t probe_owners = 0) {
     QueueLimits limits{16, 1 << 30, 0, 0};
     limits.deadline_aware = true;
     limits.mlu_local_threshold = kThetaLocal;
+    limits.mlu_probe_owners = probe_owners;
     auto queue = std::make_unique<LocalTransferAdmissionQueue>(limits);
     DegradationHooks hooks;
     hooks.on_local_decode_suggested = [&](const Request&) { ++hook_calls; };
@@ -921,7 +922,8 @@ TEST(AdmissionQueueTest, Step3FeedbackCleanStartStaysSaturated) {
                                   kOwnerBytes, kDeadline);
         ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
         ASSERT_EQ(r.dropped, 0) << "round " << round;
-        ASSERT_DOUBLE_EQ(r.rate_after, kLineRate) << "round " << round;
+        ASSERT_NEAR(r.rate_after, kLineRate, 1e-9 * kLineRate)
+            << "round " << round;
     }
     EXPECT_EQ(hook_calls, 0);
 }
@@ -954,10 +956,9 @@ TEST(AdmissionQueueTest, Step3FeedbackShallowDepressionRecovers) {
 // An estimate depressed to what 4 of 8 owners achieve is a fixed point: the
 // 5th owner scores MLU 1.0, so exactly 4 are admitted, 4 achieve exactly the
 // rate the estimate already holds, and nothing ever pulls it back up. This
-// pins the J21 finding under the queue-depth-bound model: the loop has a
-// self-sustaining plateau below saturation, and admission has no probe
-// (unlike selectMultiPath's probe_mode) to spend evidence on climbing out.
-// A probe mechanism must make this test's expectations flip.
+// pins the J21 finding under the queue-depth-bound model: with no probe
+// (mlu_probe_owners = 0, the default) the loop has a self-sustaining plateau
+// below saturation and nothing spends evidence on climbing out.
 TEST(AdmissionQueueTest, Step3FeedbackDeepDepressionIsSelfSustaining) {
     QueueDepthBoundLink link{kLineRate, kSaturatingOwners, 0.9, 0.0};
     link.rate = link.achieved(4);  // 0.5 GB/s
@@ -969,9 +970,468 @@ TEST(AdmissionQueueTest, Step3FeedbackDeepDepressionIsSelfSustaining) {
                                   kOwnerBytes, kDeadline);
         ASSERT_EQ(r.admitted, 4) << "round " << round;
         ASSERT_EQ(r.dropped, 4) << "round " << round;
-        ASSERT_DOUBLE_EQ(r.rate_after, link.achieved(4)) << "round " << round;
+        ASSERT_NEAR(r.rate_after, link.achieved(4), 1e-9 * link.achieved(4))
+            << "round " << round;
     }
     EXPECT_EQ(hook_calls, 4 * 50);
+}
+
+// One probe per pick from the same plateau: the 5th owner the drop would
+// reject is dispatched, 5 achieve more than the estimate says, it climbs
+// past the point where a 5th is admitted on its own merits, the probe moves
+// to the 6th, and so on up to saturation.
+TEST(AdmissionQueueTest, Step3FeedbackDeepDepressionRecoversWithOneProbe) {
+    QueueDepthBoundLink link{kLineRate, kSaturatingOwners, 0.9, 0.0};
+    link.rate = link.achieved(4);
+    int hook_calls = 0;
+    auto queue = makeFeedbackQueue(link, hook_calls, /*probe_owners=*/1);
+
+    int recovered_at = -1;
+    size_t probes_at_50 = 0;
+    for (uint64_t round = 1; round <= 60; ++round) {
+        auto r = runFeedbackRound(*queue, link, round, kSaturatingOwners,
+                                  kOwnerBytes, kDeadline);
+        ASSERT_GE(r.admitted, 4) << "round " << round;  // never below plateau
+        if (r.admitted == kSaturatingOwners && recovered_at < 0)
+            recovered_at = static_cast<int>(round);
+        if (recovered_at > 0)
+            ASSERT_EQ(r.admitted, kSaturatingOwners) << "round " << round;
+        if (round == 50) probes_at_50 = queue->probeStats().dispatched;
+    }
+    EXPECT_GT(recovered_at, 0);
+    EXPECT_LE(recovered_at, 40);
+    EXPECT_NEAR(link.rate, kLineRate, 0.02 * kLineRate);
+    // At most one probe a round on the way up; once the estimate carries
+    // saturation on its own nothing is infeasible and probing stops.
+    EXPECT_GT(queue->probeStats().dispatched, 0u);
+    EXPECT_LE(queue->probeStats().dispatched, 60u);
+    EXPECT_EQ(queue->probeStats().dispatched, probes_at_50);
+}
+
+// The budget buys time, not a cheaper climb. From the same plateau a larger
+// budget reaches saturation in fewer rounds, but the probes spent getting
+// there stay about the same: the estimate has a fixed distance to move and
+// each probe moves it by about the same amount whenever it is spent. What a
+// larger budget does add is exposure when the estimate is right -- that many
+// more late transfers per pick -- so 1 is the recommended value.
+TEST(AdmissionQueueTest,
+     Step3FeedbackLargerProbeBudgetRecoversFasterAtTheSameCost) {
+    struct Outcome {
+        int recovered_at;
+        size_t probes;
+    };
+    auto climb = [](size_t probe_owners) {
+        QueueDepthBoundLink link{kLineRate, kSaturatingOwners, 0.9, 0.0};
+        link.rate = link.achieved(4);
+        int hook_calls = 0;
+        auto queue = makeFeedbackQueue(link, hook_calls, probe_owners);
+        Outcome out{-1, 0};
+        for (uint64_t round = 1; round <= 60; ++round) {
+            auto r = runFeedbackRound(*queue, link, round, kSaturatingOwners,
+                                      kOwnerBytes, kDeadline);
+            if (r.admitted == kSaturatingOwners && out.recovered_at < 0)
+                out.recovered_at = static_cast<int>(round);
+        }
+        out.probes = queue->probeStats().dispatched;
+        return out;
+    };
+
+    const Outcome one = climb(1), two = climb(2), four = climb(4);
+    EXPECT_GT(one.recovered_at, 0);
+    EXPECT_GT(two.recovered_at, 0);
+    EXPECT_GT(four.recovered_at, 0);
+    EXPECT_LE(two.recovered_at, one.recovered_at);
+    EXPECT_LE(four.recovered_at, two.recovered_at);
+    EXPECT_LT(four.recovered_at, one.recovered_at);  // strictly faster overall
+    EXPECT_NEAR(static_cast<double>(two.probes),
+                static_cast<double>(one.probes), 5.0);
+    EXPECT_NEAR(static_cast<double>(four.probes),
+                static_cast<double>(one.probes), 5.0);
+}
+
+// ---- probe mechanics ----
+
+// With a probe budget the owner the drop would reject is dispatched instead:
+// not terminal, not signalled, counted as dispatching like any other owner.
+TEST(AdmissionQueueTest, Step3ProbeDispatchesTheOwnerTheDropWouldReject) {
+    QueueLimits limits = step3Limits(1.5);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    int hook_calls = 0;
+    DegradationHooks hooks;
+    hooks.on_local_decode_suggested = [&](const Request&) { ++hook_calls; };
+    queue.setDegradationPolicy([] { return 1e9; }, hooks,
+                               [] { return uint64_t{1'000'000'000}; });
+
+    // Same pair as Step3DropsInfeasibleAndKeepsFeasible: owner 1 has MLU
+    // 1.6 >= 1.5 and would be dropped; owner 2 is comfortably feasible.
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 2,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                      0, 16, 1'000'000'010),
+                                  makeDegradationEligibleOwnerWithDeadline(
+                                      1, 16, 2'000'000'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+
+    std::vector<QueueOwnerId> dropped;
+    auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+    EXPECT_EQ(picked, (std::vector<QueueOwnerId>{1, 2}));
+    EXPECT_TRUE(dropped.empty());
+    EXPECT_EQ(hook_calls, 0);
+    EXPECT_EQ(queue.probeStats().dispatched, 1u);
+    EXPECT_EQ(queue.dispatchingBytes(), 32u);  // the probe is dispatched too
+    EXPECT_EQ(queue.outstandingOwners(), 2u);
+}
+
+// The budget is per pick and covers only the infeasible: two owners that
+// each score MLU 1.6 on their own and a budget of one, the first is probed
+// and the second dropped (it would be even with nothing ahead of it); the
+// next pick starts with a fresh budget.
+TEST(AdmissionQueueTest, Step3ProbeBudgetIsPerPickAndDropsTheRest) {
+    QueueLimits limits = step3Limits(1.5);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 2,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                      0, 16, 1'000'000'010),
+                                  makeDegradationEligibleOwnerWithDeadline(
+                                      1, 16, 1'000'000'010)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{1});
+    EXPECT_EQ(dropped, std::vector<QueueOwnerId>{2});
+    EXPECT_EQ(queue.probeStats().dispatched, 1u);
+
+    ASSERT_EQ(queue.complete(1, TransferStatusEnum::COMPLETED).code(),
+              Status::Code::kOk);
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(2, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'000'010)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    dropped.clear();
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{3});
+    EXPECT_TRUE(dropped.empty());
+    EXPECT_EQ(queue.probeStats().dispatched, 2u);
+}
+
+// Probing only ever replaces a drop: with the drop disabled (no threshold)
+// the budget has nothing to spend on, and nothing is counted as a probe.
+TEST(AdmissionQueueTest, Step3ProbeIsInertWithoutDrop) {
+    QueueLimits limits = step3Limits(/*theta_local=*/0.0);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 2,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                      0, 16, 1'000'000'010),
+                                  makeDegradationEligibleOwnerWithDeadline(
+                                      1, 16, 1'000'000'011)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              (std::vector<QueueOwnerId>{1, 2}));
+    EXPECT_TRUE(dropped.empty());
+    EXPECT_EQ(queue.probeStats().dispatched, 0u);
+}
+
+// The probe's collateral when the estimate is right. A large, urgent owner
+// that genuinely cannot make its deadline is the probe; its bytes join the
+// queue ahead of everyone behind it, so a small, looser owner that was
+// feasible on its own is now judged behind 1000 bytes it did not have to wait
+// for and is dropped instead. Without the probe the large owner is dropped
+// and the small one goes: the probe trades a feasible transfer for an
+// infeasible one whenever the estimate was telling the truth. (Dispatching
+// the probe after the feasible owners would avoid this, but a pick whose
+// owner budget the feasible owners fill every time would then never have
+// room for it, and an owner held back for a probe that never comes is
+// neither transferred nor signalled.)
+TEST(AdmissionQueueTest, Step3ProbeCanDropTheFeasibleOwnerBehindIt) {
+    // 1 B per ns; A: 1000 B in a 400 ns window (MLU 2.5); B: 100 B in a
+    // 600 ns window (MLU 0.17 alone, 1.83 behind A).
+    auto admitBoth = [](LocalTransferAdmissionQueue& queue) {
+        std::vector<QueueOwnerId> ids;
+        ASSERT_EQ(
+            queue
+                .tryAdmit(makeSubmit(1, 2,
+                                     {makeDegradationEligibleOwnerWithDeadline(
+                                          0, 1000, 1'000'000'400),
+                                      makeDegradationEligibleOwnerWithDeadline(
+                                          1, 100, 1'000'000'600)}),
+                          ids)
+                .code(),
+            Status::Code::kOk);
+    };
+
+    {
+        LocalTransferAdmissionQueue queue(step3Limits(1.5));
+        queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                                   [] { return uint64_t{1'000'000'000}; });
+        admitBoth(queue);
+        std::vector<QueueOwnerId> dropped;
+        EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+                  std::vector<QueueOwnerId>{2});           // B goes
+        EXPECT_EQ(dropped, std::vector<QueueOwnerId>{1});  // A dropped
+    }
+    {
+        QueueLimits limits = step3Limits(1.5);
+        limits.mlu_probe_owners = 1;
+        LocalTransferAdmissionQueue queue(limits);
+        queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                                   [] { return uint64_t{1'000'000'000}; });
+        admitBoth(queue);
+        std::vector<QueueOwnerId> dropped;
+        EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+                  std::vector<QueueOwnerId>{1});           // A probed
+        EXPECT_EQ(dropped, std::vector<QueueOwnerId>{2});  // B collateral
+        EXPECT_EQ(queue.probeStats().dispatched, 1u);
+        EXPECT_EQ(queue.dispatchingBytes(), 1000u);
+    }
+}
+
+// Of several rejected owners the most urgent is the probe -- EDF order, the
+// same order the drop meets them in -- not the smallest or the largest: its
+// verdict is the soonest to arrive, and size is left out of the choice on
+// purpose (a bigger probe lifts the meter more per round, and costs more
+// per pick when the estimate is right). The rest are judged behind it.
+TEST(AdmissionQueueTest, Step3ProbeIsTheMostUrgentRejectedOwner) {
+    QueueLimits limits = step3Limits(1.5);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    // 1 B per ns. Owner 1: 28 B in 10 ns (MLU 2.8), the most urgent and the
+    // largest. Owner 2: 16 B in 10 ns (MLU 1.6 alone), same deadline,
+    // admitted after 1 so behind it in EDF order, and the smallest. Owner 3:
+    // 20 B in 12 ns (MLU 1.67 alone). All three are rejected; 1 is the probe.
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 3,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                      0, 28, 1'000'000'010),
+                                  makeDegradationEligibleOwnerWithDeadline(
+                                      1, 16, 1'000'000'010),
+                                  makeDegradationEligibleOwnerWithDeadline(
+                                      2, 20, 1'000'000'012)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{1});
+    EXPECT_EQ(dropped, (std::vector<QueueOwnerId>{2, 3}));
+    EXPECT_EQ(queue.probeStats().dispatched, 1u);
+}
+
+// An owner far past the threshold is infeasible whatever the estimate says;
+// probing it buys a late transfer and no information. With the default
+// ceiling of 2 x theta, an owner at MLU 3.2 is dropped with budget to spare
+// while one at 1.6 is probed, budget for both notwithstanding; with the
+// ceiling removed the 3.2 owner is a candidate like any other and goes too.
+TEST(AdmissionQueueTest, Step3ProbeSkipsOwnersFarPastTheThreshold) {
+    auto admitBoth = [](LocalTransferAdmissionQueue& queue) {
+        std::vector<QueueOwnerId> ids;
+        // 1 B per ns. Owner 1: 32 B in 10 ns (MLU 3.2); owner 2: 16 B in
+        // 10 ns (MLU 1.6). Same deadline, so EDF keeps admission order.
+        ASSERT_EQ(
+            queue
+                .tryAdmit(makeSubmit(1, 2,
+                                     {makeDegradationEligibleOwnerWithDeadline(
+                                          0, 32, 1'000'000'010),
+                                      makeDegradationEligibleOwnerWithDeadline(
+                                          1, 16, 1'000'000'010)}),
+                          ids)
+                .code(),
+            Status::Code::kOk);
+    };
+
+    {
+        QueueLimits limits = step3Limits(1.5);  // ceiling 3.0
+        limits.mlu_probe_owners = 1;
+        LocalTransferAdmissionQueue queue(limits);
+        queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                                   [] { return uint64_t{1'000'000'000}; });
+        admitBoth(queue);
+        std::vector<QueueOwnerId> dropped;
+        EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+                  std::vector<QueueOwnerId>{2});
+        EXPECT_EQ(dropped, std::vector<QueueOwnerId>{1});
+        EXPECT_EQ(queue.probeStats().dispatched, 1u);
+    }
+    {
+        QueueLimits limits = step3Limits(1.5);
+        limits.mlu_probe_owners = 2;  // budget for both, ceiling drops one
+        LocalTransferAdmissionQueue queue(limits);
+        queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                                   [] { return uint64_t{1'000'000'000}; });
+        admitBoth(queue);
+        std::vector<QueueOwnerId> dropped;
+        EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+                  std::vector<QueueOwnerId>{2});
+        EXPECT_EQ(dropped, std::vector<QueueOwnerId>{1});
+    }
+    {
+        QueueLimits limits = step3Limits(1.5);
+        limits.mlu_probe_owners = 2;
+        limits.mlu_probe_ceiling_factor = 0.0;  // no ceiling
+        LocalTransferAdmissionQueue queue(limits);
+        queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                                   [] { return uint64_t{1'000'000'000}; });
+        admitBoth(queue);
+        std::vector<QueueOwnerId> dropped;
+        EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+                  (std::vector<QueueOwnerId>{1, 2}));  // EDF order
+        EXPECT_TRUE(dropped.empty());
+        EXPECT_EQ(queue.probeStats().dispatched, 2u);
+    }
+}
+
+// complete() hands back the probe's verdict and tallies it: COMPLETED inside
+// the window is a met deadline; a late completion or any other terminal
+// status is a miss; an owner that was not a probe reports nothing.
+TEST(AdmissionQueueTest, Step3ProbeVerdictIsJudgedAtCompletion) {
+    QueueLimits limits = step3Limits(1.5);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    uint64_t now = 1'000'000'000;
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [&now] { return now; });
+    using Outcome = LocalTransferAdmissionQueue::ProbeOutcome;
+
+    // Three rounds, one owner each: 16 B in a 10 ns window is MLU 1.6, the
+    // probe every time. A fourth owner is feasible and never a probe.
+    auto admitProbeCandidate = [&](uint64_t token) {
+        std::vector<QueueOwnerId> ids;
+        ASSERT_EQ(
+            queue
+                .tryAdmit(makeSubmit(token, 1,
+                                     {makeDegradationEligibleOwnerWithDeadline(
+                                         0, 16, now + 10)}),
+                          ids)
+                .code(),
+            Status::Code::kOk);
+        ASSERT_EQ(queue.pickForDispatch(4, 1 << 20).size(), 1u);
+    };
+
+    // 1: completes before its deadline -> met.
+    admitProbeCandidate(1);
+    Outcome out = Outcome::MissedDeadline;
+    ASSERT_EQ(queue.complete(1, TransferStatusEnum::COMPLETED, &out).code(),
+              Status::Code::kOk);
+    EXPECT_EQ(out, Outcome::MetDeadline);
+
+    // 2: completes, but the clock has passed its deadline -> missed.
+    admitProbeCandidate(2);
+    now += 10;  // exactly at the deadline is not inside the window
+    ASSERT_EQ(queue.complete(2, TransferStatusEnum::COMPLETED, &out).code(),
+              Status::Code::kOk);
+    EXPECT_EQ(out, Outcome::MissedDeadline);
+
+    // 3: fails inside the window -> missed all the same.
+    admitProbeCandidate(3);
+    ASSERT_EQ(queue.complete(3, TransferStatusEnum::FAILED, &out).code(),
+              Status::Code::kOk);
+    EXPECT_EQ(out, Outcome::MissedDeadline);
+
+    // 4: a feasible owner is not a probe and reports None.
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(4, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, now + 1'000'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    ASSERT_EQ(queue.pickForDispatch(4, 1 << 20), std::vector<QueueOwnerId>{4});
+    out = Outcome::MetDeadline;
+    ASSERT_EQ(queue.complete(4, TransferStatusEnum::COMPLETED, &out).code(),
+              Status::Code::kOk);
+    EXPECT_EQ(out, Outcome::None);
+
+    const auto stats = queue.probeStats();
+    EXPECT_EQ(stats.dispatched, 3u);
+    EXPECT_EQ(stats.met_deadline, 1u);
+    EXPECT_EQ(stats.missed_deadline, 2u);
+}
+
+// A probe is still an owner: with no room left in the dispatch budget it
+// waits like a feasible one would, and is not dropped for lack of room.
+TEST(AdmissionQueueTest, Step3ProbeRespectsTheDispatchBudget) {
+    QueueLimits limits = step3Limits(1.5);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'000'010)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_TRUE(queue.pickForDispatch(4, /*max_bytes=*/8, &dropped).empty());
+    EXPECT_TRUE(dropped.empty());
+    EXPECT_EQ(queue.probeStats().dispatched, 0u);  // left queued, not counted
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{1});
+    EXPECT_EQ(queue.probeStats().dispatched, 1u);
+}
+
+// A threshold <= 0 disables the drop; a negative one must not leak through
+// the predictor's "nothing to predict" sentinel and drop (or probe) owners.
+TEST(AdmissionQueueTest, Step3NegativeThresholdDropsNothing) {
+    QueueLimits limits = step3Limits(/*theta_local=*/-2.0);
+    limits.mlu_probe_owners = 1;
+    LocalTransferAdmissionQueue queue(limits);
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'000'010)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{1});
+    EXPECT_TRUE(dropped.empty());
+    EXPECT_EQ(queue.probeStats().dispatched, 0u);
 }
 
 TEST(AdmissionQueueTest, Step3DropsAlreadyExpiredDeadline) {

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -794,6 +794,29 @@ TEST_F(MetricsRecordingTest, FailedTransferCountsFailureNotBytes) {
               0);
 }
 
+// A probe -- an owner the admission drop dispatched past its predicate -- is
+// counted by whether it met its deadline, in a counter of its own: the
+// met/missed ratio is what tells an operator whether the drop threshold is
+// over-conservative or the link genuinely full.
+TEST_F(MetricsRecordingTest, DeadlineProbeCountsByOutcome) {
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    TentMetrics::instance().recordDeadlineProbe(/*met_deadline=*/true);
+    TentMetrics::instance().recordDeadlineProbe(/*met_deadline=*/true);
+    TentMetrics::instance().recordDeadlineProbe(/*met_deadline=*/false);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(after.series("tent_deadline_probe_total{outcome=\"met\"}") -
+                  before.series("tent_deadline_probe_total{outcome=\"met\"}"),
+              2);
+    EXPECT_EQ(
+        after.series("tent_deadline_probe_total{outcome=\"missed\"}") -
+            before.series("tent_deadline_probe_total{outcome=\"missed\"}"),
+        1);
+    EXPECT_EQ(after.counter("tent_deadline_probe_total") -
+                  before.counter("tent_deadline_probe_total"),
+              3);
+}
+
 // ---------------------------------------------------------------------------
 // A transfer whose deadline was already in the past at submit must increment
 // the dedicated tent_deadline_infeasible_total counter, and must NOT pollute


### PR DESCRIPTION
## Description

  Follow-up to #3780 (RFC #2519 step 3). The admission drop divides by the transmit estimate, and the estimate only learns from traffic that was dispatched, so the two form a loop. On a queue-depth-bound link an estimate depressed by a spell of contention admits too little to ever measure more: the admitted owners achieve exactly what the estimate says, and the owners that would prove it wrong are the ones dropped. The first commit pins this with a link model and with the real `DeviceSelector` meter — a 4-of-8 plateau that 60 rounds never leave, every drop after the contention lifted being a transfer the link could have carried; alpha does not matter, theta only moves the basin. The second adds opt-in exploration:  `runtime_queue/mlu_probe_owners` (default 0, behaviour unchanged) dispatches up to N owners per pick that the drop would reject, in EDF order and capped by `runtime_queue/mlu_probe_ceiling_factor` (default 2.0) so only owners misjudged by a depressed estimate are probed, not ones infeasible at line rate. One probe per pick leaves the plateau by round 16 and stops by itself once nothing is infeasible. Recommended value is 1; the probe's cost when the estimate is right is measured in the tests, and `tent_deadline_probe_total{outcome="met"|"missed"}` exports the verdict so a deployment can tell which case it is in.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] New feature

  ## How Has This Been Tested?

  Hardware-independent. `admission_queue_test` drives the queue against a
  queue-depth-bound link model; `tent_admission_feedback_test` closes the same loop
  over the real `DeviceSelector` transmit meter; `tent_metrics_recording_test` covers
  the probe counter. Built with `-DTENT_METRICS_ENABLED=ON`.

  **Test commands:**
  ```bash
  cmake --build build-tent --target admission_queue_test tent_admission_feedback_test tent_metrics_recording_test
  ./admission_queue_test && ./tent_admission_feedback_test && ./tent_metrics_recording_test
  pre-commit run --files <files changed in this PR>

  Test results:
  - [x] Unit tests pass (55 / 8 / 26)
  
  Checklist                                                                                                                                                                                           

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue — the change is RFC #2519 step 3; ~150 LOC of production code, the rest is tests

  AI Assistance Disclosure

  - [x] AI tools were used (specify below)