### PR TITLE
[Store] Complete N08 post-launch snapshot validation

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -262,25 +262,45 @@ HA leadership and metadata replication are configured separately:
 
 - The HA coordinator elects the active master. Configure it with `--enable_ha`, `--ha_backend_type`, `--ha_backend_connstring`, and `--cluster_id`. For `ha_backend_type=etcd`, legacy `--etcd_endpoints` is used only when `--ha_backend_connstring` is empty.
 - The optional batch-record OpLog persists metadata mutations so standby masters can catch up and later be promoted. Enable it explicitly with `--enable_oplog=true`; it is disabled by default and requires `ha_backend_type=etcd` and a build with `STORE_USE_ETCD`.
+- The optional standby-generated batch OpLog snapshot path is enabled with `--enable_oplog_snapshot=true` together with `--enable_oplog=true`. It uses the batch snapshot provider/coordinator and does not use the legacy catalog snapshot manager. Startup fails when the required etcd, cluster ID, object-store, or chunk configuration is invalid; a temporary upload failure leaves OpLog apply running for a later attempt.
 
 
 - `--enable_oplog`: Enable the primary OpLog writer and standby reader. Defaults to `false`.
+- `--enable_oplog_snapshot`: Enable standby-generated snapshots for batch OpLog recovery. Defaults to `false`; requires `enable_oplog=true`, HA with etcd, a valid snapshot object store, and a persistent `MOONCAKE_SNAPSHOT_LOCAL_PATH` when using `local`.
+- `--snapshot_chunk_object_count`: Maximum objects written to one batch OpLog snapshot chunk. Defaults to `1000000`; must be greater than zero when `enable_oplog_snapshot=true`.
 - `--oplog_poll_interval_ms`: Base polling and retry delay for the batch standby, in milliseconds.
 - `--oplog_batch_max_entries`: Maximum number of entries admitted to an ordered batch. Defaults to `1024`.
 - `--batch_oplog_retry_timeout_sec`: Maximum consecutive retryable batch-standby failure window in seconds (default `180`).
 
-For snapshot-based standby bootstrap, also configure:
+For legacy catalog snapshot-based standby bootstrap, configure:
 
 - `--enable_snapshot_restore` (bool, default `false`): Enable standby to bootstrap from the latest snapshot at startup.
 - `--snapshot_object_store_type` (str): Snapshot object store type: `local` or `s3`.
 - `--snapshot_catalog_store_type` (str): Snapshot catalog store type: `embedded` (default) or `redis`.
 
+For the new batch OpLog snapshot path, configure:
+
+```yaml
+enable_ha: true
+ha_backend_type: "etcd"
+enable_oplog: true
+enable_oplog_snapshot: true
+snapshot_chunk_object_count: 1000000
+snapshot_interval_seconds: 600
+snapshot_object_store_type: "local"
+```
+
+The new path stores immutable artifacts below a cluster-specific batch OpLog
+snapshot root. It restores `latest`, then `fallback`, then a proven complete
+OpLog and replays only the suffix after the snapshot cursor. It remains
+non-serving if recovery cannot prove a complete state.
+
 ### Standby Bootstrap
 
 When a Standby starts, it follows this sequence:
 
-1. **Snapshot Bootstrap** (if `enable_snapshot_restore=true`):
-   - Load the latest snapshot from the configured catalog and object store.
+1. **Snapshot Bootstrap** (if `enable_snapshot_restore=true` for legacy catalog snapshots, or `enable_oplog_snapshot=true` for batch OpLog snapshots):
+   - Legacy mode loads the latest snapshot from the configured catalog and object store. Batch OpLog mode loads the latest/fallback descriptor and manifest directly from the batch snapshot control keys.
    - Rebuild object metadata and segment state from the snapshot baseline.
 2. **OpLog Catch-up**:
    - Start from the snapshot's `last_included_seq` (or from 1 if no snapshot).
@@ -322,9 +342,10 @@ cluster_id: "mooncake_cluster"
 enable_oplog: true
 oplog_poll_interval_ms: 1000
 oplog_batch_max_entries: 1024
-enable_snapshot: true
+enable_oplog_snapshot: true
+snapshot_chunk_object_count: 1000000
+snapshot_interval_seconds: 600
 snapshot_object_store_type: "local"
-snapshot_catalog_store_type: "embedded"
 rpc_port: 50051
 ```
 
@@ -338,9 +359,10 @@ cluster_id: "mooncake_cluster"
 enable_oplog: true
 oplog_poll_interval_ms: 1000
 oplog_batch_max_entries: 1024
-enable_snapshot_restore: true
+enable_oplog_snapshot: true
+snapshot_chunk_object_count: 1000000
+snapshot_interval_seconds: 600
 snapshot_object_store_type: "local"
-snapshot_catalog_store_type: "embedded"
 rpc_port: 50052
 ```
 
@@ -624,6 +646,8 @@ mooncake_master \
 | `--etcd_endpoints` | empty | Backward-compatible etcd HA endpoints, used only for `ha_backend_type=etcd` when `--ha_backend_connstring` is empty |
 | `--cluster_id` | `mooncake_cluster` | Cluster ID for HA persistence |
 | `--enable_oplog` | `false` | Enable the primary OpLog writer and standby reader; currently requires `enable_ha=true` and `ha_backend_type=etcd` |
+| `--enable_oplog_snapshot` | `false` | Enable standby-generated batch OpLog snapshots; requires batch OpLog, HA/etcd, valid object-store configuration, and persistent local snapshot storage when applicable |
+| `--snapshot_chunk_object_count` | `1000000` | Maximum objects per batch OpLog snapshot chunk; must be positive when the new snapshot path is enabled |
 | `--oplog_poll_interval_ms` | `1000` | Base polling and retry delay for the batch standby, in milliseconds |
 | `--oplog_batch_max_entries` | `1024` | Maximum number of entries admitted to an ordered batch |
 | `--batch_oplog_retry_timeout_sec` | `180` | Maximum consecutive retryable batch-standby failure window in seconds |

--- a/mooncake-store/tests/e2e/readme.md
+++ b/mooncake-store/tests/e2e/readme.md
@@ -149,3 +149,40 @@ python3 store_client_e2e.py \
 - `--payload-size 4096`: keep NoF writes 4K aligned
 - `--duration-sec`: total workload duration
 - `--sleep-ms`: interval between operations
+
+### run_oplog_snapshot_smoke.sh
+
+Runs the batch OpLog snapshot path with two real master processes and a local
+etcd instance. It publishes two snapshots with multiple object chunks, stops
+and restarts the standby, verifies suffix replay and promotion, and audits
+surviving and removed objects.
+
+```bash
+./run_oplog_snapshot_smoke.sh \
+  --build-dir /path/to/build \
+  --run-dir /tmp/mooncake-oplog-snapshot-smoke
+```
+
+Set `--failpoint-dir` to verify the same launcher environment path used by
+crash tests. The script requires `mooncake_master`, `oplog_ha_client`,
+`oplog_batch_inspector`, `hot_standby_snapshot_bootstrap_test`, `etcd`,
+`etcdctl`, `curl`, `setsid`, and Python `aiohttp`. It is a manual real-etcd
+check and is not registered in CI/nightly.
+
+The run directory must be new. The script stores configurations, master and
+client logs, snapshot artifacts, and audit results there, and stops its test
+processes on exit. Local snapshot storage is shared by the two test masters;
+for multi-host deployment, every master must be able to read the same durable
+snapshot artifacts.
+
+The production mode is opt-in with `enable_oplog_snapshot=true` together with
+`enable_oplog=true`, HA/etcd and a configured snapshot object store. The default
+chunk size is 1,000,000 objects and the default snapshot interval is 600 seconds.
+The smoke overrides these to two objects and two seconds. A chunk bounds object
+count, not byte size or total standby memory. Legacy catalog restore is not
+used by this mode. Snapshot upload failures do not stop OpLog apply, but a node
+must not serve if its recovery history cannot be proven complete.
+
+This smoke does not cover the full crash/corruption/lease-contention matrix,
+S3 outages, large-scale memory/freeze-time measurements, or safe OpLog pruning.
+Keep batch history until retention/pruning has its own verified recovery gate.

--- a/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
+++ b/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 source "$(dirname -- "${BASH_SOURCE[0]}")/run_oplog_batch_cluster.sh"
 parse_up_options "$@"
-[[ ! -e "$RUN_DIR" ]] || die "snapshot smoke requires a fresh run directory"
+if [[ -e "$RUN_DIR" ]]; then die "snapshot smoke requires a fresh run directory"; fi
 MASTER_COUNT=2
 CLIENT_COUNT=0
 ENABLE_OPLOG_SNAPSHOT=true

--- a/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
+++ b/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
@@ -47,7 +47,7 @@ if sys.argv[3]:
     assert ('MOONCAKE_TEST_FAILPOINT_DIR=' + sys.argv[3]).encode() in entries
 PYENV
 done
-summary=$("$INSPECTOR_BIN" summary --endpoints="$ETCD_ENDPOINTS" +  --cluster_id="$CLUSTER_ID" --json)
+summary=$("$INSPECTOR_BIN" summary --endpoints="$ETCD_ENDPOINTS" --cluster_id="$CLUSTER_ID" --json)
 python3 -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["ok"]; assert not d["errors"]' "$summary"
 client_args=(--master_server_entry="etcd://$ETCD_ENDPOINTS"
   --engine_meta_url="http://127.0.0.1:$METADATA_PORT/metadata" --protocol=tcp

--- a/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
+++ b/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
@@ -120,6 +120,11 @@ wait "$(cat "$RUN_DIR/pids/master-$leader.pid")" 2>/dev/null || true
 wait_for_single_leader "$START_TIMEOUT_SEC"
 [[ "$(ready_leader_index)" == "$standby" ]] || die "restarted standby did not promote"
 wait_master_metric_at_least "$standby" master_active_clients 1 "$START_TIMEOUT_SEC"
+# The promoted controller is reused by the supervisor after leadership loss.
+# Verify that its coordinator can publish again after it returns to standby.
+run_client seed "$RUN_DIR/workload/post-promotion.ack" --count=4 --start_index=300
+post_promotion=$(wait_snapshot "$second" "$(read_durable_sequence)")
+[[ -n "$post_promotion" ]] || die "post-promotion snapshot was not published"
 for manifest in survivors second suffix; do
   run_client verify "$RUN_DIR/workload/$manifest.ack"
 done

--- a/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
+++ b/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
@@ -120,8 +120,11 @@ wait "$(cat "$RUN_DIR/pids/master-$leader.pid")" 2>/dev/null || true
 wait_for_single_leader "$START_TIMEOUT_SEC"
 [[ "$(ready_leader_index)" == "$standby" ]] || die "restarted standby did not promote"
 wait_master_metric_at_least "$standby" master_active_clients 1 "$START_TIMEOUT_SEC"
-# The promoted controller is reused by the supervisor after leadership loss.
-# Verify that its coordinator can publish again after it returns to standby.
+# Bring the former leader back as standby after promotion and verify that its
+# coordinator can publish a new snapshot.
+start_master "$leader"
+wait_file_text "$RUN_DIR/logs/master-$leader.err" \
+  "Batch snapshot bootstrap complete" "$START_TIMEOUT_SEC"
 run_client seed "$RUN_DIR/workload/post-promotion.ack" --count=4 --start_index=300
 post_promotion=$(wait_snapshot "$second" "$(read_durable_sequence)")
 [[ -n "$post_promotion" ]] || die "post-promotion snapshot was not published"

--- a/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
+++ b/mooncake-store/tests/e2e/run_oplog_snapshot_smoke.sh
@@ -47,6 +47,8 @@ if sys.argv[3]:
     assert ('MOONCAKE_TEST_FAILPOINT_DIR=' + sys.argv[3]).encode() in entries
 PYENV
 done
+summary=$("$INSPECTOR_BIN" summary --endpoints="$ETCD_ENDPOINTS" +  --cluster_id="$CLUSTER_ID" --json)
+python3 -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["ok"]; assert not d["errors"]' "$summary"
 client_args=(--master_server_entry="etcd://$ETCD_ENDPOINTS"
   --engine_meta_url="http://127.0.0.1:$METADATA_PORT/metadata" --protocol=tcp
   --payload_size=4096 --key_prefix="snapshot-$CLUSTER_ID")

--- a/mooncake-store/tools/oplog_batch_auditor.cpp
+++ b/mooncake-store/tools/oplog_batch_auditor.cpp
@@ -163,6 +163,7 @@ OpLogAuditReport AuditOpLogNamespace(const std::string& cluster_id,
             } else if (suffix.size() == kOpLogBatchIdWidth) {
                 AddError(&report, "malformed legacy key: " + kv.key);
             } else if (suffix != "latest" && !suffix.starts_with("snapshot/") &&
+                       !suffix.starts_with("producer_view") &&
                        !suffix.starts_with("cleanup/")) {
                 report.warnings.push_back("unknown OpLog key: " + kv.key);
             }


### PR DESCRIPTION
## Description

Post-N08 follow-up for documentation, lifecycle validation, and final snapshot coordinator behavior. This branch is based directly on `upstream/main` and contains the four commits that were not included in the original N08 draft PR.

The changes add the final snapshot lifecycle checks, document batch OpLog snapshot deployment and manual real-etcd validation, and verify snapshot publication after promotion. CI/nightly integration and the broader crash/corruption fault matrix remain outside this follow-up.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Docs

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] New feature

## How Has This Been Tested?

- Real-etcd snapshot smoke with two masters: two snapshot publications, multi-chunk artifacts, cold restore, suffix replay, standby restart, promotion, and data audit passed.
- Controller lifecycle test passed for repeated start/stop, promotion and destruction.
- Focused bootstrap, promotion, catch-up, launcher, metadata and configuration tests passed.
- Scoped pre-commit passed.

The full crash/corruption/lease-contention matrix and CI/nightly registration remain follow-up work.

## Checklist

- [x] Self-review performed
- [x] Formatting and scoped pre-commit passed
- [x] Tests added/updated
- [ ] CI/nightly integration (follow-up)

## AI Assistance Disclosure

- [x] AI tools were used. Codex assisted with implementation, validation and this PR description; the human submitter must review every changed line.