### PR TITLE
[Bugfix][TENT] Plan RDMA slices from the block size: no empty slices, and fold short tails

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
@@ -188,7 +188,15 @@ class DeviceSelector {
 
     // Allocate devices for a request (new API)
     // slice_bytes: pre-calculated slice size from rdma_transport to ensure
-    // consistency
+    // consistency.
+    //
+    // The slices partition the request: the first num_slices - 1 carry
+    // slice_bytes each and the last carries what is left, which is a block
+    // plus a folded-in tail when planRdmaSlices() folded one -- so it can be
+    // longer than slice_bytes. Each device is charged what its slices
+    // actually carry, so release(), which returns a slice's real length,
+    // balances. Charging every slice slice_bytes would leave the folded tail
+    // released but never charged, and inflight_bytes is unsigned.
     Status allocate(uint64_t total_length, uint32_t num_slices,
                     uint64_t slice_bytes, const std::string &location,
                     std::vector<int> &slice_dev_ids, int priority = PRIO_HIGH,

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -41,6 +41,36 @@ struct RdmaSliceList {
     int num_slices = 0;
 };
 
+// `count` slices of `block_size` bytes, the last holding what remains.
+struct RdmaSlicePlan {
+    uint64_t block_size = 0;
+    uint64_t count = 0;
+};
+
+// Cut `length` into at most `max_slices` slices, each a whole number of
+// `base_block` bytes. Rounding the block up covers the request in fewer
+// slices than were asked for, so the count comes from the block and not the
+// other way round: an empty slice would still cost a work request, a CQE, a
+// path selection and a completion. Zero length keeps one slice -- task
+// accounting counts slices, and a task with none never reaches a terminal
+// status.
+inline RdmaSlicePlan planRdmaSlices(uint64_t length, uint64_t base_block,
+                                    uint64_t max_slices) {
+    if (base_block == 0) base_block = 1;
+    if (max_slices == 0) max_slices = 1;
+    if (length == 0) return {base_block, 1};
+
+    uint64_t count = (length + base_block - 1) / base_block;
+    if (count > max_slices) count = max_slices;
+
+    const uint64_t per_slice = (length + count - 1) / count;
+    const uint64_t block_size = (per_slice % base_block == 0)
+                                    ? per_slice
+                                    : (per_slice / base_block + 1) * base_block;
+
+    return {block_size, (length + block_size - 1) / block_size};
+}
+
 // Forward declarations
 class RdmaEndPoint;
 struct RdmaTask;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -41,7 +41,10 @@ struct RdmaSliceList {
     int num_slices = 0;
 };
 
-// `count` slices of `block_size` bytes, the last holding what remains.
+// `count` slices: the first count - 1 of `block_size` bytes and the last
+// holding what remains, which is a short tail folded in when one was worth
+// folding -- so up to `block_size` more than a block, never less than one
+// byte.
 struct RdmaSlicePlan {
     uint64_t block_size = 0;
     uint64_t count = 0;
@@ -51,11 +54,21 @@ struct RdmaSlicePlan {
 // `base_block` bytes. Rounding the block up covers the request in fewer
 // slices than were asked for, so the count comes from the block and not the
 // other way round: an empty slice would still cost a work request, a CQE, a
-// path selection and a completion. Zero length keeps one slice -- task
-// accounting counts slices, and a task with none never reaches a terminal
-// status.
+// path selection and a completion.
+//
+// A last slice shorter than `merge_ratio` of a block is given to the slice
+// before it instead of being posted on its own, trading a fraction of a
+// block of extra work on that one slice for a work request, a CQE and a
+// completion. This has to happen after the block is chosen: asking for one
+// slice fewer up front only makes the block round up to the next whole one,
+// which leaves the short tail as its own slice anyway and spreads the
+// request over half as many slices. A ratio of 0 never folds.
+//
+// Zero length keeps one slice -- task accounting counts slices, and a task
+// with none never reaches a terminal status.
 inline RdmaSlicePlan planRdmaSlices(uint64_t length, uint64_t base_block,
-                                    uint64_t max_slices) {
+                                    uint64_t max_slices,
+                                    double merge_ratio = 0.25) {
     if (base_block == 0) base_block = 1;
     if (max_slices == 0) max_slices = 1;
     if (length == 0) return {base_block, 1};
@@ -68,7 +81,12 @@ inline RdmaSlicePlan planRdmaSlices(uint64_t length, uint64_t base_block,
                                     ? per_slice
                                     : (per_slice / base_block + 1) * base_block;
 
-    return {block_size, (length + block_size - 1) / block_size};
+    count = (length + block_size - 1) / block_size;
+    if (count > 1) {
+        const uint64_t tail = length - (count - 1) * block_size;
+        if (static_cast<double>(tail) < merge_ratio * block_size) --count;
+    }
+    return {block_size, count};
 }
 
 // Forward declarations

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -142,8 +142,11 @@ Status DeviceSelector::allocate(uint64_t total_length, uint32_t num_slices,
                 int dev_id = tl_eligible[tl_rr_counter % tl_eligible.size()];
                 tl_rr_counter++;
                 slice_dev_ids.push_back(dev_id);
+                // Last slice takes what is left; see the header.
                 uint64_t this_slice_bytes =
-                    std::min(slice_bytes, total_length - offset);
+                    (i + 1 == num_slices)
+                        ? total_length - offset
+                        : std::min(slice_bytes, total_length - offset);
                 offset += this_slice_bytes;
                 // Baseline mode does not track inflight (release() and
                 // chargeDevice() skip it too); only lifetime traffic counts.
@@ -360,10 +363,16 @@ void DeviceSelector::selectMultiPath(const std::vector<Candidate>& candidates,
     }
     // Charge each device what its slices actually carry, in the caller's
     // slice order, so release() (which returns the slice's length) balances
-    // per device; ceil(total / n) per slice would not.
+    // per device; ceil(total / n) per slice would not. The last slice takes
+    // what is left rather than a whole block -- planRdmaSlices() folds a
+    // short tail into it -- so it can be longer than slice_bytes, and
+    // charging it a block would leave the fold released but never charged.
     uint64_t offset = 0;
     for (size_t i = first; i < slice_dev_ids.size(); ++i) {
-        const uint64_t bytes = std::min(slice_bytes, total_length - offset);
+        const uint64_t bytes =
+            (i + 1 == slice_dev_ids.size())
+                ? total_length - offset
+                : std::min(slice_bytes, total_length - offset);
         offset += bytes;
         auto& dev = devices_[slice_dev_ids[i]];
         dev.addInflight(bytes);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -460,10 +460,6 @@ Status RdmaTransport::freeSubBatch(SubBatchRef& batch) {
     return Status::OK();
 }
 
-static inline uint64_t roundup(uint64_t a, uint64_t b) {
-    return (a % b == 0) ? a : (a / b + 1) * b;
-}
-
 Status RdmaTransport::submitTransferTasks(
     SubBatchRef batch, const std::vector<Request>& request_list) {
     auto rdma_batch = dynamic_cast<RdmaSubBatch*>(batch);
@@ -503,26 +499,35 @@ Status RdmaTransport::submitTransferTasks(
         task->cancel_requested.store(false, std::memory_order_relaxed);
         task->ref();  // Batch holds a reference to the task
 
+        // Ask for one slice fewer when the tail is under a quarter block.
+        // Once the cap has widened the block, `tail` is not the real
+        // remainder and this is a guess -- worth revisiting, but it only
+        // moves what is asked for, never what is planned.
         const double merge_ratio = 0.25;
         uint64_t base_block = default_block_size;
-        uint64_t num_slices = (request.length + base_block - 1) / base_block;
-        num_slices = std::max<uint64_t>(
-            1, std::min<uint64_t>(num_slices, max_slice_count));
-
-        if (num_slices > 1) {
+        uint64_t requested_slices =
+            (request.length + base_block - 1) / base_block;
+        requested_slices = std::max<uint64_t>(
+            1, std::min<uint64_t>(requested_slices, max_slice_count));
+        if (requested_slices > 1) {
             uint64_t tail = request.length % base_block;
             if (tail > 0 &&
                 tail < static_cast<uint64_t>(base_block * merge_ratio)) {
-                num_slices = std::max<uint64_t>(1, num_slices - 1);
+                --requested_slices;
             }
         }
 
-        uint64_t block_size = roundup(
-            (request.length + num_slices - 1) / num_slices, default_block_size);
+        const auto plan =
+            planRdmaSlices(request.length, base_block, requested_slices);
+        const uint64_t block_size = plan.block_size;
+        const uint64_t num_slices = plan.count;
 
         std::vector<int> slice_dev_ids;
-        // Only if a single request is enough, we perform aggregated allocation
-        if (num_slices >= max_slice_count / 2) {
+        // Only if a single request is enough, we perform aggregated
+        // allocation. Gated on what was asked for, so which requests take
+        // this path did not change when the plan stopped counting empty
+        // slices; the allocation itself is sized from the plan.
+        if (requested_slices >= max_slice_count / 2) {
             std::string source_location = kWildcardLocation;
             auto source_locations =
                 Platform::getLoader().getLocation(request.source, 1, true);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -499,35 +499,14 @@ Status RdmaTransport::submitTransferTasks(
         task->cancel_requested.store(false, std::memory_order_relaxed);
         task->ref();  // Batch holds a reference to the task
 
-        // Ask for one slice fewer when the tail is under a quarter block.
-        // Once the cap has widened the block, `tail` is not the real
-        // remainder and this is a guess -- worth revisiting, but it only
-        // moves what is asked for, never what is planned.
-        const double merge_ratio = 0.25;
-        uint64_t base_block = default_block_size;
-        uint64_t requested_slices =
-            (request.length + base_block - 1) / base_block;
-        requested_slices = std::max<uint64_t>(
-            1, std::min<uint64_t>(requested_slices, max_slice_count));
-        if (requested_slices > 1) {
-            uint64_t tail = request.length % base_block;
-            if (tail > 0 &&
-                tail < static_cast<uint64_t>(base_block * merge_ratio)) {
-                --requested_slices;
-            }
-        }
-
         const auto plan =
-            planRdmaSlices(request.length, base_block, requested_slices);
+            planRdmaSlices(request.length, default_block_size, max_slice_count);
         const uint64_t block_size = plan.block_size;
         const uint64_t num_slices = plan.count;
 
         std::vector<int> slice_dev_ids;
-        // Only if a single request is enough, we perform aggregated
-        // allocation. Gated on what was asked for, so which requests take
-        // this path did not change when the plan stopped counting empty
-        // slices; the allocation itself is sized from the plan.
-        if (requested_slices >= max_slice_count / 2) {
+        // Only if a single request is enough, we perform aggregated allocation
+        if (num_slices >= max_slice_count / 2) {
             std::string source_location = kWildcardLocation;
             auto source_locations =
                 Platform::getLoader().getLocation(request.source, 1, true);
@@ -549,8 +528,12 @@ Status RdmaTransport::submitTransferTasks(
 
         uint64_t offset = 0;
         for (uint64_t slice_idx = 0; slice_idx < num_slices; ++slice_idx) {
-            uint64_t length =
-                std::min<uint64_t>(request.length - offset, block_size);
+            // The last slice takes what is left, which is a block plus a
+            // folded-in tail when the plan folded one; every other slice is
+            // exactly a block. See planRdmaSlices().
+            uint64_t length = (slice_idx + 1 == num_slices)
+                                  ? request.length - offset
+                                  : block_size;
             auto slice = RdmaSliceStorage::Get().allocate();
             slice->source_addr = (char*)request.source + offset;
             slice->target_addr = request.target_offset + offset;

--- a/mooncake-transfer-engine/tent/tests/quota_accounting_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/quota_accounting_test.cpp
@@ -37,6 +37,7 @@
 #include "tent/common/types.h"
 #include "tent/runtime/topology.h"
 #include "tent/transport/rdma/quota.h"
+#include "tent/transport/rdma/slice.h"
 
 namespace mooncake {
 namespace tent {
@@ -128,6 +129,65 @@ TEST(QuotaAccounting, ATrailingShortSliceIsChargedItsRealLength) {
         ASSERT_TRUE(sel->release(dev_ids[i], i == 3 ? 100 : 300, 0.0).ok());
     EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);
     EXPECT_EQ(InflightOf(*sel, "mlx5_1"), 0u);
+}
+
+// A folded tail makes the last slice longer than a block. It has to be
+// charged what it carries: release() returns the slice's real length, and
+// inflight_bytes is unsigned, so charging a block would wrap it around
+// rather than merely under-report it.
+TEST(QuotaAccounting, ALongLastSliceIsChargedItsRealLength) {
+    auto sel = MakeSelector(/*smart=*/true);
+    std::vector<int> dev_ids;
+    // 1000 bytes in 300-byte blocks over three slices: 300, 300 and a last
+    // one of 400 -- a 100-byte tail folded into it.
+    ASSERT_TRUE(sel->allocate(1000, /*num_slices=*/3, /*slice_bytes=*/300,
+                              "cpu:0", dev_ids)
+                    .ok());
+    ASSERT_EQ(dev_ids.size(), 3u);
+    EXPECT_EQ(TotalInflight(*sel), 1000u);  // not 3 * 300
+
+    for (size_t i = 0; i < dev_ids.size(); ++i)
+        ASSERT_TRUE(sel->release(dev_ids[i], i == 2 ? 400 : 300, 0.0).ok());
+    EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);
+    EXPECT_EQ(InflightOf(*sel, "mlx5_1"), 0u);
+}
+
+// The plan and the charging are two pieces of one rule, in two translation
+// units: planRdmaSlices() decides how a request is cut, allocate() has to
+// charge each device the same lengths the transport will hand its slices,
+// and release() returns those lengths. Walk real plans through all three and
+// the inflight bytes must come back to zero -- the folded tail is exactly
+// where the two used to disagree.
+TEST(QuotaAccounting, PlannedSlicesChargeAndReleaseBalance) {
+    constexpr uint64_t kBase = 65536;
+    for (uint64_t max_slices : {32ul, 64ul}) {
+        const uint64_t lengths[] = {
+            kBase + 1,  8 * kBase + 8192, 8 * kBase + kBase / 2,
+            3ull << 20, 10ull << 20,      100 * kBase + 7};
+        for (uint64_t length : lengths) {
+            const auto plan = planRdmaSlices(length, kBase, max_slices);
+            auto sel = MakeSelector(/*smart=*/true);
+            std::vector<int> dev_ids;
+            SCOPED_TRACE("length=" + std::to_string(length) +
+                         " max=" + std::to_string(max_slices));
+            ASSERT_TRUE(sel->allocate(length, static_cast<uint32_t>(plan.count),
+                                      plan.block_size, "cpu:0", dev_ids)
+                            .ok());
+            ASSERT_EQ(dev_ids.size(), plan.count);
+            EXPECT_EQ(TotalInflight(*sel), length);
+
+            uint64_t offset = 0;
+            for (size_t i = 0; i < dev_ids.size(); ++i) {
+                const uint64_t bytes = (i + 1 == dev_ids.size())
+                                           ? length - offset
+                                           : plan.block_size;
+                offset += bytes;
+                ASSERT_TRUE(sel->release(dev_ids[i], bytes, 0.0).ok());
+            }
+            EXPECT_EQ(offset, length);
+            EXPECT_EQ(TotalInflight(*sel), 0u);
+        }
+    }
 }
 
 // ---- chargeDevice / release are a matched pair on the device named ----

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -685,13 +685,14 @@ TEST_F(RdmaContextEventTest, CqErrLeavesAvailabilityAlone) {
 
 // ---- how a request is cut into slices ------------------------------------
 
-// Walk a plan the way submitTransferTasks() walks it: `count` slices, each
-// min(remaining, block_size). Returns the lengths handed out.
+// Walk a plan the way submitTransferTasks() walks it: a block each, and
+// whatever is left for the last. Returns the lengths handed out.
 std::vector<uint64_t> walkPlan(const RdmaSlicePlan& plan, uint64_t length) {
     std::vector<uint64_t> lengths;
     uint64_t offset = 0;
     for (uint64_t i = 0; i < plan.count; ++i) {
-        const uint64_t n = std::min<uint64_t>(length - offset, plan.block_size);
+        const uint64_t n =
+            (i + 1 == plan.count) ? length - offset : plan.block_size;
         lengths.push_back(n);
         offset += n;
     }
@@ -717,10 +718,15 @@ TEST(RdmaSlicePlanTest, EverySliceCarriesDataAndTheyCoverTheRequest) {
 
             const auto lengths = walkPlan(plan, length);
             uint64_t total = 0;
-            for (uint64_t n : lengths) {
-                EXPECT_GT(n, 0u) << "empty slice";
-                EXPECT_LE(n, plan.block_size);
-                total += n;
+            for (size_t i = 0; i < lengths.size(); ++i) {
+                EXPECT_GT(lengths[i], 0u) << "empty slice";
+                if (i + 1 < lengths.size()) {
+                    EXPECT_EQ(lengths[i], plan.block_size);
+                } else {
+                    // The last one carries a folded tail at most.
+                    EXPECT_LE(lengths[i], 2 * plan.block_size);
+                }
+                total += lengths[i];
             }
             EXPECT_EQ(total, length);
         }
@@ -735,10 +741,64 @@ TEST(RdmaSlicePlanTest, BelowTheCapTheBlockIsTheConfiguredOne) {
         EXPECT_EQ(exact.block_size, kBase) << "blocks=" << blocks;
         EXPECT_EQ(exact.count, blocks) << "blocks=" << blocks;
 
+        // One byte over is a tail far too short to post on its own, so it
+        // joins the slice before it instead of adding one.
         const auto ragged = planRdmaSlices(blocks * kBase + 1, kBase, 64);
         EXPECT_EQ(ragged.block_size, kBase) << "blocks=" << blocks;
-        EXPECT_EQ(ragged.count, blocks + 1) << "blocks=" << blocks;
+        EXPECT_EQ(ragged.count, blocks) << "blocks=" << blocks;
     }
+}
+
+// A tail under a quarter block joins the slice before it: one work request
+// and one completion saved, and the request still spread over as many
+// slices as its size deserves. Reducing the count before choosing the block
+// -- what this used to do -- would round the block up to 128 KB instead,
+// which both halves the slices and leaves the 8 KB tail on its own anyway.
+TEST(RdmaSlicePlanTest, AShortTailJoinsTheSliceBeforeIt) {
+    constexpr uint64_t kBase = 65536;
+    const uint64_t length = 8 * kBase + 8192;  // 520 KB
+
+    const auto plan = planRdmaSlices(length, kBase, 64);
+    EXPECT_EQ(plan.block_size, kBase);  // not widened
+    EXPECT_EQ(plan.count, 8u);          // not 9, and not 5
+
+    const auto lengths = walkPlan(plan, length);
+    ASSERT_EQ(lengths.size(), 8u);
+    EXPECT_EQ(lengths.back(), kBase + 8192);
+    for (size_t i = 0; i + 1 < lengths.size(); ++i)
+        EXPECT_EQ(lengths[i], kBase);
+}
+
+// A tail that is worth a slice of its own keeps one.
+TEST(RdmaSlicePlanTest, ALongTailKeepsItsOwnSlice) {
+    constexpr uint64_t kBase = 65536;
+    const uint64_t length = 8 * kBase + kBase / 2;  // half a block over
+
+    const auto plan = planRdmaSlices(length, kBase, 64);
+    EXPECT_EQ(plan.block_size, kBase);
+    EXPECT_EQ(plan.count, 9u);
+    EXPECT_EQ(walkPlan(plan, length).back(), kBase / 2);
+}
+
+// The ratio is the whole policy, so a caller can turn folding off.
+TEST(RdmaSlicePlanTest, AZeroRatioNeverFolds) {
+    constexpr uint64_t kBase = 65536;
+    const uint64_t length = 8 * kBase + 1;
+
+    const auto folded = planRdmaSlices(length, kBase, 64);
+    const auto plain = planRdmaSlices(length, kBase, 64, /*merge_ratio=*/0.0);
+    EXPECT_EQ(folded.count, 8u);
+    EXPECT_EQ(plain.count, 9u);
+    EXPECT_EQ(walkPlan(plain, length).back(), 1u);
+}
+
+// Folding never empties the plan: two slices whose tail is short become one
+// slice holding everything, not zero.
+TEST(RdmaSlicePlanTest, FoldingNeverDropsTheLastSlice) {
+    constexpr uint64_t kBase = 65536;
+    const auto plan = planRdmaSlices(kBase + 1, kBase, 64);
+    EXPECT_EQ(plan.count, 1u);
+    EXPECT_EQ(walkPlan(plan, kBase + 1).front(), kBase + 1);
 }
 
 // The regression: a 10 MB read asks for 64 slices of 160 KB, rounded up to

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -683,6 +683,116 @@ TEST_F(RdmaContextEventTest, CqErrLeavesAvailabilityAlone) {
     EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
 }
 
+// ---- how a request is cut into slices ------------------------------------
+
+// Walk a plan the way submitTransferTasks() walks it: `count` slices, each
+// min(remaining, block_size). Returns the lengths handed out.
+std::vector<uint64_t> walkPlan(const RdmaSlicePlan& plan, uint64_t length) {
+    std::vector<uint64_t> lengths;
+    uint64_t offset = 0;
+    for (uint64_t i = 0; i < plan.count; ++i) {
+        const uint64_t n = std::min<uint64_t>(length - offset, plan.block_size);
+        lengths.push_back(n);
+        offset += n;
+    }
+    return lengths;
+}
+
+// The whole contract, over a sweep of lengths against both caps: the slices
+// cover the request exactly, none is empty, the cap holds, and the block
+// stays a whole number of configured blocks.
+TEST(RdmaSlicePlanTest, EverySliceCarriesDataAndTheyCoverTheRequest) {
+    constexpr uint64_t kBase = 65536;
+    for (uint64_t max_slices : {32ul, 64ul}) {
+        for (uint64_t length :
+             {1ul, 2ul, kBase - 1, kBase, kBase + 1, 3 * kBase, 3 * kBase + 7,
+              100 * kBase, 100 * kBase + 1, 160 * kBase, 160 * kBase + 8192,
+              1000 * kBase, 1000 * kBase - 1}) {
+            const auto plan = planRdmaSlices(length, kBase, max_slices);
+            SCOPED_TRACE("length=" + std::to_string(length) +
+                         " max=" + std::to_string(max_slices));
+            EXPECT_LE(plan.count, max_slices);
+            EXPECT_GT(plan.count, 0u);
+            EXPECT_EQ(plan.block_size % kBase, 0u);
+
+            const auto lengths = walkPlan(plan, length);
+            uint64_t total = 0;
+            for (uint64_t n : lengths) {
+                EXPECT_GT(n, 0u) << "empty slice";
+                EXPECT_LE(n, plan.block_size);
+                total += n;
+            }
+            EXPECT_EQ(total, length);
+        }
+    }
+}
+
+// Under the cap nothing is rounded: blocks are not enlarged unasked.
+TEST(RdmaSlicePlanTest, BelowTheCapTheBlockIsTheConfiguredOne) {
+    constexpr uint64_t kBase = 65536;
+    for (uint64_t blocks = 1; blocks <= 32; ++blocks) {
+        const auto exact = planRdmaSlices(blocks * kBase, kBase, 64);
+        EXPECT_EQ(exact.block_size, kBase) << "blocks=" << blocks;
+        EXPECT_EQ(exact.count, blocks) << "blocks=" << blocks;
+
+        const auto ragged = planRdmaSlices(blocks * kBase + 1, kBase, 64);
+        EXPECT_EQ(ragged.block_size, kBase) << "blocks=" << blocks;
+        EXPECT_EQ(ragged.count, blocks + 1) << "blocks=" << blocks;
+    }
+}
+
+// The regression: a 10 MB read asks for 64 slices of 160 KB, rounded up to
+// 192 KB, and 54 of those cover it. Asking for 64 anyway left ten empty.
+TEST(RdmaSlicePlanTest, RoundingUpTheBlockTakesTheSurplusOutOfTheCount) {
+    constexpr uint64_t kBase = 65536;
+    const auto plan = planRdmaSlices(10ull << 20, kBase, 64);
+    EXPECT_EQ(plan.block_size, 3 * kBase);  // 192 KB
+    EXPECT_EQ(plan.count, 54u);             // not 64
+
+    // The same shape one cap down, where writes and CUDA sources live.
+    const auto write = planRdmaSlices(3ull << 20, kBase, 32);
+    EXPECT_EQ(write.block_size, 2 * kBase);  // 128 KB
+    EXPECT_EQ(write.count, 24u);             // not 32
+}
+
+// Dividing evenly needs no rounding, so the count is the cap -- nothing was
+// wasted here before the change either.
+TEST(RdmaSlicePlanTest, ArequestThatDividesEvenlyUsesTheWholeCap) {
+    constexpr uint64_t kBase = 65536;
+    const auto plan = planRdmaSlices(6ull << 20, kBase, 32);
+    EXPECT_EQ(plan.block_size, 3 * kBase);  // 192 KB
+    EXPECT_EQ(plan.count, 32u);
+}
+
+// However large the request, the count stops at the cap and the block grows.
+TEST(RdmaSlicePlanTest, TheCapBoundsTheCountAndTheBlockGrowsInstead) {
+    constexpr uint64_t kBase = 65536;
+    const auto small = planRdmaSlices(1ull << 30, kBase, 32);
+    const auto large = planRdmaSlices(1ull << 30, kBase, 64);
+    EXPECT_LE(small.count, 32u);
+    EXPECT_LE(large.count, 64u);
+    EXPECT_GT(small.block_size, large.block_size);
+    EXPECT_EQ(small.block_size % kBase, 0u);
+    EXPECT_EQ(large.block_size % kBase, 0u);
+}
+
+// A zero-length request keeps its one slice; a zero cap or block is treated
+// as one rather than dividing by zero.
+TEST(RdmaSlicePlanTest, DegenerateInputsStayInRange) {
+    constexpr uint64_t kBase = 65536;
+    const auto empty = planRdmaSlices(0, kBase, 64);
+    EXPECT_EQ(empty.count, 1u);
+    EXPECT_EQ(empty.block_size, kBase);
+
+    const auto no_cap = planRdmaSlices(4096, kBase, 0);
+    EXPECT_EQ(no_cap.count, 1u);
+
+    const auto no_block = planRdmaSlices(4096, 0, 64);
+    EXPECT_GT(no_block.count, 0u);
+    EXPECT_LE(no_block.count, 64u);
+    EXPECT_EQ(walkPlan(no_block, 4096).size(), no_block.count);
+}
+
 // ibv_query_port_speed() exists only in rdma-core >= 62. It must be resolved
 // as an optional symbol: present -> non-null, absent -> null, and either way
 // the mandatory verbs are still there (an older libibverbs must not lose


### PR DESCRIPTION
## Description

Two defects in how `submitTransferTasks` cuts a request into slices. Both come from the same place: the slice count and the block size were decided separately, in the wrong order.

**Zero-length slices.** The count came from `ceil(length / block_size)` capped at `max_slice_count` (32 for writes and CUDA sources, 64 otherwise), the block from `roundup(ceil(length / num_slices), block_size)`. The loop then ran the full count with `min(remaining, block_size)` per slice, so whenever the round up actually rounded, the surplus came out as zero-length slices. A 10 MB read was cut into 192 KB blocks, 54 of which cover it, and the other 10 were empty. It needs the cap to bite (over 2 MB for writes and CUDA, over 4 MB otherwise) or the tail merge to fire, and how much is wasted depends on whether `ceil(length / cap)` is already block-aligned, so it jumps around with request size: 8 of 32 empty for a 3 MB write, none for 6 MB. Not a correctness bug — a zero-length RDMA op is legal and the task accounting is consistent — but each empty slice still takes a work request, a CQE of the CQ quota, a full `generatePostPath` device selection and a completion settlement.

**A tail merge that widens the block instead of folding the tail.** The merge meant to keep a short last slice from being posted on its own, and did it by asking for one slice fewer. The block is chosen after, so one slice fewer only rounds the block up to the next whole one: the short tail comes back as its own slice regardless, and the wider block spreads the request over half as many slices. Its `tail` was `length % block_size`, which once the cap has widened the block is not the remainder of anything, so it could also fire for no reason. For 520 KB at a 64 KB block — the shape the merge exists for — it produced a 128 KB block, 5 slices, and the 8 KB tail still on its own.

**Fix.** `planRdmaSlices()` in `slice.h` computes the block as before and then takes the count *from* the block, so no slice is empty; since `block_size >= ceil(length / requested)` the count never exceeds the cap. The fold happens after that: when the last slice would be shorter than `merge_ratio` of a block, the count drops by one and the last slice takes what remains, one block plus the tail. The loop gives the last slice the remainder and every other slice exactly one block. `merge_ratio` is a defaulted parameter (0.25 as before, 0 never folds) rather than a constant at the call site, which loses its pre-merge block entirely and passes `max_slice_count` straight through. 520 KB now plans a 64 KB block, 8 slices, last one 72 KB. Extracted as a pure function because the arithmetic had no test coverage and `submitTransferTasks` cannot be driven without an RNIC.

**The accounting the fold breaks.** The last slice can now exceed `block_size` by up to one block, and `DeviceSelector::selectMultiPath()` reconstructed each slice's length as `min(slice_bytes, remaining)` to charge `inflight_bytes`. So the fold was charged one block but released its real length, and `inflight_bytes` is unsigned: it drifts down by the folded tail per transfer and wraps to ~2^64, which then reads as an impossibly loaded NIC in device scoring and in the deadline arbitration's queue-ahead term. Both charging walks now give the last slice what remains, and `allocate()`'s declaration states the partition so the rule is written where the two sides can be held to it. Nothing downstream constrains a slice to the block — it becomes one work request with one SGE.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Ten `RdmaSlicePlanTest` cases in `rdma_transport_test.cpp` and two in `quota_accounting_test.cpp`, all hardware-free. The plan: the contract over a sweep of lengths against both caps (the slices cover the request exactly, none is empty, the cap holds, the block is a whole number of configured blocks, every slice but the last is exactly a block), the block staying unchanged below the cap, the regressions above, the cap bounding the count while the block grows, a short tail joining the slice before it without widening the block, a tail worth its own slice keeping one, a zero ratio never folding, folding never dropping the last slice, and degenerate inputs.

The accounting: a last slice longer than a block is charged its real length, and real `planRdmaSlices()` plans walked through `allocate()` and `release()` bring the inflight bytes back to zero over a sweep of lengths against both caps.

Red-checked four ways: restoring the old count fails the sweep with "empty slice"; removing the fold fails four cases; restoring the fold-before-the-block form reproduces exactly the 128 KB block and 5 slices described above; and restoring the `min(slice_bytes, remaining)` charge leaves 18446744073709551516 inflight bytes.

**Test commands:**
```bash
cmake --build build-tent --target tent_rdma_transport_test
./tent_rdma_transport_test
ctest   # in build-tent
pre-commit run --files <files changed in this PR>
./scripts/code_format.sh --check --changed-lines --base origin/main
```

**Test results:**
- [x] Unit tests pass (`tent_rdma_transport_test` 76/76, `tent_quota_accounting_test` 9/9; full ctest green apart from four failures that reproduce on an unmodified `main`: `tcp_transport_test`, `transfer_metadata_test`, `memory_location_test`, `transfer_engine_config_override_test`)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped analyse the slicing arithmetic, write the fix and the tests. Every changed line has been reviewed by the submitter.
