### PR TITLE
[Integration] Back Python allocate_managed_buffer with POSIX shm

### DIFF
--- a/docs/source/api-reference/python/transfer-engine.md
+++ b/docs/source/api-reference/python/transfer-engine.md
@@ -71,7 +71,7 @@ Initializes the transfer engine with basic configuration.
 **Parameters:**
 - `local_hostname` (str): The hostname and port of the local server (e.g., "127.0.0.1:12345")
 - `metadata_server` (str): The metadata server connection string (e.g., "127.0.0.1:2379" or "etcd://127.0.0.1:2379")
-- `protocol` (str): The transport protocol to use ("rdma", "tcp", etc.)
+- `protocol` (str): The transport protocol to use (`"rdma"`, `"tcp"`, `"shm"`, etc.)
 - `device_name` (str): Comma-separated list of device names to filter, or empty string for all devices
 
 **Returns:**
@@ -88,7 +88,7 @@ Initializes the transfer engine with extended configuration including metadata t
 **Parameters:**
 - `local_hostname` (str): The hostname and port of the local server
 - `metadata_server` (str): The metadata server connection string
-- `protocol` (str): The transport protocol to use
+- `protocol` (str): The transport protocol to use (`"rdma"`, `"tcp"`, `"shm"`, etc.)
 - `device_name` (str): Comma-separated list of device names to filter
 - `metadata_type` (str): The type of metadata server ("etcd", "p2p", etc.)
 
@@ -127,7 +127,14 @@ Gets the RPC port that the transfer engine is listening on.
 allocate_managed_buffer(length)
 ```
 
-Allocates a managed buffer of the specified size using a buddy allocation system for efficient memory management.
+Allocates a managed buffer of the specified size using a buddy allocation system.
+
+When SHM is enabled (`MC_FORCE_SHM=1`, or `initialize(..., protocol="shm")`), the
+backing memory comes from `allocateSharedMemory` so same-host peers can copy
+over POSIX shm. Buddy slabs are 256 MiB in that mode (instead of the 2 GiB
+malloc super-slab) so `/dev/shm` stays usable. Interior buddy pointers are
+covered by the registered slab; only the slab base is registered. GPU protocols
+(`nvlink` / `hip` / `musa` / `nvlink_intra`) keep their pinned allocators.
 
 **Parameters:**
 - `length` (int): The size of the buffer to allocate in bytes

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -320,8 +320,25 @@ export MC_INTRANODE_NVLINK=true
 **Requirements:**
 - Linux POSIX shm (`/dev/shm`)
 - Buffers allocated with `TransferEngine::allocateSharedMemory` (ordinary `malloc` cannot be exported)
-- Runtime opt-in: `MC_FORCE_SHM=1`, or `installTransport("shm")`. With `-DENABLE_MULTI_PROTOCOL=ON` this adds SHM next to RDMA/TCP (`rdma,shm` / `tcp,shm`); without it, SHM is the only transport.
+- Runtime opt-in: `MC_FORCE_SHM=1`, or `installTransport("shm")` / Python `initialize(..., protocol="shm")`. With `-DENABLE_MULTI_PROTOCOL=ON` this adds SHM next to RDMA/TCP (`rdma,shm` / `tcp,shm`); without it, SHM is the only transport.
 - Same-host SHM **and** cross-host RDMA/TCP in one engine: build with `-DENABLE_MULTI_PROTOCOL=ON` (segment protocol becomes `rdma,shm` or `tcp,shm`)
+- Python `allocate_managed_buffer` uses POSIX shm when SHM is installed (buddy slabs are 256 MiB). Ordinary `numpy`/`malloc` buffers still cannot be exported as SHM.
+
+**Configuration:**
+```python
+# Python API
+engine.initialize(
+    "127.0.0.1:12345",
+    "P2PHANDSHAKE",
+    "shm",
+    ""
+)
+```
+
+```bash
+# Environment variables (classic Transfer Engine init)
+export MC_FORCE_SHM=1
+```
 
 **Limitations:**
 - Same host only. Without `ENABLE_MULTI_PROTOCOL`, `MC_FORCE_SHM=1` (or `installTransport("shm")` after another transport) sets `segment.protocol` to `shm` and replaces RDMA/TCP routing; `installTransport("shm")` logs a WARNING when it overwrites a non-empty protocol. Coexistence needs `-DENABLE_MULTI_PROTOCOL=ON`.

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -137,12 +137,25 @@ TransferEnginePy::TransferEnginePy() {
 }
 
 TransferEnginePy::~TransferEnginePy() {
-    for (auto& handle : handle_map_) engine_->closeSegment(handle.second);
-    handle_map_.clear();
-    engine_.reset();
-    for (auto& buffer : buffer_list_) freeMemory(buffer);
+    if (engine_) {
+        for (auto& handle : handle_map_) engine_->closeSegment(handle.second);
+        handle_map_.clear();
+        if (use_shm_alloc_) {
+            for (auto& buffer : buffer_list_) engine_->freeSharedMemory(buffer);
+            for (auto& buffer : large_buffer_list_)
+                engine_->freeSharedMemory(buffer);
+            buffer_list_.clear();
+            large_buffer_list_.clear();
+        }
+        engine_.reset();
+    }
+    for (auto& buffer : buffer_list_) {
+        if (freeMemory) freeMemory(buffer);
+    }
     buffer_list_.clear();
-    for (auto& buffer : large_buffer_list_) freeMemory(buffer);
+    for (auto& buffer : large_buffer_list_) {
+        if (freeMemory) freeMemory(buffer);
+    }
     large_buffer_list_.clear();
 }
 
@@ -190,6 +203,20 @@ std::string buildConnString(const std::string& metadata_type,
     return conn_string;
 }
 
+static int maybeInstallShmFromProtocol(TransferEngine& engine) {
+    if (engine.getTransport("shm") != nullptr) {
+        LOG(INFO) << "SHM transport already installed";
+        return 0;
+    }
+    LOG(INFO) << "Installing SHM transport as requested by protocol parameter";
+    if (!engine.installTransport("shm", nullptr)) {
+        LOG(ERROR) << "Failed to install SHM transport";
+        return -1;
+    }
+    LOG(INFO) << "SHM transport installed successfully";
+    return 0;
+}
+
 int TransferEnginePy::initialize(const char* local_hostname,
                                  const char* metadata_server,
                                  const char* protocol,
@@ -217,6 +244,7 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
     auto device_name_safe = device_name ? std::string(device_name) : "";
     auto device_filter = buildDeviceFilter(device_name_safe);
     bool use_flagcx = (proto == "flagcx");
+    bool use_shm = (proto == "shm");
 
 #ifdef USE_EFA
     // When using EFA protocol, we still need topology discovery but won't
@@ -243,7 +271,8 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
                   << " devices.";
     }
 #else
-    engine_ = std::make_unique<TransferEngine>(!use_flagcx, device_filter);
+    engine_ = std::make_unique<TransferEngine>(!use_flagcx && !use_shm,
+                                               device_filter);
 #endif
 
     if (getenv("MC_LEGACY_RPC_PORT_BINDING")) {
@@ -259,8 +288,9 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
     }
 
 #ifdef USE_EFA
-    // Install EFA transport when protocol is "efa"
-    if (use_efa) {
+    if (use_shm) {
+        if (maybeInstallShmFromProtocol(*engine_)) return -1;
+    } else if (use_efa) {
         LOG(INFO)
             << "Installing EFA transport as requested by protocol parameter";
         auto transport = engine_->installTransport("efa", nullptr);
@@ -292,7 +322,9 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
         LOG(INFO) << "TCP transport installed successfully";
     }
 #elif defined(USE_CXI)
-    if (use_cxi) {
+    if (use_shm) {
+        if (maybeInstallShmFromProtocol(*engine_)) return -1;
+    } else if (use_cxi) {
         LOG(INFO)
             << "Installing CXI transport as requested by protocol parameter";
         auto transport = engine_->installTransport("cxi", nullptr);
@@ -324,7 +356,9 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
         LOG(INFO) << "TCP transport installed successfully";
     }
 #else
-    if (use_flagcx) {
+    if (use_shm) {
+        if (maybeInstallShmFromProtocol(*engine_)) return -1;
+    } else if (use_flagcx) {
         LOG(INFO)
             << "Installing FlagCX transport as requested by protocol parameter";
         auto transport = engine_->installTransport("flagcx", nullptr);
@@ -336,6 +370,14 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
     }
 #endif
 
+    const bool gpu_pinned = proto == "nvlink" || proto == "musa" ||
+                            proto == "hip" || proto == "nvlink_intra";
+    use_shm_alloc_ =
+        !gpu_pinned && engine_ && engine_->getTransport("shm") != nullptr;
+    if (use_shm_alloc_) {
+        LOG(INFO) << "allocate_managed_buffer will use POSIX shm";
+    }
+
     free_list_.resize(kSlabSizeKBTabLen);
     return 0;
 }
@@ -343,18 +385,37 @@ int TransferEnginePy::initializeExt(const char* local_hostname,
 int TransferEnginePy::getRpcPort() { return engine_->getRpcPort(); }
 
 char* TransferEnginePy::allocateRawBuffer(size_t capacity) {
-    if (allocateMemory == nullptr || freeMemory == nullptr) {
-        LOG(ERROR) << "Memory allocator is not initialized";
-        return nullptr;
+    void* buffer = nullptr;
+    if (use_shm_alloc_) {
+        buffer = engine_->allocateSharedMemory(capacity);
+    } else {
+        if (allocateMemory == nullptr || freeMemory == nullptr) {
+            LOG(ERROR) << "Memory allocator is not initialized";
+            return nullptr;
+        }
+        buffer = allocateMemory(capacity);
     }
-    auto buffer = allocateMemory(capacity);
     if (!buffer) return nullptr;
     int ret = engine_->registerLocalMemory(buffer, capacity, kWildcardLocation);
     if (ret) {
-        freeMemory(buffer);
+        releaseRawBuffer(buffer);
         return nullptr;
     }
     return (char*)buffer;
+}
+
+void TransferEnginePy::releaseRawBuffer(void* buffer) {
+    if (!buffer) return;
+    if (use_shm_alloc_ && engine_) {
+        engine_->freeSharedMemory(buffer);
+        return;
+    }
+    if (freeMemory) freeMemory(buffer);
+}
+
+size_t TransferEnginePy::buddySlabCapacity() const {
+    return use_shm_alloc_ ? (1024ull * kSlabSizeKB[kMaxClassId])
+                          : kDefaultBufferCapacity;
 }
 
 int TransferEnginePy::findClassId(size_t size) {
@@ -366,10 +427,11 @@ int TransferEnginePy::findClassId(size_t size) {
 
 int TransferEnginePy::doBuddyAllocate(int class_id) {
     if (class_id == kMaxClassId) {
-        auto buffer = allocateRawBuffer(kDefaultBufferCapacity);
+        const size_t cap = buddySlabCapacity();
+        auto buffer = allocateRawBuffer(cap);
         if (!buffer) return -1;
         buffer_list_.push_back(buffer);
-        for (size_t offset = 0; offset < kDefaultBufferCapacity;
+        for (size_t offset = 0; offset < cap;
              offset += 1024ull * kSlabSizeKB[kMaxClassId])
             free_list_[kMaxClassId].push(buffer + offset);
         return 0;
@@ -408,8 +470,12 @@ int TransferEnginePy::freeManagedBuffer(uintptr_t buffer_addr, size_t length) {
     int class_id = findClassId(length);
     if (class_id < 0) {
         large_buffer_list_.erase(buffer);
-        engine_->unregisterLocalMemory(buffer);
-        freeMemory(buffer);
+        if (use_shm_alloc_) {
+            releaseRawBuffer(buffer);
+        } else {
+            engine_->unregisterLocalMemory(buffer);
+            if (freeMemory) freeMemory(buffer);
+        }
         return 0;
     }
     free_list_[class_id].push(buffer);

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -206,6 +206,8 @@ class TransferEnginePy {
 
    private:
     char *allocateRawBuffer(size_t capacity);
+    void releaseRawBuffer(void *buffer);
+    size_t buddySlabCapacity() const;
 
     int findClassId(size_t size);
 
@@ -221,6 +223,7 @@ class TransferEnginePy {
     std::unordered_set<char *> large_buffer_list_;
     std::unordered_map<std::string, Transport::SegmentHandle> handle_map_;
     bool auto_discovery_;
+    bool use_shm_alloc_ = false;
 
     uint64_t transfer_timeout_nsec_;
 };

--- a/mooncake-wheel/tests/transfer_engine_shm_test.py
+++ b/mooncake-wheel/tests/transfer_engine_shm_test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Same-host SHM e2e for Python allocate_managed_buffer."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+try:
+    from mooncake.engine import TransferEngine
+except Exception as error:  # pragma: no cover - depends on built extension
+    TransferEngine = None
+    _ENGINE_IMPORT_ERROR = error
+else:
+    _ENGINE_IMPORT_ERROR = None
+
+_SMALL_LEN = 4096
+# Buddy class_id is < 0 only when length exceeds the 256 MiB max-class slab.
+_LARGE_LEN = 256 * 1024 * 1024 + 4096
+
+
+def _segment_name(engine, host="127.0.0.1"):
+    return f"{host}:{engine.get_rpc_port()}"
+
+
+def _shm_free_bytes():
+    if not os.path.isdir("/dev/shm"):
+        return 0
+    st = os.statvfs("/dev/shm")
+    return st.f_bavail * st.f_frsize
+
+
+@unittest.skipIf(
+    TransferEngine is None,
+    f"mooncake.engine is unavailable: {_ENGINE_IMPORT_ERROR}",
+)
+@unittest.skipUnless(
+    os.path.isdir("/dev/shm"),
+    "POSIX shm requires /dev/shm",
+)
+class TransferEngineShmManagedBufferTest(unittest.TestCase):
+    def setUp(self):
+        # Two 256 MiB buddy slabs plus a little headroom for metadata.
+        needed = 2 * 256 * 1024 * 1024 + 16 * 1024 * 1024
+        free = _shm_free_bytes()
+        if free < needed:
+            self.skipTest(f"/dev/shm has {free} free bytes; need at least {needed}")
+
+        self.initiator = TransferEngine()
+        self.target = TransferEngine()
+        ret = self.initiator.initialize("127.0.0.1:12347", "P2PHANDSHAKE", "shm", "")
+        self.assertEqual(ret, 0, f"initiator initialize failed: {ret}")
+        ret = self.target.initialize("127.0.0.1:12345", "P2PHANDSHAKE", "shm", "")
+        self.assertEqual(ret, 0, f"target initialize failed: {ret}")
+        self.initiator_name = _segment_name(self.initiator)
+        self.target_name = _segment_name(self.target)
+        self._to_free = []
+
+    def tearDown(self):
+        for engine, addr, length in reversed(self._to_free):
+            if addr:
+                engine.free_managed_buffer(addr, length)
+        self._to_free.clear()
+        self.initiator = None
+        self.target = None
+
+    def _alloc(self, engine, length):
+        addr = engine.allocate_managed_buffer(length)
+        self.assertNotEqual(addr, 0, f"allocate_managed_buffer({length}) failed")
+        self._to_free.append((engine, addr, length))
+        return addr
+
+    def test_small_managed_buffer_write_read(self):
+        src = self._alloc(self.initiator, _SMALL_LEN)
+        dst = self._alloc(self.target, _SMALL_LEN)
+        payload = b"shm-managed-buffer-payload"
+        self.assertEqual(
+            self.initiator.write_bytes_to_buffer(src, payload, len(payload)), 0
+        )
+        self.assertEqual(
+            self.initiator.transfer_sync_write(
+                self.target_name, src, dst, len(payload)
+            ),
+            0,
+        )
+        self.assertEqual(self.target.read_bytes_from_buffer(dst, len(payload)), payload)
+
+        zeros = bytes(len(payload))
+        self.assertEqual(
+            self.initiator.write_bytes_to_buffer(src, zeros, len(payload)), 0
+        )
+        self.assertEqual(
+            self.initiator.transfer_sync_read(self.target_name, src, dst, len(payload)),
+            0,
+        )
+        self.assertEqual(
+            self.initiator.read_bytes_from_buffer(src, len(payload)), payload
+        )
+
+    def test_free_large_managed_buffer_then_write_fails(self):
+        needed = _LARGE_LEN + 256 * 1024 * 1024 + 16 * 1024 * 1024
+        free = _shm_free_bytes()
+        if free < needed:
+            self.skipTest(
+                f"/dev/shm has {free} free bytes; large free-after-write "
+                f"needs about {needed}"
+            )
+
+        src = self._alloc(self.initiator, _SMALL_LEN)
+        dst = self.target.allocate_managed_buffer(_LARGE_LEN)
+        if dst == 0:
+            self.skipTest("allocate_managed_buffer of 256MiB+ failed")
+        self._to_free.append((self.target, dst, _LARGE_LEN))
+
+        payload = b"before-free"
+        self.assertEqual(
+            self.initiator.write_bytes_to_buffer(src, payload, len(payload)), 0
+        )
+        self.assertEqual(
+            self.initiator.transfer_sync_write(
+                self.target_name, src, dst, len(payload)
+            ),
+            0,
+        )
+        self.assertEqual(self.target.read_bytes_from_buffer(dst, len(payload)), payload)
+
+        self.assertEqual(self.target.free_managed_buffer(dst, _LARGE_LEN), 0)
+        self._to_free = [item for item in self._to_free if item[1] != dst]
+
+        ret = self.initiator.transfer_sync_write(
+            self.target_name, src, dst, len(payload)
+        )
+        self.assertNotEqual(ret, 0, "WRITE after free_managed_buffer should fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -124,6 +124,9 @@ TARGET_PID=$!
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata MC_FORCE_TCP=true python transfer_engine_initiator_test.py
 kill $TARGET_PID || true
 
+echo "Running transfer_engine SHM Python e2e..."
+python transfer_engine_shm_test.py
+
 echo "Running master tests..."
 
 which mooncake_master 2>/dev/null | grep -q '/usr/local/bin/mooncake_master' && \


### PR DESCRIPTION
## Description

RFC follow-up to #3912 / #3918: when SHM is enabled (`MC_FORCE_SHM=1` or
`initialize(..., protocol="shm")`), Python `allocate_managed_buffer` allocates
from `allocateSharedMemory` and registers the **exact slab base**. Buddy interior
pointers stay inside that `BufferDesc` range so peers can relocate without a
per-slot `shm_open`.

SHM buddy slabs are 256 MiB (malloc stays 2 GiB) so `/dev/shm` stays usable.
GPU pinned allocators (`nvlink` / `hip` / `musa` / `nvlink_intra`) are unchanged.
SHM buffers are `freeSharedMemory`'d **before** `engine_.reset()`. TENT still
does not pretend SHM succeeded (`getTransport("shm")` / `allocateSharedMemory`
remain null). Store allocator (PR-B) is out of scope.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Against a locally built `engine.so` from this branch (`MC_FORCE_SHM` unset
except for the SHM e2e).

**Test commands:**
```bash
python3 mooncake-wheel/tests/transfer_engine_shm_test.py -v

MC_FORCE_TCP=true PROTOCOL=tcp CIRCLE=3 \
  MC_METADATA_SERVER=http://127.0.0.1:18080/metadata \
  python3 mooncake-wheel/tests/transfer_engine_initiator_test.py
# (with transfer_engine_target.py + mooncake_http_metadata_server)

./scripts/code_format.sh --check
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- SHM e2e (`transfer_engine_shm_test.py`): 2/2 — small WRITE/READ; large
  `free_managed_buffer` then WRITE fails
- Existing two-process TE suite (`initiator_test.py`, tcp + HTTP metadata): 6/6
- Same-host SGLang PD disaggregation with the new `engine.so`
- `code_format.sh --check` and scoped `pre-commit` pass
- `sphinx-build -W` for the touched docs pages

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue
      (follow-up to #3912; this PR is ~250 LOC excluding tests)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok 4.6 helped implement the Python SHM allocator path, docs, and
tests. I reviewed the diff end-to-end (exact-base registration, 256 MiB slab,
dtor order, `protocol="shm"` vs `MC_FORCE_SHM`, TENT no-op).

Made with [Cursor](https://cursor.com)