### PR TITLE
[TENT] Retire idle HP TCP client connections

### DIFF
--- a/docs/source/design/tent/hp-tcp.md
+++ b/docs/source/design/tent/hp-tcp.md
@@ -97,6 +97,16 @@ Independent peers can continue while a peer is waiting for its progress
 timeout. FIFO sharing within one peer's lanes can still delay small requests
 behind large ones; slicing is not a priority or preemption mechanism.
 
+The client separately closes a pooled socket after
+`idle_connection_timeout_ms` without active or queued work on that lane
+(default 60 seconds). New work before expiry cancels this timer and reuses the
+socket; work after expiry reconnects. This releases receiver connection slots
+held by idle updated clients. The server does not evict established idle sockets:
+it cannot know whether a client has just started another WRITE. Older clients
+that keep sockets open indefinitely still require their own pool cleanup.
+Tasks attempted while the receiver connection limit is full can still fail;
+idle cleanup is not task backpressure or an automatic retry policy.
+
 Shutdown closes admission and the listener, drains queued dispatch callbacks,
 cancels every client lane and server session on its owner, waits for operations
 and leases, then stops and joins worker threads. This makes shutdown bounded
@@ -129,6 +139,7 @@ The transport is configured under `transports.hp_tcp`:
 | `max_outstanding_tasks`, `max_outstanding_bytes` | Global admission bounds. |
 | `max_transfer_bytes` | Maximum request size. When HP TCP is enabled, coalescing of HP TCP/UNSPEC requests respects both local and advertised remote limits; an individually oversized request is still rejected. |
 | `connect_timeout_ms`, `progress_timeout_ms` | Connection and I/O deadlines. |
+| `idle_connection_timeout_ms` | Positive client idle-pool retention time; default 60000 ms. Active or queued requests are never expired by this timer. Shorter retention frees receiver slots sooner but requires more reconnections for intermittent traffic. |
 
 ### Single-rail and paired-rail examples
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/hp_tcp_transport_config.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/hp_tcp_transport_config.h
@@ -24,6 +24,8 @@ struct HighPerformanceTcpParams {
     uint64_t max_transfer_bytes{1ULL << 30};
     uint64_t connect_timeout_ms{2000};
     uint64_t progress_timeout_ms{30000};
+    // Release pooled sockets only when the client has no work on the lane.
+    uint64_t idle_connection_timeout_ms{60000};
 };
 
 struct HpTcpTransportConfig {

--- a/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_client.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_client.h
@@ -34,6 +34,7 @@ class HighPerformanceTcpClient {
         uint64_t connect_timeout_ms{2000};
         uint64_t progress_timeout_ms{30000};
         size_t connections_per_peer{4};
+        uint64_t idle_connection_timeout_ms{60000};
     };
 
     struct Operation {

--- a/mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp
@@ -121,13 +121,15 @@ Status ParseHpTcpTransportConfig(const Config& config,
                               &parsed.params.connect_timeout_ms));
     CHECK_STATUS(ReadUnsigned(hp_tcp, "progress_timeout_ms",
                               &parsed.params.progress_timeout_ms));
+    CHECK_STATUS(ReadUnsigned(hp_tcp, "idle_connection_timeout_ms",
+                              &parsed.params.idle_connection_timeout_ms));
 
     const auto& hp = parsed.params;
     if (parsed.enabled &&
         (hp.worker_count == 0 || hp.connections_per_peer == 0 ||
          hp.max_outstanding_tasks == 0 || hp.max_outstanding_bytes == 0 ||
          hp.max_transfer_bytes == 0 || hp.connect_timeout_ms == 0 ||
-         hp.progress_timeout_ms == 0)) {
+         hp.progress_timeout_ms == 0 || hp.idle_connection_timeout_ms == 0)) {
         return Invalid("transports/hp_tcp",
                        "contains zero or inconsistent limits");
     }

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
@@ -40,6 +40,7 @@ class HighPerformanceTcpClient::Lane
     }
 
     void cancelAll(TransferStatusEnum terminal) {
+        cancelTimer();
         while (!queue_.empty()) {
             Operation operation = std::move(queue_.front());
             queue_.pop_front();
@@ -50,9 +51,6 @@ class HighPerformanceTcpClient::Lane
             return;
         }
         forced_terminal_ = terminal;
-        ++timer_generation_;
-        std::error_code ignored;
-        timer_.cancel(ignored);
         resolver_.cancel();
         closeDirty();
         // The outstanding async callback owns the final completion. Releasing
@@ -355,6 +353,24 @@ class HighPerformanceTcpClient::Lane
         timer_.cancel(ignored);
     }
 
+    void armIdleTimer() {
+        if (current_ || !queue_.empty() || !socket_.is_open()) return;
+        const uint64_t generation = ++timer_generation_;
+        timer_.expires_after(
+            std::chrono::milliseconds(config_.idle_connection_timeout_ms));
+        auto self = shared_from_this();
+        timer_.async_wait([self, generation](const std::error_code& error) {
+            if (error || generation != self->timer_generation_ ||
+                self->current_ || !self->queue_.empty()) {
+                return;
+            }
+            // Only the client knows that no request is in transit. Closing
+            // here releases receiver capacity without racing a reused WRITE
+            // against server-side eviction. The next operation reconnects.
+            self->closeDirty();
+        });
+    }
+
     bool matches(uint64_t epoch) const {
         return current_.has_value() && epoch == operation_epoch_;
     }
@@ -412,6 +428,7 @@ class HighPerformanceTcpClient::Lane
         completeStandalone(std::move(operation), terminal, bytes,
                            remote_status);
         startNext();
+        armIdleTimer();
     }
 
     void completeStandalone(

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_transport.cpp
@@ -118,7 +118,8 @@ Status HighPerformanceTcpTransport::validateParams() const {
     if (params_.worker_count == 0 || params_.connections_per_peer == 0 ||
         params_.max_outstanding_tasks == 0 ||
         params_.max_outstanding_bytes == 0 || params_.max_transfer_bytes == 0 ||
-        params_.connect_timeout_ms == 0 || params_.progress_timeout_ms == 0) {
+        params_.connect_timeout_ms == 0 || params_.progress_timeout_ms == 0 ||
+        params_.idle_connection_timeout_ms == 0) {
         return Status::InvalidArgument(
             "invalid high-performance TCP limits" LOC_MARK);
     }
@@ -240,7 +241,7 @@ Status HighPerformanceTcpTransport::install(
             static_cast<size_t>(std::min<uint64_t>(kIoProgressStepBytes,
                                                    params_.max_transfer_bytes)),
             params_.connect_timeout_ms, params_.progress_timeout_ms,
-            params_.connections_per_peer},
+            params_.connections_per_peer, params_.idle_connection_timeout_ms},
         workers_.get());
 
     const uint64_t max_connections_u64 = std::max<uint64_t>(

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_socket_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_socket_test.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <optional>
 #include <thread>
 
@@ -61,13 +62,15 @@ __attribute__((no_sanitize("thread"))) bool SocketOrderedEqual(
 
 class Runtime {
    public:
-    explicit Runtime(size_t max_connections = 16, uint64_t timeout_ms = 500)
+    explicit Runtime(size_t max_connections = 16, uint64_t timeout_ms = 500,
+                     uint64_t idle_timeout_ms = 60000)
         : workers({.worker_count = 2}),
           client({.max_transfer_bytes = 1 << 20,
                   .chunk_size = 128,
                   .connect_timeout_ms = 500,
                   .progress_timeout_ms = timeout_ms,
-                  .connections_per_peer = 2},
+                  .connections_per_peer = 2,
+                  .idle_connection_timeout_ms = idle_timeout_ms},
                  &workers),
           server({.bind_address = "127.0.0.1",
                   .port = 0,
@@ -168,6 +171,116 @@ TEST(HighPerformanceTcpSocketTest, WriteReadAndReuseConnection) {
     EXPECT_EQ(read.status, COMPLETED);
     EXPECT_TRUE(SocketOrderedEqual(destination, source));
     EXPECT_EQ(runtime.client.connectionsCreatedForTest(), 1u);
+}
+
+TEST(HighPerformanceTcpSocketTest, IdleClientsReleaseCapacityAndReconnect) {
+    std::array<uint8_t, 4> remote{};
+    std::array<uint8_t, 4> source{1, 2, 3, 4};
+    Runtime runtime(/*max_connections=*/2, /*timeout_ms=*/500,
+                    /*idle_timeout_ms=*/500);
+    runtime.start();
+    uint64_t registration = 0;
+    ASSERT_TRUE(runtime.registry
+                    .add(reinterpret_cast<uint64_t>(remote.data()),
+                         remote.size(), kGlobalReadWrite, &registration)
+                    .ok());
+    uint64_t request_id = 1;
+    auto write = [&](SegmentID peer_id, Completion& completion) {
+        auto operation =
+            Operation(source.data(), source.size(),
+                      reinterpret_cast<uint64_t>(remote.data()), registration,
+                      request_id++, HighPerformanceTcpOpcode::kWrite,
+                      &completion, runtime.port);
+        operation.peer_id = peer_id;
+        return runtime.submit(std::move(operation));
+    };
+    for (SegmentID peer_id : {1, 2}) {
+        Completion completion;
+        ASSERT_TRUE(write(peer_id, completion).ok());
+        ASSERT_TRUE(completion.wait());
+        ASSERT_EQ(completion.status, COMPLETED);
+    }
+    ASSERT_EQ(runtime.server.activeSessionsForTest(), 2u);
+    Completion rejected;
+    ASSERT_TRUE(write(3, rejected).ok());
+    ASSERT_TRUE(rejected.wait());
+    EXPECT_EQ(rejected.status, FAILED);
+
+    // Completed historical traffic must eventually give up receiver slots.
+    // No server eviction or explicit client shutdown is needed.
+    ASSERT_TRUE(
+        WaitUntil([&] { return runtime.server.activeSessionsForTest() == 0; }));
+    Completion newcomer;
+    ASSERT_TRUE(write(3, newcomer).ok());
+    ASSERT_TRUE(newcomer.wait());
+    ASSERT_EQ(newcomer.status, COMPLETED);
+    EXPECT_TRUE(SocketOrderedEqual(remote, source));
+
+    // The original lane remains usable after its socket was reclaimed.
+    source.fill(0x5a);
+    Completion reconnect;
+    ASSERT_TRUE(write(1, reconnect).ok());
+    ASSERT_TRUE(reconnect.wait());
+    EXPECT_EQ(reconnect.status, COMPLETED);
+    EXPECT_EQ(reconnect.bytes, source.size());
+    EXPECT_FALSE(reconnect.protocol_status.has_value());
+    EXPECT_TRUE(SocketOrderedEqual(remote, source));
+}
+
+TEST(HighPerformanceTcpSocketTest, IdleTimerDoesNotExpireActiveOrQueuedWrites) {
+    std::array<uint8_t, 4> remote{};
+    std::array<uint8_t, 4> source{1, 2, 3, 4};
+    Runtime receiver(/*max_connections=*/16, /*timeout_ms=*/1000);
+    Runtime sender(/*max_connections=*/16, /*timeout_ms=*/1000,
+                   /*idle_timeout_ms=*/100);
+    receiver.start();
+    sender.start();
+    uint64_t registration = 0;
+    ASSERT_TRUE(receiver.registry
+                    .add(reinterpret_cast<uint64_t>(remote.data()),
+                         remote.size(), kGlobalReadWrite, &registration)
+                    .ok());
+    auto write = [&](uint64_t id, Completion& completion) {
+        return sender.submit(Operation(
+            source.data(), source.size(),
+            reinterpret_cast<uint64_t>(remote.data()), registration, id,
+            HighPerformanceTcpOpcode::kWrite, &completion, receiver.port));
+    };
+    Completion warm;
+    ASSERT_TRUE(write(1, warm).ok());
+    ASSERT_TRUE(warm.wait());
+    ASSERT_EQ(warm.status, COMPLETED);
+
+    // The first accepted session belongs to receiver worker 0. Hold it while
+    // the client's old idle deadline passes, with one WRITE awaiting its ACK
+    // and another queued. Sender workers and their timers keep running.
+    std::promise<void> entered;
+    std::promise<void> release;
+    auto resume = release.get_future().share();
+    asio::post(receiver.workers.ioContext(0), [&] {
+        entered.set_value();
+        resume.wait();
+    });
+    const auto entered_status = entered.get_future().wait_for(2s);
+    Completion first;
+    Completion second;
+    const Status submit_first = write(2, first);
+    const Status submit_second = write(3, second);
+    std::this_thread::sleep_for(200ms);
+    const bool prematurely_done = first.done.load(std::memory_order_acquire) ||
+                                  second.done.load(std::memory_order_acquire);
+    release.set_value();
+
+    ASSERT_EQ(entered_status, std::future_status::ready);
+    ASSERT_TRUE(submit_first.ok());
+    ASSERT_TRUE(submit_second.ok());
+    EXPECT_FALSE(prematurely_done);
+    ASSERT_TRUE(first.wait());
+    ASSERT_TRUE(second.wait());
+    EXPECT_EQ(first.status, COMPLETED);
+    EXPECT_EQ(second.status, COMPLETED);
+    EXPECT_EQ(sender.client.connectionsCreatedForTest(), 1u);
+    EXPECT_TRUE(SocketOrderedEqual(remote, source));
 }
 
 TEST(HighPerformanceTcpSocketTest, RejectedWriteBodyCannotBecomeNextFrame) {

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_config_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_config_test.cpp
@@ -14,6 +14,7 @@ TEST(HpTcpTransportConfigTest, DefaultsToDisabled) {
     HpTcpTransportConfig parsed;
     ASSERT_TRUE(ParseHpTcpTransportConfig(config, &parsed).ok());
     EXPECT_FALSE(parsed.enabled);
+    EXPECT_EQ(parsed.params.idle_connection_timeout_ms, 60000U);
 }
 
 TEST(HpTcpTransportConfigTest, RejectsWrongLeafTypes) {
@@ -59,6 +60,30 @@ TEST(HpTcpTransportConfigTest, ParsesRailAddresses) {
     ASSERT_TRUE(ParseHpTcpTransportConfig(config, &parsed).ok());
     ASSERT_EQ(parsed.params.rail_addresses.size(), 2U);
     EXPECT_EQ(parsed.params.rail_addresses[1], "10.1.0.1");
+}
+
+TEST(HpTcpTransportConfigTest, ParsesIndependentIdleConnectionTimeout) {
+    Config config;
+    ASSERT_TRUE(
+        config
+            .load(
+                R"({"transports":{"tcp":{"enable":false},"hp_tcp":{"enable":true,"idle_connection_timeout_ms":1234}}})")
+            .ok());
+    HpTcpTransportConfig parsed;
+    ASSERT_TRUE(ParseHpTcpTransportConfig(config, &parsed).ok());
+    EXPECT_EQ(parsed.params.idle_connection_timeout_ms, 1234U);
+    EXPECT_EQ(parsed.params.progress_timeout_ms, 30000U);
+    for (const char* value : {"0", "-1", "1.5", "\"100\""}) {
+        ASSERT_TRUE(
+            config
+                .load(
+                    std::string(
+                        R"({"transports":{"tcp":{"enable":false},"hp_tcp":{"enable":true,"idle_connection_timeout_ms":)") +
+                    value + "}}}")
+                .ok());
+        EXPECT_TRUE(
+            ParseHpTcpTransportConfig(config, &parsed).IsInvalidArgument());
+    }
 }
 
 TEST(HpTcpTransportConfigTest, AcceptsFullWidthUnsignedLimit) {


### PR DESCRIPTION
## Description

Completed HP TCP client connections remain pooled indefinitely, while the receiver counts idle sessions against its connection cap. When historical idle clients fill that cap, a new client can keep failing even with no transfers in progress.

Close a client socket after its lane has no active or queued work for `transports.hp_tcp.idle_connection_timeout_ms` (positive, default 60000 ms). Reuse the existing owner-thread timer and generation check; new work reconnects after retirement. Only the client retires the connection, avoiding receiver-side eviction racing an in-flight WRITE.

This bounds retention by updated idle clients. Older clients and continuously busy saturation remain outside this fix; failed tasks are not retried automatically. Shorter retention trades receiver capacity for more reconnects. This is distinct from the server NODELAY/coalescing fix merged in #3931.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Docs

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Ubuntu 24.04 / WSL2, GCC 13.3, C++20, RelWithDebInfo, CPU/loopback. A focused external CMake driver builds the actual TENT sources and existing repository test programs.

```bash
ctest --test-dir "$BUILD" --output-on-failure \
  -R '^tent_hp_tcp_(transport_config_test|workers_test|socket_test|transport_test|e2e_.*)$'
```

- [x] Seven CTest targets passed, including three two-process READ/WRITE cases.
- [x] New regression fills the receiver's two-session cap, verifies automatic idle release, then verifies newcomer success and old-lane reconnection with payload checks.
- [x] New regression keeps one WRITE awaiting ACK and another queued beyond the idle deadline; both complete on the same connection.
- [x] Original client/transport translation units fail the new capacity regression; restoring the fix passes.
- [x] Changed-file pre-commit hooks and documentation HTML build passed.

## Checklist

- [ ] Human submitter has reviewed every changed line (pending; draft).
- [x] Codex performed a second review of the diff and timer/completion/teardown call chains.
- [x] Changed C++ lines checked by the repository formatter through pre-commit.
- [x] Documentation and focused regression tests included.
- [x] Scope is below the architectural RFC threshold.

## AI Assistance Disclosure

- [x] AI tools were used: OpenAI Codex assisted with upstream comparison, implementation, tests and review. Human review is pending.