### PR TITLE
[Bugfix][Store] Check read leases after grouped batch gets

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1582,6 +1582,17 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGetWhenPreferSameNode(
             }
         }
     }
+    // A successful transfer is only valid while its read lease is live.
+    // Check once all segment batches have completed, as in the regular
+    // BatchGet path, and preserve errors from validation or transfer.
+    auto now = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < object_keys.size(); ++i) {
+        if (results[i].has_value() && query_results[i].IsLeaseExpired(now)) {
+            LOG(WARNING) << "lease_expired_before_data_transfer_completed key="
+                         << object_keys[i];
+            results[i] = tl::unexpected(ErrorCode::LEASE_EXPIRED);
+        }
+    }
     return results;
 }
 

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -856,6 +856,111 @@ TEST_F(ClientIntegrationTest, BatchPutGetOperations) {
     }
 }
 
+TEST_F(ClientIntegrationTest, BatchGetChecksLeasesWithPreferredNode) {
+    const std::vector<std::string> keys = {"batch_lease_expired",
+                                           "batch_lease_live",
+                                           "batch_lease_missing_slices"};
+    const std::string value = "batch read lease regression";
+    const size_t buffer_size = value.size() * 3;
+    void* buffer = client_buffer_allocator_->allocate(buffer_size);
+    ASSERT_NE(buffer, nullptr);
+    auto release_buffer = [buffer_size](void* ptr) {
+        client_buffer_allocator_->deallocate(ptr, buffer_size);
+    };
+    std::unique_ptr<void, decltype(release_buffer)> buffer_owner(
+        buffer, release_buffer);
+    memcpy(buffer, value.data(), value.size());
+    std::vector<Slice> source{{buffer, value.size()}};
+    ReplicateConfig config;
+    config.replica_num = 1;
+    // Keep both readable keys in the same transfer batch.
+    config.preferred_segment = "localhost:17812";
+    for (const auto& key : keys) {
+        ASSERT_TRUE(test_client_->Put(key, source, config).has_value());
+    }
+
+    const auto queries = test_client_->BatchQuery(keys);
+    ASSERT_EQ(queries.size(), keys.size());
+    std::vector<QueryResult> query_results;
+    const auto now = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < queries.size(); ++i) {
+        ASSERT_TRUE(queries[i].has_value());
+        ASSERT_EQ(queries[i]->replicas.size(), 1);
+        ASSERT_TRUE(queries[i]->replicas[0].is_memory_replica());
+        auto replicas = queries[i]->replicas;
+        // Use an explicit expired deadline instead of relying on a slow
+        // transfer or sleeping until the master's lease expires.
+        query_results.emplace_back(std::move(replicas),
+                                   i == 1 ? now + std::chrono::minutes(1)
+                                          : now - std::chrono::seconds(1),
+                                   queries[i]->object_checksum);
+    }
+    EXPECT_EQ(queries[0]
+                  ->replicas[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              queries[1]
+                  ->replicas[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_);
+    auto* expired_dst = static_cast<char*>(buffer) + value.size();
+    auto* live_dst = expired_dst + value.size();
+    std::unordered_map<std::string, std::vector<Slice>> destinations{
+        {keys[0], {{expired_dst, value.size()}}},
+        {keys[1], {{live_dst, value.size()}}}};
+
+    // Both public BatchGet modes must apply the same per-key lease contract.
+    for (bool prefer_same_node : {false, true}) {
+        SCOPED_TRACE(prefer_same_node);
+        memset(expired_dst, 0, value.size() * 2);
+        const auto results = test_client_->BatchGet(
+            keys, query_results, destinations, prefer_same_node);
+        ASSERT_EQ(results.size(), keys.size());
+        ASSERT_FALSE(results[0].has_value());
+        EXPECT_EQ(results[0].error(), ErrorCode::LEASE_EXPIRED);
+        EXPECT_TRUE(results[1].has_value());
+        ASSERT_FALSE(results[2].has_value());
+        EXPECT_EQ(results[2].error(), ErrorCode::INVALID_PARAMS);
+        // The expired item completed its transfer too; it must still not be
+        // reported as a successful read once its lease has expired.
+        EXPECT_EQ(memcmp(expired_dst, value.data(), value.size()), 0);
+        EXPECT_EQ(memcmp(live_dst, value.data(), value.size()), 0);
+    }
+}
+
+TEST_F(ClientIntegrationTest, BatchGetPreservesTransferErrorWithExpiredLease) {
+    const std::string key = "batch_lease_transfer_failure";
+    const std::string value = "batch read transfer error";
+    void* buffer = client_buffer_allocator_->allocate(value.size());
+    ASSERT_NE(buffer, nullptr);
+    auto release_buffer = [&value](void* ptr) {
+        client_buffer_allocator_->deallocate(ptr, value.size());
+    };
+    std::unique_ptr<void, decltype(release_buffer)> buffer_owner(
+        buffer, release_buffer);
+    memcpy(buffer, value.data(), value.size());
+    std::vector<Slice> source{{buffer, value.size()}};
+    ASSERT_TRUE(test_client_->Put(key, source, ReplicateConfig{}).has_value());
+    const auto query = test_client_->Query(key);
+    ASSERT_TRUE(query.has_value());
+    auto replicas = query->replicas;
+    const std::vector<QueryResult> query_results{
+        QueryResult(std::move(replicas),
+                    std::chrono::steady_clock::now() - std::chrono::seconds(1),
+                    query->object_checksum)};
+    // Invalid transfer length fails submission before any bytes are copied.
+    std::unordered_map<std::string, std::vector<Slice>> destinations{
+        {key, {{buffer, value.size() - 1}}}};
+    for (bool prefer_same_node : {false, true}) {
+        SCOPED_TRACE(prefer_same_node);
+        const auto results = test_client_->BatchGet(
+            {key}, query_results, destinations, prefer_same_node);
+        ASSERT_EQ(results.size(), 1);
+        ASSERT_FALSE(results[0].has_value());
+        EXPECT_EQ(results[0].error(), ErrorCode::TRANSFER_FAIL);
+    }
+}
+
 TEST_F(ClientIntegrationTest, BatchPutMixedGroupIdsThroughClient) {
     auto find_group_id_on_different_shard = [](const std::string& key) {
         static constexpr size_t kMetadataShardCountForTest = 1024;


### PR DESCRIPTION
## Description

`Client::BatchGet(..., prefer_alloc_in_same_node=true)` returns through
`BatchGetWhenPreferSameNode` before reaching the ordinary batch-get lease
validation. The grouped MEMORY path can therefore report a successful read
even when the query's read lease has expired by the time the batch returns.
The ordinary path returns `LEASE_EXPIRED` for the same query and destination.

Apply the same final per-key lease check after all grouped transfers complete.
Only successful expired reads become `LEASE_EXPIRED`; live reads and existing
validation, transfer, and checksum errors retain their results. This adds no
RPCs or retries and preserves the existing API.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Two new integration tests use the real Store client, in-process master, and
TCP transfers with local memcpy disabled:

- `BatchGetChecksLeasesWithPreferredNode`: expired and live reads share one
  source endpoint; a third item has missing destination slices. Both batch-get
  modes must return `LEASE_EXPIRED`, success, and `INVALID_PARAMS`, respectively.
  Both readable payloads are checked byte-for-byte.
- `BatchGetPreservesTransferErrorWithExpiredLease`: a one-byte-short transfer
  slice must retain `TRANSFER_FAIL` even when the query lease has expired.

The tests preserve actual queried replica descriptors and checksums, while
constructing explicit past/live lease deadlines for deterministic coverage.
They do not simulate actual concurrent eviction or allocation reuse, or inject
expiry during an in-flight transfer.

**Test commands:**

```bash
cmake --build build-review --target client_integration_test -j2
PROTOCOL=tcp MC_STORE_MEMCPY=0 MOONCAKE_STORE_CHECKSUM=0 \
  ./build-review/mooncake-store/tests/client_integration_test \
  --gtest_filter='ClientIntegrationTest.BatchGetChecksLeasesWithPreferredNode:ClientIntegrationTest.BatchGetPreservesTransferErrorWithExpiredLease:ClientIntegrationTest.BatchPutGetOperations'
PROTOCOL=tcp MC_STORE_MEMCPY=0 MOONCAKE_STORE_CHECKSUM=1 \
  ./build-review/mooncake-store/tests/client_integration_test \
  --gtest_filter='ClientIntegrationTest.BatchGetChecksLeasesWithPreferredNode:ClientIntegrationTest.BatchGetPreservesTransferErrorWithExpiredLease:ClientIntegrationTest.BatchPutGetOperations:ClientIntegrationTest.ObjectChecksumRejectsCorruptedObject:ClientIntegrationTest.BatchPutPreservesObjectChecksumPairing'
pre-commit run --files mooncake-store/src/client_service.cpp \
  mooncake-store/tests/client_integration_test.cpp
./scripts/code_format.sh --changed-lines --check --base origin/main
git diff --check origin/main...HEAD
```

Built on Linux with GCC 11.4, `CMAKE_BUILD_TYPE=Debug`,
`ENABLE_DEBUG_SYMBOLS=OFF`, `WITH_STORE=ON`, `WITH_TE=ON`, `USE_HTTP=ON`,
`USE_CUDA=OFF`, `USE_TENT=OFF`, `USE_ETCD=OFF`, and `STORE_USE_ETCD=OFF`.
The full Store suite and GPU/RDMA backends were not tested.

**Test results:**

- [x] Integration tests pass: 3/3 with checksums disabled; 5/5 with checksums
  enabled, including existing 100-key batch read/write and checksum regressions.
- [x] Baseline regression demonstrated: unmodified `bf511f5f` plus the same two
  new tests fails the expired grouped-read assertion (1 failed, 1 passed).
  Its ordinary batch-get control passes.
- [x] Rebuilt and repeated the 3-test and 5-test runs after rebasing onto
  `6c07cb7827011b82dbb05cfd59d5c778b6fafa21`.
- [x] Changed-file pre-commit, changed-line C++ formatting, and whitespace
  checks pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable: restores the existing read-lease contract)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable: 11 production lines added)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with implementation and tests; all changes were reviewed by the author.