### PR TITLE
Fix Ascend LocalCopyEngine stream/context for multi-device async copy

### DIFF
--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/local_copy_engine.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/local_copy_engine.h
@@ -16,6 +16,8 @@
 #ifndef LOCAL_COPY_ENGINE_H
 #define LOCAL_COPY_ENGINE_H
 
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 
 #include <acl/acl.h>
@@ -35,8 +37,8 @@ class LocalCopyEngine {
 
     ~LocalCopyEngine();
 
-    // Initialize the local copy engine. Creates and owns its own ACL stream
-    // for async operations internally.
+    // Initialize the local copy engine. Streams are created lazily per device
+    // under that device's current ACL context (not at Initialize time).
     // transfer_timeout: timeout in milliseconds for sync operations
     // Returns 0 on success, non-zero on failure
     int Initialize(int32_t transfer_timeout);
@@ -76,8 +78,25 @@ class LocalCopyEngine {
                                          aclrtPtrAttributes &src_attrs,
                                          aclrtPtrAttributes &dst_attrs);
 
+    // Return (or lazily create) a stream belonging to the current ACL device
+    // context. The stream must be created while that device's context is
+    // current so aclrtMemcpyAsync does not return 107003.
+    aclrtStream GetOrCreateStreamForCurrentDevice();
+
    private:
-    aclrtStream stream_;
+    // Stream plus the ACL context it was created under. Destroying a stream
+    // requires that same context to be current, otherwise aclrtDestroyStream
+    // can return 107003 (ACL_ERROR_RT_STREAM_CONTEXT).
+    struct DeviceStream {
+        aclrtStream stream = nullptr;
+        aclrtContext context = nullptr;
+    };
+
+    // Per-device streams keyed by ACL device id. A single shared stream is
+    // unsafe across devices because Initialize() may run under device0
+    // context while workers later copy under other device contexts.
+    std::unordered_map<int32_t, DeviceStream> streams_;
+    mutable std::mutex streams_mu_;
     int32_t transfer_timeout_;
     bool initialized_;
 };

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp
@@ -33,28 +33,92 @@ constexpr uint32_t kStreamFlags = ACL_STREAM_FAST_LAUNCH | ACL_STREAM_FAST_SYNC;
 }  // namespace
 
 LocalCopyEngine::LocalCopyEngine()
-    : stream_(nullptr), transfer_timeout_(10000), initialized_(false) {}
+    : transfer_timeout_(10000), initialized_(false) {}
 
 LocalCopyEngine::~LocalCopyEngine() { Finalize(); }
 
 int LocalCopyEngine::Initialize(int32_t transfer_timeout) {
     transfer_timeout_ = transfer_timeout;
-    auto ret = aclrtCreateStreamWithConfig(&stream_, 0, kStreamFlags);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(ERROR) << "aclrtCreateStreamWithConfig failed, ret:" << ret
-                   << ", errmsg:" << aclGetRecentErrMsg();
-        return -1;
-    }
+    // Do not create a stream here: initEngines() may still be under a
+    // different device context than the worker threads that later call Copy.
+    // Streams are created lazily in GetOrCreateStreamForCurrentDevice().
     initialized_ = true;
     return 0;
 }
 
 void LocalCopyEngine::Finalize() {
-    if (initialized_ && stream_ != nullptr) {
-        (void)aclrtDestroyStream(stream_);
-        stream_ = nullptr;
+    std::lock_guard<std::mutex> lock(streams_mu_);
+    aclrtContext saved_ctx = nullptr;
+    const bool have_saved =
+        (aclrtGetCurrentContext(&saved_ctx) == ACL_ERROR_NONE &&
+         saved_ctx != nullptr);
+    MAKE_GUARD(ctx_restore, [have_saved, saved_ctx]() {
+        if (have_saved) {
+            (void)aclrtSetCurrentContext(saved_ctx);
+        }
+    });
+
+    for (auto &kv : streams_) {
+        auto &info = kv.second;
+        if (info.stream == nullptr) {
+            continue;
+        }
+        aclError ret = ACL_ERROR_NONE;
+        if (info.context != nullptr) {
+            ret = aclrtSetCurrentContext(info.context);
+        } else {
+            ret = aclrtSetDevice(kv.first);
+        }
+        if (ret != ACL_ERROR_NONE) {
+            LOG(ERROR)
+                << "Failed to switch to device " << kv.first
+                << " context before destroying LocalCopyEngine stream, ret:"
+                << ret << ", errmsg:" << aclGetRecentErrMsg();
+        }
+        (void)aclrtDestroyStream(info.stream);
+        info.stream = nullptr;
+        info.context = nullptr;
     }
+    streams_.clear();
     initialized_ = false;
+}
+
+aclrtStream LocalCopyEngine::GetOrCreateStreamForCurrentDevice() {
+    int32_t device_id = 0;
+    auto ret = aclrtGetDevice(&device_id);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(ERROR) << "aclrtGetDevice failed, ret:" << ret
+                   << ", errmsg:" << aclGetRecentErrMsg();
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(streams_mu_);
+    auto it = streams_.find(device_id);
+    if (it != streams_.end() && it->second.stream != nullptr) {
+        return it->second.stream;
+    }
+
+    aclrtStream stream = nullptr;
+    ret = aclrtCreateStreamWithConfig(&stream, 0, kStreamFlags);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(ERROR) << "aclrtCreateStreamWithConfig failed for device "
+                   << device_id << ", ret:" << ret
+                   << ", errmsg:" << aclGetRecentErrMsg();
+        return nullptr;
+    }
+
+    aclrtContext ctx = nullptr;
+    ret = aclrtGetCurrentContext(&ctx);
+    if (ret != ACL_ERROR_NONE || ctx == nullptr) {
+        LOG(ERROR) << "aclrtGetCurrentContext failed after creating stream for "
+                      "device "
+                   << device_id << ", ret:" << ret
+                   << ", errmsg:" << aclGetRecentErrMsg();
+        ctx = nullptr;
+    }
+    streams_[device_id] = DeviceStream{stream, ctx};
+    VLOG(1) << "Created LocalCopyEngine stream for device " << device_id;
+    return stream;
 }
 
 void LocalCopyEngine::Copy(TransferRequest::OpCode opcode,
@@ -118,6 +182,8 @@ void LocalCopyEngine::Copy(TransferRequest::OpCode opcode,
         ret = CopyWithBatch(opcode, slice_list, kind, batch_num, slice_index);
         if (ret == ACL_ERROR_RT_FEATURE_NOT_SUPPORT) {
             // Fallback to async copy if batch copy is not supported
+            VLOG(1) << "aclrtMemcpyBatch FEATURE_NOT_SUPPORT (207000); "
+                       "falling back to CopyWithAsync";
             CopyWithAsync(opcode, slice_list, kind);
             return;
         }
@@ -243,6 +309,14 @@ void LocalCopyEngine::CopyWithSync(TransferRequest::OpCode opcode,
 void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
                                     const std::vector<Slice *> &slice_list,
                                     aclrtMemcpyKind kind) {
+    aclrtStream stream = GetOrCreateStreamForCurrentDevice();
+    if (stream == nullptr) {
+        for (auto &slice : slice_list) {
+            slice->markFailed();
+        }
+        return;
+    }
+
     std::vector<Slice *> async_list;
     async_list.reserve(slice_list.size());
 
@@ -254,11 +328,11 @@ void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
 
         aclError ret;
         if (opcode == TransferRequest::WRITE) {
-            ret = aclrtMemcpyAsync(remote_ptr, len, local_ptr, len, kind,
-                                   stream_);
+            ret =
+                aclrtMemcpyAsync(remote_ptr, len, local_ptr, len, kind, stream);
         } else {
-            ret = aclrtMemcpyAsync(local_ptr, len, remote_ptr, len, kind,
-                                   stream_);
+            ret =
+                aclrtMemcpyAsync(local_ptr, len, remote_ptr, len, kind, stream);
         }
 
         if (ret != ACL_ERROR_NONE) {
@@ -273,8 +347,7 @@ void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
         return;
     }
 
-    aclError ret =
-        aclrtSynchronizeStreamWithTimeout(stream_, transfer_timeout_);
+    aclError ret = aclrtSynchronizeStreamWithTimeout(stream, transfer_timeout_);
     if (ret == ACL_ERROR_NONE) {
         VLOG(1) << "Copy with aclrtMemcpyAsync suc.";
         for (auto &slice : async_list) {
@@ -282,7 +355,7 @@ void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
         }
     } else {
         LOG(ERROR) << "Memory copy failed, ret:" << ret;
-        (void)aclrtStreamAbort(stream_);
+        (void)aclrtStreamAbort(stream);
         for (auto &slice : async_list) {
             slice->markFailed();
         }


### PR DESCRIPTION
## Summary
- **Root cause:** `LocalCopyEngine` created a single process-wide `stream_` in `Initialize()` during `initEngines()`, still under the device0 ACL context. Worker threads later called `CopyWithAsync` under other devices' contexts, so `aclrtMemcpyAsync` returned **107003** (stream/context mismatch).
- **Fix:** Replace the shared stream with **per-device streams** (`unordered_map<device_id, aclrtStream>`), created lazily via `GetOrCreateStreamForCurrentDevice()` while that device's context is current. Mutex protects map updates. Do not create a stream at `Initialize()` time.
- **Batch fallback:** Unchanged behavior — `aclrtMemcpyBatch` **207000** (`FEATURE_NOT_SUPPORT`) still falls through to `CopyWithAsync`, with a one-line `VLOG(1)` when falling back.

## Files
- `mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/local_copy_engine.h`
- `mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp`

## Base
Branched from latest `origin/main` (`kvcache-ai/Mooncake`). LocalCopyEngine on `tent/ascend-direct-parity` matched main, so this is a clean standalone fix.

## Test plan (NPU host)
- Rebuilt `ascend_transport.so` in `/home/yx/Mooncake/build-adxl` (target-only ninja link).
- Ran `/tmp/run_2p_dummy_real_probe.sh` (2p dummy-real, devices 0,1):
  - **Before (prior probe log):** ~3660× `107003` / `aclrtMemcpyAsync failed` in `dummy_client.log`
  - **After:** rank0/1 **exit 0**, **zero** `107003` / `aclrtMemcpyAsync failed`
- Batch may still return 207000; async fallback is expected and now works across devices.
- 16p dummy-real not re-run in this WIP (8 NPUs / 16 chips available; 2p is the multi-device stream repro).