### PR TITLE
[Store] Add best_fit allocation strategy for RL data-plane offload, with trace tooling

### DIFF
--- a/docs/source/design/store/mooncake-store.md
+++ b/docs/source/design/store/mooncake-store.md
@@ -544,7 +544,7 @@ Mooncake Store provides multiple built-in allocation strategies to control how s
 ./build/mooncake-store/src/mooncake_master --allocation_strategy=free_ratio_first
 ```
 
-Valid values are: `random` (default), `free_ratio_first`, `ssd_free_ratio_first`, `cxl`, `local_first` (case-sensitive).
+Valid values are: `random` (default), `free_ratio_first`, `ssd_free_ratio_first`, `cxl`, `local_first`, `best_fit` (case-sensitive).
 
 #### How to Choose
 
@@ -555,12 +555,15 @@ Valid values are: `random` (default), `free_ratio_first`, `ssd_free_ratio_first`
 | `ssd_free_ratio_first` | SSD-aware memory allocation when SSD offloading is enabled | Depends on SSD usage metrics; falls back to random allocation when needed |
 | `cxl` | CXL memory hardware | CXL-specific; single-replica only |
 | `local_first` | Colocated inference workers and memory store segments | Requires stable host identity from `MOONCAKE_HOST_ID` or `local_hostname`; single memory replica only |
+| `best_fit` | Mixed object sizes with explicit removals (for example RL data-plane offload) where large objects must find contiguous space | Concentrates data in fewer segments; one largest-free-region lookup per segment per allocation |
 
 **Use `random`** (default) when your cluster is relatively stable (segments rarely join or leave) and you want the highest possible allocation throughput.
 
 **Use `free_ratio_first`** when you need better load balancing across segments, especially in scenarios where:
 - Segments have different capacities and you want even utilization ratios.
 - New segments are dynamically added at runtime and you need them to absorb load quickly. With `random`, convergence to a well-balanced state can be slow on large or dynamic clusters; `free_ratio_first` accelerates this by preferentially filling emptier segments, substantially increasing the likelihood that newly joined segments are selected for allocations (see details below).
+
+**Use `best_fit`** when object sizes span several orders of magnitude and objects are removed explicitly rather than evicted. Each request goes to the segment whose largest contiguous free region is the smallest one that still fits, so small objects fill partially used segments and large free regions stay available for large objects. Spreading strategies leave every segment with medium-sized holes and can fail a large allocation while the cluster still reports plenty of free space.
 
 **Use `ssd_free_ratio_first`** when SSD offloading is enabled and you want memory allocation to prefer segments whose backing SSD still has more free capacity.
 

--- a/mooncake-rl/examples/rl_dataproto_trace_driver.py
+++ b/mooncake-rl/examples/rl_dataproto_trace_driver.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""RL data-plane load driver for capturing Mooncake Store allocation traces.
+
+Each process plays one data-parallel rank of an RL trainer and reproduces the
+per-step data flow of a GRPO/PPO pipeline:
+
+1. rollout   : ``input_ids``/``attention_mask``/``position_ids``/``responses``/
+               ``response_mask`` plus non-tensor ``uid``/``data_source``/
+               ``reward_model`` rows for a variable-size batch.
+2. old_log_prob, ref_log_prob, reward, advantage stages: appended as separate
+               objects, mirroring the actor/ref/critic workers.
+3. optional  : one large whole object per step (``--big_field_mib``), like a
+               merged blob written with a single put.
+4. trainer   : reads micro-batches back.
+5. cleanup   : steps older than ``--keep_steps`` are removed explicitly, unless
+               ``--no_cleanup`` leaves reclamation to master eviction.
+
+Two write paths are available (``--api``): ``dataproto`` uses the structured
+object API (``MooncakeBundleTransfer``, chunked, ~30 keys per batch);
+``put_parts`` stores every field as one whole object with ``put_parts``, reads
+with ``get_buffer`` and frees with a forced ``remove``, for data planes that
+use only those calls.
+
+Object sizes and lifetimes are exactly what the master sees for this batch
+geometry; only the tensor contents are random. Run ``mooncake_master --v=1``
+and extract the trace with ``mooncake-store/benchmarks/extract_alloc_trace.py``.
+
+Example (8 ranks, 16 x 4 GiB segments, stop after 3x capacity written):
+
+    python rl_dataproto_trace_driver.py --ranks 8 --extra_segments 8 \
+        --segment_gib 4 --target_multiple 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+import random
+import sys
+import time
+from dataclasses import dataclass
+
+import numpy as np
+from mooncake.store import MooncakeDistributedStore
+from mooncake.structured_object_store import (
+    BundleTransferPolicy,
+    MooncakeBundleTransfer,
+)
+
+GiB = 1024**3
+MiB = 1024**2
+
+# Stages appended after the rollout, with the float fields each one carries.
+APPEND_STAGES = (
+    ("old_log_prob", ("old_log_probs", "rollout_log_probs")),
+    ("ref_log_prob", ("ref_log_prob",)),
+    ("reward", ("token_level_scores", "token_level_rewards")),
+    ("advantage", ("advantages", "returns")),
+)
+# Fields the trainer reads back for each micro-batch.
+READ_FIELDS = ("input_ids", "responses", "old_log_probs", "advantages", "uid")
+# Errors the Mooncake client raises for failed puts/gets/removes; anything else
+# is a bug in this script and should propagate.
+STORE_ERRORS = (RuntimeError, ValueError, OSError)
+
+
+@dataclass
+class StepGeometry:
+    rows: int
+    prompt_len: int
+    response_len: int
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--ranks", type=int, default=8, help="data-parallel ranks (client processes)"
+    )
+    p.add_argument(
+        "--extra_segments",
+        type=int,
+        default=0,
+        help="storage-only clients that mount a segment but write nothing",
+    )
+    p.add_argument(
+        "--segment_gib", type=float, default=4.0, help="segment size per client, GiB"
+    )
+    p.add_argument(
+        "--local_buffer_mib",
+        type=int,
+        default=1024,
+        help="registered local buffer per client",
+    )
+    p.add_argument(
+        "--steps", type=int, default=0, help="max steps (0 = until --target_multiple)"
+    )
+    p.add_argument(
+        "--target_multiple",
+        type=float,
+        default=3.0,
+        help="stop when cumulative bytes written reach this multiple of pool capacity",
+    )
+    p.add_argument(
+        "--rows_min", type=int, default=128, help="min rows per rank per step"
+    )
+    p.add_argument(
+        "--rows_max", type=int, default=512, help="max rows per rank per step"
+    )
+    p.add_argument(
+        "--prompt_len", type=int, default=2048, help="max prompt length (tokens)"
+    )
+    p.add_argument(
+        "--response_len", type=int, default=8192, help="max response length (tokens)"
+    )
+    p.add_argument(
+        "--min_len_frac",
+        type=float,
+        default=0.25,
+        help="per-step padded length is uniform in [frac, 1] x max length",
+    )
+    p.add_argument(
+        "--keep_steps", type=int, default=2, help="steps to keep alive before cleanup"
+    )
+    p.add_argument(
+        "--no_cleanup",
+        action="store_true",
+        help="never remove; rely on master eviction",
+    )
+    p.add_argument(
+        "--chunk_mib",
+        type=int,
+        default=64,
+        help="dataproto: structured object chunk size; large values give whole-field objects",
+    )
+    p.add_argument(
+        "--micro_batches", type=int, default=4, help="trainer reads per step per rank"
+    )
+    p.add_argument(
+        "--big_field_mib",
+        type=int,
+        default=0,
+        help="also write one whole object of this many MiB per rank per step; 0 = off",
+    )
+    p.add_argument(
+        "--big_field_jitter",
+        type=float,
+        default=0.0,
+        help="per-step size jitter for the big object: uniform in [1-j, 1+j] x MiB",
+    )
+    p.add_argument(
+        "--api",
+        choices=["dataproto", "put_parts"],
+        default="dataproto",
+        help="write path: structured objects, or one put_parts object per field",
+    )
+    p.add_argument(
+        "--parts_per_object",
+        type=int,
+        default=4,
+        help="put_parts: split each field into this many byte parts",
+    )
+    p.add_argument("--master", default="127.0.0.1:50051")
+    p.add_argument("--metadata", default="P2PHANDSHAKE")
+    p.add_argument("--protocol", default="tcp")
+    p.add_argument("--device", default="")
+    p.add_argument("--base_port", type=int, default=17100)
+    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--stats_file", default="", help="write per-rank byte counters here")
+    return p.parse_args(argv)
+
+
+def make_store(args, rank: int, segment_bytes: int) -> MooncakeDistributedStore:
+    store = MooncakeDistributedStore()
+    rc = store.setup(
+        f"127.0.0.1:{args.base_port + rank}",
+        args.metadata,
+        int(segment_bytes),
+        int(args.local_buffer_mib) * MiB,
+        args.protocol,
+        args.device,
+        args.master,
+    )
+    if rc != 0:
+        raise RuntimeError(f"rank {rank}: store.setup failed rc={rc}")
+    return store
+
+
+# ----------------------------------------------------------------- workload --
+
+
+def step_geometry(rng: random.Random, args) -> StepGeometry:
+    frac = rng.uniform(args.min_len_frac, 1.0)
+    return StepGeometry(
+        rows=rng.randint(args.rows_min, args.rows_max),
+        prompt_len=max(16, int(args.prompt_len * frac)),
+        response_len=max(16, int(args.response_len * frac)),
+    )
+
+
+def rollout_batch(g: StepGeometry, step: int, rank: int, rng: np.random.Generator) -> dict:
+    total = g.prompt_len + g.response_len
+    ids = rng.integers(0, 150000, size=(g.rows, total), dtype=np.int64)
+    return {
+        "batch": {
+            "input_ids": ids,
+            "attention_mask": np.ones((g.rows, total), dtype=np.int64),
+            "position_ids": np.tile(np.arange(total, dtype=np.int64), (g.rows, 1)),
+            "responses": ids[:, g.prompt_len :].copy(),
+            "response_mask": np.ones((g.rows, g.response_len), dtype=np.int64),
+        },
+        "non_tensor_batch": {
+            "uid": np.array(
+                [f"s{step}-r{rank}-{i}" for i in range(g.rows)], dtype=object
+            ),
+            "data_source": np.array(["math"] * g.rows, dtype=object),
+            "reward_model": np.array(
+                [{"style": "rule", "ground_truth": str(i)} for i in range(g.rows)],
+                dtype=object,
+            ),
+        },
+        "meta_info": {"step": step, "rank": rank, "global_token_num": [total] * g.rows},
+    }
+
+
+def float_stage(g: StepGeometry, rng: np.random.Generator, *names: str) -> dict:
+    return {
+        "batch": {
+            n: rng.standard_normal((g.rows, g.response_len), dtype=np.float32)
+            for n in names
+        }
+    }
+
+
+def big_blob(args, rng: random.Random) -> dict:
+    """One float32 array of --big_field_mib MiB (with jitter), batch size 1."""
+    mib = int(
+        args.big_field_mib
+        * rng.uniform(1.0 - args.big_field_jitter, 1.0 + args.big_field_jitter)
+    )
+    return {
+        "batch": {
+            "rollout_blob": np.empty((1, max(1, mib) * MiB // 4), dtype=np.float32)
+        }
+    }
+
+
+def tensor_bytes(data: dict) -> int:
+    return sum(a.nbytes for a in data["batch"].values())
+
+
+# ------------------------------------------------------------- write paths --
+
+
+class DataProtoStep:
+    """One RL step stored through the structured object API."""
+
+    def __init__(
+        self, transfer: MooncakeBundleTransfer, rank: int, step: int, args
+    ) -> None:
+        self.transfer = transfer
+        self.namespace = f"rank{rank}"
+        self.partition = f"step-{step}"
+        self.policy = BundleTransferPolicy(copy_mode="copy")
+        self.blob_chunk = max(2 * args.big_field_mib, args.chunk_mib) * MiB
+        self.ref = None
+        self.blob_ref = None
+
+    def put_stage(self, stage: str, data: dict) -> None:
+        if self.ref is None:
+            self.ref = self.transfer.put_dataproto(
+                data,
+                namespace=self.namespace,
+                partition=self.partition,
+                stage=stage,
+                policy=self.policy,
+            )
+        else:
+            self.ref = self.transfer.append_dataproto_fields(
+                self.ref, data, stage=stage, policy=self.policy
+            )
+
+    def put_blob(self, blob: dict) -> None:
+        # Separate DataProto (batch size 1) so the blob stays one whole object.
+        self.blob_ref = self.transfer.put_dataproto(
+            blob,
+            namespace=self.namespace,
+            partition=f"{self.partition}-blob",
+            stage="blob",
+            policy=self.policy,
+            chunk_bytes=self.blob_chunk,
+        )
+
+    def read(self, rows: slice) -> None:
+        self.transfer.get_dataproto(self.ref, fields=list(READ_FIELDS), rows=rows)
+
+    def cleanup(self) -> None:
+        for ref in (self.ref, self.blob_ref):
+            if ref is not None:
+                self.transfer.cleanup_dataproto(ref)
+        self.ref = self.blob_ref = None
+
+
+class PutPartsStep:
+    """One RL step stored as whole objects: one key per field via put_parts."""
+
+    def __init__(
+        self, store: MooncakeDistributedStore, rank: int, step: int, args
+    ) -> None:
+        self.store = store
+        self.prefix = f"rl/rank{rank}/step-{step}"
+        self.parts = max(1, args.parts_per_object)
+        self.keys: list[str] = []
+
+    def _put(self, key: str, parts: list) -> None:
+        rc = self.store.put_parts(key, *parts)
+        if rc != 0:
+            raise RuntimeError(f"put_parts failed for {key}: {rc}")
+        self.keys.append(key)
+
+    def put_stage(self, stage: str, data: dict) -> None:
+        for name, array in data["batch"].items():
+            flat = np.ascontiguousarray(array).view(np.uint8).reshape(-1)
+            parts = np.array_split(flat, min(self.parts, max(1, flat.size)))
+            self._put(f"{self.prefix}/{stage}/{name}", parts)
+        for name, values in data.get("non_tensor_batch", {}).items():
+            self._put(
+                f"{self.prefix}/{stage}/{name}", ["\n".join(map(str, values)).encode()]
+            )
+
+    def put_blob(self, blob: dict) -> None:
+        self.put_stage("blob", blob)
+
+    def read(self, rows: slice) -> None:
+        # get_buffer returns whole objects; row selection happens client-side.
+        for key in self.keys:
+            if (
+                key.rsplit("/", 1)[1] in READ_FIELDS
+                and self.store.get_buffer(key) is None
+            ):
+                raise RuntimeError(f"get_buffer miss for {key}")
+
+    def cleanup(self) -> None:
+        # force=True: objects read moments ago still carry a lease, exactly
+        # like the structured store's cleanup path.
+        for key in self.keys:
+            self.store.remove(key, True)
+        self.keys.clear()
+
+
+# --------------------------------------------------------------- processes --
+
+
+def run_rank(rank: int, args, capacity_bytes: int, barrier, counters, stop_flag):
+    rng = random.Random(args.seed * 1000 + rank)
+    np_rng = np.random.default_rng(args.seed * 1000 + rank)
+    store = make_store(args, rank, args.segment_gib * GiB)
+    transfer = MooncakeBundleTransfer(
+        store, key_prefix="rl", default_chunk_bytes=max(1, args.chunk_mib) * MiB
+    )
+
+    def new_step(step: int):
+        if args.api == "put_parts":
+            return PutPartsStep(store, rank, step, args)
+        return DataProtoStep(transfer, rank, step, args)
+
+    def quiet_cleanup(obj) -> None:
+        try:
+            obj.cleanup()
+        except STORE_ERRORS as exc:
+            print(f"[rank {rank}] cleanup failed: {str(exc)[:120]}", file=sys.stderr)
+
+    live: list[tuple[int, object]] = []  # (step, step object), oldest first
+    written = failures = step = 0
+    target = args.target_multiple * capacity_bytes
+    try:
+        while not stop_flag.value and not (args.steps and step >= args.steps):
+            g = step_geometry(rng, args)
+            current = new_step(step)
+            try:
+                data = rollout_batch(g, step, rank, np_rng)
+                written += tensor_bytes(data)
+                current.put_stage("rollout", data)
+                for stage, names in APPEND_STAGES:
+                    stage_data = float_stage(g, np_rng, *names)
+                    written += tensor_bytes(stage_data)
+                    current.put_stage(stage, stage_data)
+                if args.big_field_mib > 0:
+                    blob = big_blob(args, rng)
+                    written += tensor_bytes(blob)
+                    current.put_blob(blob)
+                mb = max(1, g.rows // args.micro_batches)
+                for lo in range(0, g.rows, mb):
+                    current.read(slice(lo, min(g.rows, lo + mb)))
+                live.append((step, current))
+            except STORE_ERRORS as exc:  # an allocation failure surfaces here
+                failures += 1
+                quiet_cleanup(current)
+                if failures <= 5 or failures % 100 == 0:
+                    print(
+                        f"[rank {rank}] step {step} failed: {type(exc).__name__}: {str(exc)[:160]}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            if not args.no_cleanup:
+                while live and live[0][0] <= step - args.keep_steps:
+                    quiet_cleanup(live.pop(0)[1])
+            counters[rank] = written
+            step += 1
+            barrier.wait()
+            if rank == 0:
+                total = sum(counters)
+                if step % 5 == 0 or total >= target:
+                    print(
+                        f"[step {step}] rows={g.rows} prompt={g.prompt_len} resp={g.response_len} "
+                        f"written={total / GiB:.1f} GiB ({total / capacity_bytes:.2f}x capacity) "
+                        f"live_steps={len(live)} failures={failures}",
+                        flush=True,
+                    )
+                if total >= target:
+                    stop_flag.value = 1
+            barrier.wait()
+    finally:
+        if not args.no_cleanup:
+            for _, obj in live:
+                quiet_cleanup(obj)
+        store.close()
+    print(
+        f"[rank {rank}] done: steps={step} written={written / GiB:.2f} GiB failures={failures}",
+        flush=True,
+    )
+
+
+def run_storage_only(rank: int, args, stop_flag):
+    store = make_store(args, rank, args.segment_gib * GiB)
+    while not stop_flag.value:
+        time.sleep(0.5)
+    store.close()
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    num_segments = args.ranks + args.extra_segments
+    capacity = int(num_segments * args.segment_gib * GiB)
+    print(
+        f"pool: {num_segments} segments x {args.segment_gib} GiB = {capacity / GiB:.0f} GiB, "
+        f"target {args.target_multiple}x = {args.target_multiple * capacity / GiB:.0f} GiB written",
+        flush=True,
+    )
+    ctx = mp.get_context("spawn")
+    barrier = ctx.Barrier(args.ranks)
+    counters = ctx.Array("q", args.ranks)
+    stop_flag = ctx.Value("i", 0)
+    procs = [
+        ctx.Process(target=run_storage_only, args=(args.ranks + i, args, stop_flag))
+        for i in range(args.extra_segments)
+    ]
+    procs += [
+        ctx.Process(
+            target=run_rank, args=(rank, args, capacity, barrier, counters, stop_flag)
+        )
+        for rank in range(args.ranks)
+    ]
+    for p in procs:
+        p.start()
+        time.sleep(0.2)
+    try:
+        for p in procs[args.extra_segments :]:
+            p.join()
+    finally:
+        stop_flag.value = 1
+        for p in procs:
+            p.join(timeout=30)
+            if p.is_alive():
+                p.terminate()
+    if args.stats_file:
+        with open(args.stats_file, "w") as handle:
+            handle.write("\n".join(str(c) for c in counters) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mooncake-store/benchmarks/README.md
+++ b/mooncake-store/benchmarks/README.md
@@ -54,7 +54,112 @@ Supported size-class patterns:
 
 - `kv_mixed`: 4KB at 70%, 256KB at 20%, and 3.12MB at 10%.
 - `dsa_pair`: 3.12MB KV pages at 50% and 643KB indexer entries at 50%.
-- `all`: run both patterns.
+- `rl`: RL data-plane offload stand-in. Sizes are drawn log-uniformly from
+  `[--rl_min_kib, --rl_max_mib]` (default 64 KiB to 512 MiB), split into one
+  equally weighted class per octave so the per-class breakdown shows which
+  size decade fails first.
+- `all`: run all three patterns.
+
+#### RL offload workload, trace replay, and large-allocation probe
+
+RL offload traffic differs from KV cache traffic in two ways that matter for
+the allocator: object sizes span several orders of magnitude, and objects are
+consumed and released at roughly the rate they are written. The following
+flags model that and measure whether a large object can still be placed:
+
+- `--size_class_release_prob=<p>`: before each measured allocation, release
+  one random live object with probability `p`. `1.0` gives a
+  free-one/allocate-one steady state that holds utilization near
+  `--prefill_pct`; `0` (default) keeps the allocate-only behavior.
+- `--probe_mib=<N>`: at every fragmentation sample point, attempt one `N` MiB
+  single-replica allocation with no eviction retry, release it immediately,
+  and report `success/attempts` together with the free space and largest free
+  region observed at probe time. A low success rate with plenty of free space
+  is the "20 GB free but 1.25 GiB fails" symptom.
+- `--rl_trace_file=<path>`: replay recorded allocation sizes (one size in
+  bytes per line, `#` starts a comment) in file order instead of a synthetic
+  pattern. Size classes for the breakdown are derived from the trace, one per
+  octave, weighted by observed counts.
+- `--segment_counts=16`: override the default `1,10,100` segment matrix, for
+  example to match a production cluster of sixteen 4 GiB segments.
+
+Reproduce the RL symptom with the synthetic pattern:
+
+```bash
+./build/mooncake-store/benchmarks/allocation_strategy_bench \
+  --workload=size_class_churn --size_class_pattern=rl \
+  --segment_capacity=4096 --segment_counts=16 \
+  --prefill_pct=70 --size_class_release_prob=1.0 \
+  --num_allocations=20000 --probe_mib=1280
+```
+
+If no RL job is at hand, `mooncake-rl/examples/rl_dataproto_trace_driver.py`
+replays the per-step DataProto data flow of a GRPO-style trainer (rollout put,
+log-prob/reward/advantage appends, micro-batch reads, cleanup or eviction)
+through the structured object API with configurable batch geometry, so the
+object sizes and lifetimes seen by the master are the real ones for that
+geometry.
+
+Capture a real trace from a running master. `mooncake_master --v=1` logs one
+`action=put_start_begin` line per PutStart with `key=` and `value_length=`,
+one `action=remove_object` line per successful Remove, one
+`action=evict_object` line per evicted object, and on allocation failure an
+`action=put_start_alloc_failed` line with the requested size, total free
+space, and largest free region across segments. Capture until cumulative
+writes reach three to four times the cluster capacity so the pool is in
+steady-state eviction, then extract sizes with:
+
+```bash
+python3 mooncake-store/benchmarks/extract_alloc_trace.py master.INFO \
+  -o rl_sizes.txt --events rl_events.txt
+```
+
+The script prints a per-octave histogram of the captured sizes; cross-check it
+against the `master_value_size_bytes` metric. Replay the sizes with:
+
+```bash
+./build/mooncake-store/benchmarks/allocation_strategy_bench \
+  --workload=size_class_churn --rl_trace_file=rl_sizes.txt \
+  --segment_capacity=4096 --segment_counts=16 \
+  --prefill_pct=70 --size_class_release_prob=1.0 \
+  --num_allocations=20000 --probe_mib=1280
+```
+
+Replay the event log with the real object lifetimes instead of sampling
+sizes. Puts allocate, removes and evicts free, and there is no eviction retry,
+so every failed put is reported together with the free space and largest free
+region at that moment, mirroring `put_start_alloc_failed`:
+
+```bash
+./build/mooncake-store/benchmarks/allocation_strategy_bench \
+  --workload=size_class_churn --rl_trace_events=rl_events.txt \
+  --segment_capacity=4096 --segment_counts=16 --replica_counts=1 \
+  --size_class_strategies=random,free_ratio_first,best_fit,hybrid,reserved \
+  --probe_mib=1280
+```
+
+`--trace_events_repeat=N` replays a short log several times back to back.
+`--size_class_strategies` selects the placement policies to compare:
+
+- `random`, `free_ratio_first`, `best_fit`: the production strategies
+  (`best_fit` places the object in the segment whose largest free region is
+  the smallest one that still fits, so large holes are preserved).
+- `largest_hole_first`: bench-only; always pick the segment with the largest
+  free region.
+- `hybrid`: bench-only; `best_fit` below `--large_object_mib`,
+  `largest_hole_first` at or above it.
+- `reserved`: bench-only; the last `--reserved_segments` segments accept only
+  objects of at least `--large_object_mib`, the others only smaller ones.
+
+The bench-only strategies rank every segment (no candidate sampling and no
+random fallback) so that the effect of the placement rule is measured in
+isolation; they are experiments, not proposals for the master as written.
+`best_fit` is the production `BestFitAllocationStrategy`, selectable on the
+master with `--allocation_strategy=best_fit`.
+
+The driver also has `--api put_parts`, which stores each field as one whole
+object through `put_parts`, reads it back with `get_buffer`, and frees it with
+a forced `remove`, for data planes that use only those calls.
 
 Key output columns:
 
@@ -67,6 +172,10 @@ Key output columns:
 - `Full/Partial/Fail/Total` reports allocation outcomes. Only results with
   `result->size() == replica_num` count as full success; shorter replica
   results are counted as partial allocations.
+- `Probe summary` (when `--probe_mib` is set) reports probe success,
+  free space at probe time, and the p10/p50/max largest free region.
+- `released=` in the fragmentation summary counts objects released by
+  `--size_class_release_prob`.
 
 Fragmentation is computed per `OffsetBufferAllocator` and then averaged by free
 space:

--- a/mooncake-store/benchmarks/allocation_strategy_bench.cpp
+++ b/mooncake-store/benchmarks/allocation_strategy_bench.cpp
@@ -1,7 +1,10 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
+#include <functional>
+#include <unordered_map>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -76,10 +79,63 @@ DEFINE_double(dsa_evict_ratio, 0.05,
               "the steady-state cluster fill closer to the fragmentation "
               "ceiling but trigger evictions more frequently.");
 DEFINE_string(size_class_pattern, "kv_mixed",
-              "Size-class churn pattern: kv_mixed, dsa_pair, or all");
+              "Size-class churn pattern: kv_mixed, dsa_pair, rl, or all");
 DEFINE_double(size_class_evict_ratio, 0.02,
               "Fraction of live objects to evict on each Allocate failure "
               "in size_class_churn mode.");
+DEFINE_double(size_class_release_prob, 0.0,
+              "Probability of releasing one random live object before each "
+              "measured size_class_churn allocation. 1.0 gives a "
+              "free-one/allocate-one steady state at the prefill level; 0 "
+              "keeps the allocate-only legacy behavior.");
+DEFINE_int64(rl_min_kib, 64,
+             "Smallest object size in KiB for the rl size-class pattern.");
+DEFINE_int64(rl_max_mib, 512,
+             "Largest object size in MiB for the rl size-class pattern.");
+DEFINE_string(rl_trace_file, "",
+              "Replay allocation sizes from a trace file (one size in bytes "
+              "per line, '#' starts a comment) instead of a synthetic "
+              "size-class pattern. Sizes are replayed in file order and "
+              "wrap around. Only used by --workload=size_class_churn.");
+DEFINE_int32(probe_mib, 0,
+             "At every fragmentation sample point, attempt one N MiB "
+             "single-replica allocation without eviction retry, release it "
+             "immediately, and report the success rate together with the "
+             "free space observed at probe time (0 = disabled).");
+DEFINE_string(segment_counts, "",
+              "Comma-separated segment counts for the size_class_churn "
+              "matrix (default: 1,10,100).");
+DEFINE_string(size_class_strategies, "random,free_ratio_first",
+              "Comma-separated allocation strategies for the size_class_churn "
+              "matrix: random, free_ratio_first, best_fit (production "
+              "strategies), largest_hole_first, reserved, hybrid (bench-only "
+              "placement experiments, see "
+              "--large_object_mib/--reserved_segments). hybrid = best_fit for "
+              "objects below --large_object_mib, largest_hole_first above.");
+DEFINE_string(replica_counts, "",
+              "Comma-separated replica counts for the size_class_churn matrix "
+              "(default: 1,2,3).");
+DEFINE_int32(large_object_mib, 256,
+             "Objects of at least this many MiB are 'large' for the reserved "
+             "strategy and go to the reserved segments only.");
+DEFINE_int32(best_fit_bucket_mib, 512,
+             "best_fit_bucketed: segments whose slack (largest hole minus "
+             "request) falls in the same bucket of this many MiB are treated "
+             "as equal and chosen at random, trading a little contiguity for "
+             "less traffic concentration.");
+DEFINE_int32(reserved_segments, 2,
+             "Number of segments (the last ones by index) reserved for large "
+             "objects in the reserved strategy.");
+DEFINE_string(rl_trace_events, "",
+              "Replay an ordered put/remove/evict event log ('kind key size' "
+              "per line, as written by extract_alloc_trace.py --events) "
+              "instead of a synthetic pattern. Puts allocate, removes and "
+              "evicts free; there is no eviction retry, so every failed put "
+              "is reported as a failure. Only used by "
+              "--workload=size_class_churn.");
+DEFINE_int32(trace_events_repeat, 1,
+             "Replay the event log this many times back to back (keys are "
+             "suffixed per pass) to reach steady state on short traces.");
 
 using namespace mooncake;
 
@@ -145,6 +201,8 @@ struct BenchConfig {
     // Size-class churn knobs (only used when workload_type ==
     // SIZE_CLASS_CHURN).
     std::string size_class_pattern = "kv_mixed";
+    // Bench-only strategy name for size_class_churn ("" = use strategy_type).
+    std::string bench_strategy;
 };
 
 struct UtilRatioStats {
@@ -159,6 +217,7 @@ struct UtilRatioStats {
 
 struct DistributionStats {
     double min = 0.0;
+    double p10 = 0.0;
     double p50 = 0.0;
     double p90 = 0.0;
     double p99 = 0.0;
@@ -177,13 +236,21 @@ struct FragmentationSnapshot {
 
 struct SizeClassSpec {
     std::string name;
+    // Fixed object size, or the inclusive lower bound when max_size > size.
     size_t size;
     int weight;
+    // Exclusive upper bound for ranged classes (sizes are drawn log-uniformly
+    // from [size, max_size)); 0 means a fixed-size class.
+    size_t max_size = 0;
+    // Observed mean size for trace-derived classes; 0 derives it from the
+    // range.
+    double mean_size = 0.0;
 };
 
 struct SizeClassStat {
     std::string name;
     size_t size = 0;
+    size_t max_size = 0;
     int weight = 0;
     int success_count = 0;
     int partial_count = 0;
@@ -283,6 +350,25 @@ struct SizeClassChurnResult : BenchResultBase {
     DistributionStats largest_free_mb_stats;
     FragmentationSnapshot final_fragmentation;
     std::vector<SizeClassStat> size_class_stats;
+    // Number of live objects released by --size_class_release_prob.
+    int released_count = 0;
+    // Large-allocation probe (--probe_mib); attempts == 0 when disabled.
+    size_t probe_bytes = 0;
+    int probe_attempts = 0;
+    int probe_success = 0;
+    DistributionStats probe_free_gb_stats;
+    DistributionStats probe_largest_free_mb_stats;
+    // Event replay: free space observed at each failed put.
+    DistributionStats fail_free_gb_stats;
+    DistributionStats fail_largest_free_mb_stats;
+    DistributionStats fail_size_mb_stats;
+    // Event replay: traffic concentration. write_skew = bytes written to the
+    // busiest segment / mean bytes per segment over the whole run;
+    // window_write_skew = the same ratio per sample window, averaged; the
+    // utilization stddev is averaged over the sample points.
+    double write_skew = 0.0;
+    double window_write_skew = 0.0;
+    double mean_util_stddev = 0.0;
 };
 
 static double computeClusterCapacityGB(int num_segments, size_t base_capacity,
@@ -491,6 +577,7 @@ static DistributionStats computeDistributionStats(std::vector<double>& values) {
     };
 
     stats.min = values.front();
+    stats.p10 = percentile(0.10);
     stats.p50 = percentile(0.50);
     stats.p90 = percentile(0.90);
     stats.p99 = percentile(0.99);
@@ -545,8 +632,156 @@ static FragmentationSnapshot computeFragmentationSnapshot(
     return snapshot;
 }
 
+static std::string humanSizeLabel(size_t bytes) {
+    static const char* const kUnits[] = {"B", "K", "M", "G", "T"};
+    int unit = 0;
+    double value = static_cast<double>(bytes);
+    while (value >= 1024.0 && unit < 4) {
+        value /= 1024.0;
+        ++unit;
+    }
+    std::ostringstream ss;
+    if (value == std::floor(value)) {
+        ss << static_cast<uint64_t>(value);
+    } else {
+        ss << std::fixed << std::setprecision(1) << value;
+    }
+    ss << kUnits[unit];
+    return ss.str();
+}
+
+// Expected value of a log-uniform draw on [lo, hi).
+static double logUniformMean(size_t lo, size_t hi) {
+    if (hi <= lo) return static_cast<double>(lo);
+    return (static_cast<double>(hi) - static_cast<double>(lo)) /
+           std::log(static_cast<double>(hi) / static_cast<double>(lo));
+}
+
+static double sizeClassMeanSize(const SizeClassSpec& spec) {
+    if (spec.mean_size > 0.0) return spec.mean_size;
+    if (spec.max_size > spec.size)
+        return logUniformMean(spec.size, spec.max_size);
+    return static_cast<double>(spec.size);
+}
+
+static size_t sampleSizeClassSize(const SizeClassSpec& spec,
+                                  std::mt19937& rng) {
+    if (spec.max_size <= spec.size) return spec.size;
+    std::uniform_real_distribution<double> dist(
+        std::log(static_cast<double>(spec.size)),
+        std::log(static_cast<double>(spec.max_size)));
+    auto size = static_cast<size_t>(std::exp(dist(rng)));
+    return std::clamp(size, spec.size, spec.max_size - 1);
+}
+
+// One equally weighted size class per octave over [min_size, max_size). With
+// log-uniform sampling inside each class this gives every size octave the
+// same share of allocations, which is the most hostile mix for large objects.
+static std::vector<SizeClassSpec> buildOctaveSpecs(size_t min_size,
+                                                   size_t max_size) {
+    std::vector<SizeClassSpec> specs;
+    if (min_size == 0 || max_size <= min_size) return specs;
+    for (size_t lo = min_size; lo < max_size; lo *= 2) {
+        size_t hi = std::min(lo * 2, max_size);
+        SizeClassSpec spec;
+        spec.name = humanSizeLabel(lo) + "-" + humanSizeLabel(hi);
+        spec.size = lo;
+        spec.max_size = hi;
+        spec.weight = 1;
+        specs.push_back(std::move(spec));
+    }
+    return specs;
+}
+
+static size_t sizeClassIndexForSize(const std::vector<SizeClassSpec>& specs,
+                                    size_t size) {
+    for (size_t i = 0; i < specs.size(); ++i) {
+        const auto& spec = specs[i];
+        if (spec.max_size > spec.size) {
+            if (size >= spec.size && size < spec.max_size) return i;
+        } else if (size == spec.size) {
+            return i;
+        }
+    }
+    return specs.empty() ? 0 : specs.size() - 1;
+}
+
+// Allocation sizes loaded from --rl_trace_file (one size in bytes per line).
+static std::vector<size_t> g_trace_sizes;
+
+static bool loadTraceSizes(const std::string& path, std::vector<size_t>& out) {
+    std::ifstream in(path);
+    if (!in) return false;
+    std::string line;
+    size_t malformed = 0;
+    while (std::getline(in, line)) {
+        auto hash = line.find('#');
+        if (hash != std::string::npos) line.erase(hash);
+        auto begin = line.find_first_not_of(" \t\r");
+        if (begin == std::string::npos) continue;
+        auto end = line.find_last_not_of(" \t\r");
+        line = line.substr(begin, end - begin + 1);
+        char* parse_end = nullptr;
+        unsigned long long value = std::strtoull(line.c_str(), &parse_end, 10);
+        if (parse_end == line.c_str() || *parse_end != '\0' || value == 0) {
+            ++malformed;
+            continue;
+        }
+        out.push_back(static_cast<size_t>(value));
+    }
+    if (malformed > 0) {
+        std::cout << "Ignored " << malformed << " malformed trace line(s) in "
+                  << path << std::endl;
+    }
+    return true;
+}
+
+// Trace-derived classes: one per power-of-two octave covering the observed
+// range, weighted by observed counts so the per-class breakdown and the
+// prefill budget reflect the recorded distribution.
+static std::vector<SizeClassSpec> buildTraceSpecs(
+    const std::vector<size_t>& sizes) {
+    if (sizes.empty()) return {};
+    const size_t min_size = *std::min_element(sizes.begin(), sizes.end());
+    const size_t max_size = *std::max_element(sizes.begin(), sizes.end());
+    size_t lo = 1;
+    while (lo * 2 <= min_size) lo *= 2;
+    size_t hi = lo;
+    while (hi <= max_size) hi *= 2;
+    auto octaves = buildOctaveSpecs(lo, hi);
+
+    std::vector<double> sums(octaves.size(), 0.0);
+    std::vector<int> counts(octaves.size(), 0);
+    for (size_t size : sizes) {
+        size_t idx = sizeClassIndexForSize(octaves, size);
+        sums[idx] += static_cast<double>(size);
+        ++counts[idx];
+    }
+
+    std::vector<SizeClassSpec> specs;
+    for (size_t i = 0; i < octaves.size(); ++i) {
+        if (counts[i] == 0) continue;
+        octaves[i].weight = counts[i];
+        octaves[i].mean_size = sums[i] / counts[i];
+        specs.push_back(octaves[i]);
+    }
+    return specs;
+}
+
 static std::vector<SizeClassSpec> getSizeClassSpecs(
     const std::string& pattern_name) {
+    if (pattern_name == "rl") {
+        const size_t min_size =
+            static_cast<size_t>(std::max<int64_t>(FLAGS_rl_min_kib, 0)) * KiB;
+        const size_t max_size =
+            static_cast<size_t>(std::max<int64_t>(FLAGS_rl_max_mib, 0)) * MiB;
+        return buildOctaveSpecs(min_size, max_size);
+    }
+
+    if (pattern_name == "trace") {
+        return buildTraceSpecs(g_trace_sizes);
+    }
+
     if (pattern_name == "kv_mixed") {
         return {
             {"small", 4 * KiB, 70},
@@ -586,6 +821,30 @@ static size_t chooseSizeClassIndex(const std::vector<SizeClassSpec>& specs,
     return specs.size() - 1;
 }
 
+struct SizeClassSample {
+    size_t class_idx = 0;
+    size_t size = 0;
+};
+
+// Draws allocation sizes either from the weighted synthetic size classes or,
+// when a trace is attached, by replaying the recorded sizes in order.
+struct SizeClassSampler {
+    std::vector<SizeClassSpec> specs;
+    const std::vector<size_t>* trace = nullptr;
+    size_t cursor = 0;
+
+    SizeClassSample next(std::mt19937& rng) {
+        if (trace != nullptr && !trace->empty()) {
+            size_t size = (*trace)[cursor % trace->size()];
+            ++cursor;
+            return {sizeClassIndexForSize(specs, size), size};
+        }
+        size_t idx = chooseSizeClassIndex(specs, rng);
+        if (specs.empty()) return {};
+        return {idx, sampleSizeClassSize(specs[idx], rng)};
+    }
+};
+
 static double computeWeightedAverageObjectSize(
     const std::vector<SizeClassSpec>& specs) {
     double weighted_size = 0.0;
@@ -593,7 +852,7 @@ static double computeWeightedAverageObjectSize(
 
     for (const auto& spec : specs) {
         if (spec.weight <= 0) continue;
-        weighted_size += static_cast<double>(spec.size) * spec.weight;
+        weighted_size += sizeClassMeanSize(spec) * spec.weight;
         total_weight += spec.weight;
     }
 
@@ -623,6 +882,180 @@ static size_t deriveSizeClassPrefillMaxAttempts(
                   kSizeClassPrefillAttemptMultiplier);
     return std::max(kSizeClassMinPrefillAttempts,
                     static_cast<size_t>(derived_attempts));
+}
+
+// Largest contiguous free region of a segment (max over its allocators).
+static size_t segmentLargestFree(const AllocatorManager& manager,
+                                 const std::string& name) {
+    const auto* allocators = manager.getAllocators(name);
+    if (!allocators) return 0;
+    size_t largest = 0;
+    for (const auto& registration : *allocators) {
+        const auto alloc = registration->GetAllocator();
+        if (!alloc) continue;
+        size_t v = alloc->getLargestFreeRegion();
+        if (v == kAllocatorUnknownFreeSpace) continue;
+        largest = std::max(largest, v);
+    }
+    return largest;
+}
+
+/**
+ * @brief Bench-only placement strategy: score every segment for the request
+ *        and allocate in descending score order. A score of -infinity marks
+ *        a segment as ineligible. Unlike RankedAllocationStrategy this ranks
+ *        all segments (no candidate sampling) and has no random fallback, so
+ *        the effect of the placement rule is measured in isolation.
+ */
+class BenchScoredStrategy : public RandomAllocationStrategy {
+   public:
+    using ScoreFn = std::function<double(const AllocatorManager&,
+                                         const std::string&, size_t)>;
+    explicit BenchScoredStrategy(ScoreFn score) : score_(std::move(score)) {}
+
+    tl::expected<std::vector<Replica>, ErrorCode> Allocate(
+        const AllocatorManager& manager, const size_t slice_length,
+        const size_t replica_num = 1,
+        const std::vector<std::string>& preferred_segments = {},
+        const std::set<std::string>& excluded_segments = {},
+        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        (void)preferred_segments;
+        if (slice_length == 0 || replica_num == 0) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        const auto& names = manager.getNames();
+        struct Candidate {
+            size_t idx;
+            double score;
+        };
+        std::vector<Candidate> candidates;
+        candidates.reserve(names.size());
+        for (size_t i = 0; i < names.size(); ++i) {
+            if (excluded_segments.contains(names[i])) continue;
+            double s = score_(manager, names[i], slice_length);
+            if (s == -std::numeric_limits<double>::infinity()) continue;
+            candidates.push_back({i, s});
+        }
+        std::stable_sort(candidates.begin(), candidates.end(),
+                         [](const Candidate& a, const Candidate& b) {
+                             return a.score > b.score;
+                         });
+        std::vector<Replica> replicas;
+        for (const auto& c : candidates) {
+            if (replicas.size() >= replica_num) break;
+            auto buffer = allocateSingle(manager, names[c.idx], slice_length);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+            }
+        }
+        if (replicas.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        return replicas;
+    }
+
+   private:
+    ScoreFn score_;
+};
+
+static constexpr double kIneligible = -std::numeric_limits<double>::infinity();
+
+// largest_hole_first: put the object into the segment with the largest
+// contiguous free region (the fragmentation_aware idea, ranked over all
+// segments).
+static double scoreLargestHoleFirst(const AllocatorManager& m,
+                                    const std::string& name, size_t size) {
+    size_t largest = segmentLargestFree(m, name);
+    return largest >= size ? static_cast<double>(largest) : kIneligible;
+}
+
+// best_fit: put the object into the segment whose largest hole is the
+// smallest one that still fits, so big holes are kept for big objects.
+static double scoreBestFit(const AllocatorManager& m, const std::string& name,
+                           size_t size) {
+    size_t largest = segmentLargestFree(m, name);
+    return largest >= size ? -static_cast<double>(largest - size) : kIneligible;
+}
+
+// reserved: the last --reserved_segments segments accept only objects of at
+// least --large_object_mib; all other segments accept only smaller objects.
+// Within each class the choice is random, like RandomAllocationStrategy.
+static double scoreReserved(const AllocatorManager& m, const std::string& name,
+                            size_t size) {
+    const auto& names = m.getNames();
+    const size_t reserved =
+        std::min<size_t>(std::max(FLAGS_reserved_segments, 0), names.size());
+    size_t idx = std::find(names.begin(), names.end(), name) - names.begin();
+    const bool is_reserved = idx + reserved >= names.size();
+    const bool is_large =
+        size >= static_cast<size_t>(std::max(FLAGS_large_object_mib, 0)) * MiB;
+    if (is_reserved != is_large) return kIneligible;
+    if (segmentLargestFree(m, name) < size) return kIneligible;
+    return static_cast<double>(std::rand()) / RAND_MAX;
+}
+
+// best_fit_bucketed: best fit with slack quantized into buckets; ties inside
+// a bucket are broken at random to spread traffic.
+static double scoreBestFitBucketed(const AllocatorManager& m,
+                                   const std::string& name, size_t size) {
+    size_t largest = segmentLargestFree(m, name);
+    if (largest < size) return kIneligible;
+    const double bucket =
+        static_cast<double>(std::max(FLAGS_best_fit_bucket_mib, 1)) * MiB;
+    const double slack_bucket = std::floor((largest - size) / bucket);
+    return -slack_bucket + static_cast<double>(std::rand()) / RAND_MAX * 0.5;
+}
+
+// hybrid: small objects best-fit into the tightest segment, large objects go
+// to the segment with the largest hole.
+static double scoreHybrid(const AllocatorManager& m, const std::string& name,
+                          size_t size) {
+    const bool is_large =
+        size >= static_cast<size_t>(std::max(FLAGS_large_object_mib, 0)) * MiB;
+    return is_large ? scoreLargestHoleFirst(m, name, size)
+                    : scoreBestFit(m, name, size);
+}
+
+static std::shared_ptr<AllocationStrategy> createBenchStrategy(
+    const BenchConfig& cfg, LocalSsdManager& local_ssd) {
+    const std::string& s = cfg.bench_strategy;
+    if (s.empty() || s == "random") {
+        return CreateAllocationStrategy(AllocationStrategyType::RANDOM,
+                                        local_ssd);
+    }
+    if (s == "free_ratio_first") {
+        return CreateAllocationStrategy(
+            AllocationStrategyType::FREE_RATIO_FIRST, local_ssd);
+    }
+    if (s == "largest_hole_first") {
+        return std::make_shared<BenchScoredStrategy>(scoreLargestHoleFirst);
+    }
+    if (s == "best_fit") {
+        return CreateAllocationStrategy(AllocationStrategyType::BEST_FIT,
+                                        local_ssd);
+    }
+    if (s == "reserved") {
+        return std::make_shared<BenchScoredStrategy>(scoreReserved);
+    }
+    if (s == "hybrid") {
+        return std::make_shared<BenchScoredStrategy>(scoreHybrid);
+    }
+    if (s == "best_fit_bucketed") {
+        return std::make_shared<BenchScoredStrategy>(scoreBestFitBucketed);
+    }
+    return nullptr;
+}
+
+static std::string benchStrategyLabel(const std::string& s) {
+    if (s == "random") return "Random";
+    if (s == "free_ratio_first") return "FreeRatioFirst";
+    if (s == "largest_hole_first") return "LargestHole";
+    if (s == "best_fit") return "BestFit";
+    if (s == "reserved") return "Reserved";
+    if (s == "hybrid") return "Hybrid";
+    if (s == "best_fit_bucketed") return "BestFitBucket";
+    return s;
 }
 
 static std::string strategyName(AllocationStrategyType type) {
@@ -1006,6 +1439,16 @@ static void evictRandomFraction(std::vector<std::vector<Replica>>& live,
     }
 }
 
+// Release exactly one random live object (free-one/allocate-one churn).
+static void releaseRandomOne(std::vector<std::vector<Replica>>& live,
+                             std::mt19937& rng) {
+    if (live.empty()) return;
+    std::uniform_int_distribution<size_t> dist(0, live.size() - 1);
+    size_t idx = dist(rng);
+    std::swap(live[idx], live.back());
+    live.pop_back();  // Replica destructor returns memory to allocator.
+}
+
 // Try to allocate once; on failure, sample utilization before eviction.
 static bool dsaAllocateWithEvict(
     const std::shared_ptr<AllocationStrategy>& strategy,
@@ -1068,12 +1511,13 @@ static SizeClassAllocationResult sizeClassAllocateWithEvict(
 static SizeClassPrefillStats prefillSizeClassChurn(
     const std::shared_ptr<AllocationStrategy>& strategy,
     AllocatorManager& manager, const BenchConfig& cfg,
-    const std::vector<SizeClassSpec>& specs,
+    SizeClassSampler& sampler,
     std::vector<std::vector<Replica>>& live_allocations, std::mt19937& rng) {
     SizeClassPrefillStats stats;
-    if (cfg.prefill_pct <= 0 || specs.empty()) return stats;
+    if (cfg.prefill_pct <= 0 || sampler.specs.empty()) return stats;
     stats.requested_pct = cfg.prefill_pct;
-    stats.max_attempts = deriveSizeClassPrefillMaxAttempts(manager, cfg, specs);
+    stats.max_attempts =
+        deriveSizeClassPrefillMaxAttempts(manager, cfg, sampler.specs);
 
     int consec_failures = 0;
     int evict_throwaway = 0;
@@ -1088,11 +1532,10 @@ static SizeClassPrefillStats prefillSizeClassChurn(
             }
         }
 
-        size_t class_idx = chooseSizeClassIndex(specs, rng);
+        auto sample = sampler.next(rng);
         auto alloc_result = sizeClassAllocateWithEvict(
-            strategy, manager, specs[class_idx].size, cfg.replica_num,
-            live_allocations, rng, evict_throwaway,
-            FLAGS_size_class_evict_ratio);
+            strategy, manager, sample.size, cfg.replica_num, live_allocations,
+            rng, evict_throwaway, FLAGS_size_class_evict_ratio);
         ++stats.attempts;
         if (alloc_result.status == SizeClassAllocationStatus::FULL) {
             ++stats.full_count;
@@ -1244,8 +1687,13 @@ static SizeClassChurnResult runSizeClassChurnBenchmark(const BenchConfig& cfg) {
     AllocatorManager manager =
         createCluster(cfg.num_segments, cfg.segment_capacity, cfg.skewed);
     LocalSsdManager local_ssd;
-    auto strategy = CreateAllocationStrategy(cfg.strategy_type, local_ssd);
-    auto specs = getSizeClassSpecs(cfg.size_class_pattern);
+    auto strategy = createBenchStrategy(cfg, local_ssd);
+    SizeClassSampler sampler;
+    sampler.specs = getSizeClassSpecs(cfg.size_class_pattern);
+    if (cfg.size_class_pattern == "trace") {
+        sampler.trace = &g_trace_sizes;
+    }
+    const auto& specs = sampler.specs;
 
     std::vector<SizeClassStat> per_class_stats;
     per_class_stats.reserve(specs.size());
@@ -1254,9 +1702,21 @@ static SizeClassChurnResult runSizeClassChurnBenchmark(const BenchConfig& cfg) {
         SizeClassStat stat;
         stat.name = spec.name;
         stat.size = spec.size;
+        stat.max_size = spec.max_size;
         stat.weight = spec.weight;
         per_class_stats.push_back(std::move(stat));
     }
+
+    const size_t probe_bytes =
+        static_cast<size_t>(std::max(FLAGS_probe_mib, 0)) * MiB;
+    const double release_prob =
+        std::clamp(FLAGS_size_class_release_prob, 0.0, 1.0);
+    std::uniform_real_distribution<double> release_dist(0.0, 1.0);
+    std::vector<double> probe_free_gb_samples;
+    std::vector<double> probe_largest_free_mb_samples;
+    int probe_attempts = 0;
+    int probe_success = 0;
+    int released_count = 0;
 
     std::vector<double> latencies;
     latencies.reserve(cfg.num_allocations);
@@ -1271,7 +1731,7 @@ static SizeClassChurnResult runSizeClassChurnBenchmark(const BenchConfig& cfg) {
 
     std::mt19937 rng(42);
     SizeClassPrefillStats prefill_stats = prefillSizeClassChurn(
-        strategy, manager, cfg, specs, live_allocations, rng);
+        strategy, manager, cfg, sampler, live_allocations, rng);
 
     int success_count = 0;
     int partial_count = 0;
@@ -1283,12 +1743,18 @@ static SizeClassChurnResult runSizeClassChurnBenchmark(const BenchConfig& cfg) {
     auto total_start = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < cfg.num_allocations; ++i) {
-        size_t class_idx = chooseSizeClassIndex(specs, rng);
-        const auto& spec = specs[class_idx];
+        if (release_prob > 0.0 && !live_allocations.empty() &&
+            release_dist(rng) < release_prob) {
+            releaseRandomOne(live_allocations, rng);
+            ++released_count;
+        }
+
+        auto sample = sampler.next(rng);
+        const size_t class_idx = sample.class_idx;
 
         auto t0 = std::chrono::high_resolution_clock::now();
         auto alloc_result = sizeClassAllocateWithEvict(
-            strategy, manager, spec.size, cfg.replica_num, live_allocations,
+            strategy, manager, sample.size, cfg.replica_num, live_allocations,
             rng, evict_count, FLAGS_size_class_evict_ratio);
         auto t1 = std::chrono::high_resolution_clock::now();
 
@@ -1316,6 +1782,17 @@ static SizeClassChurnResult runSizeClassChurnBenchmark(const BenchConfig& cfg) {
             if (snapshot.valid) {
                 fragmentation_samples.push_back(snapshot.fragmentation_ratio);
                 largest_free_mb_samples.push_back(
+                    static_cast<double>(snapshot.largest_free_region) / MiB);
+            }
+            if (probe_bytes > 0 && snapshot.valid) {
+                // Single replica, no eviction retry; the result is dropped at
+                // the end of this block so the probe never changes the pool.
+                auto probe = strategy->Allocate(manager, probe_bytes, 1);
+                ++probe_attempts;
+                if (probe.has_value() && !probe->empty()) ++probe_success;
+                probe_free_gb_samples.push_back(
+                    static_cast<double>(snapshot.total_free_space) / GiB);
+                probe_largest_free_mb_samples.push_back(
                     static_cast<double>(snapshot.largest_free_region) / MiB);
             }
             auto s1 = std::chrono::high_resolution_clock::now();
@@ -1358,6 +1835,261 @@ static SizeClassChurnResult runSizeClassChurnBenchmark(const BenchConfig& cfg) {
         computeDistributionStats(largest_free_mb_samples);
     res.final_fragmentation = computeFragmentationSnapshot(manager);
     res.size_class_stats = std::move(per_class_stats);
+    res.released_count = released_count;
+    res.probe_bytes = probe_bytes;
+    res.probe_attempts = probe_attempts;
+    res.probe_success = probe_success;
+    res.probe_free_gb_stats = computeDistributionStats(probe_free_gb_samples);
+    res.probe_largest_free_mb_stats =
+        computeDistributionStats(probe_largest_free_mb_samples);
+    computeLatencyStats(latencies, total_us, total_count, res);
+    return res;
+}
+
+struct TraceEvent {
+    char kind;  // 'p' put, 'r' remove, 'e' evict
+    std::string key;
+    size_t size;
+};
+
+static std::vector<TraceEvent> g_trace_events;
+
+static bool loadTraceEvents(const std::string& path,
+                            std::vector<TraceEvent>& out) {
+    std::ifstream in(path);
+    if (!in) return false;
+    std::string line;
+    size_t malformed = 0;
+    while (std::getline(in, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        // Format: "<kind> <key> <size>"; keys may contain spaces.
+        auto first = line.find(' ');
+        auto last = line.rfind(' ');
+        if (first == std::string::npos || last == first) {
+            ++malformed;
+            continue;
+        }
+        std::string kind = line.substr(0, first);
+        std::string key = line.substr(first + 1, last - first - 1);
+        char* end = nullptr;
+        unsigned long long size =
+            std::strtoull(line.c_str() + last + 1, &end, 10);
+        if (end == line.c_str() + last + 1 || *end != '\0') {
+            ++malformed;
+            continue;
+        }
+        char k = kind == "put"      ? 'p'
+                 : kind == "remove" ? 'r'
+                 : kind == "evict"  ? 'e'
+                                    : 0;
+        if (k == 0) {
+            ++malformed;
+            continue;
+        }
+        out.push_back({k, std::move(key), static_cast<size_t>(size)});
+    }
+    if (malformed > 0) {
+        std::cout << "Ignored " << malformed << " malformed event line(s) in "
+                  << path << std::endl;
+    }
+    return true;
+}
+
+// Replays put/remove/evict events with the real object lifetimes. No
+// eviction retry: a failed put is counted and its free-space picture is
+// recorded, exactly like action=put_start_alloc_failed in the master log.
+static SizeClassChurnResult runTraceEventsBenchmark(const BenchConfig& cfg) {
+    AllocatorManager manager =
+        createCluster(cfg.num_segments, cfg.segment_capacity, cfg.skewed);
+    LocalSsdManager local_ssd;
+    auto strategy = createBenchStrategy(cfg, local_ssd);
+
+    std::vector<size_t> put_sizes;
+    for (const auto& ev : g_trace_events) {
+        if (ev.kind == 'p') put_sizes.push_back(ev.size);
+    }
+    std::vector<SizeClassSpec> specs = buildTraceSpecs(put_sizes);
+    std::vector<SizeClassStat> per_class_stats;
+    std::vector<std::vector<double>> per_class_latencies(specs.size());
+    for (const auto& spec : specs) {
+        SizeClassStat stat;
+        stat.name = spec.name;
+        stat.size = spec.size;
+        stat.max_size = spec.max_size;
+        stat.weight = spec.weight;
+        per_class_stats.push_back(std::move(stat));
+    }
+
+    const size_t probe_bytes =
+        static_cast<size_t>(std::max(FLAGS_probe_mib, 0)) * MiB;
+    const int sample_interval = std::max(1, FLAGS_convergence_sample_interval);
+    const int repeat = std::max(1, FLAGS_trace_events_repeat);
+
+    std::unordered_map<std::string, std::vector<Replica>> live;
+    live.reserve(put_sizes.size());
+    std::unordered_map<std::string, double> bytes_per_segment;
+    std::unordered_map<std::string, double> window_bytes_per_segment;
+    std::vector<double> window_skews;
+    std::vector<double> util_stddev_samples;
+    auto account = [&](const std::vector<Replica>& replicas, size_t size) {
+        for (const auto& replica : replicas) {
+            for (const auto& name : replica.get_segment_names()) {
+                if (!name) continue;
+                bytes_per_segment[*name] += static_cast<double>(size);
+                window_bytes_per_segment[*name] += static_cast<double>(size);
+            }
+        }
+    };
+    auto skew_of = [&](const std::unordered_map<std::string, double>& m) {
+        if (m.empty()) return 0.0;
+        double total = 0.0, peak = 0.0;
+        for (const auto& [k, v] : m) {
+            total += v;
+            peak = std::max(peak, v);
+        }
+        const double mean = total / static_cast<double>(cfg.num_segments);
+        return mean > 0.0 ? peak / mean : 0.0;
+    };
+    std::vector<double> latencies;
+    latencies.reserve(put_sizes.size() * repeat);
+    std::vector<double> fragmentation_samples, largest_free_mb_samples;
+    std::vector<double> probe_free_gb_samples, probe_largest_free_mb_samples;
+    std::vector<double> fail_free_gb, fail_largest_free_mb, fail_size_mb;
+    int success_count = 0, partial_count = 0, failed_count = 0, total_count = 0,
+        released_count = 0, probe_attempts = 0, probe_success = 0;
+    double instrumentation_time_us = 0.0;
+
+    auto total_start = std::chrono::high_resolution_clock::now();
+    for (int pass = 0; pass < repeat; ++pass) {
+        const std::string suffix = repeat > 1 ? "#" + std::to_string(pass) : "";
+        for (const auto& ev : g_trace_events) {
+            if (ev.kind != 'p') {
+                auto it = live.find(ev.key + suffix);
+                if (it != live.end()) {
+                    live.erase(it);  // Replica destructors free the memory.
+                    ++released_count;
+                }
+                continue;
+            }
+            auto t0 = std::chrono::high_resolution_clock::now();
+            auto result = strategy->Allocate(manager, ev.size, cfg.replica_num);
+            auto t1 = std::chrono::high_resolution_clock::now();
+            double latency_ns =
+                std::chrono::duration<double, std::nano>(t1 - t0).count();
+            latencies.push_back(latency_ns);
+            size_t class_idx = sizeClassIndexForSize(specs, ev.size);
+            per_class_latencies[class_idx].push_back(latency_ns);
+            ++total_count;
+            ++per_class_stats[class_idx].total_count;
+            if (result.has_value() && !result->empty()) {
+                if (result->size() == static_cast<size_t>(cfg.replica_num)) {
+                    ++success_count;
+                    ++per_class_stats[class_idx].success_count;
+                } else {
+                    ++partial_count;
+                    ++per_class_stats[class_idx].partial_count;
+                }
+                account(result.value(), ev.size);
+                live[ev.key + suffix] = std::move(result.value());
+            } else {
+                ++failed_count;
+                ++per_class_stats[class_idx].failed_count;
+                auto s0 = std::chrono::high_resolution_clock::now();
+                auto snap = computeFragmentationSnapshot(manager);
+                fail_free_gb.push_back(snap.total_free_space / GiB);
+                fail_largest_free_mb.push_back(
+                    static_cast<double>(snap.largest_free_region) / MiB);
+                fail_size_mb.push_back(static_cast<double>(ev.size) / MiB);
+                auto s1 = std::chrono::high_resolution_clock::now();
+                instrumentation_time_us +=
+                    std::chrono::duration<double, std::micro>(s1 - s0).count();
+            }
+            if (total_count % sample_interval == 0) {
+                auto s0 = std::chrono::high_resolution_clock::now();
+                auto snapshot = computeFragmentationSnapshot(manager);
+                util_stddev_samples.push_back(
+                    computeUtilizationStdDev(manager));
+                window_skews.push_back(skew_of(window_bytes_per_segment));
+                window_bytes_per_segment.clear();
+                if (snapshot.valid) {
+                    fragmentation_samples.push_back(
+                        snapshot.fragmentation_ratio);
+                    largest_free_mb_samples.push_back(
+                        static_cast<double>(snapshot.largest_free_region) /
+                        MiB);
+                    if (probe_bytes > 0) {
+                        auto probe =
+                            strategy->Allocate(manager, probe_bytes, 1);
+                        ++probe_attempts;
+                        if (probe.has_value() && !probe->empty())
+                            ++probe_success;
+                        probe_free_gb_samples.push_back(
+                            static_cast<double>(snapshot.total_free_space) /
+                            GiB);
+                        probe_largest_free_mb_samples.push_back(
+                            static_cast<double>(snapshot.largest_free_region) /
+                            MiB);
+                    }
+                }
+                auto s1 = std::chrono::high_resolution_clock::now();
+                instrumentation_time_us +=
+                    std::chrono::duration<double, std::micro>(s1 - s0).count();
+            }
+        }
+    }
+    auto total_end = std::chrono::high_resolution_clock::now();
+    double total_us =
+        std::chrono::duration<double, std::micro>(total_end - total_start)
+            .count();
+    total_us = std::max(total_us - instrumentation_time_us, 1.0);
+
+    for (size_t i = 0; i < per_class_stats.size(); ++i) {
+        per_class_stats[i].latency_stats =
+            computeDistributionStats(per_class_latencies[i]);
+    }
+
+    SizeClassChurnResult res;
+    res.strategy_name = cfg.strategy_name;
+    res.num_segments = cfg.num_segments;
+    res.alloc_size = 0;
+    res.replica_num = cfg.replica_num;
+    res.skewed = cfg.skewed;
+    res.cluster_capacity_gb = computeClusterCapacityGB(
+        cfg.num_segments, cfg.segment_capacity, cfg.skewed);
+    res.final_util_stddev = computeUtilizationStdDev(manager);
+    res.final_avg_util = computeAverageUtilAll(manager);
+    res.success_count = success_count;
+    res.partial_count = partial_count;
+    res.failed_count = failed_count;
+    res.total_count = total_count;
+    res.pattern_name = "events";
+    res.fragmentation_stats = computeDistributionStats(fragmentation_samples);
+    res.largest_free_mb_stats =
+        computeDistributionStats(largest_free_mb_samples);
+    res.final_fragmentation = computeFragmentationSnapshot(manager);
+    res.size_class_stats = std::move(per_class_stats);
+    res.released_count = released_count;
+    res.probe_bytes = probe_bytes;
+    res.probe_attempts = probe_attempts;
+    res.probe_success = probe_success;
+    res.probe_free_gb_stats = computeDistributionStats(probe_free_gb_samples);
+    res.probe_largest_free_mb_stats =
+        computeDistributionStats(probe_largest_free_mb_samples);
+    res.fail_free_gb_stats = computeDistributionStats(fail_free_gb);
+    res.fail_largest_free_mb_stats =
+        computeDistributionStats(fail_largest_free_mb);
+    res.fail_size_mb_stats = computeDistributionStats(fail_size_mb);
+    res.write_skew = skew_of(bytes_per_segment);
+    if (!window_skews.empty()) {
+        res.window_write_skew =
+            std::accumulate(window_skews.begin(), window_skews.end(), 0.0) /
+            window_skews.size();
+    }
+    if (!util_stddev_samples.empty()) {
+        res.mean_util_stddev = std::accumulate(util_stddev_samples.begin(),
+                                               util_stddev_samples.end(), 0.0) /
+                               util_stddev_samples.size();
+    }
     computeLatencyStats(latencies, total_us, total_count, res);
     return res;
 }
@@ -1560,7 +2292,55 @@ static void printSizeClassChurnResult(const SizeClassChurnResult& r) {
               << ", p99=" << r.fragmentation_stats.p99
               << ", max=" << r.fragmentation_stats.max
               << ", final_largest_free=" << std::setprecision(1)
-              << final_largest_free_mb << " MB" << std::endl;
+              << final_largest_free_mb << " MB"
+              << ", released=" << r.released_count << std::endl;
+
+    if (r.pattern_name == "events") {
+        std::cout << "Traffic summary [" << r.strategy_name
+                  << ", pattern=" << r.pattern_name
+                  << ", segments=" << r.num_segments
+                  << ", replica=" << r.replica_num
+                  << "]: write_skew(max/mean)=" << std::fixed
+                  << std::setprecision(2) << r.write_skew
+                  << ", window_write_skew=" << r.window_write_skew
+                  << ", mean_util_stddev=" << std::setprecision(4)
+                  << r.mean_util_stddev << std::endl;
+    }
+
+    if (r.failed_count > 0 && r.fail_size_mb_stats.valid) {
+        std::cout << "Failure summary [" << r.strategy_name
+                  << ", pattern=" << r.pattern_name
+                  << ", segments=" << r.num_segments
+                  << ", replica=" << r.replica_num
+                  << "]: failed_puts=" << r.failed_count
+                  << ", failed_size_mb min/p50/max=" << std::fixed
+                  << std::setprecision(1) << r.fail_size_mb_stats.min << "/"
+                  << r.fail_size_mb_stats.p50 << "/" << r.fail_size_mb_stats.max
+                  << ", free_at_failure_gb avg/min/max=" << std::setprecision(2)
+                  << r.fail_free_gb_stats.avg << "/" << r.fail_free_gb_stats.min
+                  << "/" << r.fail_free_gb_stats.max
+                  << ", largest_free_mb_at_failure p50/max="
+                  << std::setprecision(1) << r.fail_largest_free_mb_stats.p50
+                  << "/" << r.fail_largest_free_mb_stats.max << std::endl;
+    }
+
+    if (r.probe_bytes > 0) {
+        std::cout << "Probe summary [" << r.strategy_name
+                  << ", pattern=" << r.pattern_name
+                  << ", segments=" << r.num_segments
+                  << ", replica=" << r.replica_num
+                  << "]: probe_size=" << (r.probe_bytes / MiB)
+                  << " MiB, success=" << r.probe_success << "/"
+                  << r.probe_attempts
+                  << ", free_at_probe_gb avg/min/max=" << std::fixed
+                  << std::setprecision(2) << r.probe_free_gb_stats.avg << "/"
+                  << r.probe_free_gb_stats.min << "/"
+                  << r.probe_free_gb_stats.max
+                  << ", largest_free_mb p10/p50/max=" << std::setprecision(1)
+                  << r.probe_largest_free_mb_stats.p10 << "/"
+                  << r.probe_largest_free_mb_stats.p50 << "/"
+                  << r.probe_largest_free_mb_stats.max << std::endl;
+    }
 
     std::cout << "Size-class breakdown:";
     for (const auto& stat : r.size_class_stats) {
@@ -1568,8 +2348,11 @@ static void printSizeClassChurnResult(const SizeClassChurnResult& r) {
                             std::to_string(stat.partial_count) + "/" +
                             std::to_string(stat.failed_count) + "/" +
                             std::to_string(stat.total_count);
-        std::cout << " " << stat.name << "(" << (stat.size / KiB)
-                  << "KB,w=" << stat.weight
+        std::string size_label = stat.max_size > stat.size
+                                     ? ""
+                                     : std::to_string(stat.size / KiB) + "KB,";
+        std::cout << " " << stat.name << "(" << size_label
+                  << "w=" << stat.weight
                   << ",full/partial/failed/total=" << ratio
                   << ",p99_ns=" << std::fixed << std::setprecision(0)
                   << stat.latency_stats.p99 << ")";
@@ -1805,18 +2588,107 @@ static void runDsaMatrix() {
     }
 }
 
+static bool parsePositiveIntList(const std::string& text,
+                                 std::vector<int>& counts) {
+    counts.clear();
+    std::stringstream ss(text);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        auto begin = item.find_first_not_of(" \t");
+        if (begin == std::string::npos) continue;
+        auto end = item.find_last_not_of(" \t");
+        item = item.substr(begin, end - begin + 1);
+        char* parse_end = nullptr;
+        long value = std::strtol(item.c_str(), &parse_end, 10);
+        if (parse_end == item.c_str() || *parse_end != '\0' || value <= 0) {
+            return false;
+        }
+        counts.push_back(static_cast<int>(value));
+    }
+    return !counts.empty();
+}
+
 static void runSizeClassChurnMatrix() {
     std::vector<bool> skewed_options = {false, true};
     std::vector<int> segment_counts = {1, 10, 100};
     std::vector<int> replica_nums = {1, 2, 3};
-    std::vector<AllocationStrategyType> strategies = {
-        AllocationStrategyType::RANDOM,
-        AllocationStrategyType::FREE_RATIO_FIRST,
-    };
+
+    std::vector<std::string> strategies;
+    {
+        std::stringstream ss(FLAGS_size_class_strategies);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+            auto b = item.find_first_not_of(" \t");
+            if (b == std::string::npos) continue;
+            auto e = item.find_last_not_of(" \t");
+            item = item.substr(b, e - b + 1);
+            BenchConfig probe_cfg;
+            probe_cfg.bench_strategy = item;
+            LocalSsdManager probe_ssd;
+            if (!createBenchStrategy(probe_cfg, probe_ssd)) {
+                std::cout << "Invalid size_class_strategies entry: " << item
+                          << ". Use random, free_ratio_first, "
+                             "largest_hole_first, best_fit, reserved, hybrid, "
+                             "or best_fit_bucketed."
+                          << std::endl;
+                return;
+            }
+            strategies.push_back(item);
+        }
+        if (strategies.empty()) {
+            std::cout << "size_class_strategies must not be empty" << std::endl;
+            return;
+        }
+    }
+
+    const bool events_mode = !FLAGS_rl_trace_events.empty();
+    if (events_mode) {
+        g_trace_events.clear();
+        if (!loadTraceEvents(FLAGS_rl_trace_events, g_trace_events)) {
+            std::cout << "Cannot open rl_trace_events: "
+                      << FLAGS_rl_trace_events << std::endl;
+            return;
+        }
+        if (g_trace_events.empty()) {
+            std::cout << "rl_trace_events contains no events: "
+                      << FLAGS_rl_trace_events << std::endl;
+            return;
+        }
+    }
+
+    if (!FLAGS_segment_counts.empty() &&
+        !parsePositiveIntList(FLAGS_segment_counts, segment_counts)) {
+        std::cout << "Invalid segment_counts: " << FLAGS_segment_counts
+                  << ". Use a comma-separated list of positive integers."
+                  << std::endl;
+        return;
+    }
+    if (!FLAGS_replica_counts.empty() &&
+        !parsePositiveIntList(FLAGS_replica_counts, replica_nums)) {
+        std::cout << "Invalid replica_counts: " << FLAGS_replica_counts
+                  << ". Use a comma-separated list of positive integers."
+                  << std::endl;
+        return;
+    }
 
     std::vector<std::string> patterns;
-    if (FLAGS_size_class_pattern == "all") {
-        patterns = {"kv_mixed", "dsa_pair"};
+    if (events_mode) {
+        patterns = {"events"};
+    } else if (!FLAGS_rl_trace_file.empty()) {
+        g_trace_sizes.clear();
+        if (!loadTraceSizes(FLAGS_rl_trace_file, g_trace_sizes)) {
+            std::cout << "Cannot open rl_trace_file: " << FLAGS_rl_trace_file
+                      << std::endl;
+            return;
+        }
+        if (g_trace_sizes.empty()) {
+            std::cout << "rl_trace_file contains no allocation sizes: "
+                      << FLAGS_rl_trace_file << std::endl;
+            return;
+        }
+        patterns = {"trace"};
+    } else if (FLAGS_size_class_pattern == "all") {
+        patterns = {"kv_mixed", "dsa_pair", "rl"};
     } else {
         patterns = {FLAGS_size_class_pattern};
     }
@@ -1830,36 +2702,74 @@ static void runSizeClassChurnMatrix() {
     }
 
     for (const auto& pattern : patterns) {
+        if (pattern == "events") continue;
         if (getSizeClassSpecs(pattern).empty()) {
-            std::cout << "Invalid size_class_pattern: " << pattern
-                      << ". Use --size_class_pattern=kv_mixed, dsa_pair, or "
-                         "all."
-                      << std::endl;
+            if (pattern == "rl") {
+                std::cout << "Invalid rl size range: rl_min_kib="
+                          << FLAGS_rl_min_kib
+                          << " KiB, rl_max_mib=" << FLAGS_rl_max_mib
+                          << " MiB. Both must be positive with min < max."
+                          << std::endl;
+            } else {
+                std::cout << "Invalid size_class_pattern: " << pattern
+                          << ". Use --size_class_pattern=kv_mixed, dsa_pair, "
+                             "rl, or all."
+                          << std::endl;
+            }
             return;
         }
     }
 
-    std::cout << "\n=== Size-Class Churn Fragmentation Benchmark Matrix ===\n"
-              << "Workload: prefill to --prefill_pct if set, then run "
-              << FLAGS_num_allocations
-              << " mixed-size allocation attempts with fail-triggered random "
-                 "eviction and retry.\n"
-              << "Fragmentation: 1 - largest_free_region / total_free_space, "
-                 "sampled every --convergence_sample_interval allocations.\n"
-              << "Config: segment_capacity=" << FLAGS_segment_capacity
-              << " MB, prefill_pct=" << FLAGS_prefill_pct
-              << ", evict_ratio=" << FLAGS_size_class_evict_ratio
-              << ", size_class_pattern=" << FLAGS_size_class_pattern << "\n"
-              << "Patterns: kv_mixed = 4KB:70%, 256KB:20%, 3198KB:10%; "
-                 "dsa_pair = 3198KB:50%, 643KB:50%.\n"
-              << "Skewed setup: half nodes are (base + 50%) capacity, half are "
-                 "(base - 50%)\n"
-              << std::endl;
+    std::cout
+        << "\n=== Size-Class Churn Fragmentation Benchmark Matrix ===\n"
+        << "Workload: prefill to --prefill_pct if set, then run "
+        << FLAGS_num_allocations
+        << " mixed-size allocation attempts with fail-triggered random "
+           "eviction and retry.\n"
+        << "Fragmentation: 1 - largest_free_region / total_free_space, "
+           "sampled every --convergence_sample_interval allocations.\n"
+        << "Config: segment_capacity=" << FLAGS_segment_capacity
+        << " MB, prefill_pct=" << FLAGS_prefill_pct
+        << ", evict_ratio=" << FLAGS_size_class_evict_ratio
+        << ", release_prob=" << FLAGS_size_class_release_prob
+        << ", size_class_pattern=" << FLAGS_size_class_pattern
+        << ", probe_mib=" << FLAGS_probe_mib << "\n"
+        << "Patterns: kv_mixed = 4KB:70%, 256KB:20%, 3198KB:10%; "
+           "dsa_pair = 3198KB:50%, 643KB:50%; rl = log-uniform sizes "
+           "in ["
+        << FLAGS_rl_min_kib << " KiB, " << FLAGS_rl_max_mib
+        << " MiB], one equally weighted class per octave"
+        << (g_trace_sizes.empty()
+                ? std::string(".\n")
+                : "; trace = sequential replay of " +
+                      std::to_string(g_trace_sizes.size()) + " sizes from " +
+                      FLAGS_rl_trace_file + ".\n")
+        << (events_mode
+                ? "Events: replaying " + std::to_string(g_trace_events.size()) +
+                      " put/remove/evict events from " + FLAGS_rl_trace_events +
+                      " x" +
+                      std::to_string(std::max(1, FLAGS_trace_events_repeat)) +
+                      " with real lifetimes and no eviction retry; "
+                      "prefill and release_prob are ignored.\n"
+                : std::string())
+        << "Strategies: " << FLAGS_size_class_strategies
+        << " (largest_hole_first/best_fit/reserved are bench-only; "
+           "reserved keeps the last "
+        << FLAGS_reserved_segments
+        << " segment(s) for objects >= " << FLAGS_large_object_mib << " MiB).\n"
+        << "Release: before each measured allocation, one random live "
+           "object is released with probability release_prob.\n"
+        << "Probe: when probe_mib > 0, each fragmentation sample also "
+           "attempts one probe_mib single-replica allocation without "
+           "eviction and releases it immediately.\n"
+        << "Skewed setup: half nodes are (base + 50%) capacity, half are "
+           "(base - 50%)\n"
+        << std::endl;
 
     std::vector<BenchConfig> configs;
     for (const auto& pattern : patterns) {
         for (auto skew : skewed_options) {
-            for (auto strategy : strategies) {
+            for (const auto& strategy : strategies) {
                 for (auto segs : segment_counts) {
                     for (auto rep : replica_nums) {
                         if (rep > segs) continue;
@@ -1871,8 +2781,12 @@ static void runSizeClassChurnMatrix() {
                         cfg.replica_num = rep;
                         cfg.num_allocations = FLAGS_num_allocations;
                         cfg.skewed = skew;
-                        cfg.strategy_type = strategy;
-                        cfg.strategy_name = strategyName(strategy);
+                        cfg.strategy_type =
+                            strategy == "free_ratio_first"
+                                ? AllocationStrategyType::FREE_RATIO_FIRST
+                                : AllocationStrategyType::RANDOM;
+                        cfg.bench_strategy = strategy;
+                        cfg.strategy_name = benchStrategyLabel(strategy);
                         cfg.prefill_pct = FLAGS_prefill_pct;
                         cfg.workload_type = WorkloadType::SIZE_CLASS_CHURN;
                         cfg.size_class_pattern = pattern;
@@ -1885,7 +2799,7 @@ static void runSizeClassChurnMatrix() {
 
     bool first = true;
     std::string prev_pattern;
-    AllocationStrategyType prev_strategy = AllocationStrategyType::RANDOM;
+    std::string prev_strategy;
 
     for (const auto& cfg : configs) {
         if (first || cfg.size_class_pattern != prev_pattern) {
@@ -1895,13 +2809,14 @@ static void runSizeClassChurnMatrix() {
             first = true;
         }
 
-        if (first || cfg.strategy_type != prev_strategy) {
+        if (first || cfg.bench_strategy != prev_strategy) {
             printSizeClassChurnHeader();
-            prev_strategy = cfg.strategy_type;
+            prev_strategy = cfg.bench_strategy;
             first = false;
         }
 
-        auto result = runSizeClassChurnBenchmark(cfg);
+        auto result = events_mode ? runTraceEventsBenchmark(cfg)
+                                  : runSizeClassChurnBenchmark(cfg);
         printSizeClassChurnResult(result);
     }
 }

--- a/mooncake-store/benchmarks/extract_alloc_trace.py
+++ b/mooncake-store/benchmarks/extract_alloc_trace.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Extract an allocation-size trace from mooncake_master logs.
+
+``mooncake_master --v=1`` logs one ``action=put_start_begin`` line per PutStart
+with ``key=`` and ``value_length=``. This script turns such logs into the
+one-size-per-line format consumed by
+``allocation_strategy_bench --rl_trace_file`` and prints a per-octave size
+histogram so the captured distribution can be sanity-checked against the
+``master_value_size_bytes`` metric.
+
+With ``--events``, it also writes an ordered event log (``put``, ``remove``,
+``evict``) keyed by object, using the ``action=remove_object`` and
+``action=evict_object`` lines, for lifetime-aware replay.
+
+Usage:
+    extract_alloc_trace.py master.INFO [more logs...] -o rl_sizes.txt
+    extract_alloc_trace.py master.INFO -o rl_sizes.txt --events rl_events.txt
+"""
+
+import argparse
+import re
+import sys
+from collections import Counter
+
+PUT_RE = re.compile(
+    r"key=(?P<key>.*?), value_length=(?P<size>\d+), .*action=put_start_begin"
+)
+REMOVE_RE = re.compile(r"key=(?P<key>.*?), size=(?P<size>\d+), .*action=remove_object")
+EVICT_RE = re.compile(r"key=(?P<key>.*?), size=(?P<size>\d+), .*action=evict_object")
+
+
+def octave_label(size):
+    units = ["B", "K", "M", "G", "T"]
+    lo = 1
+    while lo * 2 <= size:
+        lo *= 2
+    hi = lo * 2
+
+    def fmt(value):
+        unit = 0
+        while value >= 1024 and unit < len(units) - 1:
+            value //= 1024
+            unit += 1
+        return f"{value}{units[unit]}"
+
+    return f"{fmt(lo)}-{fmt(hi)}", lo
+
+
+def parse_logs(paths):
+    """Return (sizes, events). events is a list of (kind, key, size)."""
+    sizes = []
+    events = []
+    for path in paths:
+        with open(path, "r", errors="replace") as handle:
+            for line in handle:
+                match = PUT_RE.search(line)
+                if match:
+                    size = int(match.group("size"))
+                    sizes.append(size)
+                    events.append(("put", match.group("key"), size))
+                    continue
+                match = EVICT_RE.search(line)
+                if match:
+                    events.append(
+                        ("evict", match.group("key"), int(match.group("size")))
+                    )
+                    continue
+                match = REMOVE_RE.search(line)
+                if match:
+                    events.append(
+                        ("remove", match.group("key"), int(match.group("size")))
+                    )
+    return sizes, events
+
+
+def print_histogram(sizes, out=None):
+    out = out if out is not None else sys.stderr
+    if not sizes:
+        print("no put_start_begin lines found", file=out)
+        return
+    buckets = Counter()
+    order = {}
+    for size in sizes:
+        label, lo = octave_label(size)
+        buckets[label] += 1
+        order[label] = lo
+    total = len(sizes)
+    total_bytes = sum(sizes)
+    print(
+        f"{total} allocations, {total_bytes / 2**30:.2f} GiB total, "
+        f"min={min(sizes)} max={max(sizes)} bytes",
+        file=out,
+    )
+    print(f"{'octave':>12} {'count':>10} {'share':>8} {'bytes_share':>12}", file=out)
+    bytes_by_label = Counter()
+    for size in sizes:
+        bytes_by_label[octave_label(size)[0]] += size
+    for label in sorted(buckets, key=lambda name: order[name]):
+        count = buckets[label]
+        print(
+            f"{label:>12} {count:>10} {100.0 * count / total:>7.2f}% "
+            f"{100.0 * bytes_by_label[label] / total_bytes:>11.2f}%",
+            file=out,
+        )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("logs", nargs="+", help="mooncake_master log files")
+    parser.add_argument("-o", "--output", required=True, help="size trace output")
+    parser.add_argument(
+        "--events", help="optional ordered put/remove/evict event log output"
+    )
+    args = parser.parse_args(argv)
+
+    sizes, events = parse_logs(args.logs)
+    with open(args.output, "w") as handle:
+        handle.write("# allocation sizes in bytes, one per PutStart\n")
+        handle.writelines(f"{size}\n" for size in sizes)
+    if args.events:
+        with open(args.events, "w") as handle:
+            handle.write("# kind key size\n")
+            handle.writelines(f"{kind} {key} {size}\n" for kind, key, size in events)
+    print_histogram(sizes)
+    return 0 if sizes else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mooncake-store/benchmarks/test_extract_alloc_trace.py
+++ b/mooncake-store/benchmarks/test_extract_alloc_trace.py
@@ -1,0 +1,81 @@
+import importlib.util
+import io
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("extract_alloc_trace.py")
+SPEC = importlib.util.spec_from_file_location("extract_alloc_trace", MODULE_PATH)
+extract = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(extract)
+
+
+LOG_SAMPLE = """\
+I0908 10:00:00.000001 1 master_service.cpp:4695] key=obj-a, value_length=65536, config=ReplicateConfig{...}, action=put_start_begin
+I0908 10:00:00.000002 1 master_service.cpp:4695] key=obj, with comma, value_length=1342177280, config=ReplicateConfig{...}, action=put_start_begin
+I0908 10:00:00.000003 1 master_service.cpp:4427] key=obj-c, value_length=1342177280, replica_num=1, segments=16, total_free=21474836480, largest_free=805306368, error=NO_AVAILABLE_HANDLE, action=put_start_alloc_failed
+I0908 10:00:00.000004 1 master_service.cpp:6770] key=obj-a, size=65536, action=remove_object
+I0908 10:00:00.000005 1 master_service.cpp:10460] key=obj, with comma, size=1342177280, replicas=1, action=evict_object
+I0908 10:00:00.000006 1 master_service.cpp:1] unrelated line
+"""
+
+
+class ExtractAllocTraceTest(unittest.TestCase):
+    def test_parses_sizes_and_events(self):
+        with tempfile.TemporaryDirectory() as root:
+            log = Path(root) / "master.INFO"
+            log.write_text(LOG_SAMPLE)
+            sizes, events = extract.parse_logs([str(log)])
+
+        self.assertEqual(sizes, [65536, 1342177280])
+        self.assertEqual(
+            events,
+            [
+                ("put", "obj-a", 65536),
+                ("put", "obj, with comma", 1342177280),
+                ("remove", "obj-a", 65536),
+                ("evict", "obj, with comma", 1342177280),
+            ],
+        )
+
+    def test_main_writes_outputs_and_histogram(self):
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            log = root / "master.INFO"
+            log.write_text(LOG_SAMPLE)
+            sizes_out = root / "sizes.txt"
+            events_out = root / "events.txt"
+            stderr = io.StringIO()
+            with unittest.mock.patch("sys.stderr", stderr):
+                rc = extract.main(
+                    [str(log), "-o", str(sizes_out), "--events", str(events_out)]
+                )
+            self.assertEqual(rc, 0)
+            size_lines = [
+                line
+                for line in sizes_out.read_text().splitlines()
+                if not line.startswith("#")
+            ]
+            self.assertEqual(size_lines, ["65536", "1342177280"])
+            self.assertIn("put obj-a 65536", events_out.read_text())
+            self.assertIn("64K-128K", stderr.getvalue())
+            self.assertIn("1G-2G", stderr.getvalue())
+
+    def test_octave_label(self):
+        self.assertEqual(extract.octave_label(65536)[0], "64K-128K")
+        self.assertEqual(extract.octave_label(1342177280)[0], "1G-2G")
+        self.assertEqual(extract.octave_label(1)[0], "1B-2B")
+
+    def test_main_returns_error_without_puts(self):
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            log = root / "master.INFO"
+            log.write_text("nothing here\n")
+            with unittest.mock.patch("sys.stderr", io.StringIO()):
+                rc = extract.main([str(log), "-o", str(root / "sizes.txt")])
+            self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 #include <iterator>
+#include <limits>
 #include <time.h>
 #include <ylt/util/tl/expected.hpp>
 
@@ -460,13 +461,18 @@ class RandomAllocationStrategy : public AllocationStrategy {
  */
 class RankedAllocationStrategy : public RandomAllocationStrategy {
    protected:
+    // Ranks candidate segments by `score` (higher first) and allocates in that
+    // order. By default only kCandidateMultiplier * remaining segments,
+    // starting at a random index, are scored; `rank_all_segments` scores every
+    // segment instead, for policies whose choice must be a global optimum.
     template <typename ScoreFn>
     tl::expected<std::vector<Replica>, ErrorCode> AllocateRanked(
         const AllocatorManager& allocator_manager, const size_t slice_length,
         const size_t replica_num,
         const std::vector<std::string>& preferred_segments,
         const std::set<std::string>& excluded_segments,
-        const ReplicaType replica_type, ScoreFn&& score) {
+        const ReplicaType replica_type, ScoreFn&& score,
+        bool rank_all_segments = false) {
         if (slice_length == 0 || replica_num == 0) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
@@ -499,7 +505,9 @@ class RankedAllocationStrategy : public RandomAllocationStrategy {
 
         const size_t remaining = replica_num - replicas.size();
         const size_t sample_count =
-            std::min(kCandidateMultiplier * remaining, names.size());
+            rank_all_segments
+                ? names.size()
+                : std::min(kCandidateMultiplier * remaining, names.size());
         const size_t start_idx = randomIndex(names.size());
 
         struct Candidate {
@@ -518,10 +526,12 @@ class RankedAllocationStrategy : public RandomAllocationStrategy {
             candidates.push_back({idx, score(name)});
         }
 
-        std::sort(candidates.begin(), candidates.end(),
-                  [](const Candidate& lhs, const Candidate& rhs) {
-                      return lhs.score > rhs.score;
-                  });
+        // stable_sort keeps the random start order among equal scores, so
+        // ties do not systematically favor low segment indices.
+        std::stable_sort(candidates.begin(), candidates.end(),
+                         [](const Candidate& lhs, const Candidate& rhs) {
+                             return lhs.score > rhs.score;
+                         });
         for (const auto& candidate : candidates) {
             if (replicas.size() >= replica_num) {
                 break;
@@ -613,6 +623,85 @@ class FreeRatioFirstAllocationStrategy final : public RankedAllocationStrategy {
         }
         return static_cast<double>(total_free) /
                static_cast<double>(total_capacity);
+    }
+};
+
+/**
+ * @brief Best-fit allocation strategy for mixed-size workloads.
+ *
+ * Each replica goes to the segment whose largest contiguous free region is
+ * the smallest one that still fits the request. Small objects thus fill
+ * partially used segments instead of carving holes into the emptiest ones,
+ * and large contiguous regions stay available for large objects. Spreading
+ * strategies (random, free_ratio_first) leave every segment with medium-sized
+ * holes, so a large allocation can fail while the cluster still reports
+ * plenty of free space; this is the failure mode of RL data-plane offload,
+ * where object sizes span several orders of magnitude and objects are removed
+ * explicitly rather than evicted.
+ *
+ * Every segment is ranked (no candidate sampling), because the choice has to
+ * be the global tightest fit. The cost is one largest-free-region query per
+ * segment per allocation: a short mutex-protected bin lookup for
+ * OffsetBufferAllocator. Segments whose allocator cannot report a largest free
+ * region rank last; segments too small for the request rank after those and
+ * are only tried if everything else fails. Preferred segments, distinct
+ * segments per replica, and best-effort semantics come from AllocateRanked.
+ */
+class BestFitAllocationStrategy final : public RankedAllocationStrategy {
+   public:
+    tl::expected<std::vector<Replica>, ErrorCode> Allocate(
+        const AllocatorManager& allocator_manager, const size_t slice_length,
+        const size_t replica_num = 1,
+        const std::vector<std::string>& preferred_segments =
+            std::vector<std::string>(),
+        const std::set<std::string>& excluded_segments =
+            std::set<std::string>(),
+        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        return AllocateRanked(
+            allocator_manager, slice_length, replica_num, preferred_segments,
+            excluded_segments, replica_type,
+            [&](const std::string& name) {
+                const size_t largest =
+                    GetSegmentLargestFreeRegion(allocator_manager, name);
+                if (largest == kAllocatorUnknownFreeSpace) {
+                    return std::numeric_limits<double>::lowest();
+                }
+                if (largest < slice_length) {
+                    return -std::numeric_limits<double>::infinity();
+                }
+                // Higher score = tighter fit.
+                return -static_cast<double>(largest - slice_length);
+            },
+            /*rank_all_segments=*/true);
+    }
+
+   private:
+    // Largest contiguous free region over the allocators of a segment, or
+    // kAllocatorUnknownFreeSpace when no allocator can report one.
+    static size_t GetSegmentLargestFreeRegion(
+        const AllocatorManager& allocator_manager, const std::string& name) {
+        const auto* allocators = allocator_manager.getAllocators(name);
+        if (!allocators) {
+            return 0;
+        }
+        size_t largest = 0;
+        bool known = false;
+        for (const auto& registration : *allocators) {
+            if (!registration->IsServing()) {
+                continue;
+            }
+            const auto allocator = registration->GetAllocator();
+            if (!allocator) {
+                continue;
+            }
+            const size_t region = allocator->getLargestFreeRegion();
+            if (region == kAllocatorUnknownFreeSpace) {
+                continue;
+            }
+            known = true;
+            largest = std::max(largest, region);
+        }
+        return known ? largest : kAllocatorUnknownFreeSpace;
     }
 };
 
@@ -724,6 +813,8 @@ inline std::shared_ptr<AllocationStrategy> CreateAllocationStrategy(
                 local_ssd);
         case AllocationStrategyType::LOCAL_FIRST:
             return std::make_shared<RandomAllocationStrategy>();
+        case AllocationStrategyType::BEST_FIT:
+            return std::make_shared<BestFitAllocationStrategy>();
         default:
             return std::make_shared<RandomAllocationStrategy>();
     }

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -441,6 +441,8 @@ class MasterServiceSupervisorConfig {
                 AllocationStrategyType::SSD_FREE_RATIO_FIRST;
         } else if (config.allocation_strategy == "local_first") {
             allocation_strategy_type = AllocationStrategyType::LOCAL_FIRST;
+        } else if (config.allocation_strategy == "best_fit") {
+            allocation_strategy_type = AllocationStrategyType::BEST_FIT;
         } else {
             LOG(WARNING) << "Unrecognized allocation_strategy value: '"
                          << config.allocation_strategy
@@ -735,6 +737,8 @@ class WrappedMasterServiceConfig {
                 AllocationStrategyType::SSD_FREE_RATIO_FIRST;
         } else if (config.allocation_strategy == "local_first") {
             allocation_strategy_type = AllocationStrategyType::LOCAL_FIRST;
+        } else if (config.allocation_strategy == "best_fit") {
+            allocation_strategy_type = AllocationStrategyType::BEST_FIT;
         } else {
             LOG(WARNING) << "Unrecognized allocation_strategy value: '"
                          << config.allocation_strategy

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -453,7 +453,8 @@ enum class AllocationStrategyType {
     FREE_RATIO_FIRST,      // Free-ratio-first allocation
     CXL,                   // CXL-specific allocation
     SSD_FREE_RATIO_FIRST,  // SSD free-ratio-first allocation
-    LOCAL_FIRST            // Prefer local host before ordered remote fallback
+    LOCAL_FIRST,           // Prefer local host before ordered remote fallback
+    BEST_FIT               // Tightest-fitting segment first
 };
 
 /**

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -334,7 +334,7 @@ DEFINE_string(memory_allocator, "offset",
 DEFINE_string(
     allocation_strategy, "random",
     "Allocation strategy for segments, random | free_ratio_first | cxl | "
-    "ssd_free_ratio_first | local_first");
+    "ssd_free_ratio_first | local_first | best_fit");
 DEFINE_bool(enable_http_metadata_server, false,
             "Enable HTTP metadata server instead of etcd");
 DEFINE_int32(http_metadata_server_port, 8080,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -4741,8 +4741,44 @@ auto MasterService::AllocateAndInsertMetadata(
             preferred_segments, std::set<std::string>(), ReplicaType::MEMORY);
 
         if (!allocation_result.has_value()) {
-            VLOG(1) << "Failed to allocate replicas for key=" << key
-                    << ", error: " << allocation_result.error();
+            if (VLOG_IS_ON(1)) {
+                // Free-space summary for offline fragmentation analysis: a
+                // failure with total_free >> value_length but
+                // largest_free < value_length is a contiguity problem, not a
+                // capacity problem.
+                uint64_t total_free = 0;
+                uint64_t largest_free = 0;
+                size_t segment_count = 0;
+                for (const auto& name : allocator_snapshot.getNames()) {
+                    const auto* registrations =
+                        allocator_snapshot.getAllocators(name);
+                    if (registrations == nullptr) continue;
+                    for (const auto& registration : *registrations) {
+                        if (!registration->IsServing()) continue;
+                        const auto allocator = registration->GetAllocator();
+                        if (!allocator) continue;
+                        ++segment_count;
+                        const size_t capacity = allocator->capacity();
+                        if (capacity != kAllocatorUnknownFreeSpace &&
+                            capacity >= allocator->size()) {
+                            total_free += capacity - allocator->size();
+                        }
+                        const size_t largest =
+                            allocator->getLargestFreeRegion();
+                        if (largest != kAllocatorUnknownFreeSpace) {
+                            largest_free =
+                                std::max<uint64_t>(largest_free, largest);
+                        }
+                    }
+                }
+                VLOG(1) << "key=" << key << ", value_length=" << value_length
+                        << ", replica_num=" << config.replica_num
+                        << ", segments=" << segment_count
+                        << ", total_free=" << total_free
+                        << ", largest_free=" << largest_free
+                        << ", error=" << allocation_result.error()
+                        << ", action=put_start_alloc_failed";
+            }
             if (allocation_result.error() == ErrorCode::INVALID_PARAMS) {
                 refund_pending_quota();
                 return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -4758,6 +4794,19 @@ auto MasterService::AllocateAndInsertMetadata(
         } else {
             allocated_memory_replicas = allocation_result->size();
             replicas = std::move(allocation_result.value());
+            if (VLOG_IS_ON(1)) {
+                // Placement record for offline traffic/fragmentation analysis.
+                std::string segments;
+                for (const auto& replica : replicas) {
+                    for (const auto& name : replica.get_segment_names()) {
+                        if (!segments.empty()) segments += ';';
+                        segments += name.value_or("?");
+                    }
+                }
+                VLOG(1) << "key=" << key << ", value_length=" << value_length
+                        << ", segments=" << segments
+                        << ", action=put_start_allocated";
+            }
         }
     }
 
@@ -7196,9 +7245,13 @@ auto MasterService::Remove(const std::string& key, const TenantId& tenant_id,
             if (!persist_result) {
                 return tl::make_unexpected(persist_result.error());
             }
+            VLOG(1) << "key=" << key << ", size=" << metadata.size
+                    << ", action=remove_object";
             return {};
         }
     }
+    VLOG(1) << "key=" << key << ", size=" << metadata.size
+            << ", action=remove_object";
     accessor.Erase();
     return {};
 }
@@ -7715,10 +7768,14 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                             tl::make_unexpected(persist_result.error());
                         continue;
                     }
+                    VLOG(1) << "key=" << key << ", size=" << metadata.size
+                            << ", action=remove_object";
                     results[original_idx] = {};
                     continue;
                 }
             }
+            VLOG(1) << "key=" << key << ", size=" << metadata.size
+                    << ", action=remove_object";
             EraseMetadata(tenant_state, it, normalized_tenant,
                           QuotaEraseMode::kFull, &shard);
             if (tenant_state.Empty()) {
@@ -11112,11 +11169,18 @@ void MasterService::BatchEvict(double evict_ratio_target,
         [&, this](TenantState& tenant_state, ObjectMetadata& metadata,
                   std::vector<std::vector<Replica>>& deferred_replicas) {
             if (enable_oplog_) {
-                return metadata.size *
-                       metadata.CountReplicas([](const Replica& replica) {
-                           return replica.is_memory_replica() &&
-                                  replica.status() == ReplicaStatus::REMOVED;
-                       });
+                const size_t removed_count =
+                    metadata.CountReplicas([](const Replica& replica) {
+                        return replica.is_memory_replica() &&
+                               replica.status() == ReplicaStatus::REMOVED;
+                    });
+                if (removed_count > 0) {
+                    VLOG(1) << "key=" << metadata.user_key
+                            << ", size=" << metadata.size
+                            << ", replicas=" << removed_count
+                            << ", action=evict_object";
+                }
+                return metadata.size * removed_count;
             }
             const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
             auto replicas = PopReplicasWithCacheTotalAccounting(
@@ -11128,6 +11192,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
             }
             RecordDynamicReplicaRemoval(metadata, erased_ids);
             const size_t replica_count = replicas.size();
+            if (replica_count > 0) {
+                VLOG(1) << "key=" << metadata.user_key
+                        << ", size=" << metadata.size
+                        << ", replicas=" << replica_count
+                        << ", action=evict_object";
+            }
             if (!replicas.empty()) {
                 deferred_replicas.emplace_back(std::move(replicas));
             }

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <memory>
 #include <numeric>
+#include <random>
 #include <set>
 #include <string>
 #include <tuple>
@@ -27,7 +28,8 @@ static constexpr size_t MiB = 1024 * 1024;
 
 // Strategy types for parameterized tests
 const auto kStrategyTypes = ::testing::Values(
-    AllocationStrategyType::RANDOM, AllocationStrategyType::FREE_RATIO_FIRST);
+    AllocationStrategyType::RANDOM, AllocationStrategyType::FREE_RATIO_FIRST,
+    AllocationStrategyType::BEST_FIT);
 
 const auto kAllocatorTypes = ::testing::Values(BufferAllocatorType::CACHELIB,
                                                BufferAllocatorType::OFFSET);
@@ -90,6 +92,9 @@ INSTANTIATE_TEST_SUITE_P(
                 break;
             case AllocationStrategyType::SSD_FREE_RATIO_FIRST:
                 strategy_str = "SsdFreeRatioFirst";
+                break;
+            case AllocationStrategyType::BEST_FIT:
+                strategy_str = "BestFit";
                 break;
             default:
                 strategy_str = "Unknown";
@@ -750,6 +755,90 @@ TEST_F(AllocationStrategyTest, PerformanceComparison) {
               << (static_cast<double>(random_elapsed_us.count()) /
                   frf_elapsed_us.count())
               << "x\n\n";
+}
+
+// Best-fit must place each request into the segment whose largest free
+// region is the smallest one that still fits, keeping big holes for big
+// objects.
+TEST_F(AllocationStrategyTest, BestFitPrefersTightestSegment) {
+    const size_t kSegmentSize = 64 * MiB;
+    AllocatorManager allocator_manager;
+    for (const auto& name : {"seg_a", "seg_b", "seg_c"}) {
+        allocator_manager.addAllocator(
+            name, std::make_shared<OffsetBufferAllocator>(name, 0x100000000ULL,
+                                                          kSegmentSize, name));
+    }
+    RandomAllocationStrategy placer;
+    std::vector<Replica> prefill;
+    // seg_a keeps ~4 MiB free, seg_b ~32 MiB, seg_c stays empty.
+    auto a = placer.AllocateFrom(allocator_manager, 60 * MiB, "seg_a");
+    auto b = placer.AllocateFrom(allocator_manager, 32 * MiB, "seg_b");
+    ASSERT_TRUE(a.has_value() && b.has_value());
+    prefill.push_back(std::move(a.value()));
+    prefill.push_back(std::move(b.value()));
+
+    BestFitAllocationStrategy strategy;
+    auto segment_of = [](const std::vector<Replica>& replicas) {
+        auto names = replicas.at(0).get_segment_names();
+        return names.at(0).value_or("");
+    };
+
+    auto small = strategy.Allocate(allocator_manager, 3 * MiB);
+    ASSERT_TRUE(small.has_value());
+    EXPECT_EQ(segment_of(small.value()), "seg_a");
+
+    auto medium = strategy.Allocate(allocator_manager, 20 * MiB);
+    ASSERT_TRUE(medium.has_value());
+    EXPECT_EQ(segment_of(medium.value()), "seg_b");
+
+    auto large = strategy.Allocate(allocator_manager, 40 * MiB);
+    ASSERT_TRUE(large.has_value());
+    EXPECT_EQ(segment_of(large.value()), "seg_c");
+
+    // Two replicas must land on two different segments.
+    auto pair = strategy.Allocate(allocator_manager, 1 * MiB, 2);
+    ASSERT_TRUE(pair.has_value());
+    ASSERT_EQ(pair->size(), 2u);
+    EXPECT_NE(pair->at(0).get_segment_names().at(0),
+              pair->at(1).get_segment_names().at(0));
+
+    // Nothing fits 100 MiB.
+    auto too_big = strategy.Allocate(allocator_manager, 100 * MiB);
+    EXPECT_FALSE(too_big.has_value());
+}
+
+// BestFit relies on getLargestFreeRegion() meaning "the largest request this
+// segment can satisfy right now": a request of exactly that size must succeed
+// and one byte more must fail. Any fork that changes the allocator's report
+// has to keep this property.
+TEST_F(AllocationStrategyTest, LargestFreeRegionIsLargestSatisfiableRequest) {
+    const size_t kSegmentSize = 64 * MiB;
+    auto allocator = std::make_shared<OffsetBufferAllocator>(
+        "seg", 0x100000000ULL, kSegmentSize, "seg");
+    std::mt19937 rng(7);
+    std::vector<std::unique_ptr<AllocatedBuffer>> live;
+    for (int round = 0; round < 200; ++round) {
+        // Random churn: allocate a random size or free a random object.
+        if (live.empty() || rng() % 3 != 0) {
+            size_t size = 4096 + rng() % (6 * MiB);
+            if (auto buf = allocator->allocate(size))
+                live.push_back(std::move(buf));
+        } else {
+            live.erase(live.begin() + rng() % live.size());
+        }
+        const size_t largest = allocator->getLargestFreeRegion();
+        ASSERT_NE(largest, kAllocatorUnknownFreeSpace);
+        if (largest == 0) continue;
+        auto fits = allocator->allocate(largest);
+        ASSERT_TRUE(fits != nullptr)
+            << "round " << round << " largest " << largest;
+        auto too_big = allocator->allocate(largest + 1);
+        EXPECT_TRUE(too_big == nullptr)
+            << "round " << round << " largest " << largest;
+        // fits is released here; the report must be back to `largest`.
+        fits.reset();
+        EXPECT_EQ(allocator->getLargestFreeRegion(), largest);
+    }
 }
 
 TEST_F(AllocationStrategyTest, PerformanceTest) {


### PR DESCRIPTION
## Description

**Problem.** Under RL data-plane offload, large puts fail with `NO_AVAILABLE_HANDLE` while the cluster still reports plenty of free space. The cause is the object mix, not the amount of free memory.

Captured from a real RL trainer running with `--object-store-backend mooncake` (40 steps, 1360 puts, 1.28 GiB), the distribution is strongly bimodal with an empty middle:

| Size octave | Objects | Share of objects | Share of bytes |
| --- | --- | --- | --- |
| 256 B - 512 B | 440 | 32.4% | 0.01% |
| 512 B - 1 KiB | 120 | 8.8% | 0.00% |
| 1 - 2 KiB | 40 | 2.9% | 0.00% |
| 2 - 4 KiB | 560 | 41.2% | 0.09% |
| 8 - 16 KiB | 80 | 5.9% | 0.05% |
| **8 - 16 MiB** | **120** | **8.8%** | **99.84%** |

Nothing lands between 16 KiB and 8 MiB. Each Arrow buffer of a bundle is stored as its own object, so every step writes three payload buffers of 10.5 to 12.4 MiB carrying essentially all the bytes, plus 31 metadata buffers taking ten discrete values between 256 B and 9896 B. Everything is removed explicitly one to three steps later; eviction never runs. The payload sizes are data-driven -- 120 samples take 80 distinct values spanning 18.1% -- so they cannot be aligned to allocator size classes from the client side.

Replayed at scale against a live `mooncake_master` (8 segments, 16320 puts per run, eviction disabled, `--v=1`), the first failure looks like this:

```
key=.../step25-shard2/buffer/non_tensor_batch.loss_masks.data, value_length=11672576,
segments=8, total_free=176076536, largest_free=10485760,
error=NO_AVAILABLE_HANDLE, action=put_start_alloc_failed
```

86.2% of reserved capacity in use, **168 MiB still free -- 15x the request -- but the largest contiguous hole is 10.0 MiB against an 11.1 MiB request**. Every failure in every run is in the 8 to 16 MiB class; every KB-class put succeeds.

**Mechanism.** `OffsetAllocator` reserves the rounded-up size class rather than the requested size, and `getLargestFreeRegion` reports the floor of the highest non-empty bin. At `MANTISSA_BITS = 3` the bins above 8 MiB are 8, 9, 10, ... MiB, so an 11.1 MiB request needs a 12 MiB hole. When the spreading strategies scatter payloads evenly, the KB metadata objects interleave with them and every segment converges on holes around 10 MiB while none holds 12 MiB. The observed `largest_free` at failure lands exactly on a bin floor every time -- at 8 x 147 MiB it is 10485760 (10 MiB) at M = 3, 11534336 (11 MiB) at M = 4 and 10747904 (10.25 MiB) at M = 5, each the bin step for its mantissa width -- which is that mechanism showing through.

**`MANTISSA_BITS` (#3787) is not the lever.** Raising it does buy real space: per-object rounding waste on this trace drops from 5.26% (M = 3) to 2.37% (M = 4), 1.17% (M = 5) and 0.53% (M = 6). But it does not move the point where failures disappear, because holes and rounded-up requests scale together:

| | M = 3 (current) | M = 4 | M = 5 |
| --- | --- | --- | --- |
| Rounding waste on this trace | 5.26% | 2.37% | 1.17% |
| Failed puts, `best_fit`, 8 x 147 MiB | 16 | 3 | 4 |
| Reserved occupancy at first failure | 88.9% | 87.5% | 89.8% |
| Smallest segment size with zero failures | 153 MiB | 156 MiB | 152 MiB |

M changes how much RAM a unit of data costs; it does not raise the occupancy ceiling. Changing it is also a persistence-format break (`m_usedBins` width and `NUM_LEAF_BINS` are serialized), so it belongs in its own RFC. Full analysis: #RFC.

**Fix.** A `best_fit` allocation strategy (`--allocation_strategy=best_fit`, off by default): each replica goes to the segment whose largest contiguous free region is the smallest one that still fits, so small objects fill partially used segments and large regions survive for large objects.

On this workload, measured against a live master, `best_fit` reaches zero failed puts with **7.3% less memory** than the spreading strategies need (153 MiB per segment versus 165 MiB), and below that threshold it fails 2 to 3 times less often at every capacity. The tracing and replay tooling used to find and verify this is included.

### Changes

| Area | File | Change |
| --- | --- | --- |
| Strategy | `include/allocation_strategy.h` | `BestFitAllocationStrategy` on top of `AllocateRanked`, slack-based score |
| Strategy | `include/allocation_strategy.h` | `AllocateRanked`: `rank_all_segments` flag (default off), `stable_sort` for ties |
| Wiring | `include/types.h`, `include/master_config.h`, `src/master.cpp` | `BEST_FIT` enum, `best_fit` parsing, flag help |
| Docs | `docs/source/design/store/mooncake-store.md` | Strategy table row and usage guidance |
| Tests | `tests/allocation_strategy_test.cpp` | BestFit in the parameterized matrix, 2 new tests |
| Master logs | `src/master_service.cpp` | `VLOG(1)`: `put_start_allocated`, `put_start_alloc_failed`, `remove_object`, `evict_object` |
| Bench | `benchmarks/variable_length_allocation_bench.cpp` (new) | Variable-length workload: octave size pattern, large-allocation probe, size and event replay, strategy comparison, traffic skew. `allocation_strategy_bench.cpp` keeps the fixed-size workloads and is untouched |
| Tools | `benchmarks/extract_alloc_trace.py` (+ test) | Master log to size file, event log, histogram; keyed on `put_start_allocated` so rejected puts are not replayed as allocations |
| Tools | `mooncake-rl/examples/rl_dataproto_trace_driver.py` | Multi-rank RL load generator; `verl` DataProto and `miles` per-buffer workloads, `put`/`put_parts` paths |
| Docs | `benchmarks/README.md` | Capture and replay workflow |

### Strategy details

- Segments whose allocator cannot report a largest free region (cachelib) rank last; segments too small for the request rank after those and are only tried as a fallback.
- `rank_all_segments` exists because best-fit needs the global tightest fit, not a 6x sample. Existing callers keep the sampled behavior.
- `stable_sort` keeps the random start order among equal scores so ties stop favoring low segment indices. This also applies to `free_ratio_first`.
- Cost: one mutex-protected bin lookup per segment per allocation, linear in the segment count.

### Trade-off, measured on the captured trace

Offline replay of the recorded event log, 8 segments x 152 MiB, 16320 puts, uniform segment sizes, median of 5 runs:

| Metric | random | free_ratio_first | best_fit |
| --- | --- | --- | --- |
| Failed puts | 23 | 28 | **1** |
| Fragmentation p50 | 0.419 | 0.405 | **0.194** |
| p99 allocation latency | 1115 ns | 1430 ns | 1627 ns |
| Write skew, whole run (max/mean) | 1.06 | 1.03 | 1.06 |
| Write skew inside a 200-put window | 3.25 | 3.11 | 4.92 |
| Per-segment utilization stddev | 0.099 | 0.042 | 0.175 |

`best_fit` halves fragmentation and cuts failed puts by more than an order of magnitude, at about 45% higher p99 allocation latency and a markedly less even instantaneous write distribution. Long-run bytes per segment stay balanced, but deployments bound by per-segment bandwidth should measure before switching.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [x] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other (benchmark and diagnostics tooling)

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -DBUILD_UNIT_TESTS=ON -DBUILD_BENCHMARK=ON
cmake --build build --target allocation_strategy_test \
  variable_length_allocation_bench allocation_strategy_bench mooncake_master -j
./build/mooncake-store/tests/allocation_strategy_test
python3 -m unittest mooncake-store/benchmarks/test_extract_alloc_trace.py

# 1. reproduce the workload against a real master, one lane per strategy
./build/mooncake-store/src/mooncake_master --v=1 --memory_allocator=offset \
  --allocation_strategy=best_fit --eviction_ratio=0 \
  --eviction_high_watermark_ratio=0.95 --log_dir=logs &
# 0.1494 GiB = 153 MiB per segment, the point where best_fit stops failing
python3 mooncake-rl/examples/rl_dataproto_trace_driver.py --workload miles \
  --ranks 8 --keep_steps 3 --steps 60 --segment_gib 0.1494 \
  --local_buffer_mib 128 --target_multiple 1e9

# 2. extract the trace from that master's log and replay it offline
python3 mooncake-store/benchmarks/extract_alloc_trace.py logs/mooncake_master.INFO \
  -o rl_sizes.txt --events rl_events.txt
./build/mooncake-store/benchmarks/variable_length_allocation_bench \
  --trace_events=rl_events.txt \
  --segment_capacity=152 --segment_counts=8 --replica_counts=1 \
  --strategies=random,free_ratio_first,best_fit

# 3. synthetic variable-length pattern, no trace needed
./build/mooncake-store/benchmarks/variable_length_allocation_bench \
  --segment_capacity=4096 --segment_counts=16 --replica_counts=1 \
  --prefill_pct=70 --release_prob=1.0 \
  --num_allocations=20000 --probe_mib=1280
```

**Unit tests**

| Suite | Result | Notes |
| --- | --- | --- |
| `allocation_strategy_test` | 88 / 88 | `BEST_FIT` added to the parameterized matrix |
| `BestFitPrefersTightestSegment` | pass | 3, 20, 40 MiB requests land on the tightest fitting segment |
| `LargestFreeRegionIsLargestSatisfiableRequest` | pass | `allocate(largest)` succeeds, `allocate(largest + 1)` fails |
| `test_extract_alloc_trace.py` | 6 / 6 | Keys with commas, remove and evict parsing, histogram; a put rejected with `OBJECT_ALREADY_EXISTS` yields one allocation, and an `UpsertStart` allocation with no begin record is still counted |

**End-to-end on a real `mooncake_master`**, 8 segments, 16320 puts per run, `--memory_allocator=offset`, eviction disabled, one run per cell. Failed puts:

| Segment size | Cluster | random | free_ratio_first | best_fit |
| --- | --- | --- | --- | --- |
| 165 MiB | 1.29 GiB | 0 | 0 | 0 |
| 162 MiB | 1.27 GiB | 1 | 3 | **0** |
| 159 MiB | 1.24 GiB | 11 | 5 | **0** |
| 156 MiB | 1.22 GiB | 20 | 16 | **0** |
| 153 MiB | 1.20 GiB | 16 | 13 | **0** |
| 152 MiB | 1.19 GiB | 6 | 20 | 2 |
| 147 MiB | 1.15 GiB | 47 | 39 | **16** |
| 143 MiB | 1.12 GiB | 54 | 51 | **25** |
| 139 MiB | 1.09 GiB | 55 | 55 | **32** |
| 135 MiB | 1.05 GiB | 82 | 78 | **51** |

`best_fit` reaches zero failures at 153 MiB per segment; `random` and `free_ratio_first` still fail at 162 MiB and only clear at 165 MiB. Same workload, same zero-failure guarantee, **7.3% less memory**. Below that threshold `best_fit` fails 2 to 3 times less often at every size.

These are single runs, and the two spreading lanes are noisy between 152 and 162 MiB (`random` scores 6 at 152 MiB but 16 to 20 just above it) because segment choice is randomized per run. The threshold separation is well outside that noise; the individual counts in that band are not. Zero evictions in every run, so eviction is neither masking nor causing anything.

**Offline replay of the same trace (bench)**, uniform segments, failed puts as median of 5 runs (min - max in parentheses):

| Segment size | random | free_ratio_first | best_fit |
| --- | --- | --- | --- |
| 152 MiB | 23 (21 - 45) | 28 (18 - 42) | **1 (0 - 1)** |
| 147 MiB | 107 (69 - 121) | 80 (79 - 92) | **20 (17 - 36)** |
| 143 MiB | 117 (107 - 146) | 114 (106 - 122) | **38 (30 - 42)** |

Same ordering as the live runs, and the same signature: all failures in the 8 to 16 MiB class, `largest_free` at failure pinned at 10 to 11 MiB. The replay is harsher than the live master because it packs a fixed trace into fixed segments with no client-side retry.

**Trace extraction**

Keyed on `put_start_allocated`, the extracted event log balances exactly -- 16320 puts against 16320 removes on a 16320-put run. Keying on `put_start_begin` instead yields 15984 puts against 15968 removes, because `put_start_begin` is logged before the duplicate-key and quota checks and `UpsertStart` logs no begin record at all; the 16 extra puts are requests that reserved nothing but would own a lifetime in the replay.

**Other checks**

| Check | Result |
| --- | --- |
| `allocation_strategy_bench` | byte-identical to `main`; the variable-length workload lives in its own binary |
| Driver, both workloads and both write paths, real master | 60-step runs, 16320 puts and removes each |
| Generated size distribution vs captured trace | identical octave by octave (32.4 / 8.8 / 2.9 / 41.2 / 5.9 / 8.8%, 99.84% of bytes in 8 to 16 MiB) |
| clang-format 20 on changed C++ files | 0 warnings |
| `ruff check` and `ruff format` (CI-pinned 0.6.9) on changed Python files | clean |

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format 20 run directly on the changed files)
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass (pre-commit unavailable in the build environment; clang-format 20 and the CI-pinned ruff 0.6.9 were run directly)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#RFC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)