### PR TITLE
[TENT] Rotate HP TCP lanes independently per peer

### DIFF
--- a/docs/source/design/tent/hp-tcp.md
+++ b/docs/source/design/tent/hp-tcp.md
@@ -9,8 +9,11 @@ scheduling.
 ## Architecture
 
 Each worker owns one `asio::io_context` and one thread. Each peer has a
-configured number of persistent lanes, and request IDs distribute operations
-across them. A stable hash of peer and lane selects the owner; socket state
+configured number of persistent lanes. A separate sequence for each peer
+rotates operations across them, so interleaved traffic to other peers cannot
+pin a peer to one lane. Each sequence starts at that peer's first request ID
+to preserve its initial lane choice. Request IDs remain globally unique.
+A stable hash of peer and lane selects the owner; socket state
 never moves between workers, and operations on a lane are FIFO. ASIO provides
 the event queue; process-wide task and byte admission limits bound all accepted
 work, including callbacks waiting in that queue.

--- a/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_transport.h
@@ -3,6 +3,7 @@
 #define TENT_HP_TCP_TRANSPORT_H_
 
 #include <atomic>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -90,6 +91,10 @@ class HighPerformanceTcpTransport final : public Transport {
     HighPerformanceTcpBufferRegistry registry_;
 
     std::atomic<uint64_t> next_request_id_{1};
+    // Request IDs are global; lane rotation must advance independently per
+    // peer so periodic fan-out cannot pin a peer to one lane or rail.
+    std::mutex lane_sequence_mutex_;
+    std::map<SegmentID, uint64_t> next_lane_sequence_;
     std::atomic<bool> installed_{false};
     std::atomic<bool> stopping_{false};
     mutable std::mutex lifecycle_mutex_;

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_transport.cpp
@@ -422,6 +422,10 @@ Status HighPerformanceTcpTransport::uninstall() {
     workers_.reset();
     admission_.reset();
     metadata_.reset();
+    {
+        std::lock_guard<std::mutex> lock(lane_sequence_mutex_);
+        next_lane_sequence_.clear();
+    }
     installed_.store(false, std::memory_order_release);
     return first;
 }
@@ -559,6 +563,14 @@ Status HighPerformanceTcpTransport::planTask(
     task->setRequestId(request_id);
     planned_task = task;
 
+    uint64_t lane_sequence;
+    {
+        std::lock_guard<std::mutex> lock(lane_sequence_mutex_);
+        // Preserve the first lane choice, then advance independently.
+        auto it = next_lane_sequence_.try_emplace(request.target_id, request_id)
+                      .first;
+        lane_sequence = it->second++;
+    }
     uint64_t slice_offset = 0;
     for (size_t slice = 0; slice < slice_count; ++slice) {
         const uint64_t slice_length =
@@ -568,7 +580,7 @@ Status HighPerformanceTcpTransport::planTask(
         uint32_t endpoint_id = 0;
         if (slice_count == 1) {
             lane_id = static_cast<uint32_t>(
-                request_id %
+                lane_sequence %
                 static_cast<uint64_t>(params_.connections_per_peer));
             endpoint_id = static_cast<uint32_t>(lane_id % endpoint_count);
         } else {
@@ -576,9 +588,9 @@ Status HighPerformanceTcpTransport::planTask(
             const size_t lanes_for_endpoint =
                 1 + (params_.connections_per_peer - 1 - endpoint_id) /
                         endpoint_count;
-            lane_id = static_cast<uint32_t>(endpoint_id +
-                                            (request_id % lanes_for_endpoint) *
-                                                endpoint_count);
+            lane_id = static_cast<uint32_t>(
+                endpoint_id +
+                (lane_sequence % lanes_for_endpoint) * endpoint_count);
         }
         const auto& endpoint = endpoint_attr.endpoints[endpoint_id];
         const size_t owner_worker =

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
@@ -43,6 +43,11 @@ class HighPerformanceTcpTransportTestPeer {
     static Status barrier(HighPerformanceTcpTransport& transport) {
         return transport.workers_->barrier();
     }
+
+    static uint64_t activeSessions(
+        const HighPerformanceTcpTransport& transport) {
+        return transport.server_->activeSessionsForTest();
+    }
 };
 
 namespace {
@@ -799,6 +804,117 @@ TEST(HighPerformanceTcpTransportTest,
     ASSERT_TRUE(client.uninstall().ok());
     ASSERT_TRUE(server.uninstall().ok());
 }
+
+class HighPerformanceTcpLaneDistributionTest
+    : public ::testing::TestWithParam<bool> {};
+
+TEST_P(HighPerformanceTcpLaneDistributionTest,
+       InterleavedPeersUseEveryConfiguredLane) {
+    const bool sliced_read = GetParam();
+    const size_t peer_count = sliced_read ? 2 : 4;
+    const size_t length = sliced_read ? 4ULL << 20 : 4;
+    auto params = MakeParams();
+    params.bind_address.clear();
+    params.rail_addresses = {"127.0.0.1", "127.0.0.2"};
+    params.connections_per_peer = 4;
+    params.max_outstanding_bytes = 8ULL << 20;
+    params.max_transfer_bytes = 8ULL << 20;
+
+    // Each peer has its own listener, making per-peer socket counts observable.
+    // Storage outlives the transports even if an assertion ends the test.
+    std::vector<std::vector<uint8_t>> remote(peer_count,
+                                             std::vector<uint8_t>(length, 0));
+    std::vector<uint8_t> local(length, 0x5a);
+    std::vector<std::shared_ptr<ControlService>> server_metadata;
+    std::vector<std::unique_ptr<HighPerformanceTcpTransport>> servers;
+    std::vector<SegmentID> targets;
+    auto client_metadata = MakeLocalMetadata();
+    HighPerformanceTcpTransport client(params);
+    std::string client_name = "hp_lane_distribution_client";
+    ASSERT_TRUE(
+        client.install(client_name, client_metadata, nullptr, nullptr).ok());
+    for (size_t peer = 0; peer < peer_count; ++peer) {
+        if (sliced_read) {
+            std::fill(remote[peer].begin(), remote[peer].end(),
+                      static_cast<uint8_t>(peer + 1));
+        }
+        auto metadata = MakeLocalMetadata();
+        server_metadata.push_back(metadata);
+        uint16_t rpc_port = 0;
+        ASSERT_TRUE(metadata->start(rpc_port).ok());
+        std::string name = "127.0.0.1:" + std::to_string(rpc_port);
+        ASSERT_TRUE(metadata->segmentManager()
+                        .updateLocal([&](SegmentDesc& segment) -> Status {
+                            segment.name = name;
+                            segment.rpc_server_addr = name;
+                            return Status::OK();
+                        })
+                        .ok());
+        servers.push_back(
+            std::make_unique<HighPerformanceTcpTransport>(params));
+        ASSERT_TRUE(
+            servers.back()->install(name, metadata, nullptr, nullptr).ok());
+        BufferDesc buffer;
+        buffer.addr = reinterpret_cast<uint64_t>(remote[peer].data());
+        buffer.length = length;
+        buffer.location = "cpu:0";
+        MemoryOptions options;
+        options.perm = kGlobalReadWrite;
+        ASSERT_TRUE(servers.back()->addMemoryBuffer(buffer, options).ok());
+        ASSERT_TRUE(PublishBuffers(metadata, {buffer}).ok());
+        SegmentID target = 0;
+        ASSERT_TRUE(
+            client_metadata->segmentManager().openRemote(target, name).ok());
+        targets.push_back(target);
+    }
+    BufferDesc buffer;
+    buffer.addr = reinterpret_cast<uint64_t>(local.data());
+    buffer.length = length;
+    buffer.location = "cpu:0";
+    MemoryOptions options;
+    options.perm = kLocalReadWrite;
+    ASSERT_TRUE(client.addMemoryBuffer(buffer, options).ok());
+
+    // One request per peer per round, across separate submissions. The old
+    // global request ID stride used one lane per peer for the WRITE case and
+    // one lane per rail per peer for sliced READs.
+    for (size_t round = 0; round < params.connections_per_peer; ++round) {
+        for (size_t peer = 0; peer < peer_count; ++peer) {
+            if (sliced_read) std::fill(local.begin(), local.end(), 0);
+            Transport::SubBatchRef batch = nullptr;
+            ASSERT_TRUE(client.allocateSubBatch(batch, 1).ok());
+            Request request{};
+            request.opcode = sliced_read ? Request::READ : Request::WRITE;
+            request.source = local.data();
+            request.target_id = targets[peer];
+            request.target_offset =
+                reinterpret_cast<uint64_t>(remote[peer].data());
+            request.length = length;
+            ASSERT_TRUE(client.submitTransferTasks(batch, {request}).ok());
+            TransferStatus status{};
+            ASSERT_TRUE(WaitForTransportResult(client, batch, status).ok());
+            ASSERT_EQ(status.s, COMPLETED);
+            EXPECT_EQ(status.transferred_bytes, length);
+            EXPECT_EQ(std::memcmp(local.data(), remote[peer].data(), length),
+                      0);
+            ASSERT_TRUE(client.freeSubBatch(batch).ok());
+        }
+    }
+    for (const auto& server : servers) {
+        EXPECT_EQ(HighPerformanceTcpTransportTestPeer::activeSessions(*server),
+                  params.connections_per_peer);
+    }
+    ASSERT_TRUE(client.quiesce().ok());
+    ASSERT_TRUE(client.uninstall().ok());
+    for (const auto& server : servers) {
+        ASSERT_TRUE(server->quiesce().ok());
+        ASSERT_TRUE(server->uninstall().ok());
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(WriteAndSlicedRead,
+                         HighPerformanceTcpLaneDistributionTest,
+                         ::testing::Bool());
 
 }  // namespace
 }  // namespace mooncake::tent


### PR DESCRIPTION
## Description

HP TCP currently chooses a peer's lane from the global request ID. With periodic fan-out, unrelated peers consume the intervening IDs: four interleaved peers and four lanes repeatedly select only one lane per peer. The same aliasing reduces the connections used for sliced READs.

Advance a separate lane sequence per peer, seeded from its first global request ID to preserve the initial lane/rail choice. Keep global wire/cancellation IDs, the existing worker-affinity mapping, slicing and ACK semantics unchanged. This adds a short mutex-protected counter lookup per submitted request; counter entries are cleared on transport teardown.

This is separate from the accepted-socket NODELAY/coalescing fix merged in #3931. No additional throughput claim or scheduler is introduced.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Docs

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Ubuntu 24.04 / WSL2, GCC 13.3, C++20, RelWithDebInfo, CPU/loopback. A focused external CMake driver builds the actual TENT sources and existing repository test programs.

```bash
ctest --test-dir "$BUILD" --output-on-failure \
  -R '^tent_hp_tcp_(transport_config_test|workers_test|socket_test|transport_test|e2e_.*)$'
```

- [x] Seven CTest targets passed, including three two-process READ/WRITE cases.
- [x] Real transport regression: four interleaved WRITE peers each use all four lanes across two rails, with payload checks.
- [x] Real transport regression: two interleaved sliced-READ peers each use all four lanes across two rails, with payload checks.
- [x] Behavioral negative control using the original client/transport translation units fails both new regression cases; restoring the fix passes. Those upstream translation units are unchanged since the original audit.
- [x] Changed-file pre-commit hooks and documentation HTML build passed.

## Checklist

- [ ] Human submitter has reviewed every changed line (pending; draft).
- [x] Codex performed a second review of the diff and dispatch/ownership/teardown paths.
- [x] Changed C++ lines checked by the repository formatter through pre-commit.
- [x] Documentation and focused regression tests included.
- [x] Scope is below the architectural RFC threshold.

## AI Assistance Disclosure

- [x] AI tools were used