### PR TITLE
[Store] Structure NvmeKvIoConcurrencyConfig environment settings

### DIFF
--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -157,6 +157,16 @@ struct NvmeKvConnectorEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_TRANSPORT);
 };
 
+struct NvmeKvIoConcurrencyEnvironmentVariables {
+    // Keep these values as strings to preserve the existing NVMe unsigned
+    // syntax, zero fallback, and silent invalid-value behavior.
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_IO_CONCURRENCY);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY);
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_NVME_KV_PREPARE_CONCURRENCY);
+};
+
 #undef MC_DEFINE_ENV_VAR
 
 }  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -89,6 +89,7 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     nvme_kv_backend.cpp
     nvme_kv_connector.cpp
     config/nvme_kv_connector_config.cpp
+    config/nvme_kv_io_concurrency_config.cpp
     config/nvme_kv_u32_parser.cpp
     nvme_kv_executor_io_uring.cpp
     nvme_kv_executor_ioctl.cpp

--- a/mooncake-store/src/config/nvme_kv_io_concurrency_config.cpp
+++ b/mooncake-store/src/config/nvme_kv_io_concurrency_config.cpp
@@ -1,0 +1,86 @@
+#include "nvme_kv_io_concurrency_config.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+
+#include "environ.h"
+#include "environment_variables.h"
+#include "nvme_kv_u32_parser.h"
+
+namespace mooncake {
+namespace {
+
+constexpr std::size_t kDefaultMaxIoConcurrency = 256;
+constexpr std::size_t kDefaultIoConcurrency = 18;
+constexpr std::size_t kDefaultPrepareConcurrency = 12;
+constexpr std::size_t kDefaultBatchSubmitConcurrency = 6;
+constexpr std::size_t kDefaultRootSubmitConcurrency = 1;
+
+std::optional<std::size_t> ReadOptionalPositive(
+    const EnvironmentVariable<std::string>& variable) {
+    const auto value = Environ::Read(variable);
+    if (!value.has_value()) {
+        return std::nullopt;
+    }
+    const auto parsed = TryParseNvmeKvU32(value->c_str());
+    if (!parsed.has_value() || *parsed == 0) {
+        return std::nullopt;
+    }
+    return static_cast<std::size_t>(*parsed);
+}
+
+std::size_t ReadPositiveOr(const EnvironmentVariable<std::string>& variable,
+                           std::size_t fallback, std::size_t maximum) {
+    const auto parsed = ReadOptionalPositive(variable);
+    return parsed.has_value() ? std::min(*parsed, maximum) : fallback;
+}
+
+}  // namespace
+
+NvmeKvIoConcurrencyConfig NvmeKvIoConcurrencyConfig::FromEnvironment(
+    std::size_t device_queue_depth) {
+    NvmeKvIoConcurrencyConfig config;
+    config.max_io_concurrency = ReadPositiveOr(
+        NvmeKvIoConcurrencyEnvironmentVariables::
+            MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY,
+        kDefaultMaxIoConcurrency, std::numeric_limits<uint32_t>::max());
+
+    const auto configured_io =
+        ReadOptionalPositive(NvmeKvIoConcurrencyEnvironmentVariables::
+                                 MOONCAKE_NVME_KV_IO_CONCURRENCY);
+    config.io_concurrency =
+        configured_io.has_value()
+            ? std::min(*configured_io, config.max_io_concurrency)
+            : std::min(
+                  std::max<std::size_t>(device_queue_depth, 1),
+                  std::min(kDefaultIoConcurrency, config.max_io_concurrency));
+
+    const std::size_t max_submit_concurrency =
+        config.io_concurrency > 1 ? config.io_concurrency - 1 : 1;
+    config.batch_submit_concurrency = ReadPositiveOr(
+        NvmeKvIoConcurrencyEnvironmentVariables::
+            MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY,
+        std::min(kDefaultBatchSubmitConcurrency, max_submit_concurrency),
+        max_submit_concurrency);
+    config.root_submit_concurrency = ReadPositiveOr(
+        NvmeKvIoConcurrencyEnvironmentVariables::
+            MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY,
+        std::min(kDefaultRootSubmitConcurrency, max_submit_concurrency),
+        max_submit_concurrency);
+
+    const std::size_t max_prepare_concurrency =
+        config.io_concurrency > config.batch_submit_concurrency
+            ? config.io_concurrency - config.batch_submit_concurrency
+            : 1;
+    config.prepare_concurrency = ReadPositiveOr(
+        NvmeKvIoConcurrencyEnvironmentVariables::
+            MOONCAKE_NVME_KV_PREPARE_CONCURRENCY,
+        std::min(kDefaultPrepareConcurrency, max_prepare_concurrency),
+        max_prepare_concurrency);
+    return config;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/config/nvme_kv_io_concurrency_config.h
+++ b/mooncake-store/src/config/nvme_kv_io_concurrency_config.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>
+
+namespace mooncake {
+
+struct NvmeKvIoConcurrencyConfig {
+    std::size_t max_io_concurrency = 256;
+    std::size_t io_concurrency = 1;
+    std::size_t batch_submit_concurrency = 1;
+    std::size_t root_submit_concurrency = 1;
+    std::size_t prepare_concurrency = 1;
+
+    static NvmeKvIoConcurrencyConfig FromEnvironment(
+        std::size_t device_queue_depth);
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_backend.cpp
+++ b/mooncake-store/src/nvme_kv_backend.cpp
@@ -4,7 +4,6 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <exception>
@@ -18,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "config/nvme_kv_io_concurrency_config.h"
 #include "nvme_kv_executor_util.h"
 #include "nvme_kv_key_codec.h"
 #include "nvme_kv_key_conflict_policy.h"
@@ -28,31 +28,11 @@ namespace mooncake {
 namespace {
 
 constexpr uint32_t kMinMaxValueSize = sizeof(NvmeKvObjectHeader) + 1;
-constexpr size_t kDefaultMaxIoConcurrency = 256;
-constexpr size_t kDefaultIoConcurrency = 18;
-constexpr size_t kDefaultPrepareConcurrency = 12;
-constexpr size_t kDefaultBatchSubmitConcurrency = 6;
-constexpr size_t kDefaultRootSubmitConcurrency = 1;
 constexpr size_t kDefaultReadPlanBatchSize = 8;
 
 size_t PositiveSizeEnvOr(const char *name, size_t fallback, size_t maximum) {
     const uint32_t parsed = ParseNvmeKvU32EnvOr(name, 0);
     return parsed == 0 ? fallback : std::min<size_t>(parsed, maximum);
-}
-
-size_t MaxIoConcurrency() {
-    return PositiveSizeEnvOr("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY",
-                             kDefaultMaxIoConcurrency, UINT32_MAX);
-}
-
-std::optional<size_t> ConfiguredIoConcurrency(size_t max_io_concurrency) {
-    const char *configured = std::getenv("MOONCAKE_NVME_KV_IO_CONCURRENCY");
-    if (configured == nullptr || configured[0] == '\0') {
-        return std::nullopt;
-    }
-    const size_t parsed = PositiveSizeEnvOr("MOONCAKE_NVME_KV_IO_CONCURRENCY",
-                                            0, max_io_concurrency);
-    return parsed == 0 ? std::nullopt : std::optional<size_t>(parsed);
 }
 
 class IndexQueue {
@@ -216,37 +196,16 @@ NvmeKvStorageBackend::NvmeKvStorageBackend(
     : StorageBackendInterface(file_storage_config_) {}
 
 void NvmeKvStorageBackend::InitIoWorkers() {
-    const size_t max_io_concurrency = MaxIoConcurrency();
-    if (auto configured = ConfiguredIoConcurrency(max_io_concurrency);
-        configured.has_value()) {
-        io_parallelism_ = *configured;
-    } else {
-        const size_t queue_depth =
-            std::max<size_t>(1, connector_->GetCapabilities().queue_depth);
-        io_parallelism_ = std::min(
-            queue_depth, std::min(kDefaultIoConcurrency, max_io_concurrency));
-    }
+    const auto config = NvmeKvIoConcurrencyConfig::FromEnvironment(
+        connector_->GetCapabilities().queue_depth);
+    const size_t max_io_concurrency = config.max_io_concurrency;
+    io_parallelism_ = config.io_concurrency;
+    batch_submit_concurrency_ = config.batch_submit_concurrency;
+    root_submit_concurrency_ = config.root_submit_concurrency;
+    prepare_concurrency_ = config.prepare_concurrency;
     if (io_parallelism_ > 1) {
         io_workers_ = std::make_unique<ThreadPool>(io_parallelism_);
     }
-    const size_t max_submit_concurrency =
-        io_parallelism_ > 1 ? io_parallelism_ - 1 : 1;
-    batch_submit_concurrency_ = PositiveSizeEnvOr(
-        "MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY",
-        std::min(kDefaultBatchSubmitConcurrency, max_submit_concurrency),
-        max_submit_concurrency);
-    root_submit_concurrency_ = PositiveSizeEnvOr(
-        "MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY",
-        std::min(kDefaultRootSubmitConcurrency, max_submit_concurrency),
-        max_submit_concurrency);
-    const size_t max_prepare_concurrency =
-        io_parallelism_ > batch_submit_concurrency_
-            ? io_parallelism_ - batch_submit_concurrency_
-            : 1;
-    prepare_concurrency_ = PositiveSizeEnvOr(
-        "MOONCAKE_NVME_KV_PREPARE_CONCURRENCY",
-        std::min(kDefaultPrepareConcurrency, max_prepare_concurrency),
-        max_prepare_concurrency);
     if (batch_submit_concurrency_ > 1) {
         submit_workers_ =
             std::make_unique<ThreadPool>(batch_submit_concurrency_);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -257,6 +257,8 @@ add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
 add_store_test(nvme_kv_connector_config_test nvme_kv_connector_config_test.cpp)
+add_store_test(nvme_kv_io_concurrency_config_test
+               nvme_kv_io_concurrency_config_test.cpp)
 add_store_test(nvme_kv_storage_backend_test nvme_kv_storage_backend_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)
 add_store_test(file_per_key_config_test file_per_key_config_test.cpp)

--- a/mooncake-store/tests/nvme_kv_io_concurrency_config_test.cpp
+++ b/mooncake-store/tests/nvme_kv_io_concurrency_config_test.cpp
@@ -1,0 +1,153 @@
+#include "../src/config/nvme_kv_io_concurrency_config.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace mooncake::test {
+namespace {
+
+class NvmeKvIoConcurrencyConfigTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        environment_lock_ = std::unique_lock<std::mutex>(environment_mutex_);
+        for (std::size_t i = 0; i < kVariables.size(); ++i) {
+            if (const char* value = std::getenv(kVariables[i])) {
+                original_values_[i] = value;
+            }
+            ASSERT_EQ(unsetenv(kVariables[i]), 0);
+        }
+    }
+
+    void TearDown() override {
+        for (std::size_t i = 0; i < kVariables.size(); ++i) {
+            if (original_values_[i].has_value()) {
+                EXPECT_EQ(
+                    setenv(kVariables[i], original_values_[i]->c_str(), 1), 0);
+            } else {
+                EXPECT_EQ(unsetenv(kVariables[i]), 0);
+            }
+        }
+    }
+
+    void SetEnvironment(const char* name, const char* value) {
+        ASSERT_EQ(setenv(name, value, 1), 0);
+    }
+
+    void ExpectConfig(const NvmeKvIoConcurrencyConfig& config,
+                      std::size_t maximum, std::size_t io, std::size_t batch,
+                      std::size_t root, std::size_t prepare) {
+        EXPECT_EQ(config.max_io_concurrency, maximum);
+        EXPECT_EQ(config.io_concurrency, io);
+        EXPECT_EQ(config.batch_submit_concurrency, batch);
+        EXPECT_EQ(config.root_submit_concurrency, root);
+        EXPECT_EQ(config.prepare_concurrency, prepare);
+    }
+
+    inline static constexpr std::array<const char*, 5> kVariables = {
+        "MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY",
+        "MOONCAKE_NVME_KV_IO_CONCURRENCY",
+        "MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY",
+        "MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY",
+        "MOONCAKE_NVME_KV_PREPARE_CONCURRENCY"};
+
+   private:
+    inline static std::mutex environment_mutex_;
+    std::unique_lock<std::mutex> environment_lock_;
+    std::array<std::optional<std::string>, kVariables.size()> original_values_;
+};
+
+TEST_F(NvmeKvIoConcurrencyConfigTest, DefaultsFollowDeviceQueueDepth) {
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(0), 256, 1, 1, 1,
+                 1);
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(8), 256, 8, 6, 1,
+                 2);
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(64), 256, 18, 6, 1,
+                 12);
+}
+
+TEST_F(NvmeKvIoConcurrencyConfigTest, PreservesLegacyUnsignedSyntax) {
+    struct Case {
+        const char* value;
+        std::size_t expected;
+    };
+    const Case cases[] = {{"+17", 17}, {" 17", 17},
+                          {"010", 8},  {"0x10", 16},
+                          {"-0", 256}, {"4294967295", 4294967295ULL}};
+
+    for (const auto& entry : cases) {
+        SCOPED_TRACE(entry.value);
+        SetEnvironment("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY", entry.value);
+        const auto config = NvmeKvIoConcurrencyConfig::FromEnvironment(64);
+        EXPECT_EQ(config.max_io_concurrency, entry.expected);
+    }
+}
+
+TEST_F(NvmeKvIoConcurrencyConfigTest,
+       InvalidAndZeroValuesKeepDefaultsSilently) {
+    const char* values[] = {"",   "0",  "17 ",        "17x",
+                            "-1", "0x", "4294967296", "abc"};
+    for (const char* variable : kVariables) {
+        for (const char* value : values) {
+            SCOPED_TRACE(std::string(variable) + "=" + value);
+            SetEnvironment(variable, value);
+
+            testing::internal::CaptureStderr();
+            const auto config = NvmeKvIoConcurrencyConfig::FromEnvironment(64);
+            const std::string diagnostics =
+                testing::internal::GetCapturedStderr();
+
+            ExpectConfig(config, 256, 18, 6, 1, 12);
+            EXPECT_TRUE(diagnostics.empty()) << diagnostics;
+            ASSERT_EQ(unsetenv(variable), 0);
+        }
+    }
+}
+
+TEST_F(NvmeKvIoConcurrencyConfigTest, AppliesDependentCapsInOrder) {
+    SetEnvironment("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY", "8");
+    SetEnvironment("MOONCAKE_NVME_KV_IO_CONCURRENCY", "16");
+    SetEnvironment("MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY", "99");
+    SetEnvironment("MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY", "99");
+    SetEnvironment("MOONCAKE_NVME_KV_PREPARE_CONCURRENCY", "99");
+
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(64), 8, 8, 7, 7, 1);
+}
+
+TEST_F(NvmeKvIoConcurrencyConfigTest, SettingsRemainIndependent) {
+    SetEnvironment("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY", "10");
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(64), 10, 10, 6, 1,
+                 4);
+    ASSERT_EQ(unsetenv("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY"), 0);
+
+    SetEnvironment("MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY", "4");
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(64), 256, 18, 4, 1,
+                 12);
+    ASSERT_EQ(unsetenv("MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY"), 0);
+
+    SetEnvironment("MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY", "9");
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(64), 256, 18, 6, 9,
+                 12);
+    ASSERT_EQ(unsetenv("MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY"), 0);
+
+    SetEnvironment("MOONCAKE_NVME_KV_PREPARE_CONCURRENCY", "99");
+    ExpectConfig(NvmeKvIoConcurrencyConfig::FromEnvironment(64), 256, 18, 6, 1,
+                 12);
+}
+
+TEST_F(NvmeKvIoConcurrencyConfigTest, NewConfigsReadCurrentEnvironment) {
+    SetEnvironment("MOONCAKE_NVME_KV_IO_CONCURRENCY", "4");
+    const auto first = NvmeKvIoConcurrencyConfig::FromEnvironment(64);
+    SetEnvironment("MOONCAKE_NVME_KV_IO_CONCURRENCY", "7");
+    const auto second = NvmeKvIoConcurrencyConfig::FromEnvironment(64);
+
+    EXPECT_EQ(first.io_concurrency, 4);
+    EXPECT_EQ(second.io_concurrency, 7);
+}
+
+}  // namespace
+}  // namespace mooncake::test

--- a/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
+++ b/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
@@ -2,6 +2,7 @@
 #include "nvme_kv_executor_util.h"
 #include "storage_backend.h"
 
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -40,6 +41,19 @@ class EnvVarGuard {
    private:
     std::string name_;
     std::optional<std::string> old_value_;
+};
+
+class BoolFlagGuard {
+   public:
+    BoolFlagGuard(bool &flag, bool value) : flag_(flag), old_value_(flag) {
+        flag_ = value;
+    }
+
+    ~BoolFlagGuard() { flag_ = old_value_; }
+
+   private:
+    bool &flag_;
+    bool old_value_;
 };
 
 class NvmeKvStorageBackendTest : public ::testing::Test {
@@ -124,6 +138,33 @@ TEST_F(NvmeKvStorageBackendTest, StatusMappingHandlesKvSpecificStatusCodes) {
     EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
         ErrorCode::INVALID_PARAMS, 0, kDefaultNvmeKvRuntimeTransferLimit,
         kDefaultNvmeKvRuntimeTransferLimit));
+}
+
+TEST_F(NvmeKvStorageBackendTest, IoWorkerConcurrencyPreservesDependentCaps) {
+    EnvVarGuard driver_guard("MOONCAKE_NVME_KV_DRIVER", "stub");
+    EnvVarGuard maximum_guard("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY", "8");
+    EnvVarGuard io_guard("MOONCAKE_NVME_KV_IO_CONCURRENCY", "16");
+    EnvVarGuard batch_guard("MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY", "99");
+    EnvVarGuard root_guard("MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY", "99");
+    EnvVarGuard prepare_guard("MOONCAKE_NVME_KV_PREPARE_CONCURRENCY", "99");
+    BoolFlagGuard log_to_stderr_guard(FLAGS_logtostderr, true);
+
+    FileStorageConfig config;
+    config.storage_filepath = data_path_ + "/concurrency_caps";
+    config.storage_backend_type = StorageBackendType::kNvmeKv;
+
+    testing::internal::CaptureStderr();
+    NvmeKvStorageBackend backend(config);
+    const auto result = backend.Init();
+    const std::string diagnostics = testing::internal::GetCapturedStderr();
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(diagnostics.find(
+                  "NVMe KV backend I/O concurrency: 8 (max 8), batch submit "
+                  "concurrency: 7, root submit concurrency: 7, prepare "
+                  "concurrency: 1"),
+              std::string::npos)
+        << diagnostics;
 }
 
 TEST_F(NvmeKvStorageBackendTest, BackendLoadsKnownObjectsFromDevice) {


### PR DESCRIPTION
## Description

Move the NVMe KV backend's five startup-only I/O concurrency environment settings into a private `NvmeKvIoConcurrencyConfig`, following the configuration convergence tracked in #3809.

- Define the five variables in the grouped environment-variable catalog and resolve them once through `NvmeKvIoConcurrencyConfig::FromEnvironment()` after device initialization.
- Preserve the existing defaults, device queue-depth behavior, dependent cap order, base-prefixed integer syntax, leading whitespace and plus-sign handling, and silent fallback for empty, zero, invalid, negative, or overflowing values.
- Reuse the NVMe KV unsigned parser introduced by #3948 instead of adding another parser.
- Keep thread-pool construction and operational logging in `NvmeKvStorageBackend`.
- Add focused config tests plus a backend-level characterization test for the existing dependent-cap behavior.

`MOONCAKE_NVME_KV_READ_PLAN_BATCH_SIZE` remains an intentional per-operation late read, and the test-only `MOONCAKE_NVME_KV_DRIVER` selector remains outside this config owner.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target nvme_kv_io_concurrency_config_test nvme_kv_storage_backend_test mooncake_store_client_objects -j32
ctest --test-dir build --output-on-failure -R '^(nvme_kv_io_concurrency_config|nvme_kv_storage_backend)_test$'
pre-commit run --files mooncake-common/include/environment_variables.h mooncake-store/src/CMakeLists.txt mooncake-store/src/config/nvme_kv_io_concurrency_config.cpp mooncake-store/src/config/nvme_kv_io_concurrency_config.h mooncake-store/src/nvme_kv_backend.cpp mooncake-store/tests/CMakeLists.txt mooncake-store/tests/nvme_kv_io_concurrency_config_test.cpp mooncake-store/tests/nvme_kv_storage_backend_test.cpp
./scripts/code_format.sh --check --changed-lines --base kvcache/main
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

Both selected tests passed, and the Mooncake Store client objects build successfully. The backend-level characterization test also passed against the pre-extraction implementation. All applicable touched-file pre-commit hooks and the post-commit changed-lines format check passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with behavior inventory, extraction, focused tests, verification, and pre-submission review. I reviewed every changed line and verified the behavior end-to-end.