### PR TITLE
[TENT] Fix standard TCP completion, permissions and task accounting

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -30,6 +30,7 @@
 #include <thread>
 #include <unordered_map>
 #include <variant>
+#include <limits>
 
 #include "tent/runtime/metastore.h"
 #include "tent/runtime/segment.h"
@@ -121,6 +122,16 @@ struct XferDataDesc {
     uint64_t peer_mem_addr;
     size_t length;
 };
+
+// Standard TCP RPC payload boundaries. READ retains the server's 1 GiB cap;
+// WRITE uses a 32-bit RPC attachment that includes XferDataDesc.
+inline constexpr size_t kTcpMaxReadBytes = size_t{1} << 30;
+inline constexpr size_t kTcpMaxWriteBytes =
+    std::numeric_limits<uint32_t>::max() - sizeof(XferDataDesc);
+
+inline constexpr size_t tcpMaxTransferBytes(Request::OpCode opcode) {
+    return opcode == Request::READ ? kTcpMaxReadBytes : kTcpMaxWriteBytes;
+}
 
 using OnReceiveBootstrap =
     std::function<int(const BootstrapDesc& request, BootstrapDesc& response)>;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
@@ -79,6 +79,8 @@ struct BufferDesc {
     std::vector<uint32_t> lkey;  // not uploaded, available in local only
 
     bool internal{false};
+    // Local registration policy, deliberately excluded from JSON metadata.
+    Permission permission{kGlobalReadWrite};
 
    public:
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(BufferDesc, addr, length, location,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -80,6 +80,7 @@ struct TaskInfo {
     uint64_t device_mask{~0ULL};  // Device mask for quota allocation
     std::string qp_pool;          // Named QP pool (RFC #2568 step 3), "" = none
     Request request;
+    size_t public_length{0};  // Original API request; request may be merged.
     bool staging{false};
     bool cancel_requested{false};
     TransferStatusEnum status{TransferStatusEnum::PENDING};
@@ -118,6 +119,7 @@ struct TaskInfo {
           device_mask(other.device_mask),
           qp_pool(other.qp_pool),
           request(other.request),
+          public_length(other.public_length),
           staging(other.staging),
           cancel_requested(other.cancel_requested),
           status(other.status),
@@ -142,6 +144,7 @@ struct TaskInfo {
           device_mask(other.device_mask),
           qp_pool(std::move(other.qp_pool)),
           request(std::move(other.request)),
+          public_length(other.public_length),
           staging(other.staging),
           cancel_requested(other.cancel_requested),
           status(other.status),
@@ -167,6 +170,7 @@ struct TaskInfo {
             device_mask = other.device_mask;
             qp_pool = other.qp_pool;
             request = other.request;
+            public_length = other.public_length;
             staging = other.staging;
             cancel_requested = other.cancel_requested;
             status = other.status;
@@ -197,6 +201,7 @@ struct TaskInfo {
             device_mask = other.device_mask;
             qp_pool = std::move(other.qp_pool);
             request = std::move(other.request);
+            public_length = other.public_length;
             staging = other.staging;
             cancel_requested = other.cancel_requested;
             status = other.status;

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -108,6 +108,9 @@ Status ControlClient::bootstrapUb(const std::string& server_addr,
 Status ControlClient::sendData(const std::string& server_addr,
                                uint64_t peer_mem_addr, void* local_mem_addr,
                                size_t length) {
+    // Check before addition/allocation or reading the caller's source buffer.
+    if (length > kTcpMaxWriteBytes)
+        return Status::InvalidArgument("TCP WRITE exceeds RPC payload limit");
     std::string response;
     XferDataDesc desc{htole64(peer_mem_addr), htole64(length)};
     std::string request;
@@ -136,6 +139,8 @@ Status ControlClient::sendData(const std::string& server_addr,
 Status ControlClient::recvData(const std::string& server_addr,
                                uint64_t peer_mem_addr, void* local_mem_addr,
                                size_t length) {
+    if (length > kTcpMaxReadBytes)
+        return Status::InvalidArgument("TCP READ exceeds RPC payload limit");
     std::string request, response;
     XferDataDesc desc{htole64(peer_mem_addr), htole64(length)};
     request.resize(sizeof(XferDataDesc));
@@ -506,7 +511,8 @@ void ControlService::onSendData(const std::string_view& request,
     auto length = le64toh(desc->length);
 
     // Validate request size to prevent buffer over-read
-    if (request.size() < sizeof(XferDataDesc) + length) {
+    if (length > kTcpMaxWriteBytes ||
+        length > request.size() - sizeof(XferDataDesc)) {
         response = "SendData failed: invalid request size";
         return;
     }
@@ -550,8 +556,7 @@ void ControlService::onRecvData(const std::string_view& request,
     };
 
     // Validate length to prevent DoS via excessive memory allocation
-    constexpr size_t kMaxTransferSize = 1ULL << 30;  // 1GB max per RPC
-    if (length > kMaxTransferSize) {
+    if (length > kTcpMaxReadBytes) {
         fail("RecvData failed: length exceeds maximum allowed");
         return;
     }

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -511,7 +511,11 @@ void ControlService::onSendData(const std::string_view& request,
         return;
     }
 
-    if (local_desc->findBuffer(peer_mem_addr, length)) {
+    if (auto* buffer = local_desc->findBuffer(peer_mem_addr, length)) {
+        if (buffer->permission != kGlobalReadWrite) {
+            response = "SendData failed: remote write permission denied";
+            return;
+        }
         auto status =
             Platform::getLoader().copy((void*)peer_mem_addr, &desc[1], length);
         if (!status.ok()) {
@@ -552,7 +556,12 @@ void ControlService::onRecvData(const std::string_view& request,
         return;
     }
 
-    if (local_desc->findBuffer(peer_mem_addr, length)) {
+    if (auto* buffer = local_desc->findBuffer(peer_mem_addr, length)) {
+        if (buffer->permission != kGlobalReadOnly &&
+            buffer->permission != kGlobalReadWrite) {
+            fail("RecvData failed: remote read permission denied");
+            return;
+        }
         auto& loader = Platform::getLoader();
         if (loader.getMemoryType((void*)peer_mem_addr) == MTYPE_CPU) {
             // assign() skips the resize() zero-fill pass.

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1870,6 +1870,8 @@ Status TransferEngineImpl::prepareSubmit(
     // particular, an UNSPEC request selected for RDMA/HP TCP keeps its own
     // transport's limits. Ordinary-size submissions need no extra route lookup
     // or allocation here, and a too-large single request remains independent.
+    // This bounds initial TCP selection only. A later route change/failover
+    // to TCP can still reject an oversized owner; it is not split on retry.
     if (merged.request_list.size() < request_list.size()) {
         std::vector<bool> tcp_limited;
         for (size_t i = 0; i < merged.request_list.size(); ++i) {
@@ -1877,7 +1879,7 @@ Status TransferEngineImpl::prepareSubmit(
             if (request.length <= tcpMaxTransferBytes(request.opcode)) continue;
             if (request.transport_hint == TCP ||
                 (request.transport_hint == UNSPEC &&
-                 resolveTransport(request, 0).transport == TCP)) {
+                 getTransportType(request, 0).transport == TCP)) {
                 if (tcp_limited.empty())
                     tcp_limited.resize(merged.request_list.size(), false);
                 tcp_limited[i] = true;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1502,6 +1502,7 @@ struct TransferEngineImpl::PreparedSubmit {
     struct Task {
         size_t merged_task_index{0};
         size_t task_id{0};
+        size_t public_length{0};
     };
 
     struct Owner {
@@ -1889,7 +1890,8 @@ Status TransferEngineImpl::prepareSubmit(
         } else {
             owner.derived_task_ids.push_back(task_id);
         }
-        prepared.tasks.push_back({merged_task_index, task_id});
+        prepared.tasks.push_back({merged_task_index, task_id,
+                                  request_list[public_task_index].length});
     }
     return Status::OK();
 }
@@ -1932,6 +1934,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
         if (merged_task_id_map.count(merged_task_id)) {
             task = merged_task_id_map[merged_task_id];
             task.derived = true;
+            task.public_length = task_plan.public_length;
             if (task.type != UNSPEC) {
                 auto owner_it =
                     owner_task_id_by_merged_task.find(merged_task_id);
@@ -1948,6 +1951,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
         task.runtime_policy = prepared.runtime_policy;
         task.status = PENDING;
         task.request = merged_request;
+        task.public_length = task_plan.public_length;
         task.staging = false;
         task.start_time =
             prepared.submit_time;  // Record start time for latency tracking
@@ -2153,6 +2157,7 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
         task.runtime_policy = prepared.runtime_policy;
         task.status = PENDING;
         task.request = owner.request;
+        task.public_length = task_plan.public_length;
         task.staging = false;
         task.start_time = prepared.submit_time;
         task.type = UNSPEC;
@@ -2857,7 +2862,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
                 task_status.s = public_status;
                 task_status.transferred_bytes =
                     public_status == COMPLETED
-                        ? batch->task_list[public_task_id].request.length
+                        ? batch->task_list[public_task_id].public_length
                         : 0;
                 return Status::OK();
             }
@@ -2887,7 +2892,11 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
     recordTaskCompletionMetrics(batch->task_list[poll_task_id], prev_status,
                                 task_status.s);
 
-    if (task_status.s == COMPLETED) CHECK_STATUS(maybeFireSubmitHooks(batch));
+    if (task_status.s == COMPLETED) {
+        task_status.transferred_bytes =
+            batch->task_list[public_task_id].public_length;
+        CHECK_STATUS(maybeFireSubmitHooks(batch));
+    }
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -3016,13 +3016,9 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         overall_status.s = worst_failure;
     }
     // else: some tasks still PENDING → overall_status.s stays PENDING
-    // Transfer-bound notifications may only be delivered once the transfer
-    // they are attached to has actually completed. The second parameter is
-    // "verify completion before sending", so passing the batch's completion
-    // into it inverted the guard: for a batch still in flight, or one that
-    // ended in failure, check was false and every hook fired anyway.
-    if (overall_status.s == COMPLETED)
-        CHECK_STATUS(maybeFireSubmitHooks(batch, /*check=*/false));
+    // A hook belongs to its own submit interval. Other intervals can still
+    // be pending or failed without withholding this interval's notification.
+    CHECK_STATUS(maybeFireSubmitHooks(batch));
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1866,6 +1866,36 @@ Status TransferEngineImpl::prepareSubmit(
     auto merged =
         mergeRequests(request_list, merge_boundaries, merge_requests_);
 
+    // Limit only oversized merges that would use standard TCP. In
+    // particular, an UNSPEC request selected for RDMA/HP TCP keeps its own
+    // transport's limits. Ordinary-size submissions need no extra route lookup
+    // or allocation here, and a too-large single request remains independent.
+    if (merged.request_list.size() < request_list.size()) {
+        std::vector<bool> tcp_limited;
+        for (size_t i = 0; i < merged.request_list.size(); ++i) {
+            const auto& request = merged.request_list[i];
+            if (request.length <= tcpMaxTransferBytes(request.opcode)) continue;
+            if (request.transport_hint == TCP ||
+                (request.transport_hint == UNSPEC &&
+                 resolveTransport(request, 0).transport == TCP)) {
+                if (tcp_limited.empty())
+                    tcp_limited.resize(merged.request_list.size(), false);
+                tcp_limited[i] = true;
+            }
+        }
+        if (!tcp_limited.empty()) {
+            for (const auto& [public_id, owner_id] : merged.task_lookup) {
+                if (tcp_limited[owner_id]) {
+                    auto& limit = merge_boundaries[public_id].max_merge_bytes;
+                    limit = std::min<uint64_t>(
+                        limit,
+                        tcpMaxTransferBytes(request_list[public_id].opcode));
+                }
+            }
+            merged = mergeRequests(request_list, merge_boundaries, true);
+        }
+    }
+
     prepared.owners.reserve(merged.request_list.size());
     for (const auto& request : merged.request_list) {
         PreparedSubmit::Owner owner;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -932,6 +932,7 @@ Status TransferEngineImpl::registerLocalMemory(std::vector<void*> addr_list,
             }
         }
         if (options.internal) desc.internal = options.internal;
+        desc.permission = options.perm;
         desc_list.push_back(std::move(desc));
     }
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -193,18 +193,33 @@ void TcpTransport::startTransfer(TcpTask *task) {
     // The worker must own the callback and keep no task accesses after it.
     auto notify_progress = std::move(task->notify_progress);
     const auto progress_batch_id = task->progress_batch_id;
-    if (task->request.target_id == LOCAL_SEGMENT_ID &&
-        IsLoopbackEndpoint(local_segment_name_)) {
-        LOG_FIRST_N(WARNING, 1)
-            << "TCP transfer targets LOCAL_SEGMENT_ID on loopback endpoint "
-            << local_segment_name_
-            << ". When running multiple store instances on the same host with "
-               "MC_STORE_MEMCPY=0, TCP local transfers will fail. Enable "
-               "MC_STORE_MEMCPY or SHM, or use a non-loopback address.";
+    bool completed = false;
+    try {
+        if (task->request.target_id == LOCAL_SEGMENT_ID &&
+            IsLoopbackEndpoint(local_segment_name_)) {
+            LOG_FIRST_N(WARNING, 1)
+                << "TCP transfer targets LOCAL_SEGMENT_ID on loopback endpoint "
+                << local_segment_name_
+                << ". When running multiple store instances on the same host "
+                   "with "
+                   "MC_STORE_MEMCPY=0, TCP local transfers will fail. Enable "
+                   "MC_STORE_MEMCPY or SHM, or use a non-loopback address.";
+        }
+        auto status = doTransferWithRetry(task);
+        completed = status.ok();
+        if (!completed) {
+            LOG(WARNING) << "TCP transfer failed after "
+                         << params_.max_retry_count
+                         << " retries: " << status.ToString();
+        }
+    } catch (const std::exception &error) {
+        // enqueue() stores exceptions in a future which the submit path does
+        // not consume. Convert failures here while task is still owned.
+        LOG(WARNING) << "TCP worker exception: " << error.what();
+    } catch (...) {
+        LOG(WARNING) << "TCP worker exception: unknown exception";
     }
-
-    auto status = doTransferWithRetry(task);
-    if (status.ok()) {
+    if (completed) {
         // Store bytes before status: a reader who acquires COMPLETED will
         // also see the final transferred_bytes value.
         task->transferred_bytes.store(task->request.length,
@@ -212,8 +227,6 @@ void TcpTransport::startTransfer(TcpTask *task) {
         task->status_word.store(TransferStatusEnum::COMPLETED,
                                 std::memory_order_release);
     } else {
-        LOG(WARNING) << "TCP transfer failed after " << params_.max_retry_count
-                     << " retries: " << status.ToString();
         task->status_word.store(TransferStatusEnum::FAILED,
                                 std::memory_order_release);
     }

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -189,6 +189,10 @@ Status TcpTransport::removeMemoryBuffer(BufferDesc &desc) {
 }
 
 void TcpTransport::startTransfer(TcpTask *task) {
+    // Terminal publication allows freeBatch() to destroy task immediately.
+    // The worker must own the callback and keep no task accesses after it.
+    auto notify_progress = std::move(task->notify_progress);
+    const auto progress_batch_id = task->progress_batch_id;
     if (task->request.target_id == LOCAL_SEGMENT_ID &&
         IsLoopbackEndpoint(local_segment_name_)) {
         LOG_FIRST_N(WARNING, 1)
@@ -213,7 +217,7 @@ void TcpTransport::startTransfer(TcpTask *task) {
         task->status_word.store(TransferStatusEnum::FAILED,
                                 std::memory_order_release);
     }
-    if (task->notify_progress) task->notify_progress(task->progress_batch_id);
+    if (notify_progress) notify_progress(progress_batch_id);
 }
 
 Status TcpTransport::doTransferWithRetry(TcpTask *task) {

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -182,8 +182,8 @@ target_include_directories(request_merge_test
 add_test(NAME request_merge_test COMMAND request_merge_test)
 
 add_executable(local_notification_test local_notification_test.cpp)
-target_link_libraries(local_notification_test
-                      PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(local_notification_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
 target_include_directories(local_notification_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME local_notification_test COMMAND local_notification_test)
@@ -207,6 +207,16 @@ target_link_libraries(tent_tcp_transport_test PRIVATE gtest gtest_main
 target_include_directories(tent_tcp_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_tcp_transport_test COMMAND tent_tcp_transport_test)
+
+add_executable(tent_tcp_regression_test tcp_regression_test.cpp)
+target_link_libraries(tent_tcp_regression_test PRIVATE gtest gtest_main
+                                                       tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_tcp_regression_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_tcp_regression_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_tcp_regression_test COMMAND tent_tcp_regression_test)
 
 add_executable(tent_hp_tcp_transport_config_test
                hp_tcp_transport_config_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -27,6 +27,7 @@
 #include "tent/common/config.h"
 #include "tent/common/types.h"
 #include "tent/runtime/segment.h"
+#include "tent/runtime/control_plane.h"
 #include "tent/runtime/transfer_engine_impl.h"
 #include "tent/runtime/transport.h"
 
@@ -634,39 +635,236 @@ TEST(RuntimeQueueDispatch, EarlyFreeReclaimsAfterQueuedCompletion) {
 }
 
 TEST(RuntimeQueueDispatch, PollingDerivedTaskCompletesMergedOwner) {
-    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20, true);
-    TransferEngineImpl engine(cfg);
-    ASSERT_TRUE(engine.available());
+    for (bool queue : {false, true}) {
+        auto cfg = makeRuntimeQueueConfig(1, 1UL << 20, true);
+        cfg->set("enable_runtime_queue", queue);
+        cfg->set("enable_progress_worker", false);
+        TransferEngineImpl engine(cfg);
+        ASSERT_TRUE(engine.available());
 
-    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
-    installFakeRdma(engine, fake_rdma);
+        auto fake_rdma = std::make_shared<FakeTransport>(
+            RDMA, [](const Request& request, int) {
+                EXPECT_EQ(request.length, 32u);
+                return TransferStatus{COMPLETED, request.length};
+            });
+        installFakeRdma(engine, fake_rdma);
 
-    constexpr size_t kReqLen = 4096;
-    std::vector<uint8_t> buffer(kReqLen * 2, 0x44);
-    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+        constexpr size_t kReqLen = 16;
+        std::vector<uint8_t> buffer(kReqLen * 2, 0x44);
+        ASSERT_TRUE(
+            engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
 
-    BatchID batch = engine.allocateBatch(2);
-    ASSERT_NE(batch, (BatchID)0);
+        BatchID batch = engine.allocateBatch(2);
+        ASSERT_NE(batch, (BatchID)0);
 
-    ASSERT_TRUE(
-        engine
-            .submitTransfer(batch,
-                            {makeLocalWrite(buffer.data(), kReqLen),
-                             makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
-            .ok());
-    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+        ASSERT_TRUE(
+            engine
+                .submitTransfer(
+                    batch, {makeLocalWrite(buffer.data(), kReqLen),
+                            makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
+                .ok());
+        EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
 
-    TransferStatus derived{};
-    ASSERT_TRUE(engine.getTransferStatus(batch, 1, derived).ok());
-    EXPECT_EQ(derived.s, TransferStatusEnum::COMPLETED);
+        TransferStatus derived{};
+        ASSERT_TRUE(engine.getTransferStatus(batch, 1, derived).ok());
+        EXPECT_EQ(derived.s, TransferStatusEnum::COMPLETED);
+        EXPECT_EQ(derived.transferred_bytes, 16u);
 
-    TransferStatus owner{};
-    ASSERT_TRUE(engine.getTransferStatus(batch, 0, owner).ok());
-    EXPECT_EQ(owner.s, TransferStatusEnum::COMPLETED);
+        TransferStatus owner{};
+        ASSERT_TRUE(engine.getTransferStatus(batch, 0, owner).ok());
+        EXPECT_EQ(owner.s, TransferStatusEnum::COMPLETED);
+        EXPECT_EQ(owner.transferred_bytes, 16u);
+        for (int poll = 0; poll < 2; ++poll) {
+            std::vector<TransferStatus> tasks;
+            ASSERT_TRUE(engine.getTransferStatus(batch, tasks).ok());
+            ASSERT_EQ(tasks.size(), 2u);
+            for (const auto& status : tasks) {
+                EXPECT_EQ(status.s, COMPLETED);
+                EXPECT_EQ(status.transferred_bytes, 16u);
+            }
+            TransferStatus total{};
+            ASSERT_TRUE(engine.getTransferStatus(batch, total).ok());
+            EXPECT_EQ(total.s, COMPLETED);
+            EXPECT_EQ(total.transferred_bytes, 32u);
+        }
 
-    EXPECT_TRUE(engine.freeBatch(batch).ok());
-    EXPECT_TRUE(
-        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+        EXPECT_TRUE(engine.freeBatch(batch).ok());
+        EXPECT_TRUE(
+            engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+    }
+}
+
+TEST(RuntimeQueueDispatch, BatchNotificationsFollowSubmitIntervals) {
+    for (auto initial : {FAILED, PENDING}) {
+        for (bool same_submit : {false, true}) {
+            SCOPED_TRACE(testing::Message() << initial << "/" << same_submit);
+            auto cfg = makeRuntimeQueueConfig(4, 1024, true);
+            cfg->set("enable_runtime_queue", false);
+            cfg->set("enable_progress_worker", false);
+            cfg->set("enable_auto_failover_on_poll", false);
+            TransferEngineImpl engine(cfg);
+            std::vector<uint8_t> buffer(128);
+            auto second_status = initial;
+            auto fake = std::make_shared<FakeTransport>(
+                RDMA, [&](const Request& request, int) -> TransferStatus {
+                    if (request.source == buffer.data()) {
+                        EXPECT_EQ(request.length, 32u);
+                    }
+                    auto status = request.source == buffer.data() + 64
+                                      ? second_status
+                                      : COMPLETED;
+                    return {status, status == COMPLETED ? request.length : 0};
+                });
+            installFakeRdma(engine, fake);
+            ASSERT_TRUE(
+                engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+            std::vector<Request> first{makeLocalWrite(buffer.data(), 16),
+                                       makeLocalWrite(buffer.data() + 16, 16)};
+            auto second = makeLocalWrite(buffer.data() + 64, 16);
+            if (same_submit) first.push_back(second);
+            auto batch = engine.allocateBatch(3);
+            ASSERT_TRUE(
+                engine.submitTransfer(batch, first, {"first", "ready"}).ok());
+            if (!same_submit) {
+                ASSERT_TRUE(
+                    engine.submitTransfer(batch, {second}, {"second", "ready"})
+                        .ok());
+            }
+            for (int phase = 0; phase < 2; ++phase) {
+                size_t first_count = 0, second_count = 0;
+                for (int poll = 0; poll < 3; ++poll) {
+                    TransferStatus status{};
+                    ASSERT_TRUE(engine.getTransferStatus(batch, status).ok());
+                    EXPECT_EQ(status.s, second_status);
+                    std::vector<Notification> received;
+                    // No notification transport is installed; an empty poll
+                    // reports unsupported, but self notifications are
+                    // delivered.
+                    (void)engine.receiveNotification(received);
+                    for (const auto& item : received) {
+                        if (item.name == "first")
+                            ++first_count;
+                        else if (item.name == "second")
+                            ++second_count;
+                        else
+                            ADD_FAILURE() << item.name;
+                    }
+                }
+                EXPECT_EQ(first_count, phase == 0
+                                           ? !same_submit
+                                           : same_submit && initial == PENDING);
+                EXPECT_EQ(second_count,
+                          phase == 1 && !same_submit && initial == PENDING);
+                if (initial == PENDING) second_status = COMPLETED;
+            }
+            EXPECT_TRUE(engine.freeBatch(batch).ok());
+            EXPECT_TRUE(
+                engine.unregisterLocalMemory(buffer.data(), buffer.size())
+                    .ok());
+        }
+    }
+}
+
+class RangeOnlyRecordingTransport : public FakeTransport {
+   public:
+    explicit RangeOnlyRecordingTransport(TransportType type,
+                                         PollStatusFactory poll)
+        : FakeTransport(type, std::move(poll)) {}
+    static constexpr uint64_t kRange = uint64_t{1} << 34;
+    std::vector<Request> posted;
+
+    Status addMemoryBuffer(BufferDesc& desc,
+                           const MemoryOptions& options) override {
+        // Only the descriptor is large. The fake never accesses its payload.
+        desc.length = kRange;
+        return FakeTransport::addMemoryBuffer(desc, options);
+    }
+    Status submitTransferTasks(SubBatchRef batch,
+                               const std::vector<Request>& requests) override {
+        posted.insert(posted.end(), requests.begin(), requests.end());
+        return FakeTransport::submitTransferTasks(batch, requests);
+    }
+};
+
+TEST(RuntimeQueueDispatch, TcpCapsPreservePublicMappingAndOwnerBytes) {
+    for (auto type : {TCP, RDMA, HP_TCP}) {
+        for (auto hint : {UNSPEC, type}) {
+            for (auto opcode : {Request::READ, Request::WRITE}) {
+                SCOPED_TRACE(testing::Message()
+                             << type << "/" << hint << "/" << opcode);
+                const auto cap = tcpMaxTransferBytes(opcode);
+                auto cfg = makeRuntimeQueueConfig(3, 1024, true);
+                cfg->set("enable_runtime_queue", false);
+                cfg->set("enable_progress_worker", false);
+                TransferEngineImpl engine(cfg);
+                std::vector<uint8_t> buffer(64);
+                const auto addr = reinterpret_cast<uintptr_t>(buffer.data());
+                auto tail_status = PENDING;
+                auto fake = std::make_shared<RangeOnlyRecordingTransport>(
+                    type, [&](const Request& request, int) -> TransferStatus {
+                        auto status = reinterpret_cast<uintptr_t>(
+                                          request.source) == addr + cap
+                                          ? tail_status
+                                          : COMPLETED;
+                        return {status,
+                                status == COMPLETED ? request.length : 0};
+                    });
+                engine.swapTransportForTest(type, fake);
+                ASSERT_TRUE(
+                    engine.registerLocalMemory(buffer.data(), buffer.size())
+                        .ok());
+                std::vector<Request> requests;
+                uint64_t offset = 0;
+                for (size_t length : {cap - 1, size_t{1}, size_t{1}}) {
+                    auto request = makeLocalWrite(buffer.data(), length);
+                    request.source = reinterpret_cast<void*>(addr + offset);
+                    request.target_offset = addr + offset;
+                    request.opcode = opcode;
+                    request.transport_hint = hint;
+                    requests.push_back(request);
+                    offset += length;
+                }
+                auto batch = engine.allocateBatch(3);
+                ASSERT_TRUE(engine.submitTransfer(batch, requests).ok());
+                ASSERT_EQ(fake->posted.size(), type == TCP ? 2u : 1u);
+                EXPECT_EQ(fake->posted[0].length, type == TCP ? cap : cap + 1);
+                EXPECT_EQ(fake->posted[0].source, buffer.data());
+                EXPECT_EQ(fake->posted[0].target_offset, addr);
+                if (type == TCP) {
+                    EXPECT_EQ(fake->posted[1].length, 1u);
+                    EXPECT_EQ(
+                        reinterpret_cast<uintptr_t>(fake->posted[1].source),
+                        addr + cap);
+                    EXPECT_EQ(fake->posted[1].target_offset, addr + cap);
+                }
+                for (int poll = 0; poll < 3; ++poll) {
+                    for (size_t task = 0; task < requests.size(); ++task) {
+                        TransferStatus status{};
+                        ASSERT_TRUE(
+                            engine.getTransferStatus(batch, task, status).ok());
+                        const bool pending =
+                            type == TCP && poll == 0 && task == 2;
+                        EXPECT_EQ(status.s, pending ? PENDING : COMPLETED);
+                        EXPECT_EQ(status.transferred_bytes,
+                                  pending ? 0 : requests[task].length);
+                    }
+                    TransferStatus status{};
+                    ASSERT_TRUE(engine.getTransferStatus(batch, status).ok());
+                    EXPECT_EQ(status.s,
+                              type == TCP && poll == 0 ? PENDING : COMPLETED);
+                    EXPECT_EQ(status.transferred_bytes,
+                              type == TCP && poll == 0 ? cap : cap + 1);
+                    tail_status = COMPLETED;
+                }
+                EXPECT_TRUE(engine.freeBatch(batch).ok());
+                EXPECT_TRUE(
+                    engine
+                        .unregisterLocalMemory(
+                            buffer.data(), RangeOnlyRecordingTransport::kRange)
+                        .ok());
+            }
+        }
+    }
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/tcp_regression_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_regression_test.cpp
@@ -1,0 +1,332 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdlib>
+#include <future>
+#include <limits>
+#include <new>
+#include <endian.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/transport/tcp/tcp_transport.h"
+
+namespace {
+thread_local size_t fail_allocation_size = 0;
+std::atomic<int> injected_failures{0};
+}  // namespace
+
+// Inject the worker's SendData allocation. Also prevent a regressed size guard
+// from allocating a multi-GiB payload or reading beyond the small test buffer.
+[[gnu::noinline]] void* operator new(size_t size) {
+    if ((size && size == fail_allocation_size) ||
+        size > mooncake::tent::kTcpMaxReadBytes) {
+        fail_allocation_size = 0;
+        ++injected_failures;
+        throw std::bad_alloc();
+    }
+    if (void* ptr = std::malloc(size ? size : 1)) return ptr;
+    throw std::bad_alloc();
+}
+[[gnu::noinline]] void operator delete(void* ptr) noexcept { std::free(ptr); }
+[[gnu::noinline]] void operator delete(void* ptr, size_t) noexcept {
+    std::free(ptr);
+}
+// Pair the nothrow form too: GoogleTest uses it for temporary buffers under
+// ASan.
+[[gnu::noinline]] void* operator new(size_t size,
+                                     const std::nothrow_t&) noexcept {
+    try {
+        return ::operator new(size);
+    } catch (const std::bad_alloc&) {
+        return nullptr;
+    }
+}
+[[gnu::noinline]] void operator delete(void* ptr,
+                                       const std::nothrow_t&) noexcept {
+    ::operator delete(ptr);
+}
+
+namespace mooncake::tent {
+class TcpTransportTestPeer {
+   public:
+    static void arm(TcpTransport& tcp, size_t size) {
+        tcp.thread_pool_->enqueue([size] { fail_allocation_size = size; })
+            .get();
+    }
+    static void drain(TcpTransport& tcp) {
+        tcp.thread_pool_->enqueue([] {}).get();
+    }
+};
+
+namespace {
+using namespace std::chrono_literals;
+
+class ControlledTcp : public TcpTransport {
+   public:
+    bool pause = false;
+    TcpSubBatch* last_batch = nullptr;
+    std::promise<void> entered, resume;
+    std::shared_future<void> resumed = resume.get_future().share();
+    std::weak_ptr<int> callback_lifetime;
+
+    Status submitTransferTasks(SubBatchRef batch,
+                               const std::vector<Request>& requests) override {
+        last_batch = static_cast<TcpSubBatch*>(batch);
+        auto notify = batch->notify_progress;
+        if (pause) {
+            auto marker = std::make_shared<int>(0);
+            callback_lifetime = marker;
+            batch->notify_progress = [this, marker, notify](BatchID id) {
+                // Stack copies keep the test itself safe on the old version.
+                auto wait = resumed;
+                auto callback = notify;
+                entered.set_value();
+                wait.wait();
+                if (callback) callback(id);
+            };
+        }
+        auto status = TcpTransport::submitTransferTasks(batch, requests);
+        batch->notify_progress = std::move(notify);
+        return status;
+    }
+};
+
+class TcpRegression : public testing::Test {
+   protected:
+    std::array<char, 8192> data{};
+    std::unique_ptr<TransferEngineImpl> engine;
+    std::shared_ptr<ControlledTcp> tcp;
+    std::shared_ptr<ControlService> metadata;
+
+    void SetUp() override {
+        auto config = std::make_shared<Config>();
+        config->set("metadata_type", "p2p");
+        config->set("metadata_servers", "");
+        config->set("rpc_server_hostname", "127.0.0.1");
+        config->set("rpc_server_port", "0");
+        config->set("rpc_server_threads", 2);
+        config->set("enable_progress_worker", true);
+        config->set("enable_auto_failover_on_poll", false);
+        config->set("transports/tcp/enable", true);
+        config->set("transports/rdma/enable", false);
+        config->set("transports/shm/enable", false);
+        config->set("transports/tcp/max_concurrent_tasks", 1);
+        config->set("transports/tcp/max_retry_count", 0);
+        engine = std::make_unique<TransferEngineImpl>(config);
+        ASSERT_TRUE(engine->available());
+        tcp = std::make_shared<ControlledTcp>();
+        metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+        auto name = engine->getSegmentName();
+        ASSERT_TRUE(tcp->install(name, metadata, nullptr, config).ok());
+        engine->swapTransportForTest(TCP, tcp);
+        ASSERT_TRUE(engine->registerLocalMemory(data.data(), data.size()).ok());
+        ASSERT_TRUE(metadata->segmentManager()
+                        .updateLocal([&](SegmentDesc& desc) {
+                            desc.type = SegmentType::Memory;
+                            desc.rpc_server_addr = name;
+                            BufferDesc buffer;
+                            buffer.addr =
+                                reinterpret_cast<uint64_t>(data.data());
+                            buffer.length = data.size();
+                            std::get<MemorySegmentDesc>(desc.detail)
+                                .buffers.push_back(buffer);
+                            return Status::OK();
+                        })
+                        .ok());
+    }
+
+    void TearDown() override {
+        if (tcp) {
+            tcp->resume.set_value();
+            EXPECT_TRUE(tcp->uninstall().ok());
+        }
+        if (engine && engine->available()) {
+            EXPECT_TRUE(
+                engine->unregisterLocalMemory(data.data(), data.size()).ok());
+        }
+    }
+
+    Request writeRequest(size_t length = 16) {
+        Request request{};
+        request.opcode = Request::WRITE;
+        request.source = data.data();
+        request.target_id = LOCAL_SEGMENT_ID;
+        request.target_offset = reinterpret_cast<uint64_t>(data.data() + 4096);
+        request.length = length;
+        request.transport_hint = TCP;
+        return request;
+    }
+
+    void checkImmediateFree(TransferStatusEnum expected) {
+        tcp->pause = true;
+        auto batch = engine->allocateBatch(1);
+        ASSERT_TRUE(engine->submitTransfer(batch, {writeRequest()}).ok());
+        auto entered = tcp->entered.get_future();
+        ASSERT_EQ(entered.wait_for(5s), std::future_status::ready);
+        TransferStatus status{};
+        EXPECT_TRUE(engine->getTransferStatus(batch, status).ok());
+        EXPECT_EQ(status.s, expected);
+        EXPECT_TRUE(engine->freeBatch(batch).ok());
+        EXPECT_EQ(engine->aliveBatchCountForTest(), 0u);
+        EXPECT_FALSE(tcp->callback_lifetime.expired());
+        // TearDown releases and joins the worker before destroying the engine.
+    }
+};
+
+TEST_F(TcpRegression, SuccessfulTerminalAllowsImmediateFreeBatch) {
+    checkImmediateFree(COMPLETED);
+}
+
+TEST_F(TcpRegression, FailedTerminalAllowsImmediateFreeBatch) {
+    ASSERT_TRUE(metadata->segmentManager()
+                    .updateLocal([](SegmentDesc& desc) {
+                        desc.rpc_server_addr.clear();
+                        return Status::OK();
+                    })
+                    .ok());
+    checkImmediateFree(FAILED);
+}
+
+TEST_F(TcpRegression, WorkerThrowFailsBatchAndNextRequestCompletes) {
+    std::fill_n(data.data(), 4096, 'W');
+    injected_failures = 0;
+    // libstdc++ reserve(n) allocates n + one terminating byte.
+    TcpTransportTestPeer::arm(*tcp, sizeof(XferDataDesc) + 4096 + 1);
+    for (auto expected : {FAILED, COMPLETED}) {
+        auto batch = engine->allocateBatch(1);
+        ASSERT_TRUE(engine->submitTransfer(batch, {writeRequest(4096)}).ok());
+        // A FIFO fence on the same single worker also bounds the old PENDING
+        // bug.
+        TcpTransportTestPeer::drain(*tcp);
+        TransferStatus status{};
+        ASSERT_TRUE(engine->getTransferStatus(batch, status).ok());
+        EXPECT_EQ(status.s, expected);
+        EXPECT_EQ(status.transferred_bytes, expected == FAILED ? 0u : 4096u);
+        EXPECT_EQ(injected_failures.load(), 1);
+        EXPECT_EQ(data[4096], expected == FAILED ? '\0' : 'W');
+        if (status.s == PENDING) {
+            // Failed-test cleanup only, after the worker has returned.
+            tcp->last_batch->task_list[0].status_word.store(FAILED);
+        }
+        EXPECT_TRUE(engine->freeBatch(batch).ok());
+        EXPECT_EQ(engine->aliveBatchCountForTest(), 0u);
+    }
+}
+
+TEST_F(TcpRegression, ServerChecksEveryRegistrationPermission) {
+    ASSERT_TRUE(engine->unregisterLocalMemory(data.data(), data.size()).ok());
+    for (auto permission :
+         {kLocalReadWrite, kGlobalReadOnly, kGlobalReadWrite}) {
+        ASSERT_TRUE(
+            engine->registerLocalMemory(data.data(), data.size(), permission)
+                .ok());
+        for (auto opcode : {Request::READ, Request::WRITE}) {
+            SCOPED_TRACE(testing::Message() << permission << "/" << opcode);
+            data.fill('R');
+            std::array<char, 8192> local;
+            local.fill('L');
+            const bool allowed =
+                permission == kGlobalReadWrite ||
+                (permission == kGlobalReadOnly && opcode == Request::READ);
+            auto call = opcode == Request::READ ? ControlClient::recvData
+                                                : ControlClient::sendData;
+            // Direct RPC bypasses client-side registration/routing policy.
+            auto status = call(engine->getSegmentName(),
+                               reinterpret_cast<uint64_t>(data.data()),
+                               local.data(), local.size());
+            EXPECT_EQ(status.ok(), allowed) << status.ToString();
+            if (!allowed) {
+                EXPECT_NE(status.ToString().find("permission denied"),
+                          std::string::npos);
+            }
+            const char remote_value =
+                allowed && opcode == Request::WRITE ? 'L' : 'R';
+            const char local_value =
+                allowed && opcode == Request::READ ? 'R' : 'L';
+            EXPECT_TRUE(std::all_of(data.begin(), data.end(),
+                                    [=](char c) { return c == remote_value; }));
+            EXPECT_TRUE(std::all_of(local.begin(), local.end(),
+                                    [=](char c) { return c == local_value; }));
+        }
+        ASSERT_TRUE(
+            engine->unregisterLocalMemory(data.data(), data.size()).ok());
+    }
+    ASSERT_TRUE(engine->registerLocalMemory(data.data(), data.size()).ok());
+}
+
+TEST_F(TcpRegression, PayloadCapsRejectBeforeAllocationOrDataRpc) {
+    CoroRpcAgent receiver;
+    std::atomic<int> calls{0};
+    for (auto id : {SendData, RecvData}) {
+        ASSERT_TRUE(
+            receiver.registerFunction(id, [&](const auto&, auto&) { ++calls; })
+                .ok());
+    }
+    uint16_t port = 0;
+    ASSERT_TRUE(receiver.start(port).ok());
+    auto address = "127.0.0.1:" + std::to_string(port);
+    ASSERT_TRUE(ControlClient::sendData(address, 0, data.data(), 1).ok());
+    ASSERT_EQ(calls.load(), 1);
+    calls = 0;
+    injected_failures = 0;
+    for (auto opcode : {Request::READ, Request::WRITE}) {
+        for (size_t length : {tcpMaxTransferBytes(opcode) + 1,
+                              std::numeric_limits<size_t>::max()}) {
+            auto call = opcode == Request::READ ? ControlClient::recvData
+                                                : ControlClient::sendData;
+            EXPECT_NO_THROW({
+                EXPECT_TRUE(call(address,
+                                 reinterpret_cast<uint64_t>(data.data()),
+                                 data.data(), length)
+                                .IsInvalidArgument());
+            });
+        }
+    }
+    EXPECT_EQ(injected_failures.load(), 0);
+    EXPECT_EQ(calls.load(), 0);
+    EXPECT_EQ(kTcpMaxWriteBytes + sizeof(XferDataDesc),
+              std::numeric_limits<uint32_t>::max());
+    EXPECT_TRUE(receiver.stop().ok());
+}
+
+TEST_F(TcpRegression, MalformedWriteLengthCannotOverflowOrModifyTarget) {
+    data.fill('T');
+    const auto original = data;
+    CoroRpcAgent rpc;
+    for (size_t length : {size_t{1}, kTcpMaxWriteBytes + 1,
+                          std::numeric_limits<size_t>::max()}) {
+        XferDataDesc header{htole64(reinterpret_cast<uint64_t>(data.data())),
+                            htole64(length)};
+        std::string request(reinterpret_cast<char*>(&header), sizeof(header));
+        std::string response;
+        ASSERT_TRUE(
+            rpc.call(engine->getSegmentName(), SendData, request, response)
+                .ok());
+        EXPECT_EQ(response, "SendData failed: invalid request size");
+        EXPECT_EQ(data, original);
+    }
+}
+
+}  // namespace
+}  // namespace mooncake::tent


### PR DESCRIPTION
## Description

Fix six correctness issues in standard TENT TCP/RPC and shared task completion:

- Own the callback and batch ID before publishing terminal task status, so immediate `freeBatch()` cannot invalidate subsequent worker accesses.
- Convert TCP worker exceptions to FAILED instead of leaving tasks PENDING.
- Preserve registration permissions locally and enforce them in server READ/WRITE handlers. This closes remote access to local-only buffers and writes to read-only buffers; JSON/wire serialization is unchanged.
- Preserve original per-request byte counts after merging, while counting physical owners once in batch totals.
- Evaluate completion notifications per submit interval, independently of failed/pending intervals.
- Enforce standard TCP payload boundaries during initial merging and before payload construction, with overflow-safe WRITE header validation.

The original six ordered commits are retained. Two review follow-ups add the required regressions and replace speculative `resolveTransport(request, 0)` with `getTransportType(request, 0)`, avoiding explicit metadata invalidation on a failed preflight lookup. See [review feedback](https://github.com/kvcache-ai/Mooncake/pull/4001#pullrequestreview-5175325399).

Production changes total **+117/-30** across six files. Test/build changes total **+570/-30** across three files, including one new test executable and an extension of the existing runtime-queue tests. No new transport framework, protocol field, configuration option or retry slicing mechanism is introduced. CUDA context handling remains in #3973.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Base: `6c07cb7827011b82dbb05cfd59d5c778b6fafa21`  
Head: `3107ee2a80203fd736d767d2cac5058769d540eb`

All regression tests below are now included in this head:

| Regression | Evidence |
|---|---|
| Terminal lifetime | Real worker paused in notification; success and failure both allow immediate batch reclamation while the callback remains alive |
| Worker exception | Real SendData allocation throws once; FAILED/zero bytes, batch reclamation and the next successful WRITE are asserted |
| Permissions | Direct RPC bypasses client routing policy; all three permissions × READ/WRITE, specific denial response and full buffer contents checked |
| Public byte counts | Actual simulated owner length is 32; public requests report 16/16 and batch reports 32, with direct/runtime-queue submission and repeated polling |
| Notifications | Controlled local receiver; separate and shared submit intervals containing failed/pending work, merged requests and no duplicate successful notification |
| Payload boundaries | Allocation interception and a validated counting RPC handler distinguish preflight rejection from a data RPC; malformed WRITE lengths and simulated READ/WRITE merge boundaries preserve owner/request mapping and bytes |

**Results:** normal CPU suite **8/8 CTest entries, 45/45 named tests** (2.38 s), including existing TCP transport, RPC handler isolation and both two-process roundtrip modes. AddressSanitizer/LeakSanitizer: **2/2 related CTest entries, 20/20 named tests** (0.28 s), with worker injection actually observed and no sanitizer report. The nothrow allocation/deallocation pairing required by the injection fixture is included; no sanitizer suppression is used. PR-scoped pre-commit and changed-line formatting pass.

Environment: Ubuntu 24.04 WSL, GCC 13.3, CMake 3.28.3; ylt `7801bc9ad9021781f15217552214e325a1cf7373`; GoogleTest v1.17.0 `52eb8108c5bdec04579160ae17225d66034bd723`.

```sh
git submodule update --init extern/pybind11
opts=(-DUSE_TENT=ON -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF
      -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF
      -DUSE_CUDA=OFF -DTENT_METRICS_ENABLED=OFF
      -DFETCHCONTENT_SOURCE_DIR_YALANTINGLIBS=/path/to/pinned/ylt
      -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=/path/to/pinned/googletest)
cmake -S . -B build -G Ninja "${opts[@]}" -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build --target tent_tcp_transport_test tent_tcp_regression_test \
  tent_rpc_handler_isolation_test tent_tcp_datapath_roundtrip_test \
  tent_runtime_queue_dispatch_test local_notification_test request_merge_test -j 4
ctest --test-dir build -V --output-on-failure --timeout 30 \
  -R '^(tent_tcp_transport_test|tent_tcp_regression_test|tent_rpc_handler_isolation_test|tent_tcp_datapath_roundtrip_test_.*|tent_runtime_queue_dispatch_test|local_notification_test|request_merge_test)$'
cmake -S . -B build-asan -G Ninja "${opts[@]}" -DCMAKE_BUILD_TYPE=Debug \
  -DENABLE_ASAN=ON -DCMAKE_C_FLAGS=-fno-omit-frame-pointer \
  -DCMAKE_CXX_FLAGS=-fno-omit-frame-pointer
cmake --build build-asan --target tent_tcp_regression_test tent_runtime_queue_dispatch_test -j 2
ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
  ctest --test-dir build-asan -V --output-on-failure --timeout 30 \
  -R '^(tent_tcp_regression_test|tent_runtime_queue_dispatch_test)$'
```

A full host disk interrupted sanitizer builds and damaged local build/Git artifacts. After freeing task-owned cache space, recovery preserved the complete tested Git tree (`1dbfba1d0c00b0673f29d750b64dcef91fb2ccda`); rebuilt targets then executed the 20 tests counted above. Interrupted builds and empty artifacts are excluded.

## Limits

The merge cap applies to initial TCP selection. A later route change or RDMA/HP-to-TCP failover can still submit an oversized merged owner, which fails the TCP size check. Smaller original requests could have succeeded separately. This limitation is documented in the code; this PR does not add retry splitting.

No GPU/RDMA/HP hardware testing, throughput benchmark, TSan or actual multi-GiB transfer is claimed. The caps test observes payload allocation and data-handler calls, not every connection attempt. The controlled callback test and ASan do not replace the source-order proof of no task access after terminal publication.

## Checklist

- [x] Agent second-pass source/diff review completed
- [x] Targeted regressions included and executed
- [x] Existing focused tests pass
- [x] PR-scoped pre-commit and changed-line formatting pass
- [ ] Human submitter review of every changed line

The production change is below the project's architectural RFC threshold.

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with implementation, tests, review and validation. The human submitter remains responsible for reviewing and defending the changes.
