### PR TITLE
[TENT] Add scoped configuration validation and change planning

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/config.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config.h
@@ -166,6 +166,11 @@ class Config {
 
     std::string dump(int indent = 2) const;
 
+    // Return an independent copy of the complete JSON value under one lock.
+    // Validation uses this instead of dump()/parse(), which loses non-finite
+    // numeric values by serializing them as null.
+    json toJson() const;
+
     // If key_path resolves to a JSON value, dump it into *out and return true.
     bool dumpSubtree(const std::string& key_path, std::string* out) const;
 

--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -57,6 +57,13 @@ const char* configLifecycleName(ConfigLifecycle lifecycle);
 
 enum class ConfigDiagnosticCode : uint8_t {
     kInvalidRoot,
+    kInvalidPath,
+    kAmbiguousPath,
+    kInvalidType,
+    kOutOfRange,
+    kCrossFieldConstraint,
+    kBackendUnavailable,
+    kAnalysisLimitExceeded,
 };
 
 struct ConfigDiagnostic {

--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -57,13 +57,6 @@ const char* configLifecycleName(ConfigLifecycle lifecycle);
 
 enum class ConfigDiagnosticCode : uint8_t {
     kInvalidRoot,
-    kInvalidPath,
-    kAmbiguousPath,
-    kInvalidType,
-    kOutOfRange,
-    kCrossFieldConstraint,
-    kBackendUnavailable,
-    kAnalysisLimitExceeded,
 };
 
 struct ConfigDiagnostic {

--- a/mooncake-transfer-engine/tent/include/tent/common/config_parser.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_parser.h
@@ -1,0 +1,72 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_CONFIG_PARSER_H
+#define TENT_CONFIG_PARSER_H
+
+#include <limits>
+#include <type_traits>
+
+#include "tent/common/config.h"
+
+namespace mooncake {
+namespace tent {
+
+// Shared by the HP TCP parser and candidate validation. Check the original
+// JSON number before narrowing; Config::get<T>() can silently wrap it.
+template <typename T>
+Status parseUnsignedConfigValue(const json& node, const std::string& path,
+                                T* output) {
+    static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+    uint64_t value = 0;
+    if (node.is_number_unsigned()) {
+        value = node.get<uint64_t>();
+    } else if (node.is_number_integer()) {
+        const auto signed_value = node.get<int64_t>();
+        if (signed_value < 0) {
+            return Status::InvalidArgument(path + " must be non-negative" +
+                                           LOC_MARK);
+        }
+        value = static_cast<uint64_t>(signed_value);
+    } else {
+        return Status::InvalidArgument(path + " must be an integer" + LOC_MARK);
+    }
+    if (value > static_cast<uint64_t>(std::numeric_limits<T>::max())) {
+        return Status::InvalidArgument(path + " is out of range" + LOC_MARK);
+    }
+    *output = static_cast<T>(value);
+    return Status::OK();
+}
+
+Status parseBoolConfigValue(const json& node, const std::string& path,
+                            bool* output);
+
+// Startup and preflight share RPC defaults, integer-string compatibility and
+// range checks. Errors identify the field and constraint without echoing
+// values.
+Status getRpcServerPortFromConfig(const Config& config, uint16_t default_value,
+                                  uint16_t& port);
+Status getRpcServerThreadsFromConfig(const Config& config, size_t default_value,
+                                     size_t& threads);
+size_t getDefaultRpcServerThreads(const Config& config,
+                                  unsigned hardware_concurrency);
+
+Status validateTcpTransportSelection(bool tcp_enabled, bool hp_tcp_enabled);
+Status validateRuntimeQueueDispatchWindow(bool enabled, size_t max_owners,
+                                          size_t max_bytes);
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_CONFIG_PARSER_H

--- a/mooncake-transfer-engine/tent/include/tent/common/config_validation.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_validation.h
@@ -16,6 +16,7 @@
 #define TENT_CONFIG_VALIDATION_H
 
 #include "tent/common/config_lifecycle.h"
+#include "tent/common/status.h"
 
 namespace mooncake {
 namespace tent {
@@ -46,17 +47,18 @@ struct ConfigChangePlan {
     // afterwards cannot change this plan. No generation is assigned/published.
     std::shared_ptr<const Config> current;
     std::shared_ptr<const Config> candidate;
-    std::vector<ConfigDiagnostic> current_diagnostics;
-    std::vector<ConfigDiagnostic> candidate_diagnostics;
+    // Follow the existing Status convention: InvalidArgument identifying the
+    // field/component and reason. Each input reports its first validation
+    // error.
+    Status current_status;
+    Status candidate_status;
     // Sorted by canonical path; values are omitted to avoid disclosing secrets.
     std::vector<ConfigChange> changes;
 
     // Only validates the documented scope below. Unchanged out-of-scope fields
     // are carried through; changes to them are always kUnsupported.
     // A valid plan is not permission to apply: inspect every disposition.
-    bool valid() const {
-        return current_diagnostics.empty() && candidate_diagnostics.empty();
-    }
+    bool valid() const { return current_status.ok() && candidate_status.ok(); }
 };
 
 // Side-effect-free analysis of two COMPLETE, already-loaded configurations,
@@ -75,9 +77,9 @@ struct ConfigChangePlan {
 // Conflicting flat/nested aliases are rejected, not resolved silently. Unknown
 // fields use structural comparison. HP TCP enable must be nested because its
 // dedicated parser consumes a transport object. Flat object aliases are outside
-// this initial scope. Diagnostics never include input values.
-// Limits: 32 path levels, 256 bytes/path, 4096 visited nodes, 64
-// diagnostics/input and 128 changes; exceeding a limit makes the plan invalid
+// this initial scope. Error messages never include input values.
+// Limits: 32 path levels, 256 bytes/path, 4096 visited nodes, one Status per
+// input and 128 changes; exceeding a limit makes the plan invalid
 // (never a partial plan). kRuntimeCandidate is eligibility only, NOT a promise
 // of live application.
 ConfigChangePlan planTentConfigChange(

--- a/mooncake-transfer-engine/tent/include/tent/common/config_validation.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_validation.h
@@ -1,0 +1,90 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_CONFIG_VALIDATION_H
+#define TENT_CONFIG_VALIDATION_H
+
+#include "tent/common/config_lifecycle.h"
+
+namespace mooncake {
+namespace tent {
+
+enum class ConfigChangeDisposition : uint8_t {
+    kRuntimeCandidate,
+    kRestartRequired,
+    kUnsupported,
+};
+
+struct ConfigChange {
+    std::string path;
+    ConfigChangeDisposition disposition;
+};
+
+// Capture once and use for both inputs. These are build capabilities, not
+// discovered devices or proof that a backend can initialize on this host.
+// Tests and offline tools may supply a target build's context explicitly.
+struct ConfigValidationContext {
+    std::vector<std::string> compiled_transports;
+    unsigned hardware_concurrency{0};
+};
+
+ConfigValidationContext currentConfigValidationContext();
+
+struct ConfigChangePlan {
+    // Own the exact inputs analyzed. Mutating the original Config objects
+    // afterwards cannot change this plan. No generation is assigned/published.
+    std::shared_ptr<const Config> current;
+    std::shared_ptr<const Config> candidate;
+    std::vector<ConfigDiagnostic> current_diagnostics;
+    std::vector<ConfigDiagnostic> candidate_diagnostics;
+    // Sorted by canonical path; values are omitted to avoid disclosing secrets.
+    std::vector<ConfigChange> changes;
+
+    // Only validates the documented scope below. Unchanged out-of-scope fields
+    // are carried through; changes to them are always kUnsupported.
+    // A valid plan is not permission to apply: inspect every disposition.
+    bool valid() const {
+        return current_diagnostics.empty() && candidate_diagnostics.empty();
+    }
+};
+
+// Side-effect-free analysis of two COMPLETE, already-loaded configurations,
+// not a patch. Does not read files/environment, initialize services, change
+// Config::get() compatibility, or publish/apply any runtime state.
+//
+// Validation scope: RPC hostname/port/threads, merge/failover policy, progress
+// worker/queue enablement, runtime_queue fields consumed by construct(), and
+// transport enable flags. Other fields (including policy/qos subtrees) remain
+// unsupported for change, even when PR1 classifies them as runtime candidates.
+//
+// Known fields are compared with their consumer defaults; integer strings are
+// accepted only for the RPC numbers, matching existing startup behavior.
+// Backend enable flags retain absence because device/environment selection is
+// outside this API. Explicitly enabling a backend requires build support.
+// Conflicting flat/nested aliases are rejected, not resolved silently. Unknown
+// fields use structural comparison. HP TCP enable must be nested because its
+// dedicated parser consumes a transport object. Flat object aliases are outside
+// this initial scope. Diagnostics never include input values.
+// Limits: 32 path levels, 256 bytes/path, 4096 visited nodes, 64
+// diagnostics/input and 128 changes; exceeding a limit makes the plan invalid
+// (never a partial plan). kRuntimeCandidate is eligibility only, NOT a promise
+// of live application.
+ConfigChangePlan planTentConfigChange(
+    const Config& current, const Config& candidate,
+    const ConfigValidationContext& context = currentConfigValidationContext());
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_CONFIG_VALIDATION_H

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -67,6 +67,18 @@ struct QueueLimits {
     // NowProvider (via setDegradationPolicy) or defaults to steady_clock.
     // 0 (default) disables promotion entirely.
     uint64_t promotion_slack_ns{0};
+
+    Status validate() const {
+        if (staging_owner_reserve > max_outstanding_owners) {
+            return Status::InvalidArgument(
+                "staging owner reserve exceeds owner limit" LOC_MARK);
+        }
+        if (staging_byte_reserve > max_outstanding_bytes) {
+            return Status::InvalidArgument(
+                "staging byte reserve exceeds byte limit" LOC_MARK);
+        }
+        return Status::OK();
+    }
 };
 
 struct QueueOwnerInput {

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -73,6 +73,11 @@ std::string Config::dump(int indent) const {
     return config_data_.dump(indent);
 }
 
+json Config::toJson() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return config_data_;
+}
+
 bool Config::dumpSubtree(const std::string& key_path, std::string* out) const {
     if (!out || key_path.empty()) return false;
     std::lock_guard<std::mutex> lock(mutex_);

--- a/mooncake-transfer-engine/tent/src/common/config_parser.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_parser.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/common/config_parser.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+Status getRpcIntegerFromConfig(const Config& config, const std::string& path,
+                               uint64_t default_value, uint64_t minimum,
+                               uint64_t maximum, uint64_t& output) {
+    if (!config.contains(path)) {
+        output = default_value;
+        return Status::OK();
+    }
+
+    auto value = config.get<json>(path, json());
+    if (value.is_string()) {
+        const auto text = value.get<std::string>();
+        try {
+            size_t consumed = 0;
+            const auto number = std::stoll(text, &consumed);
+            if (consumed == text.size()) value = number;
+        } catch (const std::invalid_argument&) {
+        } catch (const std::out_of_range&) {
+        }
+    }
+    if (!value.is_number_integer()) {
+        return Status::InvalidArgument(
+            path + " must be an integer or integer string" + LOC_MARK);
+    }
+
+    uint64_t number = 0;
+    CHECK_STATUS(parseUnsignedConfigValue(value, path, &number));
+    if (number < minimum || number > maximum) {
+        return Status::InvalidArgument(
+            path + " must be in range [" + std::to_string(minimum) + ", " +
+            std::to_string(maximum) + "]" + LOC_MARK);
+    }
+    output = number;
+    return Status::OK();
+}
+
+}  // namespace
+
+Status parseBoolConfigValue(const json& node, const std::string& path,
+                            bool* output) {
+    if (!node.is_boolean()) {
+        return Status::InvalidArgument(path + " must be a boolean" + LOC_MARK);
+    }
+    *output = node.get<bool>();
+    return Status::OK();
+}
+
+Status getRpcServerPortFromConfig(const Config& config, uint16_t default_value,
+                                  uint16_t& port) {
+    uint64_t value = 0;
+    CHECK_STATUS(getRpcIntegerFromConfig(config, "rpc_server_port",
+                                         default_value, 0, 65535, value));
+    port = static_cast<uint16_t>(value);
+    return Status::OK();
+}
+
+Status getRpcServerThreadsFromConfig(const Config& config, size_t default_value,
+                                     size_t& threads) {
+    uint64_t value = 0;
+    CHECK_STATUS(getRpcIntegerFromConfig(config, "rpc_server_threads",
+                                         default_value, 1, 1024, value));
+    threads = static_cast<size_t>(value);
+    return Status::OK();
+}
+
+size_t getDefaultRpcServerThreads(const Config& config,
+                                  unsigned hardware_concurrency) {
+    // RPC defaults use explicit TCP enablement; transport selection itself
+    // defaults TCP on. Keep those two defaults distinct.
+    return config.get("transports/tcp/enable", false)
+               ? std::min<size_t>(8, std::max<size_t>(4, hardware_concurrency))
+               : 1;
+}
+
+Status validateTcpTransportSelection(bool tcp_enabled, bool hp_tcp_enabled) {
+    if (hp_tcp_enabled && tcp_enabled) {
+        return Status::InvalidArgument(
+            "transports tcp and hp_tcp cannot be enabled together" LOC_MARK);
+    }
+    return Status::OK();
+}
+
+Status validateRuntimeQueueDispatchWindow(bool enabled, size_t max_owners,
+                                          size_t max_bytes) {
+    if (enabled && (max_owners == 0 || max_bytes == 0)) {
+        return Status::InvalidArgument(
+            "runtime queue dispatch window must be non-zero" LOC_MARK);
+    }
+    return Status::OK();
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/common/config_validation.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_validation.cpp
@@ -1,0 +1,409 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/common/config_validation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <thread>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+using Values = std::map<std::string, json>;
+using Code = ConfigDiagnosticCode;
+enum class Kind { kBool, kString, kUnsigned, kRpcInteger, kNumber };
+
+struct Rule {
+    std::string path;
+    Kind kind;
+    json default_value;
+    uint64_t maximum{0};
+    uint64_t minimum{0};
+};
+
+// Unknown consumers may distinguish integer/float representations. JSON's
+// operator== considers 1 and 1.0 equal, including inside arrays/objects.
+bool sameValue(const json& lhs, const json& rhs) {
+    if (lhs.type() != rhs.type()) return false;
+    if (!lhs.is_structured()) return lhs == rhs;
+    if (lhs.size() != rhs.size()) return false;
+    auto right = rhs.begin();
+    for (auto left = lhs.begin(); left != lhs.end(); ++left, ++right) {
+        if (lhs.is_object() && left.key() != right.key()) return false;
+        if (!sameValue(*left, *right)) return false;
+    }
+    return true;
+}
+
+constexpr std::string_view kTransports[] = {
+    "tcp",          "hp_tcp", "shm",   "rdma", "ub",
+    "io_uring",     "nvlink", "mnnvl", "gds",  "ascend_direct",
+    "sunrise_link", "tpu",    "mpcomm"};
+
+// Defaults/ranges follow construct(), getRpcServer{Port,Threads}FromConfig(),
+// QueueLimits, and the shared failover defaults introduced by #3934. Keep these
+// checks outside the legacy loader: it intentionally defaults on type errors.
+std::vector<Rule> rules() {
+    constexpr auto size_max = std::numeric_limits<size_t>::max();
+    std::vector<Rule> result = {
+        {"rpc_server_hostname", Kind::kString, ""},
+        {"rpc_server_port", Kind::kRpcInteger, 0, 65535},
+        {"rpc_server_threads", Kind::kRpcInteger, 1, 1024, 1},
+        {"merge_requests", Kind::kBool, true},
+        {"max_failover_attempts", Kind::kUnsigned, kDefaultMaxFailoverAttempts,
+         std::numeric_limits<int>::max()},
+        {"enable_auto_failover_on_poll", Kind::kBool,
+         kDefaultAutoFailoverOnPoll},
+        {"enable_progress_worker", Kind::kBool, false},
+        {"enable_runtime_queue", Kind::kBool, false},
+        {"runtime_queue/max_outstanding_owners", Kind::kUnsigned, 1024,
+         size_max},
+        {"runtime_queue/max_outstanding_bytes", Kind::kUnsigned, 1ULL << 30,
+         size_max},
+        {"runtime_queue/staging_owner_reserve", Kind::kUnsigned, 0, size_max},
+        {"runtime_queue/staging_byte_reserve", Kind::kUnsigned, 0, size_max},
+        {"runtime_queue/deadline_aware", Kind::kBool, false},
+        // Nonpositive MLU thresholds disable degradation; do not reject them.
+        {"runtime_queue/mlu_local_threshold", Kind::kNumber, 0.0},
+        {"runtime_queue/promotion_slack_ns", Kind::kUnsigned, 0,
+         std::numeric_limits<uint64_t>::max()},
+        {"runtime_queue/max_dispatch_owners", Kind::kUnsigned, 64, size_max},
+        {"runtime_queue/max_dispatch_bytes", Kind::kUnsigned, 64ULL << 20,
+         size_max},
+        {"runtime_queue/progress_fallback_interval_us", Kind::kUnsigned, 50000,
+         static_cast<uint64_t>(std::numeric_limits<int64_t>::max())},
+    };
+    for (auto transport : kTransports) {
+        result.push_back({"transports/" + std::string(transport) + "/enable",
+                          Kind::kBool, nullptr});
+    }
+    return result;
+}
+
+void diagnose(std::vector<ConfigDiagnostic>& out, Code code,
+              const std::string& path, const std::string& message) {
+    if (out.size() >= 64) return;
+    if (out.size() == 63) {
+        out.push_back({Code::kAnalysisLimitExceeded, "$",
+                       "Configuration diagnostic limit exceeded"});
+        return;
+    }
+    // Do not echo oversized or control-character-containing paths.
+    const bool safe =
+        path.size() <= 256 &&
+        std::none_of(path.begin(), path.end(),
+                     [](unsigned char c) { return c < 32 || c == 127; });
+    out.push_back({code, safe ? path : "$", message});
+}
+
+struct Analysis {
+    Values values;
+    std::vector<ConfigDiagnostic>& diagnostics;
+    const std::vector<Rule>& fields;
+    size_t visited{0};
+
+    const Rule* rule(const std::string& path) const {
+        auto it = std::find_if(fields.begin(), fields.end(),
+                               [&](const Rule& r) { return r.path == path; });
+        return it == fields.end() ? nullptr : &*it;
+    }
+
+    bool container(const std::string& path) const {
+        return std::any_of(fields.begin(), fields.end(), [&](const Rule& r) {
+            return r.path.starts_with(path + "/");
+        });
+    }
+
+    void collect(const json& node, const std::string& path, size_t depth = 0) {
+        if (++visited > 4096 || depth > 32 || path.size() > 256 ||
+            std::count(path.begin(), path.end(), '/') >= 32) {
+            diagnose(diagnostics, Code::kAnalysisLimitExceeded, "$",
+                     "Configuration path, depth or value limit exceeded");
+            return;
+        }
+        const bool group = path.empty() || container(path);
+        if (group && node.is_null()) return;  // legacy missing/default values
+        if (group && !node.is_object()) {
+            diagnose(diagnostics,
+                     path.empty() ? Code::kInvalidRoot : Code::kInvalidType,
+                     path.empty() ? "$" : path, "Expected a JSON object");
+            return;
+        }
+        if (!rule(path) && node.is_object() && (group || !node.empty())) {
+            for (auto it = node.begin(); it != node.end(); ++it) {
+                if (visited > 4096) break;
+                const auto& key = it.key();
+                const auto child = path.empty() ? key : path + "/" + key;
+                // Config only supports slash-containing flat aliases at root.
+                if (key.empty() || key.front() == '/' || key.back() == '/' ||
+                    key.find("//") != std::string::npos ||
+                    (!path.empty() && key.find('/') != std::string::npos) ||
+                    std::any_of(key.begin(), key.end(), [](unsigned char c) {
+                        return c < 32 || c == 127;
+                    })) {
+                    diagnose(diagnostics, Code::kInvalidPath, child,
+                             "Invalid canonical configuration path");
+                    continue;
+                }
+                // HP TCP consumes the entire transport object through its
+                // dedicated parser, not Config::get() on individual flat keys.
+                if (path.empty() && key == "transports/hp_tcp/enable") {
+                    diagnose(
+                        diagnostics, Code::kInvalidPath, child,
+                        "HP TCP enable must be inside its transport object");
+                    continue;
+                }
+                // A flat object alias does not expose its children through
+                // Config::get("a/b/c"); reject that misleading representation.
+                if (key.find('/') != std::string::npos && it->is_object() &&
+                    !rule(child)) {
+                    diagnose(diagnostics, Code::kInvalidPath, child,
+                             "Flat object aliases are not supported");
+                    continue;
+                }
+                collect(*it, child, depth + 1);
+            }
+            return;
+        }
+        auto [it, inserted] = values.emplace(path, node);
+        if (!inserted && !sameValue(it->second, node)) {
+            diagnose(diagnostics, Code::kAmbiguousPath, path,
+                     "Conflicting flat and nested configuration values");
+        }
+    }
+
+    void validate(const Rule& field) {
+        if (field.path == "transports/hp_tcp/enable" &&
+            values.contains(field.path) && values.at(field.path).is_null()) {
+            diagnose(diagnostics, Code::kInvalidType, field.path,
+                     "HP TCP enable must be a boolean");
+            return;
+        }
+        auto& value =
+            values.try_emplace(field.path, field.default_value).first->second;
+        if (value.is_null()) value = field.default_value;
+        if (value.is_null()) return;  // unspecified transport enable flag
+        const auto range_message = [&] {
+            return "Expected an integer in range [" +
+                   std::to_string(field.minimum) + ", " +
+                   std::to_string(field.maximum) + "]";
+        };
+        if (field.kind == Kind::kRpcInteger && value.is_string()) {
+            try {
+                const auto text = value.get<std::string>();
+                size_t consumed = 0;
+                const auto number = std::stoll(text, &consumed);
+                if (consumed == text.size()) value = number;
+            } catch (const std::out_of_range&) {
+                diagnose(diagnostics, Code::kOutOfRange, field.path,
+                         range_message());
+                return;
+            } catch (const std::invalid_argument&) {
+            }
+        }
+        bool type_ok = false;
+        const char* type_message = "Expected an integer";
+        switch (field.kind) {
+            case Kind::kBool:
+                type_ok = value.is_boolean();
+                type_message = "Expected a boolean";
+                break;
+            case Kind::kString:
+                type_ok = value.is_string();
+                type_message = "Expected a string";
+                break;
+            case Kind::kNumber:
+                type_ok = value.is_number();
+                type_message = "Expected a finite number";
+                break;
+            case Kind::kUnsigned:
+                type_ok = value.is_number_integer();
+                break;
+            case Kind::kRpcInteger:
+                type_ok = value.is_number_integer();
+                type_message = "Expected an integer or integer string";
+                break;
+        }
+        if (!type_ok) {
+            diagnose(diagnostics, Code::kInvalidType, field.path, type_message);
+            return;
+        }
+        if (field.kind == Kind::kUnsigned || field.kind == Kind::kRpcInteger) {
+            // Check signedness/range BEFORE narrowing. json::get<T>() alone can
+            // silently wrap an oversized unsigned or a negative integer.
+            if ((!value.is_number_unsigned() && value.get<int64_t>() < 0) ||
+                value.get<uint64_t>() < field.minimum ||
+                value.get<uint64_t>() > field.maximum) {
+                diagnose(diagnostics, Code::kOutOfRange, field.path,
+                         range_message());
+                return;
+            }
+            value = value.get<uint64_t>();
+        } else if (field.kind == Kind::kNumber) {
+            if (!std::isfinite(value.get<double>())) {
+                diagnose(diagnostics, Code::kOutOfRange, field.path,
+                         "Expected a finite number");
+            }
+            value = value.get<double>();
+        }
+    }
+
+    void run(const Config& config, const ConfigValidationContext& context) {
+        // One frozen capture, not a sequence of individually locked get()s.
+        collect(config.toJson(), "");
+        if (!diagnostics.empty()) return;
+        for (const auto& field : fields) validate(field);
+        if (!diagnostics.empty()) return;
+        auto flag = [&](const std::string& path, bool fallback) {
+            const auto& value = values.at(path);
+            return value.is_null() ? fallback : value.get<bool>();
+        };
+        // construct() uses an explicit TCP enable to choose RPC thread
+        // defaults, whereas loadTransports() defaults TCP itself to enabled.
+        // Preserve both.
+        if (!config.contains("rpc_server_threads")) {
+            values["rpc_server_threads"] =
+                flag("transports/tcp/enable", false)
+                    ? std::min(8U, std::max(4U, context.hardware_concurrency))
+                    : 1U;
+        }
+        if (flag("enable_runtime_queue", false)) {
+            values["enable_progress_worker"] = true;
+            for (const auto* path : {"runtime_queue/max_dispatch_owners",
+                                     "runtime_queue/max_dispatch_bytes"}) {
+                if (values.at(path).get<uint64_t>() == 0) {
+                    diagnose(diagnostics, Code::kCrossFieldConstraint, path,
+                             "Enabled runtime queue requires a nonzero "
+                             "dispatch window");
+                }
+            }
+        }
+        // Same two invariants as admission_queue.cpp::validateLimits(). Zero
+        // total capacity and negative MLU (disabled) remain legal.
+        for (const auto& [reserve, total] :
+             {std::pair{"runtime_queue/staging_owner_reserve",
+                        "runtime_queue/max_outstanding_owners"},
+              std::pair{"runtime_queue/staging_byte_reserve",
+                        "runtime_queue/max_outstanding_bytes"}}) {
+            if (values.at(reserve).get<uint64_t>() >
+                values.at(total).get<uint64_t>()) {
+                diagnose(diagnostics, Code::kCrossFieldConstraint, reserve,
+                         "Staging reserve exceeds total queue capacity");
+            }
+        }
+        if (flag("transports/hp_tcp/enable", false) &&
+            flag("transports/tcp/enable", true)) {
+            diagnose(diagnostics, Code::kCrossFieldConstraint,
+                     "transports/hp_tcp/enable",
+                     "HP TCP and TCP cannot both be enabled");
+        }
+        for (auto transport : kTransports) {
+            const auto path =
+                "transports/" + std::string(transport) + "/enable";
+            if (flag(path, false) &&
+                std::find(context.compiled_transports.begin(),
+                          context.compiled_transports.end(),
+                          transport) == context.compiled_transports.end()) {
+                diagnose(diagnostics, Code::kBackendUnavailable, path,
+                         "Explicitly enabled transport is not compiled in");
+            }
+        }
+    }
+};
+
+}  // namespace
+
+ConfigValidationContext currentConfigValidationContext() {
+    ConfigValidationContext context{{"tcp", "hp_tcp", "shm"},
+                                    std::thread::hardware_concurrency()};
+    // Match compile guards in runtime/transport_loader.cpp, without probing
+    // topology or initializing process-wide platform/metrics singletons.
+#ifdef USE_RDMA
+    context.compiled_transports.push_back("rdma");
+#endif
+#ifdef USE_UB
+    context.compiled_transports.push_back("ub");
+#endif
+#ifdef USE_URING
+    context.compiled_transports.push_back("io_uring");
+#endif
+#ifdef USE_CUDA
+    context.compiled_transports.push_back("nvlink");
+    context.compiled_transports.push_back("mnnvl");
+#endif
+#ifdef USE_GDS
+    context.compiled_transports.push_back("gds");
+#endif
+#if defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT)
+    context.compiled_transports.push_back("ascend_direct");
+#endif
+#ifdef USE_SUNRISE
+    context.compiled_transports.push_back("sunrise_link");
+#endif
+#ifdef USE_TPU
+    context.compiled_transports.push_back("tpu");
+#endif
+#ifdef USE_MPCOMM
+    context.compiled_transports.push_back("mpcomm");
+#endif
+    return context;
+}
+
+ConfigChangePlan planTentConfigChange(const Config& current,
+                                      const Config& candidate,
+                                      const ConfigValidationContext& context) {
+    ConfigChangePlan plan;
+    plan.current = current.freeze();
+    plan.candidate = &current == &candidate ? plan.current : candidate.freeze();
+    const auto fields = rules();
+    Analysis before{{}, plan.current_diagnostics, fields};
+    Analysis after{{}, plan.candidate_diagnostics, fields};
+    before.run(*plan.current, context);
+    after.run(*plan.candidate, context);
+    if (!plan.valid()) return plan;
+    std::set<std::string> paths;
+    for (const auto& [path, value] : before.values) paths.insert(path);
+    for (const auto& [path, value] : after.values) paths.insert(path);
+    for (const auto& path : paths) {
+        const auto old = before.values.find(path);
+        const auto next = after.values.find(path);
+        if (old != before.values.end() && next != after.values.end() &&
+            sameValue(old->second, next->second))
+            continue;
+        if (plan.changes.size() == 128) {
+            diagnose(plan.candidate_diagnostics, Code::kAnalysisLimitExceeded,
+                     "$", "Configuration change limit exceeded");
+            plan.changes.clear();
+            return plan;
+        }
+        auto disposition = ConfigChangeDisposition::kUnsupported;
+        if (after.rule(path)) {
+            disposition =
+                classifyConfigPath(path) == ConfigLifecycle::kRuntimeCandidate
+                    ? ConfigChangeDisposition::kRuntimeCandidate
+                    : ConfigChangeDisposition::kRestartRequired;
+        }
+        plan.changes.push_back({path, disposition});
+    }
+    return plan;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/common/config_validation.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_validation.cpp
@@ -16,30 +16,21 @@
 
 #include <algorithm>
 #include <cmath>
-#include <limits>
 #include <map>
 #include <set>
-#include <stdexcept>
 #include <thread>
+
+#include "tent/common/config_parser.h"
+#include "tent/runtime/admission_queue.h"
 
 namespace mooncake {
 namespace tent {
 namespace {
 
 using Values = std::map<std::string, json>;
-using Code = ConfigDiagnosticCode;
-enum class Kind { kBool, kString, kUnsigned, kRpcInteger, kNumber };
 
-struct Rule {
-    std::string path;
-    Kind kind;
-    json default_value;
-    uint64_t maximum{0};
-    uint64_t minimum{0};
-};
-
-// Unknown consumers may distinguish integer/float representations. JSON's
-// operator== considers 1 and 1.0 equal, including inside arrays/objects.
+// Unknown consumers may distinguish integer/float representations, including
+// inside arrays. JSON's operator== alone considers 1 and 1.0 equal.
 bool sameValue(const json& lhs, const json& rhs) {
     if (lhs.type() != rhs.type()) return false;
     if (!lhs.is_structured()) return lhs == rhs;
@@ -57,263 +48,221 @@ constexpr std::string_view kTransports[] = {
     "io_uring",     "nvlink", "mnnvl", "gds",  "ascend_direct",
     "sunrise_link", "tpu",    "mpcomm"};
 
-// Defaults/ranges follow construct(), getRpcServer{Port,Threads}FromConfig(),
-// QueueLimits, and the shared failover defaults introduced by #3934. Keep these
-// checks outside the legacy loader: it intentionally defaults on type errors.
-std::vector<Rule> rules() {
-    constexpr auto size_max = std::numeric_limits<size_t>::max();
-    std::vector<Rule> result = {
-        {"rpc_server_hostname", Kind::kString, ""},
-        {"rpc_server_port", Kind::kRpcInteger, 0, 65535},
-        {"rpc_server_threads", Kind::kRpcInteger, 1, 1024, 1},
-        {"merge_requests", Kind::kBool, true},
-        {"max_failover_attempts", Kind::kUnsigned, kDefaultMaxFailoverAttempts,
-         std::numeric_limits<int>::max()},
-        {"enable_auto_failover_on_poll", Kind::kBool,
-         kDefaultAutoFailoverOnPoll},
-        {"enable_progress_worker", Kind::kBool, false},
-        {"enable_runtime_queue", Kind::kBool, false},
-        {"runtime_queue/max_outstanding_owners", Kind::kUnsigned, 1024,
-         size_max},
-        {"runtime_queue/max_outstanding_bytes", Kind::kUnsigned, 1ULL << 30,
-         size_max},
-        {"runtime_queue/staging_owner_reserve", Kind::kUnsigned, 0, size_max},
-        {"runtime_queue/staging_byte_reserve", Kind::kUnsigned, 0, size_max},
-        {"runtime_queue/deadline_aware", Kind::kBool, false},
-        // Nonpositive MLU thresholds disable degradation; do not reject them.
-        {"runtime_queue/mlu_local_threshold", Kind::kNumber, 0.0},
-        {"runtime_queue/promotion_slack_ns", Kind::kUnsigned, 0,
-         std::numeric_limits<uint64_t>::max()},
-        {"runtime_queue/max_dispatch_owners", Kind::kUnsigned, 64, size_max},
-        {"runtime_queue/max_dispatch_bytes", Kind::kUnsigned, 64ULL << 20,
-         size_max},
-        {"runtime_queue/progress_fallback_interval_us", Kind::kUnsigned, 50000,
-         static_cast<uint64_t>(std::numeric_limits<int64_t>::max())},
-    };
-    for (auto transport : kTransports) {
-        result.push_back({"transports/" + std::string(transport) + "/enable",
-                          Kind::kBool, nullptr});
-    }
-    return result;
-}
-
-void diagnose(std::vector<ConfigDiagnostic>& out, Code code,
-              const std::string& path, const std::string& message) {
-    if (out.size() >= 64) return;
-    if (out.size() == 63) {
-        out.push_back({Code::kAnalysisLimitExceeded, "$",
-                       "Configuration diagnostic limit exceeded"});
-        return;
-    }
-    // Do not echo oversized or control-character-containing paths.
+Status invalidConfig(const std::string& path, const std::string& message) {
+    // Never echo an oversized/control-character-containing path or raw values.
     const bool safe =
         path.size() <= 256 &&
         std::none_of(path.begin(), path.end(),
                      [](unsigned char c) { return c < 32 || c == 127; });
-    out.push_back({code, safe ? path : "$", message});
+    return Status::InvalidArgument((safe ? path : "$") + ": " + message +
+                                   LOC_MARK);
 }
 
 struct Analysis {
+    // Raw entries point into this owned document. Keep containers until their
+    // consumers check them, so an object cannot hide a mistyped scalar field.
+    json document;
+    std::map<std::string, const json*> inputs;
     Values values;
-    std::vector<ConfigDiagnostic>& diagnostics;
-    const std::vector<Rule>& fields;
+    std::set<std::string> validated_paths;
     size_t visited{0};
 
-    const Rule* rule(const std::string& path) const {
-        auto it = std::find_if(fields.begin(), fields.end(),
-                               [&](const Rule& r) { return r.path == path; });
-        return it == fields.end() ? nullptr : &*it;
-    }
-
-    bool container(const std::string& path) const {
-        return std::any_of(fields.begin(), fields.end(), [&](const Rule& r) {
-            return r.path.starts_with(path + "/");
-        });
-    }
-
-    void collect(const json& node, const std::string& path, size_t depth = 0) {
+    Status collect(const json& node, const std::string& path,
+                   size_t depth = 0) {
         if (++visited > 4096 || depth > 32 || path.size() > 256 ||
             std::count(path.begin(), path.end(), '/') >= 32) {
-            diagnose(diagnostics, Code::kAnalysisLimitExceeded, "$",
-                     "Configuration path, depth or value limit exceeded");
-            return;
+            return invalidConfig(
+                "$", "Configuration path, depth or value limit exceeded");
         }
-        const bool group = path.empty() || container(path);
-        if (group && node.is_null()) return;  // legacy missing/default values
-        if (group && !node.is_object()) {
-            diagnose(diagnostics,
-                     path.empty() ? Code::kInvalidRoot : Code::kInvalidType,
-                     path.empty() ? "$" : path, "Expected a JSON object");
-            return;
-        }
-        if (!rule(path) && node.is_object() && (group || !node.empty())) {
-            for (auto it = node.begin(); it != node.end(); ++it) {
-                if (visited > 4096) break;
-                const auto& key = it.key();
-                const auto child = path.empty() ? key : path + "/" + key;
-                // Config only supports slash-containing flat aliases at root.
-                if (key.empty() || key.front() == '/' || key.back() == '/' ||
-                    key.find("//") != std::string::npos ||
-                    (!path.empty() && key.find('/') != std::string::npos) ||
-                    std::any_of(key.begin(), key.end(), [](unsigned char c) {
-                        return c < 32 || c == 127;
-                    })) {
-                    diagnose(diagnostics, Code::kInvalidPath, child,
-                             "Invalid canonical configuration path");
-                    continue;
-                }
-                // HP TCP consumes the entire transport object through its
-                // dedicated parser, not Config::get() on individual flat keys.
-                if (path.empty() && key == "transports/hp_tcp/enable") {
-                    diagnose(
-                        diagnostics, Code::kInvalidPath, child,
-                        "HP TCP enable must be inside its transport object");
-                    continue;
-                }
-                // A flat object alias does not expose its children through
-                // Config::get("a/b/c"); reject that misleading representation.
-                if (key.find('/') != std::string::npos && it->is_object() &&
-                    !rule(child)) {
-                    diagnose(diagnostics, Code::kInvalidPath, child,
-                             "Flat object aliases are not supported");
-                    continue;
-                }
-                collect(*it, child, depth + 1);
+        if (!path.empty()) {
+            auto [it, inserted] = inputs.emplace(path, &node);
+            if (!inserted && !sameValue(*it->second, node)) {
+                return invalidConfig(
+                    path, "Conflicting flat and nested configuration values");
             }
-            return;
         }
-        auto [it, inserted] = values.emplace(path, node);
-        if (!inserted && !sameValue(it->second, node)) {
-            diagnose(diagnostics, Code::kAmbiguousPath, path,
-                     "Conflicting flat and nested configuration values");
+        if (!node.is_object()) return Status::OK();
+        for (auto it = node.begin(); it != node.end(); ++it) {
+            const auto& key = it.key();
+            const auto child = path.empty() ? key : path + "/" + key;
+            if (key.empty() || key.front() == '/' || key.back() == '/' ||
+                key.find("//") != std::string::npos ||
+                (!path.empty() && key.find('/') != std::string::npos) ||
+                std::any_of(key.begin(), key.end(), [](unsigned char c) {
+                    return c < 32 || c == 127;
+                })) {
+                return invalidConfig(child,
+                                     "Invalid canonical configuration path");
+            }
+            if (path.empty() && key == "transports/hp_tcp/enable") {
+                return invalidConfig(
+                    child, "HP TCP enable must be inside its transport object");
+            }
+            if (key.find('/') != std::string::npos && it->is_object()) {
+                return invalidConfig(child,
+                                     "Flat object aliases are not supported");
+            }
+            CHECK_STATUS(collect(*it, child, depth + 1));
         }
+        return Status::OK();
     }
 
-    void validate(const Rule& field) {
-        if (field.path == "transports/hp_tcp/enable" &&
-            values.contains(field.path) && values.at(field.path).is_null()) {
-            diagnose(diagnostics, Code::kInvalidType, field.path,
-                     "HP TCP enable must be a boolean");
-            return;
-        }
-        auto& value =
-            values.try_emplace(field.path, field.default_value).first->second;
-        if (value.is_null()) value = field.default_value;
-        if (value.is_null()) return;  // unspecified transport enable flag
-        const auto range_message = [&] {
-            return "Expected an integer in range [" +
-                   std::to_string(field.minimum) + ", " +
-                   std::to_string(field.maximum) + "]";
-        };
-        if (field.kind == Kind::kRpcInteger && value.is_string()) {
-            try {
-                const auto text = value.get<std::string>();
-                size_t consumed = 0;
-                const auto number = std::stoll(text, &consumed);
-                if (consumed == text.size()) value = number;
-            } catch (const std::out_of_range&) {
-                diagnose(diagnostics, Code::kOutOfRange, field.path,
-                         range_message());
-                return;
-            } catch (const std::invalid_argument&) {
-            }
-        }
-        bool type_ok = false;
-        const char* type_message = "Expected an integer";
-        switch (field.kind) {
-            case Kind::kBool:
-                type_ok = value.is_boolean();
-                type_message = "Expected a boolean";
-                break;
-            case Kind::kString:
-                type_ok = value.is_string();
-                type_message = "Expected a string";
-                break;
-            case Kind::kNumber:
-                type_ok = value.is_number();
-                type_message = "Expected a finite number";
-                break;
-            case Kind::kUnsigned:
-                type_ok = value.is_number_integer();
-                break;
-            case Kind::kRpcInteger:
-                type_ok = value.is_number_integer();
-                type_message = "Expected an integer or integer string";
-                break;
-        }
-        if (!type_ok) {
-            diagnose(diagnostics, Code::kInvalidType, field.path, type_message);
-            return;
-        }
-        if (field.kind == Kind::kUnsigned || field.kind == Kind::kRpcInteger) {
-            // Check signedness/range BEFORE narrowing. json::get<T>() alone can
-            // silently wrap an oversized unsigned or a negative integer.
-            if ((!value.is_number_unsigned() && value.get<int64_t>() < 0) ||
-                value.get<uint64_t>() < field.minimum ||
-                value.get<uint64_t>() > field.maximum) {
-                diagnose(diagnostics, Code::kOutOfRange, field.path,
-                         range_message());
-                return;
-            }
-            value = value.get<uint64_t>();
-        } else if (field.kind == Kind::kNumber) {
-            if (!std::isfinite(value.get<double>())) {
-                diagnose(diagnostics, Code::kOutOfRange, field.path,
-                         "Expected a finite number");
-            }
-            value = value.get<double>();
-        }
+    const json* input(const std::string& path) const {
+        const auto it = inputs.find(path);
+        return it == inputs.end() ? nullptr : it->second;
     }
 
-    void run(const Config& config, const ConfigValidationContext& context) {
-        // One frozen capture, not a sequence of individually locked get()s.
-        collect(config.toJson(), "");
-        if (!diagnostics.empty()) return;
-        for (const auto& field : fields) validate(field);
-        if (!diagnostics.empty()) return;
-        auto flag = [&](const std::string& path, bool fallback) {
-            const auto& value = values.at(path);
-            return value.is_null() ? fallback : value.get<bool>();
-        };
-        // construct() uses an explicit TCP enable to choose RPC thread
-        // defaults, whereas loadTransports() defaults TCP itself to enabled.
-        // Preserve both.
-        if (!config.contains("rpc_server_threads")) {
-            values["rpc_server_threads"] =
-                flag("transports/tcp/enable", false)
-                    ? std::min(8U, std::max(4U, context.hardware_concurrency))
-                    : 1U;
+    Status readGroup(const std::string& path) {
+        const auto* node = input(path);
+        if (node && !node->is_null() && !node->is_object()) {
+            return invalidConfig(path, "Expected a JSON object");
         }
-        if (flag("enable_runtime_queue", false)) {
-            values["enable_progress_worker"] = true;
-            for (const auto* path : {"runtime_queue/max_dispatch_owners",
-                                     "runtime_queue/max_dispatch_bytes"}) {
-                if (values.at(path).get<uint64_t>() == 0) {
-                    diagnose(diagnostics, Code::kCrossFieldConstraint, path,
-                             "Enabled runtime queue requires a nonzero "
-                             "dispatch window");
-                }
+        inputs.erase(path);
+        return Status::OK();
+    }
+
+    void remember(const std::string& path, json value) {
+        inputs.erase(path);
+        values[path] = std::move(value);
+        validated_paths.insert(path);
+    }
+
+    Status readBool(const std::string& path, bool fallback,
+                    bool* output = nullptr) {
+        bool value = fallback;
+        const auto* node = input(path);
+        if (node && !node->is_null()) {
+            CHECK_STATUS(parseBoolConfigValue(*node, path, &value));
+        }
+        remember(path, value);
+        if (output) *output = value;
+        return Status::OK();
+    }
+
+    Status readString(const std::string& path, const std::string& fallback) {
+        const auto* node = input(path);
+        if (node && !node->is_null() && !node->is_string()) {
+            return invalidConfig(path, "must be a string");
+        }
+        remember(path, node && !node->is_null() ? *node : json(fallback));
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status readUnsigned(const std::string& path, T fallback,
+                        T* output = nullptr) {
+        T value = fallback;
+        const auto* node = input(path);
+        if (node && !node->is_null()) {
+            CHECK_STATUS(parseUnsignedConfigValue(*node, path, &value));
+        }
+        remember(path, static_cast<uint64_t>(value));
+        if (output) *output = value;
+        return Status::OK();
+    }
+
+    Status readNumber(const std::string& path, double fallback) {
+        double value = fallback;
+        const auto* node = input(path);
+        if (node && !node->is_null()) {
+            if (!node->is_number() || !std::isfinite(node->get<double>())) {
+                return invalidConfig(path, "must be a finite number");
+            }
+            value = node->get<double>();
+        }
+        remember(path, value);
+        return Status::OK();
+    }
+
+    bool flag(const std::string& path, bool fallback) const {
+        const auto& value = values.at(path);
+        return value.is_null() ? fallback : value.get<bool>();
+    }
+
+    Status readTransportFlags() {
+        CHECK_STATUS(readGroup("transports"));
+        for (auto transport : kTransports) {
+            const auto group = "transports/" + std::string(transport);
+            CHECK_STATUS(readGroup(group));
+            const auto path = group + "/enable";
+            const auto* node = input(path);
+            if (node && (!node->is_null() || transport == "hp_tcp")) {
+                bool enabled = false;
+                CHECK_STATUS(parseBoolConfigValue(*node, path, &enabled));
+                remember(path, enabled);
+            } else {
+                // Preserve absence: device/environment selection is outside
+                // preflight. HP TCP's parser rejects explicit null.
+                remember(path, nullptr);
             }
         }
-        // Same two invariants as admission_queue.cpp::validateLimits(). Zero
-        // total capacity and negative MLU (disabled) remain legal.
-        for (const auto& [reserve, total] :
-             {std::pair{"runtime_queue/staging_owner_reserve",
-                        "runtime_queue/max_outstanding_owners"},
-              std::pair{"runtime_queue/staging_byte_reserve",
-                        "runtime_queue/max_outstanding_bytes"}}) {
-            if (values.at(reserve).get<uint64_t>() >
-                values.at(total).get<uint64_t>()) {
-                diagnose(diagnostics, Code::kCrossFieldConstraint, reserve,
-                         "Staging reserve exceeds total queue capacity");
-            }
-        }
-        if (flag("transports/hp_tcp/enable", false) &&
-            flag("transports/tcp/enable", true)) {
-            diagnose(diagnostics, Code::kCrossFieldConstraint,
-                     "transports/hp_tcp/enable",
-                     "HP TCP and TCP cannot both be enabled");
-        }
+        return Status::OK();
+    }
+
+    Status validateRpc(const Config& config,
+                       const ConfigValidationContext& context) {
+        CHECK_STATUS(readString("rpc_server_hostname", ""));
+        uint16_t port = 0;
+        CHECK_STATUS(getRpcServerPortFromConfig(config, 0, port));
+        remember("rpc_server_port", static_cast<uint64_t>(port));
+        const size_t fallback =
+            getDefaultRpcServerThreads(config, context.hardware_concurrency);
+        size_t threads = 0;
+        CHECK_STATUS(getRpcServerThreadsFromConfig(config, fallback, threads));
+        remember("rpc_server_threads", static_cast<uint64_t>(threads));
+        return Status::OK();
+    }
+
+    Status validateRuntime() {
+        CHECK_STATUS(readBool("merge_requests", true));
+        CHECK_STATUS(
+            readUnsigned("max_failover_attempts", kDefaultMaxFailoverAttempts));
+        CHECK_STATUS(readBool("enable_auto_failover_on_poll",
+                              kDefaultAutoFailoverOnPoll));
+        CHECK_STATUS(readBool("enable_progress_worker", false));
+        CHECK_STATUS(readBool("enable_runtime_queue", false));
+        CHECK_STATUS(readGroup("runtime_queue"));
+
+        QueueLimits limits;
+        CHECK_STATUS(readUnsigned("runtime_queue/max_outstanding_owners",
+                                  size_t{1024},
+                                  &limits.max_outstanding_owners));
+        CHECK_STATUS(readUnsigned("runtime_queue/max_outstanding_bytes",
+                                  size_t{1} << 30,
+                                  &limits.max_outstanding_bytes));
+        CHECK_STATUS(readUnsigned("runtime_queue/staging_owner_reserve",
+                                  limits.staging_owner_reserve,
+                                  &limits.staging_owner_reserve));
+        CHECK_STATUS(readUnsigned("runtime_queue/staging_byte_reserve",
+                                  limits.staging_byte_reserve,
+                                  &limits.staging_byte_reserve));
+        CHECK_STATUS(
+            readBool("runtime_queue/deadline_aware", limits.deadline_aware));
+        // Nonpositive thresholds disable degradation and remain valid.
+        CHECK_STATUS(readNumber("runtime_queue/mlu_local_threshold",
+                                limits.mlu_local_threshold));
+        CHECK_STATUS(readUnsigned("runtime_queue/promotion_slack_ns",
+                                  limits.promotion_slack_ns));
+        CHECK_STATUS(limits.validate());
+
+        size_t max_owners = 0, max_bytes = 0;
+        CHECK_STATUS(readUnsigned("runtime_queue/max_dispatch_owners",
+                                  size_t{64}, &max_owners));
+        CHECK_STATUS(readUnsigned("runtime_queue/max_dispatch_bytes",
+                                  size_t{64} << 20, &max_bytes));
+        CHECK_STATUS(readUnsigned("runtime_queue/progress_fallback_interval_us",
+                                  int64_t{50000}));
+        const bool enabled = flag("enable_runtime_queue", false);
+        CHECK_STATUS(
+            validateRuntimeQueueDispatchWindow(enabled, max_owners, max_bytes));
+        if (enabled) values["enable_progress_worker"] = true;
+        return Status::OK();
+    }
+
+    Status validateTransports(const ConfigValidationContext& context) {
+        CHECK_STATUS(validateTcpTransportSelection(
+            flag("transports/tcp/enable", true),
+            flag("transports/hp_tcp/enable", false)));
         for (auto transport : kTransports) {
             const auto path =
                 "transports/" + std::string(transport) + "/enable";
@@ -321,10 +270,31 @@ struct Analysis {
                 std::find(context.compiled_transports.begin(),
                           context.compiled_transports.end(),
                           transport) == context.compiled_transports.end()) {
-                diagnose(diagnostics, Code::kBackendUnavailable, path,
-                         "Explicitly enabled transport is not compiled in");
+                return invalidConfig(
+                    path, "explicitly enabled transport is not compiled in");
             }
         }
+        return Status::OK();
+    }
+
+    Status run(const Config& config, const ConfigValidationContext& context) {
+        document = config.toJson();
+        if (!document.is_null() && !document.is_object()) {
+            return invalidConfig("$",
+                                 "Configuration root must be a JSON object");
+        }
+        CHECK_STATUS(collect(document, ""));
+        CHECK_STATUS(readTransportFlags());
+        CHECK_STATUS(validateRpc(config, context));
+        CHECK_STATUS(validateRuntime());
+        CHECK_STATUS(validateTransports(context));
+        // Covered fields were consumed above. Keep unknown leaves and empty
+        // objects for structural diff; traversed containers are not changes.
+        for (const auto& [path, node] : inputs) {
+            if (!node->is_object() || node->empty())
+                values.emplace(path, *node);
+        }
+        return Status::OK();
     }
 };
 
@@ -333,8 +303,7 @@ struct Analysis {
 ConfigValidationContext currentConfigValidationContext() {
     ConfigValidationContext context{{"tcp", "hp_tcp", "shm"},
                                     std::thread::hardware_concurrency()};
-    // Match compile guards in runtime/transport_loader.cpp, without probing
-    // topology or initializing process-wide platform/metrics singletons.
+    // Match runtime/transport_loader.cpp without probing devices or services.
 #ifdef USE_RDMA
     context.compiled_transports.push_back("rdma");
 #endif
@@ -372,11 +341,9 @@ ConfigChangePlan planTentConfigChange(const Config& current,
     ConfigChangePlan plan;
     plan.current = current.freeze();
     plan.candidate = &current == &candidate ? plan.current : candidate.freeze();
-    const auto fields = rules();
-    Analysis before{{}, plan.current_diagnostics, fields};
-    Analysis after{{}, plan.candidate_diagnostics, fields};
-    before.run(*plan.current, context);
-    after.run(*plan.candidate, context);
+    Analysis before, after;
+    plan.current_status = before.run(*plan.current, context);
+    plan.candidate_status = after.run(*plan.candidate, context);
     if (!plan.valid()) return plan;
     std::set<std::string> paths;
     for (const auto& [path, value] : before.values) paths.insert(path);
@@ -388,13 +355,13 @@ ConfigChangePlan planTentConfigChange(const Config& current,
             sameValue(old->second, next->second))
             continue;
         if (plan.changes.size() == 128) {
-            diagnose(plan.candidate_diagnostics, Code::kAnalysisLimitExceeded,
-                     "$", "Configuration change limit exceeded");
+            plan.candidate_status =
+                invalidConfig("$", "Configuration change limit exceeded");
             plan.changes.clear();
             return plan;
         }
         auto disposition = ConfigChangeDisposition::kUnsupported;
-        if (after.rule(path)) {
+        if (after.validated_paths.contains(path)) {
             disposition =
                 classifyConfigPath(path) == ConfigLifecycle::kRuntimeCandidate
                     ? ConfigChangeDisposition::kRuntimeCandidate

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -60,22 +60,10 @@ Status checkedAdd(size_t lhs, size_t rhs, size_t& out) {
     return Status::OK();
 }
 
-Status validateLimits(const QueueLimits& limits) {
-    if (limits.staging_owner_reserve > limits.max_outstanding_owners) {
-        return Status::InvalidArgument(
-            "staging owner reserve exceeds owner limit" LOC_MARK);
-    }
-    if (limits.staging_byte_reserve > limits.max_outstanding_bytes) {
-        return Status::InvalidArgument(
-            "staging byte reserve exceeds byte limit" LOC_MARK);
-    }
-    return Status::OK();
-}
-
 }  // namespace
 
 LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
-    : limits_(limits), limits_status_(validateLimits(limits)) {}
+    : limits_(limits), limits_status_(limits.validate()) {}
 
 Status LocalTransferAdmissionQueue::tryAdmit(
     const QueueSubmit& submit, std::vector<QueueOwnerId>& admitted_owner_ids) {

--- a/mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp
@@ -1,7 +1,7 @@
 // Copyright 2026 KVCache.AI
 #include "tent/runtime/hp_tcp_transport_config.h"
+#include "tent/common/config_parser.h"
 
-#include <limits>
 #include <string_view>
 
 namespace mooncake::tent {
@@ -15,26 +15,8 @@ template <typename T>
 Status ReadUnsigned(const json& object, std::string_view key, T* output) {
     auto it = object.find(std::string(key));
     if (it == object.end()) return Status::OK();
-    uint64_t value = 0;
-    if (it->is_number_unsigned()) {
-        value = it->get<uint64_t>();
-    } else if (it->is_number_integer()) {
-        const auto signed_value = it->get<int64_t>();
-        if (signed_value < 0) {
-            return Invalid("transports/hp_tcp/" + std::string(key),
-                           "must be non-negative");
-        }
-        value = static_cast<uint64_t>(signed_value);
-    } else {
-        return Invalid("transports/hp_tcp/" + std::string(key),
-                       "must be an integer");
-    }
-    if (value > std::numeric_limits<T>::max()) {
-        return Invalid("transports/hp_tcp/" + std::string(key),
-                       "is out of range");
-    }
-    *output = static_cast<T>(value);
-    return Status::OK();
+    return parseUnsignedConfigValue(
+        *it, "transports/hp_tcp/" + std::string(key), output);
 }
 
 Status ReadString(const json& object, std::string_view key,
@@ -96,9 +78,8 @@ Status ParseHpTcpTransportConfig(const Config& config,
     }
 
     if (auto it = hp_tcp.find("enable"); it != hp_tcp.end()) {
-        if (!it->is_boolean())
-            return Invalid("transports/hp_tcp/enable", "must be a boolean");
-        parsed.enabled = it->get<bool>();
+        CHECK_STATUS(parseBoolConfigValue(*it, "transports/hp_tcp/enable",
+                                          &parsed.enabled));
     }
     CHECK_STATUS(
         ReadString(hp_tcp, "bind_address", &parsed.params.bind_address));
@@ -131,10 +112,8 @@ Status ParseHpTcpTransportConfig(const Config& config,
         return Invalid("transports/hp_tcp",
                        "contains zero or inconsistent limits");
     }
-    if (parsed.enabled && config.get("transports/tcp/enable", true)) {
-        return Invalid("transports",
-                       "tcp and hp_tcp cannot be enabled together");
-    }
+    CHECK_STATUS(validateTcpTransportSelection(
+        config.get("transports/tcp/enable", true), parsed.enabled));
 
     *out = std::move(parsed);
     return Status::OK();

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -28,6 +28,7 @@
 #include <unordered_set>
 
 #include "tent/common/config.h"
+#include "tent/common/config_parser.h"
 #include "tent/common/status.h"
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/segment.h"
@@ -104,104 +105,6 @@ std::optional<T> captureExplicitConfigValue(const Config& config,
         return std::nullopt;
     }
     return config.get<T>(key, default_value);
-}
-
-std::optional<long long> tryParseConfigIntString(const std::string& value) {
-    try {
-        size_t parsed_chars = 0;
-        long long parsed_value = std::stoll(value, &parsed_chars);
-        if (parsed_chars == value.size()) {
-            return parsed_value;
-        }
-    } catch (...) {
-    }
-    return std::nullopt;
-}
-
-Status validateRpcServerPortValue(long long value, const std::string& source,
-                                  uint16_t& port) {
-    constexpr long long kMinPort = 0;
-    constexpr long long kMaxPort = std::numeric_limits<uint16_t>::max();
-    if (value < kMinPort || value > kMaxPort) {
-        return Status::InvalidArgument("Invalid rpc_server_port '" + source +
-                                       "', expected value in range [0, " +
-                                       std::to_string(kMaxPort) + "]" +
-                                       LOC_MARK);
-    }
-
-    port = static_cast<uint16_t>(value);
-    return Status::OK();
-}
-
-Status getRpcServerPortFromConfig(const Config& config, uint16_t default_value,
-                                  uint16_t& port) {
-    constexpr const char* kKey = "rpc_server_port";
-    if (!config.contains(kKey)) {
-        port = default_value;
-        return Status::OK();
-    }
-
-    json raw_value = config.get<json>(kKey, json());
-    if (raw_value.is_number_integer() || raw_value.is_number_unsigned()) {
-        long long numeric_value = raw_value.get<long long>();
-        return validateRpcServerPortValue(numeric_value,
-                                          std::to_string(numeric_value), port);
-    }
-
-    if (raw_value.is_string()) {
-        auto string_value = raw_value.get<std::string>();
-        auto parsed_value = tryParseConfigIntString(string_value);
-        if (!parsed_value.has_value()) {
-            return Status::InvalidArgument(
-                "Invalid rpc_server_port '" + string_value +
-                "', expected integer in range [0, 65535]" LOC_MARK);
-        }
-        return validateRpcServerPortValue(*parsed_value, string_value, port);
-    }
-
-    return Status::InvalidArgument(
-        "rpc_server_port must be an integer or integer string" LOC_MARK);
-}
-
-Status getRpcServerThreadsFromConfig(const Config& config, size_t default_value,
-                                     size_t& threads) {
-    constexpr const char* kKey = "rpc_server_threads";
-    constexpr long long kMinThreads = 1;
-    constexpr long long kMaxThreads = 1024;
-    auto validate = [&](long long value, const std::string& source) -> Status {
-        if (value < kMinThreads || value > kMaxThreads) {
-            return Status::InvalidArgument(
-                "Invalid rpc_server_threads '" + source +
-                "', expected value in range [1, " +
-                std::to_string(kMaxThreads) + "]" LOC_MARK);
-        }
-        threads = static_cast<size_t>(value);
-        return Status::OK();
-    };
-    if (!config.contains(kKey)) {
-        threads = default_value;
-        return Status::OK();
-    }
-
-    json raw_value = config.get<json>(kKey, json());
-    if (raw_value.is_number_integer() || raw_value.is_number_unsigned()) {
-        long long numeric_value = raw_value.get<long long>();
-        return validate(numeric_value, std::to_string(numeric_value));
-    }
-    if (raw_value.is_string()) {
-        auto string_value = raw_value.get<std::string>();
-        auto parsed_value = tryParseConfigIntString(string_value);
-        if (!parsed_value.has_value()) {
-            return Status::InvalidArgument(
-                "Invalid rpc_server_threads '" + string_value +
-                "', expected integer in range [1, " +
-                std::to_string(kMaxThreads) + "]" LOC_MARK);
-        }
-        return validate(*parsed_value, string_value);
-    }
-
-    return Status::InvalidArgument(
-        "rpc_server_threads must be an integer or integer string" LOC_MARK);
 }
 
 PreservedTentConfigOverrides captureExplicitTransferEngineConfig(
@@ -356,10 +259,7 @@ Status TransferEngineImpl::construct() {
     // rpc_server_threads, use several so attachments can be read in parallel.
     size_t rpc_server_threads = 1;
     const size_t rpc_threads_default =
-        conf_->get("transports/tcp/enable", false)
-            ? std::min<size_t>(
-                  8, std::max<size_t>(4, std::thread::hardware_concurrency()))
-            : 1;
+        getDefaultRpcServerThreads(*conf_, std::thread::hardware_concurrency());
     CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, rpc_threads_default,
                                                rpc_server_threads));
     merge_requests_ = conf_->get("merge_requests", true);
@@ -387,12 +287,10 @@ Status TransferEngineImpl::construct() {
     runtime_queue_config_.progress_fallback_interval =
         std::chrono::microseconds(
             conf_->get("runtime_queue/progress_fallback_interval_us", 50000UL));
-    if (runtime_queue_config_.enabled &&
-        (runtime_queue_config_.max_dispatch_owners == 0 ||
-         runtime_queue_config_.max_dispatch_bytes == 0)) {
-        return Status::InvalidArgument(
-            "runtime queue dispatch window must be non-zero" LOC_MARK);
-    }
+    CHECK_STATUS(validateRuntimeQueueDispatchWindow(
+        runtime_queue_config_.enabled,
+        runtime_queue_config_.max_dispatch_owners,
+        runtime_queue_config_.max_dispatch_bytes));
     runtime_queue_ = std::make_unique<LocalTransferAdmissionQueue>(
         runtime_queue_config_.limits);
     if (!hostname_.empty())

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -34,6 +34,14 @@ target_include_directories(config_lifecycle_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME config_lifecycle_test COMMAND config_lifecycle_test)
 
+# Candidate validation/diff is pure: no engine, transports or live services.
+add_executable(config_validation_test config_validation_test.cpp)
+target_link_libraries(config_validation_test PRIVATE tent_common gtest
+                                                     gtest_main)
+target_include_directories(config_validation_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME config_validation_test COMMAND config_validation_test)
+
 # TENT Metrics HTTP server test: validates that initialize() detects a busy
 # metrics port and degrades to log-only metrics instead of falsely reporting a
 # listening endpoint.
@@ -182,8 +190,8 @@ target_include_directories(request_merge_test
 add_test(NAME request_merge_test COMMAND request_merge_test)
 
 add_executable(local_notification_test local_notification_test.cpp)
-target_link_libraries(local_notification_test
-                      PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(local_notification_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
 target_include_directories(local_notification_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME local_notification_test COMMAND local_notification_test)

--- a/mooncake-transfer-engine/tent/tests/config_validation_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_validation_test.cpp
@@ -1,0 +1,484 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+
+#include "tent/common/config_validation.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+using Code = ConfigDiagnosticCode;
+using Disposition = ConfigChangeDisposition;
+
+const ConfigValidationContext kCpuBuild{{"tcp", "hp_tcp", "shm"}, 16};
+
+bool hasDiagnostic(const std::vector<ConfigDiagnostic>& diagnostics, Code code,
+                   const std::string& path) {
+    return std::any_of(diagnostics.begin(), diagnostics.end(),
+                       [&](const ConfigDiagnostic& d) {
+                           return d.code == code && d.path == path;
+                       });
+}
+
+bool hasChange(const ConfigChangePlan& plan, const std::string& path,
+               Disposition disposition) {
+    return std::any_of(
+        plan.changes.begin(), plan.changes.end(), [&](const ConfigChange& c) {
+            return c.path == path && c.disposition == disposition;
+        });
+}
+
+TEST(ConfigValidationTest, EmptyAndExplicitDefaultsHaveNoChanges) {
+    Config current, candidate;
+    ASSERT_TRUE(candidate
+                    .load(R"({"rpc_server_port":0,"rpc_server_threads":1,
+      "rpc_server_hostname":"","merge_requests":true,
+      "max_failover_attempts":3,"enable_auto_failover_on_poll":true,
+      "enable_runtime_queue":false,"enable_progress_worker":false,
+      "runtime_queue":{"max_outstanding_owners":1024,
+        "max_outstanding_bytes":1073741824,"staging_owner_reserve":0,
+        "staging_byte_reserve":0,"deadline_aware":false,
+        "mlu_local_threshold":0,"promotion_slack_ns":0,
+        "max_dispatch_owners":64,"max_dispatch_bytes":67108864,
+        "progress_fallback_interval_us":50000}})")
+                    .ok());
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    EXPECT_TRUE(current.toJson().is_null());
+    auto copy = candidate.toJson();
+    copy["rpc_server_port"] = 9;
+    EXPECT_EQ(candidate.get("rpc_server_port", -1), 0);
+}
+
+TEST(ConfigValidationTest, SeparatesRuntimeRestartAndUnsupportedChanges) {
+    Config current, candidate;
+    current.set("rpc_server_port", 18080);
+    candidate.set("rpc_server_port", 28080);
+    candidate.set("merge_requests", false);
+    candidate.set("runtime_queue/typo", 5);
+    // PR1 permits the entire policy subtree. That is not validation coverage.
+    candidate.set("policy", json::array());
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    ASSERT_TRUE(plan.valid());
+    ASSERT_EQ(plan.changes.size(), 4);
+    EXPECT_TRUE(
+        hasChange(plan, "rpc_server_port", Disposition::kRestartRequired));
+    EXPECT_TRUE(
+        hasChange(plan, "merge_requests", Disposition::kRuntimeCandidate));
+    EXPECT_TRUE(
+        hasChange(plan, "runtime_queue/typo", Disposition::kUnsupported));
+    EXPECT_TRUE(hasChange(plan, "policy", Disposition::kUnsupported));
+    EXPECT_TRUE(std::is_sorted(
+        plan.changes.begin(), plan.changes.end(),
+        [](const auto& a, const auto& b) { return a.path < b.path; }));
+}
+
+TEST(ConfigValidationTest,
+     RemovalRestoresDefaultAndUnknownRemovalIsUnsupported) {
+    Config current, candidate;
+    current.set("max_failover_attempts", 0);
+    current.set("rpc_server_port", 1234);
+    current.set("custom_backend/token", "do-not-print-this-value");
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    ASSERT_TRUE(plan.valid());
+    ASSERT_EQ(plan.changes.size(), 3);
+    EXPECT_TRUE(hasChange(plan, "max_failover_attempts",
+                          Disposition::kRuntimeCandidate));
+    EXPECT_TRUE(
+        hasChange(plan, "rpc_server_port", Disposition::kRestartRequired));
+    EXPECT_TRUE(
+        hasChange(plan, "custom_backend/token", Disposition::kUnsupported));
+}
+
+TEST(ConfigValidationTest, UnchangedUnknownFieldsCanBeCarriedThrough) {
+    Config current, candidate;
+    ASSERT_TRUE(current.load(R"({"plugin":{"custom":[1,2,3]}})").ok());
+    ASSERT_TRUE(candidate.load(current.dump()).ok());
+    candidate.set("max_failover_attempts", 7);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    ASSERT_TRUE(plan.valid());
+    ASSERT_EQ(plan.changes.size(), 1);
+    EXPECT_TRUE(hasChange(plan, "max_failover_attempts",
+                          Disposition::kRuntimeCandidate));
+}
+
+TEST(ConfigValidationTest, DoesNotHideTypeChangesInUnknownArrays) {
+    Config current, candidate;
+    ASSERT_TRUE(current.load(R"({"policy":[{"value":1}]})").ok());
+    ASSERT_TRUE(candidate.load(R"({"policy":[{"value":1.0}]})").ok());
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    ASSERT_TRUE(plan.valid());
+    ASSERT_EQ(plan.changes.size(), 1);
+    EXPECT_TRUE(hasChange(plan, "policy", Disposition::kUnsupported));
+}
+
+TEST(ConfigValidationTest, AcceptsFlatAndNestedRepresentationsAndRpcStrings) {
+    Config current, candidate;
+    ASSERT_TRUE(current
+                    .load(R"({"runtime_queue/max_dispatch_owners":8,
+      "rpc_server_port":"  +18080","rpc_server_threads":"4"})")
+                    .ok());
+    ASSERT_TRUE(candidate
+                    .load(R"({"runtime_queue":{"max_dispatch_owners":8},
+      "rpc_server_port":18080,"rpc_server_threads":4})")
+                    .ok());
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    // Repeating the same alias is unambiguous.
+    ASSERT_TRUE(candidate
+                    .load(R"({"runtime_queue/max_dispatch_owners":8,
+      "runtime_queue":{"max_dispatch_owners":8},
+      "rpc_server_port":18080,"rpc_server_threads":4})")
+                    .ok());
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+}
+
+TEST(ConfigValidationTest,
+     RejectsConflictingAliasesWithoutChangingLegacyLookup) {
+    Config current, candidate;
+    ASSERT_TRUE(candidate
+                    .load(R"({"runtime_queue/max_dispatch_owners":9,
+      "runtime_queue":{"max_dispatch_owners":8}})")
+                    .ok());
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_FALSE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kAmbiguousPath,
+                              "runtime_queue/max_dispatch_owners"));
+    EXPECT_EQ(candidate.get("runtime_queue/max_dispatch_owners", 0), 8);
+}
+
+TEST(ConfigValidationTest, RejectsMalformedPathsAndRootShapes) {
+    Config current;
+    for (const auto* input :
+         {R"({"":1})", R"({"/merge_requests":false})",
+          R"({"runtime_queue//max_dispatch_owners":1})",
+          R"({"runtime_queue/":{}})", R"({"transports":{"tcp/enable":false}})",
+          R"({"transports/tcp":{"enable":false}})"}) {
+        Config candidate;
+        ASSERT_TRUE(candidate.load(input).ok());
+        auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+        EXPECT_FALSE(plan.valid()) << input;
+        EXPECT_TRUE(plan.changes.empty());
+        EXPECT_EQ(plan.candidate_diagnostics.front().code, Code::kInvalidPath);
+    }
+    for (const auto* input : {"[]", "123", "true", "\"object\""}) {
+        Config candidate;
+        ASSERT_TRUE(candidate.load(input).ok());
+        auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+        EXPECT_TRUE(
+            hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidRoot, "$"));
+    }
+}
+
+TEST(ConfigValidationTest, NullAndEmptyGroupsUseDefaults) {
+    Config current, candidate;
+    ASSERT_TRUE(candidate
+                    .load(R"({"rpc_server_port":null,
+      "runtime_queue":{},"transports":null})")
+                    .ok());
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    candidate.set("runtime_queue", 123);
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidType,
+                              "runtime_queue"));
+}
+
+TEST(ConfigValidationTest, RejectsWrongTypesInsteadOfSilentlyDefaulting) {
+    Config current;
+    const std::vector<std::pair<std::string, json>> bad = {
+        {"merge_requests", "false"},
+        {"enable_runtime_queue", 1},
+        {"enable_auto_failover_on_poll", "true"},
+        {"max_failover_attempts", 1.5},
+        {"max_failover_attempts", "3"},
+        {"rpc_server_hostname", false},
+        {"rpc_server_threads", "4junk"},
+        {"rpc_server_port", 1.0},
+        {"runtime_queue/max_outstanding_bytes", "1024"},
+        {"runtime_queue/deadline_aware", json::array()},
+        {"runtime_queue/mlu_local_threshold", "1.5"},
+        {"transports/rdma/enable", 1},
+        {"rpc_server_port", json::object()}};
+    for (const auto& [path, value] : bad) {
+        Config candidate;
+        candidate.set(path, value);
+        auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+        EXPECT_FALSE(plan.valid()) << path;
+        EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                                  Code::kInvalidType, path));
+    }
+}
+
+TEST(ConfigValidationTest, ChecksRangeBeforeIntegerNarrowing) {
+    Config current;
+    const std::vector<std::pair<std::string, json>> bad = {
+        {"rpc_server_port", -1},
+        {"rpc_server_port", 65536},
+        {"rpc_server_port", std::numeric_limits<uint64_t>::max()},
+        {"rpc_server_threads", 0},
+        {"rpc_server_threads", 1025},
+        {"max_failover_attempts", -1},
+        {"max_failover_attempts",
+         static_cast<uint64_t>(std::numeric_limits<int>::max()) + 1},
+        {"runtime_queue/max_outstanding_bytes", -1},
+        {"runtime_queue/promotion_slack_ns", -1},
+        {"runtime_queue/progress_fallback_interval_us",
+         std::numeric_limits<uint64_t>::max()}};
+    for (const auto& [path, value] : bad) {
+        Config candidate;
+        candidate.set(path, value);
+        auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+        EXPECT_TRUE(
+            hasDiagnostic(plan.candidate_diagnostics, Code::kOutOfRange, path))
+            << path;
+    }
+    Config candidate;
+    candidate.set("rpc_server_port", 65535);
+    candidate.set("rpc_server_threads", 1024);
+    candidate.set("max_failover_attempts", 0);
+    candidate.set("runtime_queue/promotion_slack_ns",
+                  std::numeric_limits<uint64_t>::max());
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+}
+
+TEST(ConfigValidationTest, PreservesNonFiniteNumbersForValidation) {
+    Config current;
+    for (auto value : {std::numeric_limits<double>::infinity(),
+                       std::numeric_limits<double>::quiet_NaN()}) {
+        Config candidate;
+        candidate.set("runtime_queue/mlu_local_threshold", value);
+        auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+        EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kOutOfRange,
+                                  "runtime_queue/mlu_local_threshold"));
+    }
+}
+
+TEST(ConfigValidationTest, QueueReservesCannotExceedCapacity) {
+    Config current, candidate;
+    candidate.set("runtime_queue/max_outstanding_owners", 1);
+    candidate.set("runtime_queue/staging_owner_reserve", 2);
+    candidate.set("runtime_queue/max_outstanding_bytes", 1);
+    candidate.set("runtime_queue/staging_byte_reserve", 2);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_FALSE(plan.valid());
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kCrossFieldConstraint,
+                              "runtime_queue/staging_owner_reserve"));
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kCrossFieldConstraint,
+                              "runtime_queue/staging_byte_reserve"));
+    candidate.set("runtime_queue/staging_owner_reserve", 1);
+    candidate.set("runtime_queue/staging_byte_reserve", 1);
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+}
+
+TEST(ConfigValidationTest, QueueDispatchWindowsAreRequiredOnlyWhenEnabled) {
+    Config current, candidate;
+    candidate.set("runtime_queue/max_dispatch_owners", 0);
+    candidate.set("runtime_queue/max_dispatch_bytes", 0);
+    candidate.set("runtime_queue/max_outstanding_owners", 0);
+    candidate.set("runtime_queue/max_outstanding_bytes", 0);
+    candidate.set("runtime_queue/mlu_local_threshold", -1.0);
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+    candidate.set("enable_runtime_queue", true);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_EQ(plan.candidate_diagnostics.size(), 2);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kCrossFieldConstraint,
+                              "runtime_queue/max_dispatch_owners"));
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kCrossFieldConstraint,
+                              "runtime_queue/max_dispatch_bytes"));
+}
+
+TEST(ConfigValidationTest, AccountsForDerivedProgressWorkerAndRpcDefaults) {
+    Config current, candidate;
+    current.set("enable_runtime_queue", true);
+    candidate.set("enable_runtime_queue", true);
+    candidate.set("enable_progress_worker", true);
+    EXPECT_TRUE(
+        planTentConfigChange(current, candidate, kCpuBuild).changes.empty());
+    current.set("transports/tcp/enable", true);
+    candidate.set("transports/tcp/enable", true);
+    candidate.set("rpc_server_threads", 8);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    candidate.set("transports/tcp/enable", false);
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasChange(plan, "transports/tcp/enable",
+                          Disposition::kRestartRequired));
+    // Explicit 8 preserves the previous effective thread count.
+    EXPECT_FALSE(
+        hasChange(plan, "rpc_server_threads", Disposition::kRestartRequired));
+}
+
+TEST(ConfigValidationTest, RpcDefaultChangesWithTcpEnablement) {
+    Config current, candidate;
+    candidate.set("transports/tcp/enable", true);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(plan.valid());
+    EXPECT_TRUE(
+        hasChange(plan, "rpc_server_threads", Disposition::kRestartRequired));
+    for (const auto count : {0U, 2U, 6U, 128U}) {
+        const auto expected = std::min(8U, std::max(4U, count));
+        Config explicit_threads;
+        explicit_threads.set("transports/tcp/enable", true);
+        explicit_threads.set("rpc_server_threads", expected);
+        const ConfigValidationContext context{{"tcp", "hp_tcp", "shm"}, count};
+        EXPECT_TRUE(planTentConfigChange(candidate, explicit_threads, context)
+                        .changes.empty());
+    }
+}
+
+TEST(ConfigValidationTest, BuildCapabilitiesApplyOnlyToExplicitEnables) {
+    Config current, candidate;
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+    candidate.set("transports/rdma/enable", true);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kBackendUnavailable,
+                              "transports/rdma/enable"));
+    auto rdma_build = kCpuBuild;
+    rdma_build.compiled_transports.push_back("rdma");
+    plan = planTentConfigChange(current, candidate, rdma_build);
+    EXPECT_TRUE(plan.valid());
+    EXPECT_TRUE(hasChange(plan, "transports/rdma/enable",
+                          Disposition::kRestartRequired));
+    candidate.set("transports/rdma/enable", false);
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+    candidate.set("transports/unknown/enable", true);
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasChange(plan, "transports/unknown/enable",
+                          Disposition::kUnsupported));
+}
+
+TEST(ConfigValidationTest, HpTcpRequiresExplicitlyDisablingDefaultTcp) {
+    Config current, candidate;
+    candidate.set("transports/hp_tcp/enable", true);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kCrossFieldConstraint,
+                              "transports/hp_tcp/enable"));
+    candidate.set("transports/tcp/enable", false);
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+    ASSERT_TRUE(candidate
+                    .load(R"({"transports/hp_tcp/enable":true,
+      "transports/tcp/enable":false})")
+                    .ok());
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidPath,
+                              "transports/hp_tcp/enable"));
+    ASSERT_TRUE(
+        candidate.load(R"({"transports":{"hp_tcp":{"enable":null}}})").ok());
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidType,
+                              "transports/hp_tcp/enable"));
+}
+
+TEST(ConfigValidationTest, OwnsInputsAndDoesNotChangePublishedSnapshots) {
+    Config current, candidate;
+    current.set("max_failover_attempts", 1);
+    candidate.set("max_failover_attempts", 5);
+    auto active = buildTentConfigBundle(current, 42).runtime;
+    auto before = current.dump();
+    auto next = candidate.dump();
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    ASSERT_TRUE(plan.valid());
+    EXPECT_EQ(current.dump(), before);
+    EXPECT_EQ(candidate.dump(), next);
+    current.set("max_failover_attempts", 8);
+    candidate.set("max_failover_attempts", 9);
+    EXPECT_EQ(plan.current->get("max_failover_attempts", -1), 1);
+    EXPECT_EQ(plan.candidate->get("max_failover_attempts", -1), 5);
+    EXPECT_EQ(active->generation, 42);
+    EXPECT_EQ(active->max_failover_attempts, 1);
+    candidate.set("rpc_server_port", -1);
+    auto rejected = planTentConfigChange(*plan.current, candidate, kCpuBuild);
+    EXPECT_FALSE(rejected.valid());
+    EXPECT_TRUE(rejected.changes.empty());
+    EXPECT_EQ(active->generation, 42);
+    EXPECT_EQ(active->max_failover_attempts, 1);
+}
+
+TEST(ConfigValidationTest, ReportsInvalidCurrentInputSeparately) {
+    Config current, candidate;
+    current.set("rpc_server_port", -1);
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_FALSE(plan.valid());
+    EXPECT_FALSE(plan.current_diagnostics.empty());
+    EXPECT_TRUE(plan.candidate_diagnostics.empty());
+    EXPECT_TRUE(plan.changes.empty());
+}
+
+TEST(ConfigValidationTest, BoundsOutputAndNeverIncludesValues) {
+    Config current, candidate;
+    candidate.set("rpc_server_port", "SECRET_TOKEN_VALUE");
+    auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    for (const auto& d : plan.candidate_diagnostics) {
+        EXPECT_EQ(d.message.find("SECRET_TOKEN_VALUE"), std::string::npos);
+    }
+    candidate.set(std::string(257, 'x'), true);
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kAnalysisLimitExceeded, "$"));
+
+    Config many_changes;
+    for (size_t i = 0; i < 129; ++i)
+        many_changes.set("key" + std::to_string(i), i);
+    plan = planTentConfigChange(current, many_changes, kCpuBuild);
+    EXPECT_FALSE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
+                              Code::kAnalysisLimitExceeded, "$"));
+
+    json bad_paths = json::object();
+    for (size_t i = 0; i < 100; ++i) bad_paths["/key" + std::to_string(i)] = i;
+    Config many_errors;
+    ASSERT_TRUE(many_errors.load(bad_paths.dump()).ok());
+    plan = planTentConfigChange(current, many_errors, kCpuBuild);
+    EXPECT_FALSE(plan.valid());
+    EXPECT_EQ(plan.candidate_diagnostics.size(), 64);
+    EXPECT_EQ(plan.candidate_diagnostics.back().code,
+              Code::kAnalysisLimitExceeded);
+}
+
+TEST(ConfigValidationTest, LimitsDepthAndInputCount) {
+    Config current, candidate;
+    std::string deep = "x";
+    for (size_t i = 0; i < 33; ++i) deep += "/x";
+    candidate.set(deep, 1);
+    EXPECT_FALSE(planTentConfigChange(current, candidate, kCpuBuild).valid());
+    Config many_values;
+    for (size_t i = 0; i < 4096; ++i)
+        many_values.set("key" + std::to_string(i), i);
+    auto plan = planTentConfigChange(many_values, many_values, kCpuBuild);
+    EXPECT_FALSE(plan.valid());
+    EXPECT_TRUE(hasDiagnostic(plan.current_diagnostics,
+                              Code::kAnalysisLimitExceeded, "$"));
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/config_validation_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_validation_test.cpp
@@ -18,24 +18,20 @@
 #include <limits>
 
 #include "tent/common/config_validation.h"
+#include "tent/common/config_parser.h"
 
 namespace mooncake {
 namespace tent {
 namespace {
 
-using Code = ConfigDiagnosticCode;
 using Disposition = ConfigChangeDisposition;
 
 const ConfigValidationContext kCpuBuild{{"tcp", "hp_tcp", "shm"}, 16};
 
-bool hasDiagnostic(const std::vector<ConfigDiagnostic>& diagnostics, Code code,
-                   const std::string& path) {
-    return std::any_of(diagnostics.begin(), diagnostics.end(),
-                       [&](const ConfigDiagnostic& d) {
-                           return d.code == code && d.path == path;
-                       });
+bool hasError(const Status& status, const std::string& reason) {
+    return status.IsInvalidArgument() &&
+           status.message().find(reason) != std::string_view::npos;
 }
-
 bool hasChange(const ConfigChangePlan& plan, const std::string& path,
                Disposition disposition) {
     return std::any_of(
@@ -161,8 +157,8 @@ TEST(ConfigValidationTest,
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
     EXPECT_FALSE(plan.valid());
     EXPECT_TRUE(plan.changes.empty());
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kAmbiguousPath,
-                              "runtime_queue/max_dispatch_owners"));
+    EXPECT_TRUE(
+        hasError(plan.candidate_status, "runtime_queue/max_dispatch_owners"));
     EXPECT_EQ(candidate.get("runtime_queue/max_dispatch_owners", 0), 8);
 }
 
@@ -178,14 +174,13 @@ TEST(ConfigValidationTest, RejectsMalformedPathsAndRootShapes) {
         auto plan = planTentConfigChange(current, candidate, kCpuBuild);
         EXPECT_FALSE(plan.valid()) << input;
         EXPECT_TRUE(plan.changes.empty());
-        EXPECT_EQ(plan.candidate_diagnostics.front().code, Code::kInvalidPath);
+        EXPECT_TRUE(plan.candidate_status.IsInvalidArgument());
     }
     for (const auto* input : {"[]", "123", "true", "\"object\""}) {
         Config candidate;
         ASSERT_TRUE(candidate.load(input).ok());
         auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-        EXPECT_TRUE(
-            hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidRoot, "$"));
+        EXPECT_TRUE(hasError(plan.candidate_status, "$"));
     }
 }
 
@@ -200,8 +195,7 @@ TEST(ConfigValidationTest, NullAndEmptyGroupsUseDefaults) {
     EXPECT_TRUE(plan.changes.empty());
     candidate.set("runtime_queue", 123);
     plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidType,
-                              "runtime_queue"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "runtime_queue"));
 }
 
 TEST(ConfigValidationTest, RejectsWrongTypesInsteadOfSilentlyDefaulting) {
@@ -225,8 +219,7 @@ TEST(ConfigValidationTest, RejectsWrongTypesInsteadOfSilentlyDefaulting) {
         candidate.set(path, value);
         auto plan = planTentConfigChange(current, candidate, kCpuBuild);
         EXPECT_FALSE(plan.valid()) << path;
-        EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                                  Code::kInvalidType, path));
+        EXPECT_TRUE(hasError(plan.candidate_status, path));
     }
 }
 
@@ -249,9 +242,7 @@ TEST(ConfigValidationTest, ChecksRangeBeforeIntegerNarrowing) {
         Config candidate;
         candidate.set(path, value);
         auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-        EXPECT_TRUE(
-            hasDiagnostic(plan.candidate_diagnostics, Code::kOutOfRange, path))
-            << path;
+        EXPECT_TRUE(hasError(plan.candidate_status, path)) << path;
     }
     Config candidate;
     candidate.set("rpc_server_port", 65535);
@@ -269,8 +260,8 @@ TEST(ConfigValidationTest, PreservesNonFiniteNumbersForValidation) {
         Config candidate;
         candidate.set("runtime_queue/mlu_local_threshold", value);
         auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-        EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kOutOfRange,
-                                  "runtime_queue/mlu_local_threshold"));
+        EXPECT_TRUE(hasError(plan.candidate_status,
+                             "runtime_queue/mlu_local_threshold"));
     }
 }
 
@@ -282,13 +273,10 @@ TEST(ConfigValidationTest, QueueReservesCannotExceedCapacity) {
     candidate.set("runtime_queue/staging_byte_reserve", 2);
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
     EXPECT_FALSE(plan.valid());
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kCrossFieldConstraint,
-                              "runtime_queue/staging_owner_reserve"));
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kCrossFieldConstraint,
-                              "runtime_queue/staging_byte_reserve"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "staging owner reserve"));
     candidate.set("runtime_queue/staging_owner_reserve", 1);
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasError(plan.candidate_status, "staging byte reserve"));
     candidate.set("runtime_queue/staging_byte_reserve", 1);
     EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
 }
@@ -303,13 +291,12 @@ TEST(ConfigValidationTest, QueueDispatchWindowsAreRequiredOnlyWhenEnabled) {
     EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
     candidate.set("enable_runtime_queue", true);
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_EQ(plan.candidate_diagnostics.size(), 2);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kCrossFieldConstraint,
-                              "runtime_queue/max_dispatch_owners"));
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kCrossFieldConstraint,
-                              "runtime_queue/max_dispatch_bytes"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "dispatch window"));
+    candidate.set("runtime_queue/max_dispatch_owners", 1);
+    plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasError(plan.candidate_status, "dispatch window"));
+    candidate.set("runtime_queue/max_dispatch_bytes", 1);
+    EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
 }
 
 TEST(ConfigValidationTest, AccountsForDerivedProgressWorkerAndRpcDefaults) {
@@ -357,9 +344,7 @@ TEST(ConfigValidationTest, BuildCapabilitiesApplyOnlyToExplicitEnables) {
     EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
     candidate.set("transports/rdma/enable", true);
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kBackendUnavailable,
-                              "transports/rdma/enable"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "transports/rdma/enable"));
     auto rdma_build = kCpuBuild;
     rdma_build.compiled_transports.push_back("rdma");
     plan = planTentConfigChange(current, candidate, rdma_build);
@@ -378,9 +363,8 @@ TEST(ConfigValidationTest, HpTcpRequiresExplicitlyDisablingDefaultTcp) {
     Config current, candidate;
     candidate.set("transports/hp_tcp/enable", true);
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kCrossFieldConstraint,
-                              "transports/hp_tcp/enable"));
+    EXPECT_TRUE(hasError(plan.candidate_status,
+                         "tcp and hp_tcp cannot be enabled together"));
     candidate.set("transports/tcp/enable", false);
     EXPECT_TRUE(planTentConfigChange(current, candidate, kCpuBuild).valid());
     ASSERT_TRUE(candidate
@@ -388,13 +372,11 @@ TEST(ConfigValidationTest, HpTcpRequiresExplicitlyDisablingDefaultTcp) {
       "transports/tcp/enable":false})")
                     .ok());
     plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidPath,
-                              "transports/hp_tcp/enable"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "transports/hp_tcp/enable"));
     ASSERT_TRUE(
         candidate.load(R"({"transports":{"hp_tcp":{"enable":null}}})").ok());
     plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics, Code::kInvalidType,
-                              "transports/hp_tcp/enable"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "transports/hp_tcp/enable"));
 }
 
 TEST(ConfigValidationTest, OwnsInputsAndDoesNotChangePublishedSnapshots) {
@@ -427,22 +409,58 @@ TEST(ConfigValidationTest, ReportsInvalidCurrentInputSeparately) {
     current.set("rpc_server_port", -1);
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
     EXPECT_FALSE(plan.valid());
-    EXPECT_FALSE(plan.current_diagnostics.empty());
-    EXPECT_TRUE(plan.candidate_diagnostics.empty());
+    EXPECT_FALSE(plan.current_status.ok());
+    EXPECT_TRUE(plan.candidate_status.ok());
     EXPECT_TRUE(plan.changes.empty());
+}
+
+TEST(ConfigValidationTest, ReportsBothInputErrorsUsingStatus) {
+    Config current, candidate;
+    current.set("rpc_server_port", -1);
+    candidate.set("merge_requests", "invalid-boolean");
+    const auto plan = planTentConfigChange(current, candidate, kCpuBuild);
+    EXPECT_TRUE(hasError(plan.current_status, "rpc_server_port"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "merge_requests"));
+    EXPECT_FALSE(plan.valid());
+    EXPECT_TRUE(plan.changes.empty());
+    EXPECT_NE(plan.candidate_status.ToString().find("InvalidArgument"),
+              std::string::npos);
+}
+
+TEST(ConfigValidationTest, SharedRpcParsersPreserveOutputOnInvalidInput) {
+    Config config;
+    uint16_t port = 1234;
+    size_t threads = 4;
+    config.set("rpc_server_port", std::numeric_limits<uint64_t>::max());
+    config.set("rpc_server_threads", "1025");
+    EXPECT_TRUE(
+        getRpcServerPortFromConfig(config, 0, port).IsInvalidArgument());
+    EXPECT_TRUE(
+        getRpcServerThreadsFromConfig(config, 1, threads).IsInvalidArgument());
+    EXPECT_EQ(port, 1234);
+    EXPECT_EQ(threads, 4);
+
+    config.set("rpc_server_port", "  +65535");
+    config.set("rpc_server_threads", "1024");
+    ASSERT_TRUE(getRpcServerPortFromConfig(config, 0, port).ok());
+    ASSERT_TRUE(getRpcServerThreadsFromConfig(config, 1, threads).ok());
+    EXPECT_EQ(port, 65535);
+    EXPECT_EQ(threads, 1024);
+    config.set("rpc_server_threads", nullptr);
+    ASSERT_TRUE(getRpcServerThreadsFromConfig(config, 8, threads).ok());
+    EXPECT_EQ(threads, 8);
 }
 
 TEST(ConfigValidationTest, BoundsOutputAndNeverIncludesValues) {
     Config current, candidate;
     candidate.set("rpc_server_port", "SECRET_TOKEN_VALUE");
     auto plan = planTentConfigChange(current, candidate, kCpuBuild);
-    for (const auto& d : plan.candidate_diagnostics) {
-        EXPECT_EQ(d.message.find("SECRET_TOKEN_VALUE"), std::string::npos);
-    }
+    EXPECT_TRUE(plan.candidate_status.IsInvalidArgument());
+    EXPECT_EQ(plan.candidate_status.message().find("SECRET_TOKEN_VALUE"),
+              std::string_view::npos);
     candidate.set(std::string(257, 'x'), true);
     plan = planTentConfigChange(current, candidate, kCpuBuild);
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kAnalysisLimitExceeded, "$"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "$"));
 
     Config many_changes;
     for (size_t i = 0; i < 129; ++i)
@@ -450,8 +468,7 @@ TEST(ConfigValidationTest, BoundsOutputAndNeverIncludesValues) {
     plan = planTentConfigChange(current, many_changes, kCpuBuild);
     EXPECT_FALSE(plan.valid());
     EXPECT_TRUE(plan.changes.empty());
-    EXPECT_TRUE(hasDiagnostic(plan.candidate_diagnostics,
-                              Code::kAnalysisLimitExceeded, "$"));
+    EXPECT_TRUE(hasError(plan.candidate_status, "$"));
 
     json bad_paths = json::object();
     for (size_t i = 0; i < 100; ++i) bad_paths["/key" + std::to_string(i)] = i;
@@ -459,9 +476,10 @@ TEST(ConfigValidationTest, BoundsOutputAndNeverIncludesValues) {
     ASSERT_TRUE(many_errors.load(bad_paths.dump()).ok());
     plan = planTentConfigChange(current, many_errors, kCpuBuild);
     EXPECT_FALSE(plan.valid());
-    EXPECT_EQ(plan.candidate_diagnostics.size(), 64);
-    EXPECT_EQ(plan.candidate_diagnostics.back().code,
-              Code::kAnalysisLimitExceeded);
+    EXPECT_TRUE(hasError(plan.candidate_status,
+                         "Invalid canonical configuration path"));
+    EXPECT_LT(plan.candidate_status.message().size(), 1024);
+    EXPECT_TRUE(plan.changes.empty());
 }
 
 TEST(ConfigValidationTest, LimitsDepthAndInputCount) {
@@ -475,8 +493,7 @@ TEST(ConfigValidationTest, LimitsDepthAndInputCount) {
         many_values.set("key" + std::to_string(i), i);
     auto plan = planTentConfigChange(many_values, many_values, kCpuBuild);
     EXPECT_FALSE(plan.valid());
-    EXPECT_TRUE(hasDiagnostic(plan.current_diagnostics,
-                              Code::kAnalysisLimitExceeded, "$"));
+    EXPECT_TRUE(hasError(plan.current_status, "$"));
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

TENT's immutable configuration bundles do not yet tell a caller whether a complete candidate is well-formed or which changes require a restart. This adds `planTentConfigChange(current, candidate, context)`, a side-effect-free validation and diff API for an initial set of fields. For example, changing `rpc_server_port` from 18080 to 28080 produces `kRestartRequired`, changing `merge_requests` produces `kRuntimeCandidate`, and changing an uncovered `policy` field produces `kUnsupported`.

This is the initial validation/planning slice of **PR2 in RFC #3833**, building on #3836. It complements the merged #3934: the analyzer reuses its failover defaults, while submission-time policy pinning, task handling, retries, and snapshot publication remain unchanged. The result is intended for future configuration diagnostics such as #2864.

The API:

- Owns frozen copies of both complete, already-loaded inputs and reports `current_status` and `candidate_status` separately. Each input stops at its first error using the existing `Status::InvalidArgument` convention, with the field/component and reason in the message. Inputs are not patches.
- Shares the RPC port/thread parsers, HP TCP boolean/unsigned-number parsing, TCP/HP TCP selection check, and runtime queue dispatch-window check with startup through `config_parser.h/.cpp`. Admission and preflight both call `QueueLimits::validate()` for reserve/capacity constraints.
- Checks canonical paths, conflicting flat/nested aliases, raw types, numeric ranges before narrowing, queue cross-field constraints, and explicitly enabled transports against a captured build context.
- Compares covered fields with their consumer defaults, including the derived RPC thread count and progress-worker setting. RPC integer strings remain supported; backend absence is preserved because device/environment selection is outside this API.
- Returns sorted path/disposition changes without embedding configuration values. Path, traversal, and change-count limits reject incomplete analysis rather than returning a partial plan. Validation uses ordinary functions and `CHECK_STATUS` propagation.
- Adds `Config::toJson()` to copy JSON under one lock without losing non-finite numbers through a dump/parse round trip.

**Initial coverage:** RPC hostname/port/threads, merge/failover settings, progress worker and runtime queue enablement, queue fields consumed by `construct()`, and transport enable flags. Detailed backend parameters, policy/QoS, metrics, and other uncovered fields may pass through unchanged; their additions, removals, or modifications are always `kUnsupported`. HP TCP enablement must use its nested transport object, matching its dedicated parser.

`valid()` means that validation within this documented scope succeeded; callers must still inspect every change disposition. `kRuntimeCandidate` is eligibility for a future consumer protocol, not a promise of live application. This PR does not add an update entry point, assign generations, publish snapshots, probe devices, or wire the complete preflight into startup. Startup reuses the extracted checks; loading precedence, accepted RPC types/ranges/defaults, and `Config::get()` fallback behavior are preserved. RPC error messages identify the field and constraint without echoing the configured value.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

CPU Debug build in WSL with GCC 15, CUDA/HIP disabled. All six targets passed, totaling 132 test cases. Hardware-dependent GPU/RDMA execution was not tested.

**Test commands:**

```bash
cmake --build build/clion-tent-debug --target \
  config_validation_test config_lifecycle_test admission_queue_test \
  transfer_engine_config_override_test tent_hp_tcp_transport_config_test \
  tent_engine_failover_e2e_test -j2
ctest --test-dir build/clion-tent-debug -R '^(config_validation_test|config_lifecycle_test|admission_queue_test)$' -V
ctest --test-dir build/clion-tent-debug -R '^(transfer_engine_config_override_test|tent_hp_tcp_transport_config_test|tent_engine_failover_e2e_test)$' -V

pre-commit run --files \
  mooncake-transfer-engine/tent/include/tent/common/config.h \
  mooncake-transfer-engine/tent/include/tent/common/config_parser.h \
  mooncake-transfer-engine/tent/include/tent/common/config_validation.h \
  mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h \
  mooncake-transfer-engine/tent/src/common/config.cpp \
  mooncake-transfer-engine/tent/src/common/config_parser.cpp \
  mooncake-transfer-engine/tent/src/common/config_validation.cpp \
  mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp \
  mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp \
  mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp \
  mooncake-transfer-engine/tent/tests/CMakeLists.txt \
  mooncake-transfer-engine/tent/tests/config_validation_test.cpp
git diff --cached --check
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass (local engine/fake transport coverage)
- [ ] Manual testing done (describe below)

`config_validation_test` passed **24 tests** covering defaults, alias/path handling, wrong types, overflow, non-finite numbers, cross-field constraints, build capabilities, unknown-field changes, output limits, frozen-input ownership, independent Status results for both inputs, and shared RPC parser output preservation on failure.

Regression checks: `config_lifecycle_test` passed **16 tests**; `admission_queue_test` passed **41 tests**; `tent_engine_failover_e2e_test` passed **30 tests**, including both #3934 `PolicyIsPinnedAtSubmit` cases; `transfer_engine_config_override_test` passed **14 tests**; `tent_hp_tcp_transport_config_test` passed **7 tests**. Scoped pre-commit checks passed with clang-format 20.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

The API contract, validation scope, and limits are documented in `config_validation.h`. RFC: #3833.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with implementation, test development/execution, and this PR description. The human submitter reviewed the code and directed reuse of the repository's existing validation routines and Status convention.
