### PR TITLE
[TENT] Drain standard TCP workers during quiesce

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -88,6 +88,8 @@ class TcpTransport : public Transport {
 
     virtual Status uninstall();
 
+    virtual Status quiesce() override;
+
     virtual Status allocateSubBatch(SubBatchRef &batch, size_t max_size);
 
     virtual Status freeSubBatch(SubBatchRef &batch);

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
 
@@ -128,6 +129,7 @@ class TcpTransport : public Transport {
     std::shared_ptr<Topology> local_topology_;
     std::shared_ptr<ControlService> metadata_;
     TcpParams params_;
+    std::mutex lifecycle_mutex_;
     std::unique_ptr<ThreadPool> thread_pool_;
     std::atomic<bool> shutting_down_{false};
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -119,8 +119,14 @@ Status TcpTransport::uninstall() {
 }
 
 Status TcpTransport::quiesce() {
-    shutting_down_.store(true, std::memory_order_release);
-    thread_pool_.reset();
+    std::unique_ptr<ThreadPool> thread_pool;
+    {
+        std::lock_guard<std::mutex> guard(lifecycle_mutex_);
+        shutting_down_.store(true, std::memory_order_release);
+        thread_pool = std::move(thread_pool_);
+    }
+    // Join outside the admission lock so completion callbacks can return.
+    thread_pool.reset();
     return Status::OK();
 }
 
@@ -148,6 +154,7 @@ Status TcpTransport::submitTransferTasks(
     auto tcp_batch = dynamic_cast<TcpSubBatch *>(batch);
     if (!tcp_batch)
         return Status::InvalidArgument("Invalid TCP sub-batch" LOC_MARK);
+    std::lock_guard<std::mutex> guard(lifecycle_mutex_);
     if (shutting_down_.load(std::memory_order_acquire)) {
         return Status::InternalError("TCP transport is shutting down" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -86,6 +86,7 @@ Status TcpTransport::install(std::string &local_segment_name,
                       params_.max_concurrent_tasks);
     }
 
+    shutting_down_.store(false, std::memory_order_release);
     thread_pool_ = std::make_unique<ThreadPool>(params_.max_concurrent_tasks);
 
     installed_ = true;
@@ -110,11 +111,16 @@ Status TcpTransport::install(std::string &local_segment_name,
 Status TcpTransport::uninstall() {
     if (installed_) {
         if (metadata_) metadata_->setNotifyCallback(nullptr);
-        shutting_down_.store(true, std::memory_order_release);
-        thread_pool_.reset();
+        quiesce();
         metadata_.reset();
         installed_ = false;
     }
+    return Status::OK();
+}
+
+Status TcpTransport::quiesce() {
+    shutting_down_.store(true, std::memory_order_release);
+    thread_pool_.reset();
     return Status::OK();
 }
 
@@ -142,6 +148,9 @@ Status TcpTransport::submitTransferTasks(
     auto tcp_batch = dynamic_cast<TcpSubBatch *>(batch);
     if (!tcp_batch)
         return Status::InvalidArgument("Invalid TCP sub-batch" LOC_MARK);
+    if (shutting_down_.load(std::memory_order_acquire)) {
+        return Status::InternalError("TCP transport is shutting down" LOC_MARK);
+    }
     if (request_list.size() + tcp_batch->task_list.size() > tcp_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
 
@@ -217,6 +226,9 @@ void TcpTransport::startTransfer(TcpTask *task) {
 }
 
 Status TcpTransport::doTransferWithRetry(TcpTask *task) {
+    if (shutting_down_.load(std::memory_order_acquire))
+        return Status::InternalError("Transport shutting down");
+
     std::string rpc_server_addr;
     auto status =
         findRemoteSegment(task->request.target_offset, task->request.length,

--- a/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
@@ -14,9 +14,6 @@
 
 #include <gtest/gtest.h>
 
-#include <atomic>
-#include <chrono>
-#include <future>
 #include <memory>
 #include <string>
 #include <vector>
@@ -33,36 +30,12 @@ class TcpTransportTestPeer {
     static const TcpParams& params(const TcpTransport& transport) {
         return transport.params_;
     }
-
-    static std::future<void> enqueueInternal(TcpTransport& transport,
-                                             std::function<void()> task) {
-        return transport.thread_pool_->enqueue(std::move(task));
-    }
 };
 
 namespace {
 
-using namespace std::chrono_literals;
-
 std::shared_ptr<ControlService> makeP2PMetadata() {
     return std::make_shared<ControlService>("p2p", "", nullptr);
-}
-
-std::shared_ptr<Config> makeSingleWorkerConfig() {
-    auto conf = std::make_shared<Config>();
-    conf->set("transports/tcp/max_concurrent_tasks", 1);
-    conf->set("transports/tcp/max_retry_count", 0);
-    return conf;
-}
-
-Request makeUnresolvableRequest() {
-    Request request;
-    request.opcode = Request::WRITE;
-    request.source = nullptr;
-    request.target_id = 999999;
-    request.target_offset = 0;
-    request.length = 1;
-    return request;
 }
 
 TEST(TcpTransportConfigTest, InstallWithoutConfigKeepsStructDefaults) {
@@ -138,131 +111,6 @@ TEST(TcpRetryBackoffTest, ExponentialGrowthWithCap) {
     EXPECT_EQ(delays[3], 800u);
     EXPECT_EQ(delays[4], 1600u);
     EXPECT_EQ(delays[5], 2000u);
-}
-
-TEST(TcpTransportQuiesceTest, DrainsQueuedTcpTaskBeforeReturning) {
-    TcpTransport transport;
-    auto metadata = makeP2PMetadata();
-    std::string name = "tcp-quiesce-queued";
-    ASSERT_TRUE(
-        transport.install(name, metadata, nullptr, makeSingleWorkerConfig())
-            .ok());
-
-    std::promise<void> blocker_started;
-    auto blocker_started_future = blocker_started.get_future();
-    std::promise<void> release_blocker;
-    auto release_blocker_future = release_blocker.get_future().share();
-    auto blocker = TcpTransportTestPeer::enqueueInternal(transport, [&] {
-        blocker_started.set_value();
-        release_blocker_future.wait();
-    });
-    ASSERT_EQ(blocker_started_future.wait_for(3s), std::future_status::ready);
-
-    Transport::SubBatchRef batch = nullptr;
-    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
-    batch->progress_batch_id = 42;
-
-    std::atomic<int> callbacks{0};
-    std::promise<void> progress_notified;
-    auto progress_notified_future = progress_notified.get_future();
-    batch->notify_progress = [&](BatchID batch_id) {
-        EXPECT_EQ(batch_id, 42u);
-        callbacks.fetch_add(1, std::memory_order_relaxed);
-        progress_notified.set_value();
-    };
-
-    std::vector<Request> requests{makeUnresolvableRequest()};
-    ASSERT_TRUE(transport.submitTransferTasks(batch, requests).ok());
-
-    auto quiesce_result =
-        std::async(std::launch::async, [&] { return transport.quiesce(); });
-    EXPECT_EQ(quiesce_result.wait_for(100ms), std::future_status::timeout);
-
-    release_blocker.set_value();
-    ASSERT_EQ(blocker.wait_for(3s), std::future_status::ready);
-    blocker.get();
-    ASSERT_EQ(quiesce_result.wait_for(3s), std::future_status::ready);
-    EXPECT_TRUE(quiesce_result.get().ok());
-    ASSERT_EQ(progress_notified_future.wait_for(3s), std::future_status::ready);
-    EXPECT_EQ(callbacks.load(std::memory_order_relaxed), 1);
-
-    TransferStatus status;
-    ASSERT_TRUE(transport.getTransferStatus(batch, 0, status).ok());
-    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
-
-    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
-    EXPECT_TRUE(transport.uninstall().ok());
-}
-
-TEST(TcpTransportQuiesceTest, WaitsForRunningTcpTaskCallback) {
-    TcpTransport transport;
-    auto metadata = makeP2PMetadata();
-    std::string name = "tcp-quiesce-running";
-    ASSERT_TRUE(
-        transport.install(name, metadata, nullptr, makeSingleWorkerConfig())
-            .ok());
-
-    Transport::SubBatchRef batch = nullptr;
-    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
-    batch->progress_batch_id = 7;
-
-    std::promise<void> callback_entered;
-    auto callback_entered_future = callback_entered.get_future();
-    std::promise<void> release_callback;
-    auto release_callback_future = release_callback.get_future().share();
-    std::atomic<int> callbacks{0};
-    batch->notify_progress = [&](BatchID batch_id) {
-        EXPECT_EQ(batch_id, 7u);
-        callbacks.fetch_add(1, std::memory_order_relaxed);
-        callback_entered.set_value();
-        release_callback_future.wait();
-    };
-
-    std::vector<Request> requests{makeUnresolvableRequest()};
-    ASSERT_TRUE(transport.submitTransferTasks(batch, requests).ok());
-    ASSERT_EQ(callback_entered_future.wait_for(3s), std::future_status::ready);
-
-    TransferStatus status;
-    ASSERT_TRUE(transport.getTransferStatus(batch, 0, status).ok());
-    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
-
-    auto quiesce_result =
-        std::async(std::launch::async, [&] { return transport.quiesce(); });
-    EXPECT_EQ(quiesce_result.wait_for(100ms), std::future_status::timeout);
-
-    release_callback.set_value();
-    ASSERT_EQ(quiesce_result.wait_for(3s), std::future_status::ready);
-    EXPECT_TRUE(quiesce_result.get().ok());
-    EXPECT_EQ(callbacks.load(std::memory_order_relaxed), 1);
-
-    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
-    EXPECT_TRUE(transport.uninstall().ok());
-}
-
-TEST(TcpTransportQuiesceTest, IdleAndRepeatedCleanupAreIdempotent) {
-    TcpTransport transport;
-    auto metadata = makeP2PMetadata();
-    std::string name = "tcp-quiesce-idle";
-    ASSERT_TRUE(transport.install(name, metadata, nullptr).ok());
-
-    EXPECT_TRUE(transport.quiesce().ok());
-    EXPECT_TRUE(transport.quiesce().ok());
-
-    Transport::SubBatchRef batch = nullptr;
-    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
-    std::vector<Request> requests{makeUnresolvableRequest()};
-    auto submit_status = transport.submitTransferTasks(batch, requests);
-    EXPECT_TRUE(submit_status.IsInternalError());
-    EXPECT_TRUE(transport.uninstall().ok());
-    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
-
-    auto metadata2 = makeP2PMetadata();
-    ASSERT_TRUE(transport.install(name, metadata2, nullptr).ok());
-    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
-    EXPECT_TRUE(transport.submitTransferTasks(batch, requests).ok());
-    EXPECT_TRUE(transport.uninstall().ok());
-    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
-    EXPECT_TRUE(transport.uninstall().ok());
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
@@ -14,6 +14,9 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <vector>
@@ -30,12 +33,36 @@ class TcpTransportTestPeer {
     static const TcpParams& params(const TcpTransport& transport) {
         return transport.params_;
     }
+
+    static std::future<void> enqueueInternal(TcpTransport& transport,
+                                             std::function<void()> task) {
+        return transport.thread_pool_->enqueue(std::move(task));
+    }
 };
 
 namespace {
 
+using namespace std::chrono_literals;
+
 std::shared_ptr<ControlService> makeP2PMetadata() {
     return std::make_shared<ControlService>("p2p", "", nullptr);
+}
+
+std::shared_ptr<Config> makeSingleWorkerConfig() {
+    auto conf = std::make_shared<Config>();
+    conf->set("transports/tcp/max_concurrent_tasks", 1);
+    conf->set("transports/tcp/max_retry_count", 0);
+    return conf;
+}
+
+Request makeUnresolvableRequest() {
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = nullptr;
+    request.target_id = 999999;
+    request.target_offset = 0;
+    request.length = 1;
+    return request;
 }
 
 TEST(TcpTransportConfigTest, InstallWithoutConfigKeepsStructDefaults) {
@@ -111,6 +138,131 @@ TEST(TcpRetryBackoffTest, ExponentialGrowthWithCap) {
     EXPECT_EQ(delays[3], 800u);
     EXPECT_EQ(delays[4], 1600u);
     EXPECT_EQ(delays[5], 2000u);
+}
+
+TEST(TcpTransportQuiesceTest, DrainsQueuedTcpTaskBeforeReturning) {
+    TcpTransport transport;
+    auto metadata = makeP2PMetadata();
+    std::string name = "tcp-quiesce-queued";
+    ASSERT_TRUE(
+        transport.install(name, metadata, nullptr, makeSingleWorkerConfig())
+            .ok());
+
+    std::promise<void> blocker_started;
+    auto blocker_started_future = blocker_started.get_future();
+    std::promise<void> release_blocker;
+    auto release_blocker_future = release_blocker.get_future().share();
+    auto blocker = TcpTransportTestPeer::enqueueInternal(transport, [&] {
+        blocker_started.set_value();
+        release_blocker_future.wait();
+    });
+    ASSERT_EQ(blocker_started_future.wait_for(3s), std::future_status::ready);
+
+    Transport::SubBatchRef batch = nullptr;
+    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
+    batch->progress_batch_id = 42;
+
+    std::atomic<int> callbacks{0};
+    std::promise<void> progress_notified;
+    auto progress_notified_future = progress_notified.get_future();
+    batch->notify_progress = [&](BatchID batch_id) {
+        EXPECT_EQ(batch_id, 42u);
+        callbacks.fetch_add(1, std::memory_order_relaxed);
+        progress_notified.set_value();
+    };
+
+    std::vector<Request> requests{makeUnresolvableRequest()};
+    ASSERT_TRUE(transport.submitTransferTasks(batch, requests).ok());
+
+    auto quiesce_result =
+        std::async(std::launch::async, [&] { return transport.quiesce(); });
+    EXPECT_EQ(quiesce_result.wait_for(100ms), std::future_status::timeout);
+
+    release_blocker.set_value();
+    ASSERT_EQ(blocker.wait_for(3s), std::future_status::ready);
+    blocker.get();
+    ASSERT_EQ(quiesce_result.wait_for(3s), std::future_status::ready);
+    EXPECT_TRUE(quiesce_result.get().ok());
+    ASSERT_EQ(progress_notified_future.wait_for(3s), std::future_status::ready);
+    EXPECT_EQ(callbacks.load(std::memory_order_relaxed), 1);
+
+    TransferStatus status;
+    ASSERT_TRUE(transport.getTransferStatus(batch, 0, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
+
+    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
+    EXPECT_TRUE(transport.uninstall().ok());
+}
+
+TEST(TcpTransportQuiesceTest, WaitsForRunningTcpTaskCallback) {
+    TcpTransport transport;
+    auto metadata = makeP2PMetadata();
+    std::string name = "tcp-quiesce-running";
+    ASSERT_TRUE(
+        transport.install(name, metadata, nullptr, makeSingleWorkerConfig())
+            .ok());
+
+    Transport::SubBatchRef batch = nullptr;
+    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
+    batch->progress_batch_id = 7;
+
+    std::promise<void> callback_entered;
+    auto callback_entered_future = callback_entered.get_future();
+    std::promise<void> release_callback;
+    auto release_callback_future = release_callback.get_future().share();
+    std::atomic<int> callbacks{0};
+    batch->notify_progress = [&](BatchID batch_id) {
+        EXPECT_EQ(batch_id, 7u);
+        callbacks.fetch_add(1, std::memory_order_relaxed);
+        callback_entered.set_value();
+        release_callback_future.wait();
+    };
+
+    std::vector<Request> requests{makeUnresolvableRequest()};
+    ASSERT_TRUE(transport.submitTransferTasks(batch, requests).ok());
+    ASSERT_EQ(callback_entered_future.wait_for(3s), std::future_status::ready);
+
+    TransferStatus status;
+    ASSERT_TRUE(transport.getTransferStatus(batch, 0, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
+
+    auto quiesce_result =
+        std::async(std::launch::async, [&] { return transport.quiesce(); });
+    EXPECT_EQ(quiesce_result.wait_for(100ms), std::future_status::timeout);
+
+    release_callback.set_value();
+    ASSERT_EQ(quiesce_result.wait_for(3s), std::future_status::ready);
+    EXPECT_TRUE(quiesce_result.get().ok());
+    EXPECT_EQ(callbacks.load(std::memory_order_relaxed), 1);
+
+    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
+    EXPECT_TRUE(transport.uninstall().ok());
+}
+
+TEST(TcpTransportQuiesceTest, IdleAndRepeatedCleanupAreIdempotent) {
+    TcpTransport transport;
+    auto metadata = makeP2PMetadata();
+    std::string name = "tcp-quiesce-idle";
+    ASSERT_TRUE(transport.install(name, metadata, nullptr).ok());
+
+    EXPECT_TRUE(transport.quiesce().ok());
+    EXPECT_TRUE(transport.quiesce().ok());
+
+    Transport::SubBatchRef batch = nullptr;
+    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
+    std::vector<Request> requests{makeUnresolvableRequest()};
+    auto submit_status = transport.submitTransferTasks(batch, requests);
+    EXPECT_TRUE(submit_status.IsInternalError());
+    EXPECT_TRUE(transport.uninstall().ok());
+    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
+
+    auto metadata2 = makeP2PMetadata();
+    ASSERT_TRUE(transport.install(name, metadata2, nullptr).ok());
+    ASSERT_TRUE(transport.allocateSubBatch(batch, 1).ok());
+    EXPECT_TRUE(transport.submitTransferTasks(batch, requests).ok());
+    EXPECT_TRUE(transport.uninstall().ok());
+    EXPECT_TRUE(transport.freeSubBatch(batch).ok());
+    EXPECT_TRUE(transport.uninstall().ok());
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Standard TCP's workers must finish before engine teardown releases sub-batches. Implement the existing `quiesce()` barrier and serialize admission through the complete enqueue loop with pool detachment.

A shutdown flag alone left a race: a submit could pass the flag check, lose the pool to `quiesce()`, then call `enqueue()` through a null/destroyed pool. Use one mutex for admission and detachment, then join the detached `unique_ptr` outside that mutex. A rejected submission appends no tasks; a completion callback can finish a submission attempt while shutdown joins workers. Actual RPC/I/O execution does not take the admission mutex.

Final diff: **+25/-2 in two production files**. The review follow-up is +11/-2 (net +9), with no new shared ownership, helper framework, state flag or configuration.

The engine's existing no-in-flight-transfer destruction precondition remains. This does not make arbitrary external engine calls safe during destruction, support concurrent install/multiple shutdown callers, or add an RPC cancellation deadline. An outstanding RPC may still delay quiesce.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Reviewed head: `4d26fcf8414f9e357af880d2b1e2255305a9a76c`. The new race comparison uses previous PR head `5fc90c6d51b0744a64f3026069db1ad43ffabad2`, separately from the original fixed audit baseline `1caf8f8f9e800886debf9013a22b3403faf4ecfb`.

Local regression fixtures are kept outside the PR diff at the submitter's request. Seven transport tests are retained from [the earlier test snapshot](https://github.com/jacklin78911-collab/Mooncake/commit/d8b0db160a8a356de9cb424465dd66281cb93817), with two new admission/shutdown cases. The old snapshot is not described as identical to the revised production code.

| Check | Evidence |
| --- | --- |
| Submit paused after shutdown check, before enqueue | A latch in the progress-callback copy fixes the ordering without a production test hook. Prior head lets quiesce return, then ASan captures a zero-page SEGV in enqueue. Revised code waits and completes the admitted task's callback once. |
| Callback submits while quiesce joins workers | Submission is rejected, the new sub-batch stays empty, and the callback and join both return. |
| Retained queued/running/idle/reinstall regressions and new cases | All 9 tests pass in both normal and ASan builds. ASan leak detection is disabled; this is access-safety evidence. |
| Ordinary real TCP data path | Both cross-process WRITE/READ payload roundtrips pass, with single-threaded and multi-threaded RPC servers. |

Commands for the local artifacts:

```bash
/home/jacklin/tent-d1-review-20260911/transport-revised
ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:symbolize=1 \
  /home/jacklin/tent-d1-review-20260911/transport-revised-asan
ctest --test-dir /home/jacklin/tent-d-recovery-d1-build \
  -R '^tent_tcp_datapath_roundtrip_test_' --output-on-failure
```

The new sanitizer observation is a direct transport admission/reset race, not an observed UAF in normal public-engine destruction. The earlier audit-baseline task-storage UAF is a separate experiment. No new full-engine shutdown sanitizer, TSan or performance benchmark claim is made.

Patch parent: `6c07cb7827011b82dbb05cfd59d5c778b6fafa21`. Current main checked separately: `738ab1b7b8b82c2753f7739837a3c3a788ba46de`. Merge compatibility was checked separately from the branch's build evidence; the branch was not rebased.

## Checklist

- [x] Complete diff and lifecycle/callback call chain reviewed again.
- [x] Scoped pre-commit and diff checks passed on the two changed production files.
- [ ] Human submitter has reviewed every changed line.
- [ ] New regression tests included in the final diff (retained locally at the submitter's request).
- Documentation/RFC: no new configuration or protocol; below the architectural RFC threshold.

## AI Assistance Disclosure

- [x] AI tools were used.
