### PR TITLE
[Conductor] Add PR classification and automatic labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,10 @@ store:
   - changed-files:
     - any-glob-to-any-file: 'mooncake-store/**/*'
 
+Mooncake Conductor:
+  - changed-files:
+    - any-glob-to-any-file: 'mooncake-conductor/**/*'
+
 Transfer Engine:
   - changed-files:
     - any-glob-to-any-file: 'mooncake-transfer-engine/**/*'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 
 - [ ] Transfer Engine (`mooncake-transfer-engine`)
 - [ ] Mooncake Store (`mooncake-store`)
+- [ ] Mooncake Conductor (`mooncake-conductor`)
 - [ ] Reshard (`mooncake-reshard`)
 - [ ] Mooncake EP (`mooncake-ep`)
 - [ ] Mooncake PG (`mooncake-pg`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Prefer one of the following documented prefixes:
 - ``[Bugfix]`` for bug fixes.
 - ``[CI/Build]`` for build or continuous integration improvements.
 - ``[Doc]`` for documentation fixes and improvements.
+- ``[Conductor]`` for changes in the ``mooncake-conductor``.
 - ``[Integration]`` for changes in the ``mooncake-integration``.
 - ``[P2PStore]`` for changes in the ``mooncake-p2p-store``.
 - ``[Store]`` for changes in the ``mooncake-store``.


### PR DESCRIPTION
## Description

Add missing contribution-workflow support for `mooncake-conductor`:
- Document the `[Conductor]` PR title prefix.
- Add Mooncake Conductor to the PR template module checklist.
- Automatically apply the `Mooncake Conductor` label to changes under `mooncake-conductor/`.

Checked existing open issues and PRs. #2189 tracks the Conductor roadmap, while #3879 and #1828 concern implementation work; this PR only adds contribution-workflow metadata.

## Module

- [x] Mooncake Conductor (`mooncake-conductor`)
- [x] CI/CD
- [x] Docs

## Type of Change

- [x] Documentation update
- [x] Other: PR classification and automatic labeling

## How Has This Been Tested?

**Test commands:**
```bash
prek run --files CONTRIBUTING.md .github/pull_request_template.md .github/labeler.yml
git diff --check origin/main...HEAD
```

**Test results:**
- All applicable hooks and diff checks passed.
- No runtime code changes; unit/integration tests are not applicable.
- Live GitHub label application has not been tested.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable: no C/C++ changes)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass (using `prek`)
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective (not applicable: metadata-only)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding assistant inspected the repository configuration, made these changes, ran checks, and prepared this PR. This PR is a draft pending human review of every changed line; the human submitter is responsible for understanding and defending all changes.