### PR TITLE
[TE] Fix transfer byte accounting races and completion caching

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -387,6 +387,8 @@ class Transport {
         std::atomic<bool> has_failure{false};
         std::atomic<bool> is_finished{
             false};  // Completion flag for wait predicate
+        // Completion events do not populate the status-query byte cache.
+        std::atomic<bool> status_cached{false};
         std::atomic<uint64_t> finished_transfer_bytes{0};
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -308,11 +308,14 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     }
 
     // Fallback for tasks without a transport pointer (legacy path)
-    status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count =
         __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
     uint64_t failed_slice_count =
         __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the byte updates made by
+    // Slice::markSuccess().
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     assert(task.slice_count);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
@@ -374,7 +377,7 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
     const size_t task_count = batch_desc.task_list.size();
     status.transferred_bytes = 0;
 
-    if (batch_desc.is_finished.load(std::memory_order_acquire) ||
+    if (batch_desc.status_cached.load(std::memory_order_acquire) ||
         task_count == 0) {
         status.s = Transport::TransferStatusEnum::COMPLETED;
         status.transferred_bytes =
@@ -406,9 +409,10 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
                    ? Transport::TransferStatusEnum::COMPLETED
                    : Transport::TransferStatusEnum::WAITING;
     if (status.s == Transport::TransferStatusEnum::COMPLETED) {
-        batch_desc.is_finished.store(true, std::memory_order_release);
         batch_desc.finished_transfer_bytes.store(status.transferred_bytes,
-                                                 std::memory_order_release);
+                                                 std::memory_order_relaxed);
+        batch_desc.status_cached.store(true, std::memory_order_release);
+        batch_desc.is_finished.store(true, std::memory_order_release);
     } else if (status.s == Transport::TransferStatusEnum::FAILED) {
         batch_desc.has_failure.store(true, std::memory_order_release);
     }

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -330,9 +330,13 @@ Status AscendDirectTransport::getTransferStatus(BatchID batch_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
@@ -224,7 +224,6 @@ void HcclTransport::initiatorLoop(int deviceLogicId, int selfIdx) {
         for (auto slice : slice_list) {
             if (slice->status != Slice::SliceStatus::FAILED) {
                 slice->markSuccess();
-                slice->task->transferred_bytes = slice->length;
             }
         }
         (void)start;
@@ -538,9 +537,13 @@ Status HcclTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ubshmem_transport/ubshmem_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ubshmem_transport/ubshmem_transport.cpp
@@ -523,9 +523,13 @@ Status UBShmemTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
     // Get task and status info
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
 
     // Determine completion status
     if (success_slice_count + failed_slice_count == task.slice_count) {

--- a/mooncake-transfer-engine/src/transport/barex_transport/barex_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/barex_transport/barex_transport.cpp
@@ -1205,9 +1205,13 @@ Status BarexTransport::getTransferStatus(BatchID batch_id,
     status.resize(task_count);
     for (size_t task_id = 0; task_id < task_count; task_id++) {
         auto &task = batch_desc.task_list[task_id];
-        status[task_id].transferred_bytes = task.transferred_bytes;
-        uint64_t success_slice_count = task.success_slice_count;
-        uint64_t failed_slice_count = task.failed_slice_count;
+        uint64_t success_slice_count =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+        uint64_t failed_slice_count =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+        // Completion counters publish the preceding byte updates.
+        status[task_id].transferred_bytes =
+            __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
         if (success_slice_count + failed_slice_count == task.slice_count) {
             if (failed_slice_count) {
                 status[task_id].s = TransferStatusEnum::FAILED;
@@ -1232,9 +1236,13 @@ Status BarexTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count)
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/cxi_transport/cxi_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/cxi_transport/cxi_transport.cpp
@@ -839,9 +839,13 @@ Status CxiTransport::getTransferStatus(BatchID batch_id,
     status.resize(task_count);
     for (size_t task_id = 0; task_id < task_count; task_id++) {
         auto& task = batch_desc.task_list[task_id];
-        status[task_id].transferred_bytes = task.transferred_bytes;
-        uint64_t success_slice_count = task.success_slice_count;
-        uint64_t failed_slice_count = task.failed_slice_count;
+        uint64_t success_slice_count =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+        uint64_t failed_slice_count =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+        // Completion counters publish the preceding byte updates.
+        status[task_id].transferred_bytes =
+            __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
         if (success_slice_count + failed_slice_count == task.slice_count) {
             if (failed_slice_count)
                 status[task_id].s = TransferStatusEnum::FAILED;
@@ -865,9 +869,13 @@ Status CxiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto& task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count)
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/cxl_transport/cxl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/cxl_transport/cxl_transport.cpp
@@ -301,9 +301,13 @@ Status CxlTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -1110,9 +1110,13 @@ Status EfaTransport::getTransferStatus(BatchID batch_id,
     status.resize(task_count);
     for (size_t task_id = 0; task_id < task_count; task_id++) {
         auto& task = batch_desc.task_list[task_id];
-        status[task_id].transferred_bytes = task.transferred_bytes;
-        uint64_t success_slice_count = task.success_slice_count;
-        uint64_t failed_slice_count = task.failed_slice_count;
+        uint64_t success_slice_count =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+        uint64_t failed_slice_count =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+        // Completion counters publish the preceding byte updates.
+        status[task_id].transferred_bytes =
+            __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
         if (success_slice_count + failed_slice_count == task.slice_count) {
             if (failed_slice_count)
                 status[task_id].s = TransferStatusEnum::FAILED;
@@ -1136,9 +1140,13 @@ Status EfaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto& task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count)
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/flagcx_transport/flagcx_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/flagcx_transport/flagcx_transport.cpp
@@ -457,11 +457,16 @@ Status FlagCxTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             "FlagCxTransport::getTransferStatus task_id out of range");
     }
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    if (task.success_slice_count + task.failed_slice_count ==
-        task.slice_count) {
-        status.s = task.failed_slice_count ? TransferStatusEnum::FAILED
-                                           : TransferStatusEnum::COMPLETED;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
+    if (success_slice_count + failed_slice_count == task.slice_count) {
+        status.s = failed_slice_count ? TransferStatusEnum::FAILED
+                                      : TransferStatusEnum::COMPLETED;
         task.is_finished = true;
     } else {
         status.s = TransferStatusEnum::WAITING;

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -603,9 +603,13 @@ Status HipTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
     // Get task and status info
     auto& task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
 
     // Determine completion status
     if (success_slice_count + failed_slice_count == task.slice_count) {

--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -533,9 +533,13 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
             }
         }
     }
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/kunpeng_transport/ub_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/kunpeng_transport/ub_transport.cpp
@@ -342,9 +342,13 @@ Status UbTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto& task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count)
             status.s = FAILED;

--- a/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
@@ -518,9 +518,13 @@ Status MacaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             }
         }
     }
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/nccl_transport/nccl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nccl_transport/nccl_transport.cpp
@@ -775,11 +775,16 @@ class NcclHostTransport::Impl {
             if (saved_device >= 0) cudaSetDevice(saved_device);
         }
 
-        status.transferred_bytes = task.transferred_bytes;
-        if (task.success_slice_count + task.failed_slice_count ==
-            task.slice_count) {
-            status.s = task.failed_slice_count ? TransferStatusEnum::FAILED
-                                               : TransferStatusEnum::COMPLETED;
+        uint64_t success_slice_count =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+        uint64_t failed_slice_count =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+        // Completion counters publish the preceding byte updates.
+        status.transferred_bytes =
+            __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
+        if (success_slice_count + failed_slice_count == task.slice_count) {
+            status.s = failed_slice_count ? TransferStatusEnum::FAILED
+                                          : TransferStatusEnum::COMPLETED;
             task.is_finished = true;
         } else {
             status.s = TransferStatusEnum::WAITING;

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -861,9 +861,13 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             }
         }
     }
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -994,11 +994,14 @@ Status RdmaTransport::getTransferStatus(BatchID batch_id,
     status.resize(task_count);
     for (size_t task_id = 0; task_id < task_count; task_id++) {
         auto &task = batch_desc.task_list[task_id];
-        status[task_id].transferred_bytes = task.transferred_bytes;
         uint64_t success_slice_count =
             __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
         uint64_t failed_slice_count =
             __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+        // Completion counters publish the preceding byte updates. Read bytes
+        // afterwards so a terminal status cannot carry a stale byte count.
+        status[task_id].transferred_bytes =
+            __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
         if (success_slice_count + failed_slice_count == task.slice_count) {
             if (failed_slice_count)
                 status[task_id].s = TransferStatusEnum::FAILED;
@@ -1022,11 +1025,13 @@ Status RdmaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count =
         __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
     uint64_t failed_slice_count =
         __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Pair with Slice::markSuccess(): observe completion before reading bytes.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count)
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/src/transport/sunrise_link/sunrise_link_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/sunrise_link/sunrise_link_transport.cpp
@@ -748,9 +748,13 @@ Status SunriseLinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     }
 
     auto& task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Completion counters publish the preceding byte updates.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         status.s = failed_slice_count ? TransferStatusEnum::FAILED
                                       : TransferStatusEnum::COMPLETED;

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -515,16 +515,13 @@ Status TcpTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto& task = batch_desc.task_list[task_id];
-    // These counters are updated with __atomic_fetch_add from the I/O
-    // thread(s) in Slice::markSuccess/markFailed; read them atomically here to
-    // match MultiTransport::getTransferStatus and avoid a data race with the
-    // completion path (the read runs on the polling submission thread).
-    status.transferred_bytes =
-        __atomic_load_n(&task.transferred_bytes, __ATOMIC_ACQUIRE);
     uint64_t success_slice_count =
         __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
     uint64_t failed_slice_count =
         __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
+    // Acquire completion counters before reading the bytes they publish.
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_RELAXED);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <utility>
 
+#include "multi_transport.h"
 #include "transfer_engine.h"
 #include "transfer_engine_impl.h"
 #include "transport/transport.h"
@@ -832,6 +833,87 @@ TEST_F(TransportTest, ScatterSubmitFailurePreservesCompletedFragments) {
     EXPECT_EQ(transport->request_counts, (std::vector<size_t>{2}));
     transport->addExtraSlice();
     EXPECT_EQ(run(), (std::vector<bool>{false, false}));
+}
+
+// Model the state left by completion events explicitly so these regressions
+// also run in default builds without USE_EVENT_DRIVEN_COMPLETION.
+TEST_F(TransportTest, FailedCompletionEventDoesNotReportSuccess) {
+    std::string server_name = "localhost";
+    MultiTransport transport(nullptr, server_name);
+    Transport::BatchDesc batch{};
+    batch.id = reinterpret_cast<Transport::BatchID>(&batch);
+    batch.batch_size = 1;
+    batch.task_list.resize(1);
+    auto& task = batch.task_list.front();
+    task.batch_id = batch.id;
+    task.slice_count = 1;
+    task.failed_slice_count = 1;
+    task.is_finished = true;
+    batch.has_failure.store(true);
+    batch.is_finished.store(true);
+    ASSERT_FALSE(batch.status_cached.load());
+
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport.getBatchTransferStatus(batch.id, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::FAILED);
+    EXPECT_FALSE(batch.status_cached.load());
+}
+
+TEST_F(TransportTest, SuccessfulCompletionEventPreservesTransferredBytes) {
+    std::string server_name = "localhost";
+    MultiTransport transport(nullptr, server_name);
+    Transport::BatchDesc batch{};
+    batch.id = reinterpret_cast<Transport::BatchID>(&batch);
+    batch.batch_size = 1;
+    batch.task_list.resize(1);
+    auto& task = batch.task_list.front();
+    task.batch_id = batch.id;
+    task.slice_count = 1;
+    task.transferred_bytes = 65536;
+    task.success_slice_count = 1;
+    task.is_finished = true;
+    batch.is_finished.store(true);
+    ASSERT_FALSE(batch.has_failure.load());
+    ASSERT_FALSE(batch.status_cached.load());
+    ASSERT_EQ(batch.finished_transfer_bytes.load(), 0);
+
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport.getBatchTransferStatus(batch.id, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, 65536);
+}
+
+TEST_F(TransportTest, RepeatedBatchQueryPreservesAggregatedBytes) {
+    std::string server_name = "localhost";
+    MultiTransport transport(nullptr, server_name);
+    Transport::BatchDesc batch{};
+    batch.id = reinterpret_cast<Transport::BatchID>(&batch);
+    batch.batch_size = 2;
+    batch.task_list.resize(2);
+    const std::array<uint64_t, 2> task_bytes{65536, 131072};
+    for (size_t i = 0; i < batch.task_list.size(); ++i) {
+        auto& task = batch.task_list[i];
+        task.batch_id = batch.id;
+        task.slice_count = 1;
+        task.transferred_bytes = task_bytes[i];
+        task.success_slice_count = 1;
+    }
+    const auto total_bytes = task_bytes[0] + task_bytes[1];
+    ASSERT_FALSE(batch.is_finished.load());
+    ASSERT_FALSE(batch.status_cached.load());
+
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport.getBatchTransferStatus(batch.id, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, total_bytes);
+    EXPECT_TRUE(batch.is_finished.load());
+    ASSERT_TRUE(batch.status_cached.load());
+    EXPECT_EQ(batch.finished_transfer_bytes.load(), total_bytes);
+
+    status = {};
+    ASSERT_TRUE(transport.getBatchTransferStatus(batch.id, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, total_bytes);
 }
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION


### PR DESCRIPTION
## Description

- Status queries can read transferred bytes before observing slice completion, returning `COMPLETED` with a stale byte count that the batch cache then retains.
- Batch queries treat the completion flag as proof that cached bytes are ready. Polling can publish this flag before the bytes, while event completion sets it without populating the cache, allowing zero-byte results or failed batches to be reported as successful.
- HCCL overwrites the accumulated byte count with the current slice's length after `markSuccess()`, losing bytes from earlier slices.

## Fix

- Acquire the completion counters before atomically loading transferred bytes in 17 transports (21 query sites) and the `MultiTransport` fallback.
- Add a separate cache-valid flag and publish it only after storing the aggregated byte count. Batch queries use this flag so completion events cannot expose an unpopulated cache or bypass failure checks.
- Remove HCCL's post-`markSuccess()` assignment, preserving the byte total accumulated by `markSuccess()`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Tested on two NVIDIA H20 nodes with four RoCE HCAs each, using Release/CUDA builds with event-driven completion enabled and disabled, covering bidirectional CPU/GPU reads and writes over peermem and DMA-BUF. Earlier RDMA tests observed byte undercounts despite correct data. After the fix, all 128 cases (64 GiB, 131,072 requests) passed byte-count and payload checks, including 2,048 batches queried after completion events. Repeated cache queries, success/failure ordering checks, selected existing unit tests, and TCP loopback tests also passed. HCCL and other vendor-specific backends were not hardware-tested.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (<500 LOC)

## AI Assistance Disclosure

- [x] AI tools were used

OpenAI Codex assisted with analysis, implementation, and validation. The human submitter is responsible for reviewing the changes.