### PR TITLE
[Bugfix] Handle unavailable target segments in classic tebench

### DIFF
--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -101,4 +101,23 @@ if(BUILD_UNIT_TESTS)
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
             "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
   add_test(NAME tebench_target_metrics_test COMMAND tebench_target_metrics_test)
+
+  if(USE_TCP AND NOT USE_SUNRISE)
+    add_executable(tebench_startup_test tests/startup_test.cpp te_backend.cpp
+                                        utils.cpp)
+    target_link_libraries(tebench_startup_test PRIVATE transfer_engine gtest
+                                                       gtest_main)
+    target_include_directories(
+      tebench_startup_test
+      PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+              "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
+    if(USE_CUDA)
+      target_link_libraries(tebench_startup_test PRIVATE CUDA::cudart)
+    endif()
+    if(USE_HIP)
+      target_link_libraries(tebench_startup_test PRIVATE hip::host)
+    endif()
+    add_test(NAME tebench_startup_test COMMAND tebench_startup_test)
+    set_tests_properties(tebench_startup_test PROPERTIES TIMEOUT 60)
+  endif()
 endif()

--- a/mooncake-transfer-engine/benchmark/te_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/te_backend.cpp
@@ -364,7 +364,19 @@ int TEBenchRunner::startInitiator(int num_threads) {
     target_infos_.clear();
     for (const auto& name : names) {
         SegmentID handle = engine_->openSegment(name);
+        if (handle == static_cast<SegmentID>(ERR_INVALID_ARGUMENT)) {
+            LOG(ERROR) << "Failed to open target segment: " << name;
+            return -1;
+        }
         auto info = engine_->getMetadata()->getSegmentDescByID(handle);
+        if (!info) {
+            LOG(ERROR) << "Target segment descriptor not found: " << name;
+            return -1;
+        }
+        if (info->buffers.empty()) {
+            LOG(ERROR) << "Target segment has no registered buffers: " << name;
+            return -1;
+        }
         std::sort(info->buffers.begin(), info->buffers.end(),
                   [](const TransferMetadata::BufferDesc& a,
                      const TransferMetadata::BufferDesc& b) {

--- a/mooncake-transfer-engine/benchmark/tests/startup_test.cpp
+++ b/mooncake-transfer-engine/benchmark/tests/startup_test.cpp
@@ -1,0 +1,145 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "te_backend.h"
+#include "tent/common/types.h"
+
+namespace mooncake::tent {
+namespace {
+
+class TEBenchStartupTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        ASSERT_EQ(setenv("MC_FORCE_TCP", "1", 1), 0);
+        ASSERT_EQ(unsetenv("MC_USE_TENT"), 0);
+        ASSERT_EQ(unsetenv("MC_USE_TEV1"), 0);
+    }
+
+    void SetUp() override {
+        XferBenchConfig::loadFromFlags();
+        XferBenchConfig::seg_name = "127.0.0.1";
+        XferBenchConfig::seg_type = "DRAM";
+        XferBenchConfig::metadata_type = "p2p";
+        XferBenchConfig::xport_type = "tcp";
+        XferBenchConfig::total_buffer_size = buffer_.size();
+
+        reserved_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        ASSERT_GE(reserved_fd_, 0);
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        ASSERT_EQ(bind(reserved_fd_, reinterpret_cast<sockaddr*>(&address),
+                       sizeof(address)),
+                  0);
+        socklen_t length = sizeof(address);
+        ASSERT_EQ(getsockname(reserved_fd_,
+                              reinterpret_cast<sockaddr*>(&address), &length),
+                  0);
+        missing_target_ =
+            "127.0.0.1:" + std::to_string(ntohs(address.sin_port));
+    }
+
+    void TearDown() override {
+        target_.reset();
+        if (reserved_fd_ >= 0) close(reserved_fd_);
+    }
+
+    void createTarget(bool register_buffer) {
+        target_ = std::make_unique<mooncake::TransferEngine>(false);
+        ASSERT_EQ(target_->init("P2PHANDSHAKE", "127.0.0.1"), 0);
+        if (register_buffer) {
+            ASSERT_EQ(target_->registerLocalMemory(buffer_.data(),
+                                                   buffer_.size(), "cpu:0"),
+                      0);
+        }
+        XferBenchConfig::target_seg_name = target_->getLocalIpAndPort();
+    }
+
+    void expectStartFailure(TEBenchRunner& runner) {
+        const int rc = runner.startInitiator(1);
+        if (rc == 0) {
+            EXPECT_EQ(runner.stopInitiator(), 0);
+        }
+        EXPECT_EQ(rc, -1);
+    }
+
+    std::vector<char> buffer_ = std::vector<char>(65536);
+    std::unique_ptr<mooncake::TransferEngine> target_;
+    int reserved_fd_ = -1;
+    std::string missing_target_;
+};
+
+TEST_F(TEBenchStartupTest, UnavailableTargetReturnsError) {
+    XferBenchConfig::target_seg_name = missing_target_;
+    TEBenchRunner runner;
+    expectStartFailure(runner);
+}
+
+TEST_F(TEBenchStartupTest, EmptyTargetBuffersReturnError) {
+    ASSERT_NO_FATAL_FAILURE(createTarget(false));
+    TEBenchRunner runner;
+    expectStartFailure(runner);
+}
+
+TEST_F(TEBenchStartupTest, LaterUnavailableTargetReturnsErrorAndCanRetry) {
+    ASSERT_NO_FATAL_FAILURE(createTarget(true));
+    const auto valid_target = XferBenchConfig::target_seg_name;
+    XferBenchConfig::target_seg_name += "," + missing_target_;
+    TEBenchRunner runner;
+    expectStartFailure(runner);
+
+    XferBenchConfig::target_seg_name = valid_target;
+    ASSERT_EQ(runner.startInitiator(1), 0);
+    EXPECT_EQ(runner.getTargetCount(), 1u);
+    EXPECT_EQ(runner.stopInitiator(), 0);
+}
+
+TEST_F(TEBenchStartupTest, ValidTargetSupportsWriteAndRead) {
+    ASSERT_NO_FATAL_FAILURE(createTarget(true));
+    TEBenchRunner runner;
+    ASSERT_EQ(runner.startInitiator(1), 0);
+    const auto local = runner.getLocalBufferBase(0, 4096, 1);
+    const auto remote = runner.getTargetBufferBase(0, 4096, 1);
+    const auto segment = runner.getTargetSegmentId(0);
+    std::vector<char> expected(4096);
+    for (size_t i = 0; i < expected.size(); ++i)
+        expected[i] = static_cast<char>(i * 17 + 3);
+    std::memcpy(reinterpret_cast<void*>(local), expected.data(),
+                expected.size());
+    EXPECT_GE(runner.runSingleTransfer(local, segment, remote, 4096, 1, WRITE,
+                                       0, IntentType::INTENT_UNSPEC),
+              0);
+    std::memset(reinterpret_cast<void*>(local), 0, expected.size());
+    EXPECT_GE(runner.runSingleTransfer(local, segment, remote, 4096, 1, READ, 0,
+                                       IntentType::INTENT_UNSPEC),
+              0);
+    EXPECT_EQ(std::memcmp(reinterpret_cast<void*>(local), expected.data(),
+                          expected.size()),
+              0);
+    EXPECT_EQ(runner.stopInitiator(), 0);
+}
+
+}  // namespace
+}  // namespace mooncake::tent


### PR DESCRIPTION
## Description

Fixes #3979.

Classic `tebench` dereferenced a null segment descriptor when
`openSegment()` could not resolve a target. This caused the initiator to
terminate with `SIGSEGV` instead of reporting a startup failure.

This change validates the segment handle, descriptor, and registered buffer
list before starting worker threads. Invalid targets now produce a
target-specific error and `tebench` exits normally with a nonzero status.

The change does not alter transport selection, wire protocols, public APIs, or
benchmark result formats.

The regression test uses real Classic TCP engines and covers an unavailable
target, a target with no registered buffers, retry after a partial multi-target
failure, and a valid WRITE/READ path.

## Reproduction

Run a Classic initiator without starting the specified target:

```bash
MC_FORCE_TCP=1 ./build/issue-3979/mooncake-transfer-engine/benchmark/tebench \
  --backend=classic \
  --xport_type=tcp \
  --metadata_type=p2p \
  --target_seg_name=127.0.0.1:1 \
  --seg_type=DRAM \
  --total_buffer_size=65536
```

Before this change, the initiator terminates with `SIGSEGV`. After this change,
it logs `Failed to open target segment: 127.0.0.1:1` and exits normally with
status 1. See #3979 for the complete reproduction details.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Test environment:

- Linux x86_64
- GCC 12.2, CMake 3.25.1
- Release build (`-O3`) with debug symbols
- `USE_TCP=ON`, `USE_TENT=OFF`, `USE_CUDA=OFF`
- Base commit: `b9059252aa8db150ada8220241707d47e27ebb79`

```bash
cmake --build build/issue-3979 --target \
  tebench \
  tebench_startup_test \
  tebench_qos_metrics_test \
  tebench_target_metrics_test \
  tcp_address_validation_test \
  -j32

ctest --test-dir build/issue-3979 \
  -R '^(tebench_(qos_metrics|target_metrics|startup)_test|tcp_address_validation_test)$' \
  --output-on-failure

ctest --test-dir build/issue-3979 \
  -R '^tebench_startup_test$' \
  --repeat until-fail:5 \
  --output-on-failure
```

Results:

- Focused CTest suite: 4/4 passed.
- New startup regression test: five consecutive passes.
- Old/new controlled comparison:
  - old code: unavailable targets terminate with `SIGSEGV`;
  - fixed code: `startInitiator()` returns `-1`.
- Valid target: WRITE, READ, byte-for-byte verification, and stop pass.
- Multi-target case: one valid target followed by an unavailable target returns
  an error without killing the valid target.
- Same-host Classic TCP consistency runs pass for 4 KiB, 128 KiB, and 8 MiB
  transfers.
- Relevant translation units compile with
  `-O3 -g -Wall -Wextra -Werror`.
- Scoped pre-commit passes all applicable hooks.

Not tested: CUDA, TENT builds, sanitizers, full-repository CI, or two-host
performance.

## Checklist

- [x] I have performed a human review of every changed line.
- [x] I have formatted the changed code.
- [x] I have run scoped pre-commit and all applicable hooks pass.
- [x] I have added tests that fail against the old implementation and pass
      against this change.
- [x] I have updated the documentation (not applicable: no user-facing API or
      option changes).
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable: this is
      a small bug fix).

## AI Assistance Disclosure

- [x] AI tools were used for investigation, implementation, testing, and code
      review. The human submitter remains responsible for reviewing and
      defending every changed line.