### PR TITLE
[Integration] Release GIL during single memory registration

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -909,11 +909,13 @@ int TransferEnginePy::batchUnregisterMemory(
 
 int TransferEnginePy::registerMemory(uintptr_t buffer_addr, size_t capacity,
                                      const std::string& location) {
+    pybind11::gil_scoped_release release;
     char* buffer = reinterpret_cast<char*>(buffer_addr);
     return engine_->registerLocalMemory(buffer, capacity, location);
 }
 
 int TransferEnginePy::unregisterMemory(uintptr_t buffer_addr) {
+    pybind11::gil_scoped_release release;
     char* buffer = reinterpret_cast<char*>(buffer_addr);
     return engine_->unregisterLocalMemory(buffer);
 }

--- a/mooncake-wheel/tests/test_transfer_engine_gil.py
+++ b/mooncake-wheel/tests/test_transfer_engine_gil.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Verify that single-buffer registration does not block other Python threads."""
+
+import ctypes
+import mmap
+import socket
+import sys
+import threading
+import unittest
+from collections.abc import Callable
+
+from mooncake.engine import TransferEngine
+
+
+class _OneShotWorker:
+    def __init__(self) -> None:
+        self.arm = threading.Event()
+        self.ran = threading.Event()
+        self.ready = threading.Event()
+        self.stop = threading.Event()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        self.ready.set()
+        while not self.stop.is_set():
+            if not self.arm.wait(timeout=0.1):
+                continue
+            self.arm.clear()
+            if not self.stop.is_set():
+                self.ran.set()
+
+    def start(self) -> None:
+        self.thread.start()
+        if not self.ready.wait(timeout=5):
+            raise RuntimeError("worker did not start")
+
+    def observe(self, call: Callable[[int], int], max_calls: int) -> tuple[bool, int]:
+        self.ran.clear()
+        self.arm.set()
+        calls_attempted = 0
+        for index in range(max_calls):
+            result = call(index)
+            if result != 0:
+                raise RuntimeError(f"memory registration returned {result}")
+            calls_attempted += 1
+            if self.ran.is_set():
+                break
+        self.arm.clear()
+        return self.ran.is_set(), calls_attempted
+
+    def close(self) -> None:
+        self.stop.set()
+        self.arm.set()
+        self.thread.join(timeout=5)
+
+
+class TestTransferEngineGil(unittest.TestCase):
+    def test_single_memory_registration_releases_gil(self) -> None:
+        max_calls = 2048
+        region_size = 4096
+        region = mmap.mmap(-1, max_calls * region_size)
+        base_address = ctypes.addressof(ctypes.c_char.from_buffer(region))
+        ctypes.memset(base_address, 0, max_calls * region_size)
+        addresses = [base_address + i * region_size for i in range(max_calls)]
+        sizes = [region_size] * max_calls
+
+        engine = TransferEngine()
+        hostname = socket.gethostbyname(socket.gethostname())
+        self.assertEqual(
+            engine.initialize(f"{hostname}:0", "P2PHANDSHAKE", "tcp", ""), 0
+        )
+
+        worker = _OneShotWorker()
+        worker.start()
+        old_switch_interval = sys.getswitchinterval()
+        sys.setswitchinterval(10.0)
+        registered: set[int] = set()
+        register_observed = False
+        unregister_observed = False
+        try:
+
+            def register_one(index: int) -> int:
+                result = engine.register_memory(addresses[index], region_size)
+                if result == 0:
+                    registered.add(addresses[index])
+                return result
+
+            register_observed, _ = worker.observe(register_one, max_calls)
+            self.assertEqual(engine.batch_unregister_memory(list(registered)), 0)
+            registered.clear()
+
+            self.assertEqual(engine.batch_register_memory(addresses, sizes), 0)
+            registered.update(addresses)
+
+            def unregister_one(index: int) -> int:
+                result = engine.unregister_memory(addresses[index])
+                if result == 0:
+                    registered.discard(addresses[index])
+                return result
+
+            unregister_observed, _ = worker.observe(unregister_one, max_calls)
+            self.assertEqual(engine.batch_unregister_memory(list(registered)), 0)
+            registered.clear()
+        finally:
+            if registered:
+                engine.batch_unregister_memory(list(registered))
+            sys.setswitchinterval(old_switch_interval)
+            worker.close()
+            region.close()
+
+        self.assertTrue(register_observed, "register_memory retained the GIL")
+        self.assertTrue(unregister_observed, "unregister_memory retained the GIL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -43,6 +43,7 @@ pip install torch numpy
 python -c "import mooncake._fast_copy"
 python tests/test_fast_copy.py
 python tests/test_import_structure.py
+python tests/test_transfer_engine_gil.py
 
 echo "Running mooncake config test..."
 python tests/test_mooncake_config.py


### PR DESCRIPTION
# [Integration] Release GIL during single memory registration

## Description

`TransferEngine.register_memory()` and `unregister_memory()` currently keep the
Python GIL while their native `registerLocalMemory()` and
`unregisterLocalMemory()` calls execute. The batch wrappers already release the
GIL around the corresponding native calls.

This change applies the same scoped release to the single-buffer wrappers.
Python argument conversion remains before the C++ method, pybind11 reacquires
the GIL before converting the return value, and native address, length,
location, metadata, ordering, and error behavior are unchanged.

The regression test arms another Python thread before a bounded series of TCP
host-memory registration calls. It passes only when that thread can run during
both the single-register and single-unregister native spans. This is adjacent
to the GIL work in #300 and #3947 and the batch wrappers in #2191, but a current
open-PR search found no exact duplicate for these two wrappers.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Source: base `9cfb33810629f91b07e913ad3fdaf478287f31b9`, candidate
`b41d8e7b1f16c803bac65b486fec65a8bdf3b9f1`.

The build and wheel commands below were run in a repository-devcontainer-derived
Linux image, with the repository mounted at `/src`:

**Test commands:**

```bash
cmake -S /src -B /build \
  -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DWITH_TE=ON \
  -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=ON \
  -DUSE_CUDA=OFF -DUSE_ETCD=OFF -DUSE_REDIS=OFF -DUSE_HTTP=ON
cmake --build /build --target engine transfer_engine_bench -j2

NON_CUDA_BUILD=1 PYTHON_VERSION=3.10 \
  OUTPUT_DIR=/evidence/dist ./scripts/build_wheel.sh

/usr/bin/python3.10 -m virtualenv /tmp/mooncake-gil-venv
source /tmp/mooncake-gil-venv/bin/activate
python -m pip install /evidence/dist/mooncake_transfer_engine_non_cuda-*.whl
python /src/mooncake-wheel/tests/test_transfer_engine_gil.py -v
python -m pip check

pre-commit run --files \
  mooncake-integration/transfer_engine/transfer_engine_py.cpp \
  mooncake-wheel/tests/test_transfer_engine_gil.py \
  scripts/test_installation.sh
git diff --check origin/main...HEAD
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass (TCP host memory)
- [x] Manual testing done (exact unchanged-control/candidate comparison)

The candidate passed 10/10 isolated direct-module runs and 10/10 isolated runs
after fresh installation of its locally built non-CUDA wheel. The exact
unchanged control failed 3/3 because both wrappers retained the GIL. A separate
sealed probe observed both candidate wrappers release the GIL in 2/2 repeats
and both control wrappers retain it in 2/2 repeats; every registration call
returned zero.

The exact candidate configured, compiled, linked, built a repaired wheel,
installed into a fresh Python 3.10 environment, passed `pip check`, and had no
unresolved dynamic dependencies in the build container. PR-scoped pre-commit
passed.

No GPU or RDMA runtime was used. This PR claims only that the single-buffer
Python wrappers no longer retain the GIL during their native calls. It does not
claim lower native registration latency, RDMA throughput, GPU speedup, or
end-to-end workload improvement.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: no public API or configuration change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable: 119 lines including tests)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with source auditing, implementation, regression-test
design, and qualification. The human submitter remains responsible for
reviewing every changed line and defending the change before submission.