### PR TITLE
[TE] Report buffered JSONL write failures in tebench

### DIFF
--- a/mooncake-transfer-engine/benchmark/target_metrics.cpp
+++ b/mooncake-transfer-engine/benchmark/target_metrics.cpp
@@ -133,6 +133,8 @@ bool appendTargetMetricsJsonl(const std::string& path,
         return false;
     }
     output << root.dump() << '\n';
+    // Closing flushes buffered output and can reveal delayed write errors.
+    output.close();
     if (!output) {
         *error = "failed to write target JSONL output: " + path;
         return false;

--- a/mooncake-transfer-engine/benchmark/tests/qos_metrics_test.cpp
+++ b/mooncake-transfer-engine/benchmark/tests/qos_metrics_test.cpp
@@ -14,9 +14,13 @@
 
 #include "qos_metrics_adapter.h"
 
+#include <csignal>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <string>
+#include <sys/resource.h>
+#include <unistd.h>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -27,6 +31,38 @@
 namespace mooncake {
 namespace tent {
 namespace {
+
+TEST(QosMetricsDeathTest, ReportsBufferedWriteFailure) {
+    std::string path = testing::TempDir() + "tebench-qos-jsonl-XXXXXX";
+    const int fd = mkstemp(path.data());
+    ASSERT_GE(fd, 0);
+    close(fd);
+
+    // Keep the file-size limit and signal handler out of the parent process.
+    EXPECT_EXIT(
+        {
+            if (std::signal(SIGXFSZ, SIG_IGN) == SIG_ERR) std::_Exit(2);
+            struct rlimit limit{};
+            if (setrlimit(RLIMIT_FSIZE, &limit) != 0) std::_Exit(3);
+            QosMetricsReport report;
+            std::string error;
+            const bool ok = appendQosMetricsJsonl(path, report, &error);
+            std::_Exit(!ok && error ==
+                                   "failed to write QoS JSONL output: " + path
+                           ? 0
+                           : 1);
+        },
+        testing::ExitedWithCode(0), "");
+    std::remove(path.c_str());
+}
+
+TEST(QosMetricsTest, ReportsOpenFailure) {
+    QosMetricsReport report;
+    std::string error;
+    const auto path = testing::TempDir();
+    EXPECT_FALSE(appendQosMetricsJsonl(path, report, &error));
+    EXPECT_EQ(error, "failed to open QoS JSONL output: " + path);
+}
 
 TEST(QosMetricsTest, SupportsBulkSamples) {
     XferMetricStats stats;
@@ -203,6 +239,9 @@ TEST(QosMetricsTest, UsesNullForUnavailableJsonMetrics) {
     std::remove(path.c_str());
     std::string error;
     ASSERT_TRUE(appendQosMetricsJsonl(path, report, &error)) << error;
+    auto next_report = report;
+    next_report.batch_size = 2;
+    ASSERT_TRUE(appendQosMetricsJsonl(path, next_report, &error)) << error;
 
     std::ifstream input(path);
     nlohmann::json record;
@@ -214,6 +253,9 @@ TEST(QosMetricsTest, UsesNullForUnavailableJsonMetrics) {
     EXPECT_TRUE(record["classes"][0]["slo_attainment"].is_null());
     EXPECT_TRUE(record["classes"][0]["isolation_leakage"].is_null());
     EXPECT_TRUE(record["classes"][0]["isolated_throughput_gbps"].is_null());
+    EXPECT_EQ(record["batch_size"], 1);
+    ASSERT_NO_THROW(input >> record);
+    EXPECT_EQ(record["batch_size"], 2);
     std::remove(path.c_str());
 }
 

--- a/mooncake-transfer-engine/benchmark/tests/target_metrics_test.cpp
+++ b/mooncake-transfer-engine/benchmark/tests/target_metrics_test.cpp
@@ -14,8 +14,12 @@
 
 #include "target_metrics.h"
 
+#include <csignal>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
+#include <sys/resource.h>
+#include <unistd.h>
 
 #include <gtest/gtest.h>
 
@@ -24,6 +28,39 @@
 namespace mooncake {
 namespace tent {
 namespace {
+
+TEST(TargetMetricsDeathTest, ReportsBufferedWriteFailure) {
+    std::string path = testing::TempDir() + "tebench-target-jsonl-XXXXXX";
+    const int fd = mkstemp(path.data());
+    ASSERT_GE(fd, 0);
+    close(fd);
+
+    // Limit only the child: opening succeeds, but even a buffered write fails
+    // when the stream is flushed or closed.
+    EXPECT_EXIT(
+        {
+            if (std::signal(SIGXFSZ, SIG_IGN) == SIG_ERR) std::_Exit(2);
+            struct rlimit limit{};
+            if (setrlimit(RLIMIT_FSIZE, &limit) != 0) std::_Exit(3);
+            TargetMetricsReport report;
+            std::string error;
+            const bool ok = appendTargetMetricsJsonl(path, report, &error);
+            std::_Exit(!ok && error == "failed to write target JSONL output: " +
+                                           path
+                           ? 0
+                           : 1);
+        },
+        testing::ExitedWithCode(0), "");
+    std::remove(path.c_str());
+}
+
+TEST(TargetMetricsTest, ReportsOpenFailure) {
+    TargetMetricsReport report;
+    std::string error;
+    const auto path = testing::TempDir();
+    EXPECT_FALSE(appendTargetMetricsJsonl(path, report, &error));
+    EXPECT_EQ(error, "failed to open target JSONL output: " + path);
+}
 
 TEST(TargetMetricsTest, NonConstantPayloadOnlyForHpTcpConsistencyChecks) {
     const auto saved_transport = XferBenchConfig::xport_type;
@@ -70,6 +107,9 @@ TEST(TargetMetricsTest, ReportsEachTargetAndWritesJsonl) {
     std::remove(path.c_str());
     std::string error;
     ASSERT_TRUE(appendTargetMetricsJsonl(path, report, &error)) << error;
+    auto next_report = report;
+    next_report.batch_size = 3;
+    ASSERT_TRUE(appendTargetMetricsJsonl(path, next_report, &error)) << error;
     std::ifstream input(path);
     nlohmann::json record;
     ASSERT_NO_THROW(input >> record);
@@ -78,6 +118,9 @@ TEST(TargetMetricsTest, ReportsEachTargetAndWritesJsonl) {
     ASSERT_EQ(record["targets"].size(), 2u);
     EXPECT_EQ(record["targets"][0]["segment_name"], "target-a");
     EXPECT_EQ(record["targets"][1]["operations"], 0);
+    EXPECT_EQ(record["batch_size"], 2);
+    ASSERT_NO_THROW(input >> record);
+    EXPECT_EQ(record["batch_size"], 3);
     std::remove(path.c_str());
 }
 

--- a/mooncake-transfer-engine/tent/src/common/qos_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/common/qos_metrics.cpp
@@ -368,6 +368,8 @@ bool appendQosMetricsJsonl(const std::string& path,
         return false;
     }
     output << root.dump() << '\n';
+    // Closing flushes buffered output and can reveal delayed write errors.
+    output.close();
     if (!output) {
         *error = "failed to write QoS JSONL output: " + path;
         return false;


### PR DESCRIPTION
## Description

The target and QoS JSONL writers can return success before buffered output is flushed during stream destruction. If that write fails, tebench can report success even though the output file is empty or incomplete.

Explicitly close each output stream before checking its state so delayed write and close errors reach the existing benchmark failure path. Add regression coverage for buffered write failures, open failures, and appending multiple reports without overwriting earlier records.


## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Both new buffered-write regression tests fail on the original implementation and pass with this fix. They create a writable temporary file, then limit file size to zero and ignore `SIGXFSZ` inside an isolated child process. Opening the file succeeds, but writing its buffered report fails; the test requires the writer to return `false` with the write-error message.

The complete focused suites pass: `target_metrics_test` **4/4** and `qos_metrics_test` **11/11**. They also cover open failures and preserve two distinct reports across consecutive appends.


**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with analysis, implementation, and validation. The human submitter is responsible for reviewing the changes.