### PR TITLE
[Store] Support online DFS shard capacity expansion

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -814,7 +814,7 @@ is required.
 | `MOONCAKE_ENABLE_DFS` | Master | `false` | Enable master-side DFS allocation. `MOONCAKE_DFS_ENABLED` is accepted as a compatibility fallback. |
 | `MOONCAKE_DFS_ROOT_DIR` | Master and clients | `/mnt/3fs/mooncake` | Absolute shared shard root; use the same path string in every process. Falls back to `MOONCAKE_DISTRIBUTED_ROOT_DIR`. |
 | `MOONCAKE_DFS_FS_ADAPTER` | Master and clients | `hf3fs` | Filesystem adapter: `hf3fs` or `posix`. Falls back to `MOONCAKE_DISTRIBUTED_FS_TYPE`. |
-| `MOONCAKE_DFS_SHARD_COUNT` | Master and clients | `64` | Number of DFS shard files. |
+| `MOONCAKE_DFS_SHARD_COUNT` | Master and clients | `64` | Initial shard count. The master also discovers existing contiguous shard files at startup; running clients open added shards on demand. |
 | `MOONCAKE_DFS_SHARD_CAPACITY` | Master and clients | `4294967296` (4 GiB) | Logical file capacity of each shard in bytes. Each object is allocated wholly within one shard. |
 | `MOONCAKE_DFS_ALIGNMENT` | Master and clients | `4096` | Allocation alignment in bytes; must be a power of two and divide the shard capacity. |
 | `MOONCAKE_DFS_SINGLE_TENANT` | Master and clients | `true` | Currently must remain `true`. |
@@ -823,6 +823,51 @@ is required.
 | `MOONCAKE_DFS_EVICTION_LOW_WATERMARK` | Master | `0.7` | Usage ratio targeted by an eviction cycle. |
 | `MOONCAKE_DFS_DEFERRED_FREE_SECONDS` | Master | `30` | Delay before a freed shard range may be reused. |
 | `MOONCAKE_DFS_EVICTION_CHECK_INTERVAL` | Master | `5` | Eviction check interval in seconds. |
+
+#### Growing DFS capacity online
+
+The default shard allocator supports adding shard files while the master and
+clients remain running. Use the master's existing HTTP admin listener:
+
+```bash
+curl http://127.0.0.1:9003/api/v1/dfs/shard_count
+curl -X PUT http://127.0.0.1:9003/api/v1/dfs/shard_count \
+  -H 'Content-Type: application/json' -d '{"shard_count": 128}'
+```
+
+Both requests return the current count, for example
+`{"success":true,"shard_count":128}`. A PUT sets the desired **total** count,
+not the number to add. Repeating the current count succeeds without changing
+anything; shrinking, non-integer values, and non-positive counts return HTTP
+400. DFS-disabled masters and concurrent expansion requests return HTTP 409;
+unavailable or standby services return HTTP 503. Filesystem preparation runs
+off the HTTP I/O threads, so health checks and other administration remain
+available while an expansion is pending.
+
+Upgrade the master and every DFS client to a version supporting online shard
+expansion before increasing capacity. An already running upgraded client can
+open a new shard from its descriptor even when its initial
+`MOONCAKE_DFS_SHARD_COUNT` is smaller. Older binaries reject those descriptors.
+Every process must still use the same shared root, adapter, shard capacity, and
+alignment. Provision sufficient backing filesystem space before expanding;
+changing the root or per-shard capacity online is unsupported.
+
+Only one active master may manage a DFS root. Do not create, rename, truncate,
+or remove its shard files outside that master. Clients do not create shard
+files during initialization; they open them only from published descriptors.
+
+The allocator prepares new files and allocation state before publishing the
+expanded shard set. Existing paths and allocated ranges remain unchanged,
+including when the shard index gains another decimal digit. Allocation, reads,
+writes, deferred frees, and eviction continue to use ready shards. A failed
+expansion leaves the published shard count unchanged.
+
+On startup, the master discovers the contiguous existing shard layout and uses
+at least the configured count. Duplicate indices, missing intermediate shards,
+and unexpected file sizes are rejected rather than silently changing the
+layout. This preserves **capacity**, not cached key metadata or allocation
+ownership: DFS allocator recovery, snapshots, and HA remain subject to the
+limitations below. Do not treat online expansion as a data durability guarantee.
 
 #### Requesting and accessing DFS replicas
 
@@ -841,10 +886,11 @@ store.put("key", b"value", config)
 with at least one memory replica (`replica_num >= 1`), so DFS-only placement is
 not supported.
 
-Each key hashes to exactly one DFS shard. Allocation does not fall back to a
-different shard, so a request may return `NO_AVAILABLE_HANDLE` when its selected
-shard is full even if other shards have free space. A DFS object is never
-striped across shards. The selected shard must have room for the object rounded
+Allocation first tries the key's hash-selected DFS shard, then tries other
+ready shards if that shard has no suitable extent. This lets new shards accept
+writes even when older shards are full. `NO_AVAILABLE_HANDLE` means no ready
+shard could satisfy the allocation. A DFS object is never striped across shards.
+The selected shard must have room for the object rounded
 up to `MOONCAKE_DFS_ALIGNMENT`, plus up to one alignment unit of allocator
 padding (`MOONCAKE_DFS_ALIGNMENT - 1` bytes); usable object capacity is
 therefore lower than the shard file's
@@ -876,9 +922,8 @@ reads for that descriptor.
   their replication configuration does not expose `dfs_replica_num`, and their
   setup API cannot initialize the distributed `FileStorage` backend. Use the
   native C++ or Python/RealClient API.
-- A DFS object must fit in its key-selected shard after alignment and allocator
-  padding; objects are not striped and allocation does not fall back to another
-  shard.
+- A DFS object must fit in a single shard after alignment and allocator
+  padding; objects are not striped across shards.
 - DFS allocator state is currently in memory. A master restart or HA leader
   failover does not reconstruct existing DFS allocations, so DFS cannot provide
   continuity across those events.

--- a/docs/source/design/store/mooncake-store.md
+++ b/docs/source/design/store/mooncake-store.md
@@ -759,10 +759,22 @@ finalized. Removal, revocation, replacement, and allocator eviction release
 the range, with a configurable deferred-free interval preventing immediate
 offset reuse.
 
+The shard set can grow online through the master admin API. Expansion prepares
+new shard files and allocator state, then atomically publishes the complete
+ready set; existing shard paths and ranges remain unchanged. Allocation tries
+the hash-selected shard first and falls back to other ready shards, so added
+capacity can relieve full shards. Startup discovers the existing contiguous
+layout to retain the expanded capacity; it does not recover allocation or key
+metadata.
+
 The client owns the DFS data plane. `DistributedStorageBackend` validates the
 descriptor and delegates positional I/O to either `PosixFsAdapter` or
 `Hf3fsAdapter`. The master and clients must use the same DFS root and shard
 layout so that a descriptor identifies the same physical file everywhere.
+Clients do not open or create shard files during initialization. They open a
+shard only when first using its published descriptor, validating the path,
+shard index, and file capacity before caching the file handle. This prevents
+clients from retaining files that an unsuccessful expansion rolls back.
 
 For a write, the client first completes the requested memory and NoF transfers,
 then writes the DFS replica. `Put`, `BatchPut`, `Upsert`, and `BatchUpsert`

--- a/mooncake-store/include/master_admin_service.h
+++ b/mooncake-store/include/master_admin_service.h
@@ -86,6 +86,10 @@ class MasterAdminServer {
                                  coro_http::coro_http_response& resp);
     void HandleQuerySegment(coro_http::coro_http_request& req,
                             coro_http::coro_http_response& resp);
+    void HandleGetDfsShardCount(coro_http::coro_http_request& req,
+                                coro_http::coro_http_response& resp);
+    async_simple::coro::Lazy<void> HandleExpandDfsShards(
+        coro_http::coro_http_request& req, coro_http::coro_http_response& resp);
     void HandleCreateDrainJob(coro_http::coro_http_request& req,
                               coro_http::coro_http_response& resp);
     void HandleQueryDrainJob(coro_http::coro_http_request& req,
@@ -118,6 +122,10 @@ class MasterAdminServer {
     std::atomic<bool> metric_report_running_{false};
     std::binary_semaphore metric_report_stop_sem_{0};
     std::atomic<bool> started_{false};
+    // Retained by each handler across its blocking operation and completion.
+    // Only one admin expansion may be pending, including disconnected requests.
+    std::shared_ptr<std::atomic<bool>> dfs_expansion_running_{
+        std::make_shared<std::atomic<bool>>(false)};
     // Serializes storage projection with service-plane handoff so a refresh
     // that sampled the old leader cannot publish after it becomes unavailable.
     mutable std::mutex storage_metrics_refresh_mutex_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -913,6 +913,11 @@ class MasterService {
                                                  const std::string& source,
                                                  const std::string& target);
 
+    // Admin-only, grow-only DFS capacity management. Existing placements remain
+    // valid.
+    tl::expected<int, ErrorCode> GetDfsShardCount() const;
+    tl::expected<int, ErrorCode> ExpandDfsShards(int shard_count);
+
     /**
      * @brief Create a drain job to gracefully evacuate one or more segments.
      */

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -247,6 +247,11 @@ class WrappedMasterService {
         const UUID& client_id, const std::string& key,
         const std::string& tenant_id);
 
+    // Admin-only, grow-only DFS capacity management. Existing placements remain
+    // valid.
+    tl::expected<int, ErrorCode> GetDfsShardCount() const;
+    tl::expected<int, ErrorCode> ExpandDfsShards(int shard_count);
+
     tl::expected<UUID, ErrorCode> CreateDrainJob(
         const CreateDrainJobRequest& request);
 

--- a/mooncake-store/include/storage/distributed/dfs_global_allocator.h
+++ b/mooncake-store/include/storage/distributed/dfs_global_allocator.h
@@ -76,6 +76,12 @@ class DfsGlobalAllocator {
         return initialized_.load(std::memory_order_acquire);
     }
 
+    // Append shards without moving existing allocations. Equal counts are
+    // idempotent; shrinking is not supported. The returned count is ready for
+    // allocation only after every new shard has been initialized.
+    tl::expected<int, ErrorCode> ExpandShards(int target_count);
+    int GetShardCount() const;
+
     tl::expected<DistributedFSDescriptor, ErrorCode> Allocate(
         const std::string& key, uint64_t size);
     void Free(uint64_t offset, uint64_t aligned_size, int shard_idx,
@@ -99,6 +105,7 @@ class DfsGlobalAllocator {
     using OffsetAllocationHandle = offset_allocator::OffsetAllocationHandle;
 
     struct ShardState {
+        std::string path;
         uint64_t capacity = 0;
         std::shared_ptr<OffsetAllocator> allocator;
 
@@ -130,6 +137,12 @@ class DfsGlobalAllocator {
         uint64_t pending_free_bytes = 0;
     };
 
+    using ShardList = std::vector<std::shared_ptr<ShardState>>;
+
+    tl::expected<std::shared_ptr<ShardState>, ErrorCode> CreateShard(
+        const std::string& path, std::vector<std::string>& created_files);
+    void CleanupCreatedFiles(const std::vector<std::string>& created_files);
+
     static constexpr size_t kNumKeyStripes = 65536;
 
     std::unique_lock<std::mutex> LockKey(const std::string& key) {
@@ -137,7 +150,6 @@ class DfsGlobalAllocator {
             key_stripes_[std::hash<std::string>{}(key) % kNumKeyStripes]);
     }
 
-    void ProcessPendingFrees(int shard_idx);
     void QueuePendingFree(ShardState& shard,
                           const std::shared_ptr<OffsetAllocationHandle>& handle,
                           uint64_t bytes,
@@ -145,14 +157,17 @@ class DfsGlobalAllocator {
     void CleanupExpiredPendingFrees(ShardState& shard,
                                     std::chrono::steady_clock::time_point now);
     double EffectiveUsage(ShardState& shard);
-    void PrepareEvictionFromShard(int shard_idx, PendingEviction& pending);
-    int SelectShard(const std::string& key) const;
+    void PrepareEvictionFromShard(ShardState& shard, int shard_idx,
+                                  PendingEviction& pending);
     uint64_t AlignSize(uint64_t size) const;
 
     std::string mount_path_;
-    int shard_count_ = 0;
+    uint64_t shard_capacity_ = 0;
     uint64_t alignment_ = 4096;
-    std::vector<std::unique_ptr<ShardState>> shards_;
+    // Readers retain an immutable topology snapshot. Expansion shares existing
+    // ShardState objects and publishes the complete new topology in one step.
+    std::shared_ptr<const ShardList> shards_;
+    std::mutex expansion_mutex_;
     std::unique_ptr<FileSystemAdapter> fs_adapter_;
     bool eviction_enabled_ = true;
     double eviction_high_watermark_ = 0.9;

--- a/mooncake-store/include/storage/distributed/distributed_storage_backend.h
+++ b/mooncake-store/include/storage/distributed/distributed_storage_backend.h
@@ -105,7 +105,9 @@ class DistributedStorageBackend : public StorageBackendInterface {
     std::unique_ptr<ObjectStorageAdapter> object_storage_adapter_;
     DistributedStorageConfig distributed_config_;
     std::string root_dir_;
-    // Cache only shards opened from descriptors published by the master.
+    // Create shard entries only from descriptors published by the master.
+    // The cache lock protects lookup/insertion; each shard's mutex protects
+    // initialization (fd stays -1 until opening succeeds) and positional I/O.
     // Entries are never erased while the backend is running, so callers can
     // retain a ShardFile pointer after releasing the cache lock.
     std::mutex shard_files_mutex_;

--- a/mooncake-store/include/storage/distributed/distributed_storage_backend.h
+++ b/mooncake-store/include/storage/distributed/distributed_storage_backend.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "config/distributed_storage_config.h"
@@ -97,11 +98,18 @@ class DistributedStorageBackend : public StorageBackendInterface {
         std::mutex mutex;
     };
 
+    tl::expected<ShardFile*, ErrorCode> GetOrOpenShard(
+        const DistributedFSDescriptor& descriptor);
+
     std::unique_ptr<FileSystemAdapter> fs_adapter_;
     std::unique_ptr<ObjectStorageAdapter> object_storage_adapter_;
     DistributedStorageConfig distributed_config_;
     std::string root_dir_;
-    std::vector<std::unique_ptr<ShardFile>> shard_files_;
+    // Cache only shards opened from descriptors published by the master.
+    // Entries are never erased while the backend is running, so callers can
+    // retain a ShardFile pointer after releasing the cache lock.
+    std::mutex shard_files_mutex_;
+    std::unordered_map<int, std::unique_ptr<ShardFile>> shard_files_;
     DistributedStorageMode storage_mode_ = DistributedStorageMode::kFileSystem;
     bool initialized_ = false;
 };

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -10,7 +10,14 @@
 #include <utility>
 #include <vector>
 
+#include <asio/executor_work_guard.hpp>
 #include <glog/logging.h>
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>
+#else
+#include <json/json.h>
+#endif
+#include <ylt/coro_io/coro_io.hpp>
 #include <ylt/reflection/user_reflect_macro.hpp>
 #include <ylt/struct_json/json_reader.h>
 #include <ylt/struct_json/json_writer.h>
@@ -171,6 +178,12 @@ std::string EscapePrometheusLabel(std::string_view input) {
     }
     return escaped;
 }
+
+struct HttpDfsShardCountResponse {
+    bool success{true};
+    int shard_count{0};
+};
+YLT_REFL(HttpDfsShardCountResponse, success, shard_count);
 
 struct HttpTenantQuotaSnapshot {
     std::string tenant_id;
@@ -804,6 +817,87 @@ struct HttpCreateDrainJobResponse {
 YLT_REFL(HttpCreateDrainJobResponse, success, job_id, status, error_code,
          error_message);
 
+void MasterAdminServer::HandleGetDfsShardCount(
+    coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
+    WithActiveService(resp, [&](auto service) {
+        auto result = service->GetDfsShardCount();
+        if (!result) {
+            WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                               result.error());
+            return;
+        }
+        WriteJsonResponse(resp, coro_http::status_type::ok,
+                          HttpDfsShardCountResponse{true, *result});
+    });
+}
+
+async_simple::coro::Lazy<void> MasterAdminServer::HandleExpandDfsShards(
+    coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
+    Json::CharReaderBuilder builder;
+    builder["rejectDupKeys"] = true;
+    builder["failIfExtra"] = true;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    Json::Value body;
+    std::string errors;
+    const auto text = req.get_body();
+    const bool parsed =
+        reader->parse(text.data(), text.data() + text.size(), &body, &errors);
+    if (!parsed || !body.isObject() || !body.isMember("shard_count") ||
+        (body["shard_count"].type() != Json::intValue &&
+         body["shard_count"].type() != Json::uintValue) ||
+        !body["shard_count"].isInt() || body["shard_count"].asInt() <= 0) {
+        WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                           ErrorCode::INVALID_PARAMS,
+                           "shard_count must be an integer in [1, INT_MAX]");
+        co_return;
+    }
+    const int shard_count = body["shard_count"].asInt();
+    auto service = GetActiveService();
+    if (!service) {
+        SetServiceUnavailable(resp, "Master service is not available");
+        co_return;
+    }
+    auto running = dfs_expansion_running_;
+    if (running->exchange(true)) {
+        WriteErrorResponse(resp, coro_http::status_type::conflict,
+                           ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS,
+                           "A DFS expansion is already in progress");
+        co_return;
+    }
+    struct ResetRunning {
+        std::shared_ptr<std::atomic<bool>> flag;
+        ~ResetRunning() { flag->store(false); }
+    } reset{running};
+    // Filesystem preparation can block, especially on a shared filesystem.
+    // Retain the HTTP executor until the worker finishes: server stop() drains
+    // that executor, but does not wait for the global blocking pool itself.
+    const auto io_executor =
+        req.get_conn()->get_executor()->get_asio_executor();
+    auto work = asio::make_work_guard(io_executor);
+    // Keep the owning callable and pending operation in the coroutine frame.
+    auto expand = [service, shard_count]() {
+        return service->ExpandDfsShards(shard_count);
+    };
+    auto pending = coro_io::post(expand);
+    auto completion = co_await std::move(pending);
+    // post() resumes on the worker. Response/socket handling must return to
+    // the connection's executor before releasing its outstanding work.
+    co_await coro_io::dispatch(io_executor);
+    if (completion.hasError()) {
+        WriteErrorResponse(resp, coro_http::status_type::internal_server_error,
+                           ErrorCode::INTERNAL_ERROR);
+        co_return;
+    }
+    auto result = std::move(completion).value();
+    if (!result) {
+        WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                           result.error());
+        co_return;
+    }
+    WriteJsonResponse(resp, coro_http::status_type::ok,
+                      HttpDfsShardCountResponse{true, *result});
+}
+
 void MasterAdminServer::HandleCreateDrainJob(
     coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
     CreateDrainJobRequest request;
@@ -1278,6 +1372,16 @@ void MasterAdminServer::RegisterHandler() {
         "/query_segment",
         [this](coro_http_request& req, coro_http_response& resp) {
             HandleQuerySegment(req, resp);
+        });
+    http_server_.set_http_handler<GET>(
+        "/api/v1/dfs/shard_count",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            HandleGetDfsShardCount(req, resp);
+        });
+    http_server_.set_http_handler<PUT>(
+        "/api/v1/dfs/shard_count",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            return HandleExpandDfsShards(req, resp);
         });
     http_server_.set_http_handler<POST>(
         "/api/v1/drain_jobs",

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -572,6 +572,20 @@ MasterService::MasterService(const MasterServiceConfig& config)
     }
 }
 
+tl::expected<int, ErrorCode> MasterService::GetDfsShardCount() const {
+    if (!dfs_allocator_ || !dfs_allocator_->IsInitialized()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    return dfs_allocator_->GetShardCount();
+}
+
+tl::expected<int, ErrorCode> MasterService::ExpandDfsShards(int shard_count) {
+    if (!dfs_allocator_ || !dfs_allocator_->IsInitialized()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    return dfs_allocator_->ExpandShards(shard_count);
+}
+
 void MasterService::InitDfsAllocatorFromEnvironment(
     const MasterServiceConfig& config) {
     enable_dfs_ = Environ::GetBool(
@@ -606,7 +620,7 @@ void MasterService::InitDfsAllocatorFromEnvironment(
     }
 
     LOG(INFO) << "DFS allocator initialized, config={" << dfs_config.FormatStr()
-              << "}";
+              << "}, ready_shard_count=" << dfs_allocator_->GetShardCount();
 }
 
 std::unique_ptr<ha::SnapshotCatalogStore>

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1697,6 +1697,15 @@ tl::expected<void, ErrorCode> WrappedMasterService::NotifyPromotionFailure(
     return result;
 }
 
+tl::expected<int, ErrorCode> WrappedMasterService::GetDfsShardCount() const {
+    return master_service_.GetDfsShardCount();
+}
+
+tl::expected<int, ErrorCode> WrappedMasterService::ExpandDfsShards(
+    int shard_count) {
+    return master_service_.ExpandDfsShards(shard_count);
+}
+
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateDrainJob(
     const CreateDrainJobRequest& request) {
     return master_service_.CreateDrainJob(request);

--- a/mooncake-store/src/storage/distributed/dfs_global_allocator.cpp
+++ b/mooncake-store/src/storage/distributed/dfs_global_allocator.cpp
@@ -1,10 +1,14 @@
 #include "storage/distributed/dfs_global_allocator.h"
 
 #include <algorithm>
+#include <charconv>
+#include <exception>
 #include <filesystem>
 #include <iomanip>
 #include <limits>
+#include <map>
 #include <sstream>
+#include <string_view>
 #include <utility>
 
 #include "config/distributed_storage_config.h"
@@ -34,17 +38,19 @@ DfsGlobalAllocator::~DfsGlobalAllocator() {
 
 tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
     const DistributedStorageConfig& config) {
+    std::lock_guard expansion_lock(expansion_mutex_);
     if (initialized_.load(std::memory_order_acquire)) return {};
-    if (!config.ValidateForAllocator()) {
+    if (!config.ValidateForAllocator() ||
+        config.shard_capacity >
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+        config.shard_capacity > std::numeric_limits<uint64_t>::max() /
+                                    static_cast<uint64_t>(config.shard_count)) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     mount_path_ = config.fsdir;
-    shard_count_ = config.shard_count;
+    shard_capacity_ = config.shard_capacity;
     alignment_ = config.alignment;
-    shards_.clear();
-    shards_.resize(shard_count_);
-
     eviction_enabled_ = config.eviction_enabled;
     eviction_high_watermark_ = config.eviction_high_watermark;
     eviction_low_watermark_ = config.eviction_low_watermark;
@@ -59,6 +65,7 @@ tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
 
+    if (fs_adapter_) fs_adapter_->Shutdown();
     if (config.fs_adapter_type == "posix") {
         fs_adapter_ = std::make_unique<PosixFsAdapter>();
     } else if (config.fs_adapter_type == "hf3fs") {
@@ -81,36 +88,169 @@ tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
         return tl::make_unexpected(adapter_init.error());
     }
 
-    for (int i = 0; i < shard_count_; ++i) {
-        std::string path = mount_path_ + "/dfs_shard_" +
-                           FormatShardIdx(i, shard_count_) + ".data";
-        auto prealloc =
-            fs_adapter_->PreallocateFile(path, config.shard_capacity);
-        if (!prealloc) {
-            LOG(ERROR) << "Failed to preallocate DFS shard " << path << ": "
-                       << prealloc.error();
-            return tl::make_unexpected(prealloc.error());
+    // Recover the capacity layout only. Allocation handles and key metadata
+    // remain empty; snapshot/oplog recovery is deliberately still unsupported.
+    // Keep the exact paths of older layouts whose padding depended on count.
+    auto files = fs_adapter_->ListFiles(mount_path_);
+    if (!files) return tl::make_unexpected(files.error());
+    std::map<int, std::string> existing_paths;
+    constexpr std::string_view prefix = "dfs_shard_";
+    constexpr std::string_view suffix = ".data";
+    for (const auto& name : *files) {
+        std::string_view view(name);
+        if (!view.starts_with(prefix) || !view.ends_with(suffix)) continue;
+        const auto digits = view.substr(
+            prefix.size(), view.size() - prefix.size() - suffix.size());
+        int index = -1;
+        const auto [end, error] = std::from_chars(
+            digits.data(), digits.data() + digits.size(), index);
+        if (digits.size() < 2 || digits.front() < '0' || digits.front() > '9' ||
+            error != std::errc{} || end != digits.data() + digits.size() ||
+            index < 0 || index == std::numeric_limits<int>::max() ||
+            !existing_paths.emplace(index, mount_path_ + "/" + name).second) {
+            LOG(ERROR) << "Invalid or ambiguous DFS shard filename " << name;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
-
-        auto shard = std::make_unique<ShardState>();
-        shard->capacity = config.shard_capacity;
-        uint32_t init_cap = static_cast<uint32_t>(std::max<uint64_t>(
-            1, std::min<uint64_t>(config.shard_capacity / 4096, 64ULL * 1024)));
-        uint32_t max_cap = static_cast<uint32_t>(std::max<uint64_t>(
-            init_cap, std::min<uint64_t>(config.shard_capacity / 1024,
-                                         64ULL * 1024 * 1024)));
-        shard->allocator = OffsetAllocator::create(0, config.shard_capacity,
-                                                   init_cap, max_cap);
-        if (!shard->allocator) {
-            LOG(ERROR) << "Failed to create offset allocator for DFS shard "
-                       << i;
-            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-        shards_[i] = std::move(shard);
     }
 
+    int discovered_count = 0;
+    for (const auto& [index, path] : existing_paths) {
+        if (index != discovered_count++) {
+            LOG(ERROR) << "DFS shard layout is not contiguous at " << path;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+    }
+    const int target_count = std::max(config.shard_count, discovered_count);
+    if (shard_capacity_ > std::numeric_limits<uint64_t>::max() /
+                              static_cast<uint64_t>(target_count)) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::vector<std::string> created_files;
+    try {
+        auto ready = std::make_shared<ShardList>();
+        for (int i = 0; i < target_count; ++i) {
+            const auto existing = existing_paths.find(i);
+            const std::string path = existing == existing_paths.end()
+                                         ? mount_path_ + "/dfs_shard_" +
+                                               FormatShardIdx(i, 0) + ".data"
+                                         : existing->second;
+            auto shard = CreateShard(path, created_files);
+            if (!shard) {
+                CleanupCreatedFiles(created_files);
+                return tl::make_unexpected(shard.error());
+            }
+            ready->push_back(std::move(*shard));
+        }
+        std::atomic_store_explicit(
+            &shards_, std::shared_ptr<const ShardList>(std::move(ready)),
+            std::memory_order_release);
+    } catch (const std::exception& error) {
+        CleanupCreatedFiles(created_files);
+        LOG(ERROR) << "Failed to initialize DFS shards: " << error.what();
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
     initialized_.store(true, std::memory_order_release);
     return {};
+}
+
+int DfsGlobalAllocator::GetShardCount() const {
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
+    return shards ? static_cast<int>(shards->size()) : 0;
+}
+
+tl::expected<int, ErrorCode> DfsGlobalAllocator::ExpandShards(
+    int target_count) {
+    std::lock_guard expansion_lock(expansion_mutex_);
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::DFS_SERVICE_UNAVAILABLE);
+    }
+    const auto current =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
+    if (target_count <= 0 || target_count < static_cast<int>(current->size()) ||
+        shard_capacity_ > std::numeric_limits<uint64_t>::max() /
+                              static_cast<uint64_t>(target_count)) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (target_count == static_cast<int>(current->size())) return target_count;
+
+    std::vector<std::string> created_files;
+    try {
+        auto ready = std::make_shared<ShardList>(*current);
+        for (int i = static_cast<int>(current->size()); i < target_count; ++i) {
+            const std::string path =
+                mount_path_ + "/dfs_shard_" + FormatShardIdx(i, 0) + ".data";
+            auto shard = CreateShard(path, created_files);
+            if (!shard) {
+                // Files from before this operation are never truncated or
+                // removed. Failed cleanup can leave a ready file for retry,
+                // but no staged shard is allocatable before publication.
+                CleanupCreatedFiles(created_files);
+                return tl::make_unexpected(shard.error());
+            }
+            ready->push_back(std::move(*shard));
+        }
+        std::atomic_store_explicit(
+            &shards_, std::shared_ptr<const ShardList>(std::move(ready)),
+            std::memory_order_release);
+    } catch (const std::exception& error) {
+        CleanupCreatedFiles(created_files);
+        LOG(ERROR) << "Failed to expand DFS shards: " << error.what();
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return target_count;
+}
+
+tl::expected<std::shared_ptr<DfsGlobalAllocator::ShardState>, ErrorCode>
+DfsGlobalAllocator::CreateShard(const std::string& path,
+                                std::vector<std::string>& created_files) {
+    auto exists = fs_adapter_->FileExists(path);
+    if (!exists) return tl::make_unexpected(exists.error());
+    if (*exists) {
+        std::error_code ec;
+        if (!std::filesystem::is_regular_file(path, ec)) {
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+        auto size = fs_adapter_->GetFileSize(path);
+        if (!size) return tl::make_unexpected(size.error());
+        if (*size != shard_capacity_) {
+            LOG(ERROR) << "DFS shard capacity mismatch for " << path
+                       << ": expected=" << shard_capacity_
+                       << ", actual=" << *size;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+    } else {
+        created_files.push_back(path);
+        auto prealloc = fs_adapter_->PreallocateFile(path, shard_capacity_);
+        if (!prealloc) return tl::make_unexpected(prealloc.error());
+    }
+
+    auto shard = std::make_shared<ShardState>();
+    shard->path = path;
+    shard->capacity = shard_capacity_;
+    uint32_t init_cap = static_cast<uint32_t>(std::max<uint64_t>(
+        1, std::min<uint64_t>(shard_capacity_ / 4096, 64ULL * 1024)));
+    uint32_t max_cap = static_cast<uint32_t>(std::max<uint64_t>(
+        init_cap,
+        std::min<uint64_t>(shard_capacity_ / 1024, 64ULL * 1024 * 1024)));
+    shard->allocator =
+        OffsetAllocator::create(0, shard_capacity_, init_cap, max_cap);
+    if (!shard->allocator) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return shard;
+}
+
+void DfsGlobalAllocator::CleanupCreatedFiles(
+    const std::vector<std::string>& created_files) {
+    for (const auto& path : created_files) {
+        auto result = fs_adapter_->DeleteFile(path);
+        if (!result && result.error() != ErrorCode::FILE_NOT_FOUND) {
+            LOG(WARNING) << "Failed to clean up unpublished DFS shard " << path
+                         << ": " << result.error();
+        }
+    }
 }
 
 tl::expected<DistributedFSDescriptor, ErrorCode> DfsGlobalAllocator::Allocate(
@@ -118,48 +258,56 @@ tl::expected<DistributedFSDescriptor, ErrorCode> DfsGlobalAllocator::Allocate(
     if (!initialized_.load(std::memory_order_acquire)) {
         return tl::make_unexpected(ErrorCode::DFS_SERVICE_UNAVAILABLE);
     }
-    if (key.empty() || size == 0) {
+    if (key.empty() || size == 0 ||
+        size > std::numeric_limits<uint64_t>::max() - (alignment_ - 1)) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    const uint64_t aligned_size = AlignSize(size);
+    if (aligned_size >
+        std::numeric_limits<uint64_t>::max() - (alignment_ - 1)) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    const uint64_t allocation_size = aligned_size + alignment_ - 1;
+    if (allocation_size > shard_capacity_) {
+        return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
     auto key_lock = LockKey(key);
-    int shard_idx = SelectShard(key);
-    uint64_t aligned_size = AlignSize(size);
-    auto& shard = *shards_[shard_idx];
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
+    const size_t preferred = std::hash<std::string>{}(key) % shards->size();
+    // A full preferred shard must not hide capacity in newly appended shards.
+    // Existing descriptors remain authoritative even when the modulo changes.
+    for (size_t attempt = 0; attempt < shards->size(); ++attempt) {
+        const size_t shard_idx = (preferred + attempt) % shards->size();
+        auto& shard = *(*shards)[shard_idx];
+        std::unique_lock handle_lock(shard.handle_mutex);
+        CleanupExpiredPendingFrees(shard, std::chrono::steady_clock::now());
+        const uint64_t reserved_bytes =
+            shard.allocator->normalizedAllocationSize(allocation_size);
+        auto handle = shard.allocator->allocate(allocation_size);
+        if (!handle) continue;
 
-    std::unique_lock handle_lock(shard.handle_mutex);
-    ProcessPendingFrees(shard_idx);
-
-    const uint64_t allocation_size = aligned_size + alignment_ - 1;
-    const uint64_t reserved_bytes =
-        shard.allocator->normalizedAllocationSize(allocation_size);
-    auto handle = shard.allocator->allocate(allocation_size);
-    if (!handle) return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-
-    uint64_t raw_offset = handle->address();
-    uint64_t alloc_offset = AlignSize(raw_offset);
-    auto alloc_handle =
-        std::make_shared<OffsetAllocationHandle>(std::move(*handle));
-    shard.offset_to_handle[alloc_offset] = {key, std::move(alloc_handle),
-                                            reserved_bytes};
-    handle_lock.unlock();
-
-    return DistributedFSDescriptor{
-        mount_path_ + "/dfs_shard_" + FormatShardIdx(shard_idx, shard_count_) +
-            ".data",
-        alloc_offset,
-        size,
-        aligned_size,
-        shard_idx,
-    };
+        const uint64_t alloc_offset = AlignSize(handle->address());
+        auto alloc_handle =
+            std::make_shared<OffsetAllocationHandle>(std::move(*handle));
+        shard.offset_to_handle[alloc_offset] = {key, std::move(alloc_handle),
+                                                reserved_bytes};
+        return DistributedFSDescriptor{shard.path, alloc_offset, size,
+                                       aligned_size,
+                                       static_cast<int>(shard_idx)};
+    }
+    return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
 }
 
 void DfsGlobalAllocator::Free(uint64_t offset, uint64_t /*aligned_size*/,
                               int shard_idx, const std::string& key) {
     if (!initialized_.load(std::memory_order_acquire)) return;
-    if (shard_idx < 0 || shard_idx >= shard_count_) return;
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
+    if (shard_idx < 0 || shard_idx >= static_cast<int>(shards->size())) return;
 
-    auto& shard = *shards_[shard_idx];
+    auto& shard = *(*shards)[shard_idx];
     std::lock_guard lru_lock(shard.lru_mutex);
     std::lock_guard handle_lock(shard.handle_mutex);
 
@@ -182,9 +330,11 @@ void DfsGlobalAllocator::Free(uint64_t offset, uint64_t /*aligned_size*/,
 void DfsGlobalAllocator::UpdateAccess(const std::string& key, int shard_idx,
                                       uint64_t offset) {
     if (!initialized_.load(std::memory_order_acquire)) return;
-    if (shard_idx < 0 || shard_idx >= shard_count_) return;
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
+    if (shard_idx < 0 || shard_idx >= static_cast<int>(shards->size())) return;
 
-    auto& shard = *shards_[shard_idx];
+    auto& shard = *(*shards)[shard_idx];
     std::lock_guard lru_lock(shard.lru_mutex);
     {
         std::shared_lock handle_lock(shard.handle_mutex);
@@ -210,24 +360,28 @@ DfsGlobalAllocator::PendingEviction DfsGlobalAllocator::PrepareEviction() {
     PendingEviction pending(this);
     if (!initialized_.load(std::memory_order_acquire)) return pending;
 
-    for (int i = 0; i < shard_count_; ++i) {
-        auto& shard = *shards_[i];
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
+    for (size_t i = 0; i < shards->size(); ++i) {
+        auto& shard = *(*shards)[i];
         {
             std::unique_lock handle_lock(shard.handle_mutex);
             CleanupExpiredPendingFrees(shard, std::chrono::steady_clock::now());
         }
-        PrepareEvictionFromShard(i, pending);
+        PrepareEvictionFromShard(shard, static_cast<int>(i), pending);
     }
     return pending;
 }
 
 void DfsGlobalAllocator::CommitPreparedEviction(PendingEviction&& pending) {
     if (pending.owner_ != this) return;
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
 
     const auto free_at =
         std::chrono::steady_clock::now() + deferred_free_duration_;
     for (const auto& prepared : pending.prepared_) {
-        auto& shard = *shards_[prepared.candidate.shard_idx];
+        auto& shard = *(*shards)[prepared.candidate.shard_idx];
         std::lock_guard handle_lock(shard.handle_mutex);
         auto it = shard.offset_to_handle.find(prepared.candidate.offset);
         if (it == shard.offset_to_handle.end() ||
@@ -248,13 +402,15 @@ void DfsGlobalAllocator::CommitPreparedEviction(PendingEviction&& pending) {
 
 void DfsGlobalAllocator::RestorePreparedEviction(PendingEviction&& pending) {
     if (pending.owner_ != this) return;
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
 
     // Candidates were removed oldest-first. Restore in reverse order so the
     // original relative LRU order is preserved.
     for (auto prepared_it = pending.prepared_.rbegin();
          prepared_it != pending.prepared_.rend(); ++prepared_it) {
         const auto& prepared = *prepared_it;
-        auto& shard = *shards_[prepared.candidate.shard_idx];
+        auto& shard = *(*shards)[prepared.candidate.shard_idx];
         std::lock_guard lru_lock(shard.lru_mutex);
         std::lock_guard handle_lock(shard.handle_mutex);
 
@@ -284,6 +440,8 @@ void DfsGlobalAllocator::RestorePreparedEviction(PendingEviction&& pending) {
 void DfsGlobalAllocator::ResolvePreparedEviction(
     PendingEviction&& pending, const std::vector<bool>& accepted) {
     if (pending.owner_ != this) return;
+    const auto shards =
+        std::atomic_load_explicit(&shards_, std::memory_order_acquire);
     if (accepted.size() != pending.prepared_.size()) {
         LOG(ERROR) << "DFS eviction decision count " << accepted.size()
                    << " does not match prepared candidate count "
@@ -298,7 +456,7 @@ void DfsGlobalAllocator::ResolvePreparedEviction(
         if (!accepted[i]) continue;
 
         const auto& prepared = pending.prepared_[i];
-        auto& shard = *shards_[prepared.candidate.shard_idx];
+        auto& shard = *(*shards)[prepared.candidate.shard_idx];
         std::lock_guard handle_lock(shard.handle_mutex);
         auto handle_it = shard.offset_to_handle.find(prepared.candidate.offset);
         if (handle_it == shard.offset_to_handle.end() ||
@@ -318,7 +476,7 @@ void DfsGlobalAllocator::ResolvePreparedEviction(
         if (accepted[i - 1]) continue;
 
         const auto& prepared = pending.prepared_[i - 1];
-        auto& shard = *shards_[prepared.candidate.shard_idx];
+        auto& shard = *(*shards)[prepared.candidate.shard_idx];
         std::lock_guard lru_lock(shard.lru_mutex);
         std::lock_guard handle_lock(shard.handle_mutex);
 
@@ -344,17 +502,13 @@ void DfsGlobalAllocator::ResolvePreparedEviction(
     pending.owner_ = nullptr;
 }
 
-std::string DfsGlobalAllocator::FormatShardIdx(int idx, int shard_count) {
-    int width = static_cast<int>(std::max<size_t>(
-        2, std::to_string(std::max(0, shard_count - 1)).size()));
+std::string DfsGlobalAllocator::FormatShardIdx(int idx, int /*shard_count*/) {
+    // Retain the second argument for source compatibility. New filenames are
+    // independent of total count; discovered legacy filenames stay unchanged.
+    constexpr int width = 2;
     std::ostringstream oss;
     oss << std::setw(width) << std::setfill('0') << idx;
     return oss.str();
-}
-
-void DfsGlobalAllocator::ProcessPendingFrees(int shard_idx) {
-    auto& shard = *shards_[shard_idx];
-    CleanupExpiredPendingFrees(shard, std::chrono::steady_clock::now());
 }
 
 void DfsGlobalAllocator::QueuePendingFree(
@@ -406,10 +560,9 @@ double DfsGlobalAllocator::EffectiveUsage(ShardState& shard) {
                      static_cast<double>(shard.capacity);
 }
 
-void DfsGlobalAllocator::PrepareEvictionFromShard(int shard_idx,
+void DfsGlobalAllocator::PrepareEvictionFromShard(ShardState& shard,
+                                                  int shard_idx,
                                                   PendingEviction& pending) {
-    auto& shard = *shards_[shard_idx];
-
     const double usage = EffectiveUsage(shard);
     uint64_t prepared_bytes = 0;
     std::lock_guard lru_lock(shard.lru_mutex);
@@ -460,10 +613,6 @@ void DfsGlobalAllocator::PrepareEvictionFromShard(int shard_idx,
                         static_cast<double>(shard.capacity);
         if (projected_usage < eviction_low_watermark_) break;
     }
-}
-
-int DfsGlobalAllocator::SelectShard(const std::string& key) const {
-    return std::hash<std::string>{}(key) % shard_count_;
 }
 
 uint64_t DfsGlobalAllocator::AlignSize(uint64_t size) const {

--- a/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
+++ b/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
@@ -79,7 +79,7 @@ DistributedStorageBackend::DistributedStorageBackend(
 }
 
 DistributedStorageBackend::~DistributedStorageBackend() {
-    for (auto& [index, shard] : shard_files_) {
+    for (auto& [_, shard] : shard_files_) {
         if (shard && shard->fd >= 0 && fs_adapter_) {
             fs_adapter_->CloseFile(shard->fd);
             shard->fd = -1;
@@ -136,18 +136,33 @@ DistributedStorageBackend::GetOrOpenShard(
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    std::lock_guard cache_lock(shard_files_mutex_);
-    auto existing = shard_files_.find(descriptor.shard_idx);
-    if (existing != shard_files_.end()) {
-        if (existing->second->path != path.string()) {
+    ShardFile* shard;
+    {
+        std::lock_guard cache_lock(shard_files_mutex_);
+        auto existing = shard_files_.find(descriptor.shard_idx);
+        if (existing == shard_files_.end()) {
+            existing = shard_files_
+                           .emplace(descriptor.shard_idx,
+                                    std::make_unique<ShardFile>())
+                           .first;
+        }
+        shard = existing->second.get();
+    }
+
+    // File validation and opening may block. Serialize them only with this
+    // shard's initialization and I/O, leaving other cached shards available.
+    std::lock_guard shard_lock(shard->mutex);
+    auto file_path = path.string();
+    if (shard->fd >= 0) {
+        if (shard->path != file_path) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
-        return existing->second.get();
+        return shard;
     }
 
     // The master prepares new shards before publishing their descriptors.
     // OpenFile may create a file, so reject missing/unprepared shards first.
-    auto file_size = fs_adapter_->GetFileSize(path.string());
+    auto file_size = fs_adapter_->GetFileSize(file_path);
     if (!file_size) return tl::make_unexpected(file_size.error());
     if (*file_size != distributed_config_.shard_capacity) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -161,14 +176,13 @@ DistributedStorageBackend::GetOrOpenShard(
         canonical_path.filename() != path.filename()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    auto fd = fs_adapter_->OpenFile(path.string());
+    auto fd = fs_adapter_->OpenFile(file_path);
     if (!fd) return tl::make_unexpected(fd.error());
-    auto shard = std::make_unique<ShardFile>();
-    shard->path = path.string();
+    // Failed attempts keep fd == -1 so a later request can retry
+    // initialization.
+    shard->path = std::move(file_path);
     shard->fd = *fd;
-    auto* result = shard.get();
-    shard_files_.emplace(descriptor.shard_idx, std::move(shard));
-    return result;
+    return shard;
 }
 
 tl::expected<int64_t, ErrorCode> DistributedStorageBackend::BatchOffload(

--- a/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
+++ b/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
@@ -3,13 +3,35 @@
 #include <algorithm>
 #include <filesystem>
 #include <limits>
+#include <optional>
+#include <string_view>
 
-#include "storage/distributed/dfs_global_allocator.h"
 #include "types.h"
 
 namespace mooncake {
 
 namespace {
+
+std::optional<int> ParseShardFileName(std::string_view name) {
+    constexpr std::string_view prefix = "dfs_shard_";
+    constexpr std::string_view suffix = ".data";
+    if (!name.starts_with(prefix) || !name.ends_with(suffix)) {
+        return std::nullopt;
+    }
+    name.remove_prefix(prefix.size());
+    name.remove_suffix(suffix.size());
+    if (name.size() < 2) return std::nullopt;
+
+    int index = 0;
+    for (char digit : name) {
+        if (digit < '0' || digit > '9' ||
+            index > (std::numeric_limits<int>::max() - (digit - '0')) / 10) {
+            return std::nullopt;
+        }
+        index = index * 10 + (digit - '0');
+    }
+    return index;
+}
 
 bool IsDfsDescriptorRangeValid(const DistributedFSDescriptor& desc,
                                const DistributedStorageConfig& config) {
@@ -57,7 +79,7 @@ DistributedStorageBackend::DistributedStorageBackend(
 }
 
 DistributedStorageBackend::~DistributedStorageBackend() {
-    for (auto& shard : shard_files_) {
+    for (auto& [index, shard] : shard_files_) {
         if (shard && shard->fd >= 0 && fs_adapter_) {
             fs_adapter_->CloseFile(shard->fd);
             shard->fd = -1;
@@ -92,26 +114,61 @@ tl::expected<void, ErrorCode> DistributedStorageBackend::Init() {
     auto init_result = fs_adapter_->Init(root_dir_);
     if (!init_result) return init_result;
 
-    shard_files_.reserve(distributed_config_.shard_count);
-    for (int i = 0; i < distributed_config_.shard_count; ++i) {
-        std::string path = root_dir_ + "/dfs_shard_" +
-                           DfsGlobalAllocator::FormatShardIdx(
-                               i, distributed_config_.shard_count) +
-                           ".data";
-        auto fd_result = fs_adapter_->OpenFile(path);
-        if (!fd_result) {
-            LOG(ERROR) << "Failed to open DFS shard " << path << ": "
-                       << fd_result.error();
-            return tl::make_unexpected(fd_result.error());
-        }
-        auto shard = std::make_unique<ShardFile>();
-        shard->path = std::move(path);
-        shard->fd = *fd_result;
-        shard_files_.push_back(std::move(shard));
-    }
-
+    // Only descriptors returned by the master identify published shards.
+    // Opening files from the configured count or a directory scan can retain
+    // handles to staged shards that a failed expansion subsequently unlinks.
     initialized_ = true;
     return {};
+}
+
+tl::expected<DistributedStorageBackend::ShardFile*, ErrorCode>
+DistributedStorageBackend::GetOrOpenShard(
+    const DistributedFSDescriptor& descriptor) {
+    const auto path =
+        std::filesystem::path(descriptor.file_path).lexically_normal();
+    auto root = std::filesystem::path(root_dir_).lexically_normal();
+    if (root.filename().empty()) root = root.parent_path();
+    auto parent = path.parent_path();
+    if (parent.empty()) parent = ".";
+    const auto index = ParseShardFileName(path.filename().string());
+    if (descriptor.shard_idx < 0 || !index || *index != descriptor.shard_idx ||
+        parent != root) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard cache_lock(shard_files_mutex_);
+    auto existing = shard_files_.find(descriptor.shard_idx);
+    if (existing != shard_files_.end()) {
+        if (existing->second->path != path.string()) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        return existing->second.get();
+    }
+
+    // The master prepares new shards before publishing their descriptors.
+    // OpenFile may create a file, so reject missing/unprepared shards first.
+    auto file_size = fs_adapter_->GetFileSize(path.string());
+    if (!file_size) return tl::make_unexpected(file_size.error());
+    if (*file_size != distributed_config_.shard_capacity) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    std::error_code ec;
+    const auto canonical_root = std::filesystem::canonical(root, ec);
+    if (ec) return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    const auto canonical_path = std::filesystem::canonical(path, ec);
+    if (ec) return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    if (canonical_path.parent_path() != canonical_root ||
+        canonical_path.filename() != path.filename()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    auto fd = fs_adapter_->OpenFile(path.string());
+    if (!fd) return tl::make_unexpected(fd.error());
+    auto shard = std::make_unique<ShardFile>();
+    shard->path = path.string();
+    shard->fd = *fd;
+    auto* result = shard.get();
+    shard_files_.emplace(descriptor.shard_idx, std::move(shard));
+    return result;
 }
 
 tl::expected<int64_t, ErrorCode> DistributedStorageBackend::BatchOffload(
@@ -203,24 +260,6 @@ DistributedStorageBackend::BatchWrite(
 
     for (const auto& request : requests) {
         const auto& desc = request.descriptor;
-        if (desc.shard_idx < 0 ||
-            desc.shard_idx >= static_cast<int>(shard_files_.size())) {
-            LOG(ERROR) << "Invalid DFS shard_idx " << desc.shard_idx
-                       << " for key " << request.key;
-            results.emplace_back(
-                tl::make_unexpected(ErrorCode::INVALID_PARAMS));
-            continue;
-        }
-
-        auto& shard = *shard_files_[desc.shard_idx];
-        if (desc.file_path != shard.path) {
-            LOG(ERROR) << "DFS path mismatch for key " << request.key
-                       << ", descriptor=" << desc.file_path
-                       << ", configured=" << shard.path;
-            results.emplace_back(
-                tl::make_unexpected(ErrorCode::INVALID_PARAMS));
-            continue;
-        }
         if (!IsDfsDescriptorRangeValid(desc, distributed_config_)) {
             LOG(ERROR) << "Invalid DFS descriptor range for key " << request.key
                        << ", offset=" << desc.offset
@@ -256,6 +295,14 @@ DistributedStorageBackend::BatchWrite(
             continue;
         }
 
+        auto shard_result = GetOrOpenShard(desc);
+        if (!shard_result) {
+            LOG(ERROR) << "Failed to open DFS shard for key " << request.key
+                       << ": " << shard_result.error();
+            results.emplace_back(tl::make_unexpected(shard_result.error()));
+            continue;
+        }
+        auto& shard = **shard_result;
         std::lock_guard lock(shard.mutex);
         auto write_result =
             fs_adapter_->WriteAt(shard.fd, iovs.data(), iovs.size(),
@@ -298,24 +345,6 @@ std::vector<tl::expected<void, ErrorCode>> DistributedStorageBackend::BatchRead(
 
     for (const auto& request : requests) {
         const auto& desc = request.descriptor;
-        if (desc.shard_idx < 0 ||
-            desc.shard_idx >= static_cast<int>(shard_files_.size())) {
-            LOG(ERROR) << "Invalid DFS shard_idx " << desc.shard_idx
-                       << " for key " << request.key;
-            results.emplace_back(
-                tl::make_unexpected(ErrorCode::INVALID_PARAMS));
-            continue;
-        }
-
-        auto& shard = *shard_files_[desc.shard_idx];
-        if (desc.file_path != shard.path) {
-            LOG(ERROR) << "DFS path mismatch for key " << request.key
-                       << ", descriptor=" << desc.file_path
-                       << ", configured=" << shard.path;
-            results.emplace_back(
-                tl::make_unexpected(ErrorCode::INVALID_PARAMS));
-            continue;
-        }
         if (!IsDfsDescriptorRangeValid(desc, distributed_config_)) {
             LOG(ERROR) << "Invalid DFS descriptor range for key " << request.key
                        << ", offset=" << desc.offset
@@ -359,6 +388,14 @@ std::vector<tl::expected<void, ErrorCode>> DistributedStorageBackend::BatchRead(
             continue;
         }
 
+        auto shard_result = GetOrOpenShard(desc);
+        if (!shard_result) {
+            LOG(ERROR) << "Failed to open DFS shard for key " << request.key
+                       << ": " << shard_result.error();
+            results.emplace_back(tl::make_unexpected(shard_result.error()));
+            continue;
+        }
+        auto& shard = **shard_result;
         std::lock_guard lock(shard.mutex);
         auto read_result = fs_adapter_->ReadAt(
             shard.fd, iovs.data(), static_cast<int>(iovs.size()),

--- a/mooncake-store/tests/dfs_posix_test.cpp
+++ b/mooncake-store/tests/dfs_posix_test.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -604,6 +605,293 @@ TEST(DfsGlobalAllocatorTest, ConcurrentAllocate) {
     EXPECT_EQ(fail_count.load(), 0);
 }
 
+TEST(DfsGlobalAllocatorTest, ExpansionValidatesCountAndUsesEmptyShards) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_capacity");
+    DfsGlobalAllocator alloc;
+    ASSERT_TRUE(alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096)));
+    auto old = alloc.Allocate("old", 100);
+    ASSERT_TRUE(old);
+    ASSERT_FALSE(alloc.Allocate("full", 100));
+
+    for (int count : {-1, 0}) {
+        auto result = alloc.ExpandShards(count);
+        ASSERT_FALSE(result);
+        EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+    }
+    auto unchanged = alloc.ExpandShards(1);
+    ASSERT_TRUE(unchanged);
+    EXPECT_EQ(*unchanged, 1);
+    auto expanded = alloc.ExpandShards(2);
+    ASSERT_TRUE(expanded);
+    EXPECT_EQ(*expanded, 2);
+    EXPECT_EQ(alloc.GetShardCount(), 2);
+    ASSERT_TRUE(alloc.ExpandShards(2));
+    auto shrink = alloc.ExpandShards(1);
+    ASSERT_FALSE(shrink);
+    EXPECT_EQ(shrink.error(), ErrorCode::INVALID_PARAMS);
+
+    // This key still prefers the full original shard. Expansion must provide
+    // usable capacity even when hashing does not select the new shard.
+    std::string key;
+    for (int i = 0; i < 1000; ++i) {
+        key = "fallback_" + std::to_string(i);
+        if (std::hash<std::string>{}(key) % 2 == 0) break;
+    }
+    ASSERT_EQ(std::hash<std::string>{}(key) % 2, 0);
+    auto added = alloc.Allocate(key, 100);
+    ASSERT_TRUE(added);
+    EXPECT_EQ(added->shard_idx, 1);
+    alloc.Free(old->offset, old->aligned_size, old->shard_idx, "old");
+    alloc.Free(added->offset, added->aligned_size, added->shard_idx, key);
+}
+
+TEST(DfsGlobalAllocatorTest, ExpansionPreservesLegacyPathsAndRestartsLayout) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_legacy");
+    // Seed the legacy padded layout rather than relying on how new roots are
+    // named after this change. Crossing 100 must never rename these files.
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp.path()));
+    for (int i = 0; i < 100; ++i) {
+        const auto path =
+            tmp.file("dfs_shard_" + DfsGlobalAllocator::FormatShardIdx(i, 100) +
+                     ".data");
+        ASSERT_TRUE(adapter.PreallocateFile(path, 8192));
+    }
+    std::string old_path;
+    {
+        DfsGlobalAllocator alloc;
+        ASSERT_TRUE(
+            alloc.Init(MakeAllocatorConfig(tmp.path(), 100, 8192, 4096)));
+        auto old = alloc.Allocate("preserved", 100);
+        ASSERT_TRUE(old);
+        old_path = old->file_path;
+        const int fd = ::open(old_path.c_str(), O_WRONLY);
+        ASSERT_GE(fd, 0);
+        const char marker = 'P';
+        EXPECT_EQ(::pwrite(fd, &marker, 1, old->offset), 1);
+        EXPECT_EQ(::close(fd), 0);
+        ASSERT_TRUE(alloc.ExpandShards(101));
+        EXPECT_EQ(alloc.GetShardCount(), 101);
+        EXPECT_TRUE(std::filesystem::exists(old_path));
+        char readback = 0;
+        const int read_fd = ::open(old_path.c_str(), O_RDONLY);
+        ASSERT_GE(read_fd, 0);
+        EXPECT_EQ(::pread(read_fd, &readback, 1, old->offset), 1);
+        EXPECT_EQ(::close(read_fd), 0);
+        EXPECT_EQ(readback, marker);
+    }
+    // Only the shard layout is recovered. This deliberately makes no claim
+    // about recovering the previous object's allocation or Master metadata.
+    DfsGlobalAllocator restarted;
+    ASSERT_TRUE(restarted.Init(MakeAllocatorConfig(tmp.path(), 2, 8192, 4096)));
+    EXPECT_EQ(restarted.GetShardCount(), 101);
+    EXPECT_TRUE(std::filesystem::exists(old_path));
+}
+
+TEST(DfsGlobalAllocatorTest, ExpansionRetainsPaddedLegacyShardDescriptors) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_padded");
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp.path()));
+    ASSERT_TRUE(adapter.PreallocateFile(tmp.file("dfs_shard_000.data"), 8192));
+    ASSERT_TRUE(adapter.PreallocateFile(tmp.file("dfs_shard_001.data"), 8192));
+    DfsGlobalAllocator alloc;
+    ASSERT_TRUE(alloc.Init(MakeAllocatorConfig(tmp.path(), 2, 8192, 4096)));
+    auto old = alloc.Allocate("old", 100);
+    ASSERT_TRUE(old);
+    EXPECT_EQ(old->file_path,
+              tmp.file(old->shard_idx == 0 ? "dfs_shard_000.data"
+                                           : "dfs_shard_001.data"));
+    ASSERT_TRUE(alloc.ExpandShards(3));
+    EXPECT_TRUE(std::filesystem::exists(old->file_path));
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_00.data")));
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_01.data")));
+}
+
+TEST(DfsGlobalAllocatorTest, InitRejectsMalformedShardNames) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    for (const std::string& name :
+         {"dfs_shard_0.data", "dfs_shard_.data", "dfs_shard_+0.data",
+          "dfs_shard_-1.data", "dfs_shard_00x.data",
+          "dfs_shard_2147483647.data", "dfs_shard_2147483648.data"}) {
+        SCOPED_TRACE(name);
+        TempDir tmp("dfs_invalid_shard_name");
+        PosixFsAdapter adapter;
+        ASSERT_TRUE(adapter.Init(tmp.path()));
+        ASSERT_TRUE(adapter.PreallocateFile(tmp.file(name), 8192));
+        DfsGlobalAllocator alloc;
+        auto result =
+            alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096));
+        ASSERT_FALSE(result);
+        EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+        EXPECT_FALSE(alloc.IsInitialized());
+        EXPECT_EQ(alloc.GetShardCount(), 0);
+        EXPECT_EQ(std::filesystem::file_size(tmp.file(name)), 8192);
+        EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_00.data")));
+    }
+}
+
+TEST(DfsGlobalAllocatorTest, InitRejectsAmbiguousOrNoncontiguousLayout) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    for (const std::string& second_name :
+         {"dfs_shard_000.data", "dfs_shard_02.data"}) {
+        SCOPED_TRACE(second_name);
+        TempDir tmp("dfs_invalid_shard_layout");
+        PosixFsAdapter adapter;
+        ASSERT_TRUE(adapter.Init(tmp.path()));
+        ASSERT_TRUE(
+            adapter.PreallocateFile(tmp.file("dfs_shard_00.data"), 8192));
+        ASSERT_TRUE(adapter.PreallocateFile(tmp.file(second_name), 8192));
+        DfsGlobalAllocator alloc;
+        auto result =
+            alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096));
+        ASSERT_FALSE(result);
+        EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+        EXPECT_EQ(alloc.GetShardCount(), 0);
+        EXPECT_EQ(std::filesystem::file_size(tmp.file("dfs_shard_00.data")),
+                  8192);
+        EXPECT_EQ(std::filesystem::file_size(tmp.file(second_name)), 8192);
+        EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_01.data")));
+    }
+}
+
+TEST(DfsGlobalAllocatorTest, InitRejectsExistingCapacityWithoutTruncation) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_invalid_shard_capacity");
+    const auto path = tmp.file("dfs_shard_00.data");
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp.path()));
+    ASSERT_TRUE(adapter.PreallocateFile(path, 4096));
+    DfsGlobalAllocator alloc;
+    auto result = alloc.Init(MakeAllocatorConfig(tmp.path(), 2, 8192, 4096));
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+    EXPECT_FALSE(alloc.IsInitialized());
+    EXPECT_EQ(alloc.GetShardCount(), 0);
+    EXPECT_EQ(std::filesystem::file_size(path), 4096);
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_01.data")));
+}
+
+TEST(DfsGlobalAllocatorTest, FailedExpansionPreservesExistingUnpublishedShard) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_existing_failure");
+    DfsGlobalAllocator alloc;
+    ASSERT_TRUE(alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096)));
+    // A previous interrupted expansion may have left a complete shard. Failed
+    // retries must only clean files created by the current operation.
+    const auto existing = tmp.file("dfs_shard_01.data");
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp.path()));
+    ASSERT_TRUE(adapter.PreallocateFile(existing, 8192));
+    const auto blocked = tmp.file("dfs_shard_03.data");
+    ASSERT_TRUE(std::filesystem::create_directory(blocked));
+    auto result = alloc.ExpandShards(4);
+    ASSERT_FALSE(result);
+    EXPECT_EQ(alloc.GetShardCount(), 1);
+    EXPECT_EQ(std::filesystem::file_size(existing), 8192);
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_02.data")));
+    ASSERT_TRUE(std::filesystem::remove(blocked));
+    ASSERT_TRUE(alloc.ExpandShards(4));
+    EXPECT_EQ(alloc.GetShardCount(), 4);
+}
+
+TEST(DfsGlobalAllocatorTest, FailedExpansionDoesNotPublishPartialCapacity) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_failure");
+    DfsGlobalAllocator alloc;
+    ASSERT_TRUE(alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096)));
+    // The second new shard cannot be prepared. The first must not become
+    // visible to allocators when the whole expansion request fails.
+    const auto blocked = tmp.file("dfs_shard_02.data");
+    ASSERT_TRUE(std::filesystem::create_directory(blocked));
+    auto result = alloc.ExpandShards(3);
+    ASSERT_FALSE(result);
+    EXPECT_EQ(alloc.GetShardCount(), 1);
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_01.data")));
+    auto old = alloc.Allocate("still_usable", 100);
+    ASSERT_TRUE(old);
+    EXPECT_EQ(old->shard_idx, 0);
+    EXPECT_FALSE(alloc.Allocate("not_published", 100));
+    ASSERT_TRUE(std::filesystem::remove(blocked));
+    ASSERT_TRUE(alloc.ExpandShards(3));
+    EXPECT_EQ(alloc.GetShardCount(), 3);
+}
+
+TEST(DfsGlobalAllocatorTest, PreparedEvictionRemainsValidAcrossExpansion) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_eviction");
+    DfsGlobalAllocator alloc;
+    ASSERT_TRUE(alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096)));
+    auto old = alloc.Allocate("old", 100);
+    ASSERT_TRUE(old);
+    alloc.UpdateAccess("old", old->shard_idx, old->offset);
+    auto pending = alloc.PrepareEviction();
+    ASSERT_EQ(pending.Candidates().size(), 1);
+    ASSERT_TRUE(alloc.ExpandShards(2));
+    alloc.CommitPreparedEviction(std::move(pending));
+    auto after = alloc.Allocate("after", 100);
+    ASSERT_TRUE(after);
+    alloc.Free(after->offset, after->aligned_size, after->shard_idx, "after");
+    EXPECT_TRUE(alloc.PrepareEviction().Empty());
+}
+
+TEST(DfsGlobalAllocatorTest, ConcurrentExpansionAllocationAndEvictionRestore) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_expand_concurrent");
+    DfsGlobalAllocator alloc;
+    ASSERT_TRUE(alloc.Init(MakeAllocatorConfig(tmp.path(), 1, 1 << 20, 4096)));
+    std::atomic<bool> start{false};
+    std::atomic<int> failures{0};
+    std::vector<std::thread> workers;
+    for (int worker = 0; worker < 4; ++worker) {
+        workers.emplace_back([&, worker] {
+            while (!start.load()) std::this_thread::yield();
+            for (int i = 0; i < 200; ++i) {
+                const auto key = "worker_" + std::to_string(worker) + "_" +
+                                 std::to_string(i);
+                auto desc = alloc.Allocate(key, 100);
+                if (!desc) {
+                    ++failures;
+                    continue;
+                }
+                alloc.UpdateAccess(key, desc->shard_idx, desc->offset);
+                alloc.Free(desc->offset, desc->aligned_size, desc->shard_idx,
+                           key);
+            }
+        });
+    }
+    workers.emplace_back([&] {
+        while (!start.load()) std::this_thread::yield();
+        for (int i = 0; i < 200; ++i) {
+            auto pending = alloc.PrepareEviction();
+            alloc.RestorePreparedEviction(std::move(pending));
+        }
+    });
+    workers.emplace_back([&] {
+        while (!start.load()) std::this_thread::yield();
+        for (int count = 2; count <= 8; ++count) {
+            if (!alloc.ExpandShards(count)) ++failures;
+        }
+    });
+    start.store(true);
+    for (auto& worker : workers) worker.join();
+    EXPECT_EQ(failures.load(), 0);
+    EXPECT_EQ(alloc.GetShardCount(), 8);
+    EXPECT_TRUE(alloc.PrepareEviction().Empty());
+}
+
 TEST(ReplicaDfsTest, HelpersAndDescriptor) {
     DistributedFSDescriptor desc{"/mnt/3fs/shard0.data", 4096, 100, 4096, 0};
     Replica replica(desc, ReplicaStatus::PROCESSING);
@@ -655,6 +943,15 @@ class DfsBackendTest : public ::testing::Test {
         distributed_config.shard_count = 4;
         distributed_config.shard_capacity = 64 * 1024 * 1024;
         distributed_config.alignment = 4096;
+
+        // The master prepares shard files; client initialization only sets up
+        // the adapter and must not create or open files before descriptors.
+        PosixFsAdapter adapter;
+        ASSERT_TRUE(adapter.Init(tmp_->path()));
+        for (int i = 0; i < distributed_config.shard_count; ++i) {
+            ASSERT_TRUE(adapter.PreallocateFile(
+                ShardPath(i), distributed_config.shard_capacity));
+        }
 
         backend_ = std::make_unique<DistributedStorageBackend>(
             file_config, distributed_config,
@@ -727,6 +1024,225 @@ class ControlledPosixFsAdapter : public PosixFsAdapter {
     int fail_read_call_ = -1;
     int short_read_call_ = -1;
 };
+
+TEST(DfsBackendInitializationTest, ClientBeforeMasterDoesNotCreateShards) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_client_before_master");
+    const auto client_config = MakeAllocatorConfig(tmp.path(), 4, 8192, 4096);
+    FileStorageConfig file_config;
+    file_config.storage_backend_type = StorageBackendType::kDistributed;
+    file_config.storage_filepath = tmp.path();
+    DistributedStorageBackend client(file_config, client_config,
+                                     std::make_unique<PosixFsAdapter>());
+    ASSERT_TRUE(client.Init());
+    EXPECT_TRUE(std::filesystem::is_empty(tmp.path()));
+
+    DfsGlobalAllocator allocator;
+    ASSERT_TRUE(allocator.Init(MakeAllocatorConfig(tmp.path(), 1, 8192, 4096)));
+    EXPECT_EQ(allocator.GetShardCount(), 1);
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_01.data")));
+    ASSERT_TRUE(allocator.ExpandShards(4));
+    auto descriptor = allocator.Allocate("after_master_start", 100);
+    ASSERT_TRUE(descriptor);
+    std::string value(100, 'S'), output(100, '\0');
+    auto writes = client.BatchWrite(
+        {{"after_master_start", *descriptor, {{value.data(), value.size()}}}});
+    ASSERT_EQ(writes.size(), 1);
+    ASSERT_TRUE(writes[0]);
+    auto reads = client.BatchRead({{"after_master_start",
+                                    *descriptor,
+                                    {{output.data(), output.size()}}}});
+    ASSERT_EQ(reads.size(), 1);
+    ASSERT_TRUE(reads[0]);
+    EXPECT_EQ(output, value);
+}
+
+TEST(DfsBackendInitializationTest, DoesNotCacheRolledBackPreparedShard) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_prepared_shard_rollback");
+    auto config = MakeAllocatorConfig(tmp.path(), 1, 8192, 4096);
+    DfsGlobalAllocator allocator;
+    ASSERT_TRUE(allocator.Init(config));
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp.path()));
+    const auto path = tmp.file("dfs_shard_01.data");
+    // Reproduce the preparation window before an expansion publishes shard 1.
+    ASSERT_TRUE(adapter.PreallocateFile(path, config.shard_capacity));
+    const int prepared_fd = ::open(path.c_str(), O_RDONLY);
+    ASSERT_GE(prepared_fd, 0);
+    struct stat prepared_stat{};
+    ASSERT_EQ(::fstat(prepared_fd, &prepared_stat), 0);
+
+    FileStorageConfig file_config;
+    file_config.storage_backend_type = StorageBackendType::kDistributed;
+    file_config.storage_filepath = tmp.path();
+    auto client_config = config;
+    client_config.shard_count = 2;
+    DistributedStorageBackend writer(file_config, client_config,
+                                     std::make_unique<PosixFsAdapter>());
+    ASSERT_TRUE(writer.Init());
+    // A failed expansion removes the unpublished file. Keep its old inode
+    // alive until retry creates a different file with the same pathname.
+    ASSERT_TRUE(std::filesystem::remove(path));
+    ASSERT_TRUE(allocator.ExpandShards(2));
+    struct stat published_stat{};
+    ASSERT_EQ(::stat(path.c_str(), &published_stat), 0);
+    EXPECT_NE(prepared_stat.st_ino, published_stat.st_ino);
+    ASSERT_EQ(::close(prepared_fd), 0);
+
+    std::string key;
+    for (int i = 0; i < 1000; ++i) {
+        key = "retry_shard_" + std::to_string(i);
+        if (std::hash<std::string>{}(key) % 2 == 1) break;
+    }
+    ASSERT_EQ(std::hash<std::string>{}(key) % 2, 1);
+    auto descriptor = allocator.Allocate(key, 100);
+    ASSERT_TRUE(descriptor);
+    ASSERT_EQ(descriptor->shard_idx, 1);
+    std::string value(100, 'R'), output(100, '\0');
+    auto writes =
+        writer.BatchWrite({{key, *descriptor, {{value.data(), value.size()}}}});
+    ASSERT_EQ(writes.size(), 1);
+    ASSERT_TRUE(writes[0]);
+    DistributedStorageBackend reader(file_config, config,
+                                     std::make_unique<PosixFsAdapter>());
+    ASSERT_TRUE(reader.Init());
+    auto reads = reader.BatchRead(
+        {{key, *descriptor, {{output.data(), output.size()}}}});
+    ASSERT_EQ(reads.size(), 1);
+    ASSERT_TRUE(reads[0]);
+    EXPECT_EQ(output, value);
+}
+
+TEST(DfsBackendInitializationTest, OpensLegacyPaddedDescriptorWithoutAliases) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir tmp("dfs_backend_legacy_padding");
+    const auto config = MakeAllocatorConfig(tmp.path(), 2, 8192, 4096);
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp.path()));
+    const auto path = tmp.file("dfs_shard_000.data");
+    ASSERT_TRUE(adapter.PreallocateFile(path, config.shard_capacity));
+    FileStorageConfig file_config;
+    file_config.storage_backend_type = StorageBackendType::kDistributed;
+    file_config.storage_filepath = tmp.path();
+    DistributedStorageBackend client(file_config, config,
+                                     std::make_unique<PosixFsAdapter>());
+    ASSERT_TRUE(client.Init());
+    const DistributedFSDescriptor descriptor{path, 0, 100, 4096, 0};
+    std::string value(100, 'L'), output(100, '\0');
+    auto writes = client.BatchWrite(
+        {{"legacy", descriptor, {{value.data(), value.size()}}}});
+    ASSERT_EQ(writes.size(), 1);
+    ASSERT_TRUE(writes[0]);
+    auto reads = client.BatchRead(
+        {{"legacy", descriptor, {{output.data(), output.size()}}}});
+    ASSERT_EQ(reads.size(), 1);
+    ASSERT_TRUE(reads[0]);
+    EXPECT_EQ(output, value);
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_00.data")));
+    EXPECT_FALSE(std::filesystem::exists(tmp.file("dfs_shard_01.data")));
+}
+
+// Four shard files exist before initialization. A descriptor published after
+// capacity expansion must work without restarting that existing client.
+TEST_F(DfsBackendTest, OpensNewShardDescriptorAfterClientInitialization) {
+    const std::string new_path = ShardPath(4);
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp_->path()));
+    ASSERT_TRUE(adapter.PreallocateFile(new_path, 64 * 1024 * 1024));
+
+    AlignedBuffer expected(4096), actual(4096);
+    ASSERT_NE(expected.data(), nullptr);
+    ASSERT_NE(actual.data(), nullptr);
+    expected.Fill('N');
+    actual.Fill('X');
+    const DistributedFSDescriptor descriptor{new_path, 0, 4096, 4096, 4};
+
+    auto writes = backend_->BatchWrite(
+        {{"new_shard", descriptor, {{expected.data(), expected.size()}}}});
+    ASSERT_EQ(writes.size(), 1);
+    ASSERT_TRUE(writes[0].has_value());
+    auto reads = backend_->BatchRead(
+        {{"new_shard", descriptor, {{actual.data(), actual.size()}}}});
+    ASSERT_EQ(reads.size(), 1);
+    ASSERT_TRUE(reads[0].has_value());
+    EXPECT_EQ(std::memcmp(expected.data(), actual.data(), expected.size()), 0);
+}
+
+TEST_F(DfsBackendTest, LazyOpenRejectsMissingAndMalformedShardFiles) {
+    AlignedBuffer value(4096);
+    ASSERT_NE(value.data(), nullptr);
+    value.Fill('V');
+    const auto missing = ShardPath(4);
+    auto write = backend_->BatchWrite({{"missing",
+                                        {missing, 0, 4096, 4096, 4},
+                                        {{value.data(), value.size()}}}});
+    ASSERT_EQ(write.size(), 1);
+    EXPECT_FALSE(write[0]);
+    EXPECT_FALSE(std::filesystem::exists(missing));
+
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp_->path()));
+    ASSERT_TRUE(adapter.PreallocateFile(missing, 8192));
+    write = backend_->BatchWrite({{"wrong_capacity",
+                                   {missing, 0, 4096, 4096, 4},
+                                   {{value.data(), value.size()}}}});
+    ASSERT_EQ(write.size(), 1);
+    ASSERT_FALSE(write[0]);
+    EXPECT_EQ(write[0].error(), ErrorCode::INVALID_PARAMS);
+
+    const auto mismatched = ShardPath(5);
+    ASSERT_TRUE(adapter.PreallocateFile(mismatched, 64 * 1024 * 1024));
+    write = backend_->BatchWrite({{"wrong_index",
+                                   {mismatched, 0, 4096, 4096, 4},
+                                   {{value.data(), value.size()}}}});
+    ASSERT_EQ(write.size(), 1);
+    ASSERT_FALSE(write[0]);
+    EXPECT_EQ(write[0].error(), ErrorCode::INVALID_PARAMS);
+}
+
+TEST_F(DfsBackendTest, ConcurrentLazyOpenPreservesIndependentWrites) {
+    PosixFsAdapter adapter;
+    ASSERT_TRUE(adapter.Init(tmp_->path()));
+    const auto path = ShardPath(4);
+    ASSERT_TRUE(adapter.PreallocateFile(path, 64 * 1024 * 1024));
+    std::atomic<bool> start{false};
+    std::atomic<int> failures{0};
+    std::vector<std::thread> workers;
+    for (int i = 0; i < 8; ++i) {
+        workers.emplace_back([&, i] {
+            AlignedBuffer input(4096), output(4096);
+            if (!input.data() || !output.data()) {
+                ++failures;
+                return;
+            }
+            input.Fill(static_cast<char>('A' + i));
+            output.Fill('X');
+            const DistributedFSDescriptor descriptor{
+                path, static_cast<uint64_t>(i) * 4096, 4096, 4096, 4};
+            while (!start.load()) std::this_thread::yield();
+            auto writes =
+                backend_->BatchWrite({{std::to_string(i),
+                                       descriptor,
+                                       {{input.data(), input.size()}}}});
+            auto reads =
+                backend_->BatchRead({{std::to_string(i),
+                                      descriptor,
+                                      {{output.data(), output.size()}}}});
+            if (writes.size() != 1 || !writes[0] || reads.size() != 1 ||
+                !reads[0] ||
+                std::memcmp(input.data(), output.data(), input.size())) {
+                ++failures;
+            }
+        });
+    }
+    start.store(true);
+    for (auto& worker : workers) worker.join();
+    EXPECT_EQ(failures.load(), 0);
+}
 
 TEST_F(DfsBackendTest, BatchWriteUsesExplicitDescriptors) {
     AlignedBuffer write_buf(4096);

--- a/mooncake-store/tests/dfs_posix_test.cpp
+++ b/mooncake-store/tests/dfs_posix_test.cpp
@@ -4,11 +4,13 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <functional>
+#include <future>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -976,6 +978,16 @@ class DfsBackendTest : public ::testing::Test {
 
 class ControlledPosixFsAdapter : public PosixFsAdapter {
    public:
+    void FailOpenCall(int call) { fail_open_call_ = call; }
+    int OpenCallCount() const { return open_calls_.load(); }
+
+    tl::expected<int, ErrorCode> OpenFile(const std::string& path) override {
+        if (++open_calls_ == fail_open_call_) {
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+        return PosixFsAdapter::OpenFile(path);
+    }
+
     void FailWriteCall(int call) { fail_write_call_ = call; }
     void ShortWriteCall(int call) { short_write_call_ = call; }
     void FailReadCall(int call) { fail_read_call_ = call; }
@@ -1017,6 +1029,8 @@ class ControlledPosixFsAdapter : public PosixFsAdapter {
     }
 
    private:
+    std::atomic<int> open_calls_{0};
+    int fail_open_call_ = -1;
     std::atomic<int> write_calls_{0};
     std::atomic<int> read_calls_{0};
     int fail_write_call_ = -1;
@@ -1024,6 +1038,116 @@ class ControlledPosixFsAdapter : public PosixFsAdapter {
     int fail_read_call_ = -1;
     int short_read_call_ = -1;
 };
+
+class BlockingShardFsAdapter : public PosixFsAdapter {
+   public:
+    BlockingShardFsAdapter(std::string path, bool block_file_size)
+        : path_(std::move(path)), block_file_size_(block_file_size) {}
+
+    bool WaitUntilBlocked() {
+        return blocked_.wait_for(std::chrono::seconds(5)) ==
+               std::future_status::ready;
+    }
+
+    void Release() {
+        if (!released_once_.exchange(true)) release_signal_.set_value();
+    }
+
+    int OpenCallCount() const { return open_calls_.load(); }
+
+    tl::expected<size_t, ErrorCode> GetFileSize(
+        const std::string& path) override {
+        if (path == path_ && block_file_size_) Block();
+        return PosixFsAdapter::GetFileSize(path);
+    }
+
+    tl::expected<int, ErrorCode> OpenFile(const std::string& path) override {
+        if (path == path_) {
+            ++open_calls_;
+            if (!block_file_size_) Block();
+        }
+        return PosixFsAdapter::OpenFile(path);
+    }
+
+   private:
+    void Block() {
+        if (!blocked_once_.exchange(true)) blocked_signal_.set_value();
+        released_.wait();
+    }
+
+    std::string path_;
+    bool block_file_size_;
+    std::atomic<int> open_calls_{0};
+    std::atomic<bool> blocked_once_{false};
+    std::atomic<bool> released_once_{false};
+    std::promise<void> blocked_signal_;
+    std::future<void> blocked_{blocked_signal_.get_future()};
+    std::promise<void> release_signal_;
+    std::shared_future<void> released_{release_signal_.get_future().share()};
+};
+
+TEST_F(DfsBackendTest, SlowShardInitializationDoesNotBlockOtherShards) {
+    for (bool block_file_size : {false, true}) {
+        SCOPED_TRACE(block_file_size ? "GetFileSize" : "OpenFile");
+        FileStorageConfig file_config;
+        file_config.storage_backend_type = StorageBackendType::kDistributed;
+        file_config.storage_filepath = tmp_->path();
+        auto config =
+            MakeAllocatorConfig(tmp_->path(), 4, 64 * 1024 * 1024, 4096);
+        config.fs_adapter_type = "posix";
+        auto adapter = std::make_unique<BlockingShardFsAdapter>(
+            ShardPath(1), block_file_size);
+        auto* controlled = adapter.get();
+        backend_ = std::make_unique<DistributedStorageBackend>(
+            file_config, config, std::move(adapter));
+        ASSERT_TRUE(backend_->Init());
+
+        auto write_and_read = [&](int index, uint64_t offset) {
+            std::string input(4096, 'V'), output(4096, '\0');
+            const DistributedFSDescriptor descriptor{ShardPath(index), offset,
+                                                     4096, 4096, index};
+            auto writes = backend_->BatchWrite(
+                {{"value", descriptor, {{input.data(), input.size()}}}});
+            auto reads = backend_->BatchRead(
+                {{"value", descriptor, {{output.data(), output.size()}}}});
+            return writes.size() == 1 && writes[0] && reads.size() == 1 &&
+                   reads[0] && output == input;
+        };
+        ASSERT_TRUE(write_and_read(0, 0));
+
+        // Release the adapter before waiting on any async future's destructor,
+        // including when an assertion fails while initialization is blocked.
+        std::future<bool> first, same_shard, other_shards;
+        struct ReleaseOnExit {
+            BlockingShardFsAdapter* adapter;
+            ~ReleaseOnExit() { adapter->Release(); }
+        } release{controlled};
+        first = std::async(std::launch::async,
+                           [&] { return write_and_read(1, 0); });
+        ASSERT_TRUE(controlled->WaitUntilBlocked());
+        same_shard = std::async(std::launch::async,
+                                [&] { return write_and_read(1, 4096); });
+        other_shards = std::async(std::launch::async, [&] {
+            std::string output(4096, '\0');
+            auto reads =
+                backend_->BatchRead({{"cached",
+                                      {ShardPath(0), 0, 4096, 4096, 0},
+                                      {{output.data(), output.size()}}}});
+            return reads.size() == 1 && reads[0] &&
+                   output == std::string(4096, 'V') &&
+                   write_and_read(0, 4096) && write_and_read(2, 0);
+        });
+        EXPECT_EQ(other_shards.wait_for(std::chrono::seconds(5)),
+                  std::future_status::ready);
+        EXPECT_EQ(same_shard.wait_for(std::chrono::seconds(0)),
+                  std::future_status::timeout);
+        controlled->Release();
+        EXPECT_TRUE(first.get());
+        EXPECT_TRUE(same_shard.get());
+        EXPECT_TRUE(other_shards.get());
+        EXPECT_EQ(controlled->OpenCallCount(), 1);
+    }
+}
 
 TEST(DfsBackendInitializationTest, ClientBeforeMasterDoesNotCreateShards) {
     EnvGuard env;
@@ -1170,6 +1294,38 @@ TEST_F(DfsBackendTest, OpensNewShardDescriptorAfterClientInitialization) {
     ASSERT_EQ(reads.size(), 1);
     ASSERT_TRUE(reads[0].has_value());
     EXPECT_EQ(std::memcmp(expected.data(), actual.data(), expected.size()), 0);
+}
+
+TEST_F(DfsBackendTest, LazyOpenRetriesAfterOpenFailure) {
+    FileStorageConfig file_config;
+    file_config.storage_backend_type = StorageBackendType::kDistributed;
+    file_config.storage_filepath = tmp_->path();
+    auto config = MakeAllocatorConfig(tmp_->path(), 4, 64 * 1024 * 1024, 4096);
+    config.fs_adapter_type = "posix";
+    auto adapter = std::make_unique<ControlledPosixFsAdapter>();
+    auto* controlled = adapter.get();
+    controlled->FailOpenCall(1);
+    backend_ = std::make_unique<DistributedStorageBackend>(file_config, config,
+                                                           std::move(adapter));
+    ASSERT_TRUE(backend_->Init());
+
+    std::string input(4096, 'R'), output(4096, '\0');
+    const DistributedFSDescriptor descriptor{ShardPath(1), 0, 4096, 4096, 1};
+    const std::vector<DfsWriteRequest> request{
+        {"retry", descriptor, {{input.data(), input.size()}}}};
+    auto failed = backend_->BatchWrite(request);
+    ASSERT_EQ(failed.size(), 1);
+    ASSERT_FALSE(failed[0]);
+    EXPECT_EQ(failed[0].error(), ErrorCode::FILE_OPEN_FAIL);
+    auto retried = backend_->BatchWrite(request);
+    ASSERT_EQ(retried.size(), 1);
+    ASSERT_TRUE(retried[0]);
+    auto reads = backend_->BatchRead(
+        {{"retry", descriptor, {{output.data(), output.size()}}}});
+    ASSERT_EQ(reads.size(), 1);
+    ASSERT_TRUE(reads[0]);
+    EXPECT_EQ(output, input);
+    EXPECT_EQ(controlled->OpenCallCount(), 2);
 }
 
 TEST_F(DfsBackendTest, LazyOpenRejectsMissingAndMalformedShardFiles) {

--- a/mooncake-store/tests/dfs_sync_client_test.cpp
+++ b/mooncake-store/tests/dfs_sync_client_test.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -279,6 +280,40 @@ TEST_F(DfsSyncClientTest, MissingDfsBackendRevokesObject) {
     auto query = client_without_backend->Query("sync_no_backend");
     ASSERT_FALSE(query.has_value());
     EXPECT_EQ(query.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(DfsSyncClientTest, ExistingClientUsesOnlineExpandedDfsCapacity) {
+    const std::string old_key = "before_expansion";
+    std::string old_value(4096, 'O');
+    std::vector<Slice> old_slices{{old_value.data(), old_value.size()}};
+    ASSERT_TRUE(writer_->Put(old_key, old_slices, DfsConfig()));
+    auto old_query = QueryDfsOnly(old_key);
+    ASSERT_TRUE(old_query);
+    const auto old_path = old_query->replicas[0].get_dfs_descriptor().file_path;
+    auto expanded = master_.service()->ExpandDfsShards(4);
+    ASSERT_TRUE(expanded);
+    EXPECT_EQ(*expanded, 4);
+
+    std::string new_key;
+    for (int i = 0; i < 1000; ++i) {
+        new_key = "after_expansion_" + std::to_string(i);
+        if (std::hash<std::string>{}(new_key) % 4 == 3) break;
+    }
+    ASSERT_EQ(std::hash<std::string>{}(new_key) % 4, 3);
+    std::string value(4096, 'N');
+    std::vector<Slice> write_slices{{value.data(), value.size()}};
+    ASSERT_TRUE(writer_->Put(new_key, write_slices, DfsConfig()));
+    auto query = QueryDfsOnly(new_key);
+    ASSERT_TRUE(query);
+    EXPECT_EQ(query->replicas[0].get_dfs_descriptor().shard_idx, 3);
+    std::string output(value.size(), '\0');
+    std::vector<Slice> read_slices{{output.data(), output.size()}};
+    ASSERT_TRUE(writer_->Get(new_key, *query, read_slices));
+    EXPECT_EQ(output, value);
+    ExpectDfsValue(old_key, old_value);
+    auto after = QueryDfsOnly(old_key);
+    ASSERT_TRUE(after);
+    EXPECT_EQ(after->replicas[0].get_dfs_descriptor().file_path, old_path);
 }
 
 TEST_F(DfsSyncClientTest, GetReadsDfsIntoMultipleSlices) {

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -1,16 +1,22 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <csignal>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <ylt/coro_http/coro_http_client.hpp>
+#include <ylt/coro_io/coro_io.hpp>
 #include <ylt/struct_json/json_reader.h>
 #include <ylt/struct_json/json_writer.h>
 
@@ -29,6 +35,97 @@ namespace mooncake {
 namespace test {
 
 namespace {
+
+struct HttpDfsShardCountResponse {
+    bool success{false};
+    int shard_count{0};
+};
+YLT_REFL(HttpDfsShardCountResponse, success, shard_count);
+
+class DfsAdminEnvironment {
+   public:
+    explicit DfsAdminEnvironment(bool enabled) {
+        root_ = std::filesystem::temp_directory_path() /
+                ("mooncake_admin_dfs_" + UuidToString(generate_uuid()));
+        std::filesystem::create_directories(root_);
+        Set("MOONCAKE_ENABLE_DFS", enabled ? "1" : "0");
+        Set("MOONCAKE_DFS_FS_ADAPTER", "posix");
+        Set("MOONCAKE_DFS_ROOT_DIR", root_.string());
+        Set("MOONCAKE_DFS_SHARD_COUNT", "1");
+        Set("MOONCAKE_DFS_SHARD_CAPACITY", "8192");
+        Set("MOONCAKE_DFS_ALIGNMENT", "4096");
+        Set("MOONCAKE_DFS_EVICTION_ENABLED", "0");
+        Set("MOONCAKE_DFS_SINGLE_TENANT", "true");
+    }
+
+    ~DfsAdminEnvironment() {
+        for (const auto& [key, value] : saved_) {
+            if (value) {
+                ::setenv(key.c_str(), value->c_str(), 1);
+            } else {
+                ::unsetenv(key.c_str());
+            }
+        }
+        std::error_code ec;
+        std::filesystem::remove_all(root_, ec);
+    }
+
+   private:
+    void Set(const std::string& key, const std::string& value) {
+        const char* previous = ::getenv(key.c_str());
+        saved_.push_back({key, previous ? std::optional<std::string>(previous)
+                                        : std::nullopt});
+        ::setenv(key.c_str(), value.c_str(), 1);
+    }
+    std::filesystem::path root_;
+    std::vector<std::pair<std::string, std::optional<std::string>>> saved_;
+};
+
+// Queue filesystem work deterministically without adding a production test
+// hook. HTTP uses its own pool, so it must remain responsive while this pool
+// is held. Release before destroying futures that may await queued work.
+class ScopedBlockingPoolHold {
+   public:
+    ScopedBlockingPoolHold()
+        : release_(std::make_unique<std::promise<void>>()),
+          entered_(std::make_shared<std::atomic<size_t>>(0)) {
+        const auto ready = release_->get_future().share();
+        const auto executors =
+            coro_io::g_block_io_context_pool<>().get_all_executor();
+        count_ = executors.size();
+        for (const auto& executor : executors) {
+            asio::post(executor->get_asio_executor(),
+                       [ready, entered = entered_] {
+                           entered->fetch_add(1);
+                           ready.wait();
+                       });
+        }
+    }
+
+    ~ScopedBlockingPoolHold() { Release(); }
+
+    bool WaitUntilBlocked() const {
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        while (entered_->load() != count_) {
+            if (std::chrono::steady_clock::now() >= deadline) return false;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return true;
+    }
+
+    void Release() {
+        if (release_) {
+            release_->set_value();
+            release_.reset();
+        }
+    }
+
+   private:
+    std::unique_ptr<std::promise<void>> release_;
+    std::shared_ptr<std::atomic<size_t>> entered_;
+    size_t count_ = 0;
+};
 
 struct HttpCreateDrainJobResponse {
     bool success{false};
@@ -154,6 +251,146 @@ class MasterAdminServerTest : public ::testing::Test {
 // =========================================================================
 // Always-available endpoint tests
 // =========================================================================
+
+TEST_F(MasterAdminServerTest, DfsShardCountExpandsAndValidatesRequests) {
+    DfsAdminEnvironment env(true);
+    WrappedMasterServiceConfig config;
+    config.default_kv_lease_ttl = 5000;
+    config.enable_metric_reporting = false;
+    config.client_active_ttl_sec = 3600;
+    auto service = std::make_shared<WrappedMasterService>(config);
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+    const std::string path = "/api/v1/dfs/shard_count";
+
+    auto before = HttpGet(port, path);
+    ASSERT_EQ(before.http_status, 200);
+    HttpDfsShardCountResponse parsed;
+    struct_json::from_json(parsed, before.body);
+    EXPECT_TRUE(parsed.success);
+    EXPECT_EQ(parsed.shard_count, 1);
+    for (int i = 0; i < 2; ++i) {
+        auto expanded = HttpPutJson(port, path, R"({"shard_count":3})");
+        ASSERT_EQ(expanded.http_status, 200);
+        struct_json::from_json(parsed, expanded.body);
+        EXPECT_TRUE(parsed.success);
+        EXPECT_EQ(parsed.shard_count, 3);
+    }
+    for (const auto& invalid :
+         {R"({"shard_count":2})", R"({"shard_count":0})",
+          R"({"shard_count":-1})", R"({"shard_count":3.0})",
+          R"({"shard_count":true})", R"({"shard_count":"3"})",
+          R"({"shard_count":null})", R"({"shard_count":2147483648})",
+          R"({"shard_count":3,"shard_count":4})", "{}", "[]",
+          R"({"shard_count":4} trailing)"}) {
+        EXPECT_EQ(HttpPutJson(port, path, invalid).http_status, 400) << invalid;
+    }
+    auto after = HttpGet(port, path);
+    ASSERT_EQ(after.http_status, 200);
+    struct_json::from_json(parsed, after.body);
+    EXPECT_EQ(parsed.shard_count, 3);
+    auto count = service->GetDfsShardCount();
+    ASSERT_TRUE(count);
+    EXPECT_EQ(*count, 3);
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, DfsExpansionKeepsHttpResponsiveAndDrainsOnStop) {
+    DfsAdminEnvironment env(true);
+    WrappedMasterServiceConfig config;
+    config.default_kv_lease_ttl = 5000;
+    config.enable_metric_reporting = false;
+    config.client_active_ttl_sec = 3600;
+    auto service = std::make_shared<WrappedMasterService>(config);
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+    const std::string path = "/api/v1/dfs/shard_count";
+
+    // Declare futures first so a failed assertion releases the held workers
+    // before future destruction waits for either request or shutdown.
+    std::future<HttpResponse> first;
+    std::future<HttpResponse> second;
+    std::future<void> stopped;
+    ScopedBlockingPoolHold hold;
+    ASSERT_TRUE(hold.WaitUntilBlocked());
+    auto expand = [&] {
+        return HttpPutJson(port, path, R"({"shard_count":3})");
+    };
+    first = std::async(std::launch::async, expand);
+    second = std::async(std::launch::async, expand);
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (
+        first.wait_for(std::chrono::seconds(0)) != std::future_status::ready &&
+        second.wait_for(std::chrono::seconds(0)) != std::future_status::ready &&
+        std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const bool first_ready =
+        first.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+    auto& rejected = first_ready ? first : second;
+    auto& pending = first_ready ? second : first;
+    ASSERT_EQ(rejected.wait_for(std::chrono::seconds(0)),
+              std::future_status::ready);
+    EXPECT_EQ(rejected.get().http_status, 409);
+    EXPECT_EQ(HttpGet(port, "/health").http_status, 200);
+    EXPECT_EQ(pending.wait_for(std::chrono::seconds(0)),
+              std::future_status::timeout);
+
+    stopped = std::async(std::launch::async, [&] { admin.Stop(); });
+    // Stop closes the client connection, but must retain its executor until
+    // the queued expansion has resumed and finished the handler.
+    ASSERT_EQ(pending.wait_for(std::chrono::seconds(10)),
+              std::future_status::ready);
+    pending.get();
+    EXPECT_EQ(stopped.wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+    hold.Release();
+    ASSERT_EQ(stopped.wait_for(std::chrono::seconds(10)),
+              std::future_status::ready);
+    stopped.get();
+    auto count = service->GetDfsShardCount();
+    ASSERT_TRUE(count);
+    EXPECT_EQ(*count, 3);
+}
+
+TEST_F(MasterAdminServerTest, DfsShardCountRejectsDisabledBackend) {
+    DfsAdminEnvironment env(false);
+    WrappedMasterServiceConfig config;
+    config.default_kv_lease_ttl = 5000;
+    config.enable_metric_reporting = false;
+    config.client_active_ttl_sec = 3600;
+    auto service = std::make_shared<WrappedMasterService>(config);
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+    const std::string path = "/api/v1/dfs/shard_count";
+    EXPECT_EQ(HttpGet(port, path).http_status, 409);
+    EXPECT_EQ(HttpPutJson(port, path, R"({"shard_count":3})").http_status, 409);
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, DfsShardCountRejectsUnavailableService) {
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kStandby);
+    const std::string path = "/api/v1/dfs/shard_count";
+    EXPECT_EQ(HttpGet(port, path).http_status, 503);
+    EXPECT_EQ(HttpPutJson(port, path, R"({"shard_count":3})").http_status, 503);
+    admin.Stop();
+}
 
 TEST_F(MasterAdminServerTest, MetricsEndpointReturns200) {
     int port = getFreeTcpPort();


### PR DESCRIPTION
## Description

The default DFS shard allocator fixes capacity when the Master starts. Increasing that capacity currently requires a restart, which loses the in-memory cache metadata. This change lets an operator append shard files through the existing Master HTTP admin service while upgraded clients keep using existing descriptors.

Related RFC: [#3812 — DFS replica dynamic capacity scaling](https://github.com/kvcache-ai/Mooncake/issues/3812), including the [maintainer's lifecycle and compatibility requirements](https://github.com/kvcache-ai/Mooncake/issues/3812#issuecomment-5490632735).

The admin interface is:

```http
GET /api/v1/dfs/shard_count
PUT /api/v1/dfs/shard_count
Content-Type: application/json

{"shard_count":128}
```

The PUT value is the desired total count. Repeating the current count succeeds; shrinking and invalid values return HTTP 400. Disabled DFS or an already active expansion returns HTTP 409; an unavailable or standby service returns HTTP 503. Filesystem preparation runs outside the HTTP I/O threads. A work guard retains the connection executor until the accepted operation completes, including during Stop; completion returns to that executor before responding.

The implementation addresses the RFC requirements as follows:

- Prepare all new files and allocator states, then atomically publish one immutable topology snapshot. Existing shard states remain shared by allocation, free, access tracking, and prepared eviction transactions. Failed preparation leaves the published count unchanged and rollback only removes files created by that request.
- Make new filenames independent of the total count, preserving the exact paths of discovered legacy padded files.
- Start allocation at the hash-selected shard and try the other ready shards when it has no suitable extent, so empty appended shards provide usable capacity.
- Open client shard handles only when consuming a published descriptor. Validate the path, index, and capacity before caching the handle; client initialization does not create or open shard files.
- Discover the contiguous existing shard layout on Master startup and retain at least the configured initial capacity. Reject ambiguous indices, gaps, and capacity mismatches.

### Compatibility and limits

Upgrade the Master and every DFS client before expanding. Older clients can reject descriptors for added shards. All processes must use the same shared root, filesystem adapter, shard capacity, and alignment. Only one active Master may manage a root, and shard files must not be created, renamed, truncated, or deleted externally.

Expansion only adds shards. It does not resize individual files, move existing objects, change the root, or stripe an object across files. Operators must provision the backing filesystem space.

Startup discovery preserves the capacity layout only. It does not recover keys or allocation ownership, add snapshot/OpLog/HA support, or provide a new data durability guarantee. Existing single-tenant and DFS replica placement limits remain.

[#3902](https://github.com/kvcache-ai/Mooncake/pull/3902) adds a separate immutable bucket allocator and an online bucket-count limit; it preserves default shard behavior. [#3849](https://github.com/kvcache-ai/Mooncake/pull/3849) adds configured multiple roots. This change addresses online growth of the default fixed-shard allocator.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Validated on a remote Linux node with GCC 11.5, a Release build, native TCP transport and the POSIX filesystem adapter. The final patch is based on `b9059252aa8db150ada8220241707d47e27ebb79`.

| Target | Result |
| --- | --- |
| `dfs_posix_test` | 43 passed |
| `dfs_sync_client_test` | 8 passed; checksum-only case skipped in the default configuration |
| `dfs_batch_read_checksum_test` | 1 passed with `MOONCAKE_STORE_CHECKSUM=1`, covering that skipped case |
| `master_admin_server_test` | 59 passed |
| `master_service_dfs_scenario_test` | 6 passed |

All five CTest entries passed, covering 117 distinct passing test cases. Coverage includes an already initialized client writing and reading a newly added shard, old data remaining readable, failed preparation and retry, legacy names, concurrent allocation/eviction and lazy opening, request validation, HTTP responsiveness during queued expansion, and Stop draining the accepted operation.

The baseline at `1caf8f8f9e800886debf9013a22b3403faf4ecfb` passed its 27 existing POSIX tests. The added baseline-compatible `DfsBackendTest.OpensNewShardDescriptorAfterClientInitialization` fails on that baseline with `Invalid DFS shard_idx 4`. That is a separate earlier baseline; it is not claimed as an A/B run against the newer final base.

**Test commands:**

```bash
cmake --build build --target dfs_posix_test dfs_sync_client_test \
  master_admin_server_test master_service_dfs_scenario_test -j4
ctest --test-dir build -V -j1 --timeout 180 \
  -R '^(dfs_posix_test|dfs_sync_client_test|dfs_batch_read_checksum_test|master_admin_server_test|master_service_dfs_scenario_test)$'
git diff --cached --name-only -z | xargs -0 pre-commit run --files
(cd docs && make html)
```

Build options included `USE_CUDA=OFF`, `USE_TCP=ON`, `USE_ETCD=OFF`, `USE_HTTP=ON`, `USE_3FS=OFF`, `WITH_STORE=ON`, `WITH_STORE_RUST=OFF`, and `BUILD_UNIT_TESTS=ON`. Changed-line clang-format 20.1.8 and all applicable pre-commit hooks passed. Documentation built successfully, and the generated sections were inspected.

No GPU/RDMA, live HF3FS deployment, full-library sanitizer, or performance result is claimed.

**Test results:**

- [x] Unit tests pass
- [x] Native TCP Master/client and POSIX integration tests pass
- [ ] Manual deployment testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: covered by existing RFC #3812

Existing design RFC: [#3812](https://github.com/kvcache-ai/Mooncake/issues/3812), opened by @sun-baoshan-sunshine. The submitter has reviewed the final diff.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with upstream screening, implementation, tests, documentation, and independent static review. The submitter has reviewed the final diff and is responsible for understanding and defending the changes.