### PR TITLE
[Store] Fix snapshot restore deadlock for unready segments

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -10715,16 +10715,27 @@ tl::expected<void, SerializationError> MasterService::ApplySnapshotState(
                 segment_name);
         }
 
-        ScopedSegmentAccess segment_access =
-            segment_manager_.getSegmentAccess();
         std::vector<std::pair<Segment, UUID>> unready_segments;
-        if (segment_access.GetUnreadySegments(unready_segments) ==
-            ErrorCode::OK) {
-            for (const auto& [segment, client_id] : unready_segments) {
-                UnmountSegment(segment.id, client_id);
+        {
+            // Copy the records while holding the segment lock. UnmountSegment
+            // acquires the same lock, so it must run after this accessor is
+            // destroyed or snapshot restore deadlocks on an unready segment.
+            ScopedSegmentAccess segment_access =
+                segment_manager_.getSegmentAccess();
+            (void)segment_access.GetUnreadySegments(unready_segments);
+        }
+        for (const auto& [segment, client_id] : unready_segments) {
+            auto unmount_result = UnmountSegment(segment.id, client_id);
+            if (!unmount_result &&
+                unmount_result.error() != ErrorCode::SEGMENT_NOT_FOUND) {
+                LOG(WARNING)
+                    << "[Restore] Failed to unmount unready segment "
+                    << segment.name << ": " << toString(unmount_result.error());
             }
         }
 
+        ScopedSegmentAccess segment_access =
+            segment_manager_.getSegmentAccess();
         std::vector<std::pair<Segment, UUID>> all_segments;
         auto err = segment_access.GetAllSegments(all_segments);
 

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -132,6 +132,23 @@ TEST_F(MasterServiceSnapshotTest, MountUnmountSegmentWithOffsetAllocator) {
     EXPECT_TRUE(unmount_result4.has_value());
 }
 
+TEST_F(MasterServiceSnapshotTest,
+       ApplySnapshotStateUnmountsUnreadySegmentsWithoutDeadlocking) {
+    service_.reset(new MasterService());
+    const auto context = PrepareSimpleSegment(*service_);
+
+    auto graceful_unmount_result = service_->GracefulUnmountSegment(
+        context.segment_id, context.client_id, /*grace_period_ms=*/60000);
+    ASSERT_TRUE(graceful_unmount_result.has_value());
+
+    // ApplySnapshotState must release its segment accessor before calling
+    // UnmountSegment, which acquires the same non-recursive mutex.
+    auto result = ApplySnapshotStateForTest(*service_);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_FALSE(
+        service_->QuerySegmentStatusById(context.segment_id).has_value());
+}
+
 TEST_F(MasterServiceSnapshotTest, RandomMountUnmountSegment) {
     service_.reset(new MasterService());
     // Define a constant buffer address for the segment.

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -159,6 +159,11 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         return {.segment_id = segment.id, .client_id = client_id};
     }
 
+    tl::expected<void, SerializationError> ApplySnapshotStateForTest(
+        MasterService& service) const {
+        return service.ApplySnapshotState(std::chrono::system_clock::now());
+    }
+
     // ==================== Snapshot Helper Methods ====================
 
     // Wrapper method: Call MasterSnapshotManager's PersistState through


### PR DESCRIPTION
## Description

`MasterService::ApplySnapshotState()` held a `ScopedSegmentAccess` while
calling `UnmountSegment()` for unready segments.

`ScopedSegmentAccess` owns the segment manager's non-recursive
`std::shared_mutex`, and `UnmountSegment()` acquires the same lock again.
When a snapshot contains a segment in a non-OK lifecycle state, snapshot
restore can deadlock permanently while cleaning up that segment.

This change copies unready segment records while holding the segment lock,
releases the accessor, and then unmounts the segments. Unexpected unmount
errors are also logged.

A regression test covers snapshot restore with a
`GRACEFULLY_UNMOUNTING` segment.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target master_service_test_for_snapshot -j4
./build/mooncake-store/tests/master_service_test_for_snapshot \
  --gtest_filter=MasterServiceSnapshotTest.ApplySnapshotStateUnmountsUnreadySegmentsWithoutDeadlocking
./build/mooncake-store/tests/master_service_test_for_snapshot \
  --gtest_filter=MasterServiceSnapshotTest.*
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (not applicable; the restore path is covered by the unit test)

The focused regression test passed, and all 70
`MasterServiceSnapshotTest` tests passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `clang-format`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

AI assistance was used for this contribution.