### PR TITLE
[Bugfix] Align NoF allocation offsets to the namespace block size

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2187,11 +2187,12 @@ PYBIND11_MODULE(store, m) {
                 const std::string &nqn = "", size_t nsid = 1,
                 const std::string &traddr = "", size_t trsvcid = 4420,
                 uintptr_t base = 0x0, size_t size = 1024,
-                const std::string &master_server_addr = "127.0.0.1:50051") {
+                const std::string &master_server_addr = "127.0.0.1:50051",
+                uint32_t block_size = 0) {
                  self.register_ = std::make_shared<NoFRegisterClient>();
-                 return self.register_->set_register(nqn, nsid, traddr, trsvcid,
-                                                     base, size,
-                                                     master_server_addr);
+                 return self.register_->set_register(
+                     nqn, nsid, traddr, trsvcid, base, size, master_server_addr,
+                     block_size);
              })
         .def("real_unregister_by_endpoint",
              [](MooncakeDistributedNoFRegisterPyWrapper &self,

--- a/mooncake-store/include/allocator.h
+++ b/mooncake-store/include/allocator.h
@@ -356,7 +356,8 @@ class OffsetBufferAllocator
    public:
     OffsetBufferAllocator(std::string segment_name, size_t base, size_t size,
                           std::string transport_endpoint,
-                          ReplicaType replica_type = ReplicaType::MEMORY);
+                          ReplicaType replica_type = ReplicaType::MEMORY,
+                          uint32_t min_alignment_bytes = 1);
 
     ~OffsetBufferAllocator() override;
 
@@ -419,7 +420,8 @@ tl::expected<std::shared_ptr<BufferAllocatorBase>, ErrorCode>
 CreateBufferAllocator(BufferAllocatorType allocator_type,
                       std::string segment_name, size_t base, size_t size,
                       std::string transport_endpoint,
-                      ReplicaType replica_type = ReplicaType::MEMORY);
+                      ReplicaType replica_type = ReplicaType::MEMORY,
+                      uint32_t min_alignment_bytes = 1);
 
 // The main difference is that it allocates real memory and returns it, while
 // BufferAllocator allocates an address

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -126,8 +126,9 @@ std::ostream& operator<<(std::ostream& os,
 
 // Wrapper class for __Allocator, it 1) supports thread-safe allocation and
 // deallocation, 2) supports creating a buffer or allocating a memory region
-// that is larger than the largest bin size (3.75GB). The __allocator class is
-// also optimized to:
+// that is larger than the largest bin size (3.75GB), and 3) supports a
+// configurable power-of-two minimum allocation unit via min_alignment_bytes.
+// The __allocator class is also optimized to:
 // 1) round up the allocated size to a bin size. This will a) slightly decrease
 // the memory utilization ratio in general cases, b) makes no difference when
 // the allocated size is equal to a bin size, c) largely improve the memory
@@ -142,7 +143,7 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // Factory method to create shared_ptr<OffsetAllocator>
     static std::shared_ptr<OffsetAllocator> create(
         uint64_t base, size_t size, uint32 init_capacity = 128 * 1024,
-        uint32 max_capacity = (1 << 20));
+        uint32 max_capacity = (1 << 20), uint32 min_alignment_bytes = 1);
 
     // Disable copy constructor and copy assignment
     OffsetAllocator(const OffsetAllocator&) = delete;
@@ -227,7 +228,7 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
 
     // Private constructor - use create() factory method instead
     OffsetAllocator(uint64_t base, size_t size, uint32 init_capacity,
-                    uint32 max_capacity);
+                    uint32 max_capacity, uint32 min_alignment_bytes);
 
     // Private constructor for creating from saved state with pre-constructed
     // allocator This constructor is used during deserialization when we already

--- a/mooncake-store/include/ssd_register_client.h
+++ b/mooncake-store/include/ssd_register_client.h
@@ -16,7 +16,8 @@ class NoFRegisterClient {
 
     int set_register(const std::string &nqn, size_t nsid,
                      const std::string &traddr, size_t trsvcid, uintptr_t base,
-                     size_t size, const std::string &master_server_addr);
+                     size_t size, const std::string &master_server_addr,
+                     uint32_t block_size);
 
     /**
      * @brief Unregister a NoF SSD segment by its te_endpoint

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -466,9 +466,11 @@ struct NoFSegment {
     size_t size{0};
     // TE p2p endpoint (ip:port) for transport-only addressing
     std::string te_endpoint{};
+    // Logical block size in bytes
+    uint32_t block_size{0};
     NoFSegment() = default;
 };
-YLT_REFL(NoFSegment, id, name, base, size, te_endpoint);
+YLT_REFL(NoFSegment, id, name, base, size, te_endpoint, block_size);
 
 /**
  * @brief Client status from the master's perspective

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -152,8 +152,8 @@ CachelibBufferAllocator::Create(std::string segment_name, size_t base,
 tl::expected<std::shared_ptr<BufferAllocatorBase>, ErrorCode>
 CreateBufferAllocator(BufferAllocatorType allocator_type,
                       std::string segment_name, size_t base, size_t size,
-                      std::string transport_endpoint,
-                      ReplicaType replica_type) {
+                      std::string transport_endpoint, ReplicaType replica_type,
+                      uint32_t min_alignment_bytes) {
     switch (allocator_type) {
         case BufferAllocatorType::CACHELIB: {
             auto allocator = CachelibBufferAllocator::Create(
@@ -170,7 +170,8 @@ CreateBufferAllocator(BufferAllocatorType allocator_type,
             return std::shared_ptr<BufferAllocatorBase>(
                 std::make_shared<OffsetBufferAllocator>(
                     std::move(segment_name), base, size,
-                    std::move(transport_endpoint), replica_type));
+                    std::move(transport_endpoint), replica_type,
+                    min_alignment_bytes));
         default:
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -345,7 +346,8 @@ std::optional<RestoredCachelibBufferAllocator> ImportCachelibBufferAllocator(
 OffsetBufferAllocator::OffsetBufferAllocator(std::string segment_name,
                                              size_t base, size_t size,
                                              std::string transport_endpoint,
-                                             ReplicaType replica_type)
+                                             ReplicaType replica_type,
+                                             uint32_t min_alignment_bytes)
     : segment_name_(segment_name),
       base_(base),
       total_size_(size),
@@ -370,7 +372,7 @@ OffsetBufferAllocator::OffsetBufferAllocator(std::string segment_name,
         // Create the offset allocator
         offset_allocator_ = offset_allocator::OffsetAllocator::create(
             base, size, static_cast<uint32_t>(init_capacity),
-            static_cast<uint32_t>(max_capacity));
+            static_cast<uint32_t>(max_capacity), min_alignment_bytes);
         if (!offset_allocator_) {
             LOG(ERROR) << "status=failed_to_create_offset_allocator";
             throw std::runtime_error("Failed to create offset allocator");

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -532,28 +532,29 @@ OffsetAllocationHandle::~OffsetAllocationHandle() {
 }
 
 // Helper function to calculate the multiplier
-static uint64_t calculateMultiplier(size_t size) {
+static uint64_t calculateMultiplier(size_t size, uint32 min_alignment_bytes) {
     uint64_t multiplier_bits = 0;
-    for (; SmallFloat::MAX_BIN_SIZE < (size >> multiplier_bits);
+    for (; (uint64_t{1} << multiplier_bits) < min_alignment_bytes ||
+           SmallFloat::MAX_BIN_SIZE < (size >> multiplier_bits);
          multiplier_bits++) {
     }
     return multiplier_bits;
 }
 
 // Thread-safe OffsetAllocator implementation
-std::shared_ptr<OffsetAllocator> OffsetAllocator::create(uint64_t base,
-                                                         size_t size,
-                                                         uint32 init_capacity,
-                                                         uint32 max_capacity) {
+std::shared_ptr<OffsetAllocator> OffsetAllocator::create(
+    uint64_t base, size_t size, uint32 init_capacity, uint32 max_capacity,
+    uint32 min_alignment_bytes) {
     // Use a custom deleter to allow private constructor
-    return std::shared_ptr<OffsetAllocator>(
-        new OffsetAllocator(base, size, init_capacity, max_capacity));
+    return std::shared_ptr<OffsetAllocator>(new OffsetAllocator(
+        base, size, init_capacity, max_capacity, min_alignment_bytes));
 }
 
 OffsetAllocator::OffsetAllocator(uint64_t base, size_t size,
-                                 uint32 init_capacity, uint32 max_capacity)
+                                 uint32 init_capacity, uint32 max_capacity,
+                                 uint32 min_alignment_bytes)
     : m_base(base),
-      m_multiplier_bits(calculateMultiplier(size)),
+      m_multiplier_bits(calculateMultiplier(size, min_alignment_bytes)),
       m_capacity(size) {
     m_allocator = std::make_unique<__Allocator>(size >> m_multiplier_bits,
                                                 init_capacity, max_capacity);

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1270,6 +1270,12 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
                                                const UUID& client_id) {
     const uintptr_t buffer = segment.base;
     const size_t size = segment.size;
+    const uint32_t block_size = segment.block_size;
+
+    if (block_size < 512 || (block_size & (block_size - 1)) != 0) {
+        LOG(ERROR) << "NoF segment mount: invalid block_size=" << block_size;
+        return ErrorCode::INVALID_PARAMS;
+    }
 
     // NoF segment base is an NVMe namespace offset, so 0 is valid.
     if (size == 0) {

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1284,6 +1284,13 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
         return ErrorCode::INVALID_PARAMS;
     }
 
+    if (buffer % block_size != 0 || size % block_size != 0) {
+        LOG(ERROR) << "NoF segment mount: buffer=" << buffer
+                   << ", size=" << size
+                   << " is not aligned to block_size=" << block_size;
+        return ErrorCode::INVALID_PARAMS;
+    }
+
     if (nof_segment_manager_->memory_allocator_ ==
             BufferAllocatorType::CACHELIB &&
         (buffer % facebook::cachelib::Slab::kSize ||
@@ -1325,7 +1332,7 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
 
     auto created = CreateBufferAllocator(
         nof_segment_manager_->memory_allocator_, segment.name, buffer, size,
-        segment.te_endpoint, ReplicaType::NOF_SSD);
+        segment.te_endpoint, ReplicaType::NOF_SSD, block_size);
     if (!created) {
         return created.error();
     }

--- a/mooncake-store/src/ssd_register_client.cpp
+++ b/mooncake-store/src/ssd_register_client.cpp
@@ -12,11 +12,17 @@ NoFRegisterClient::~NoFRegisterClient() = default;
 int NoFRegisterClient::set_register(const std::string &nqn, size_t nsid,
                                     const std::string &traddr, size_t trsvcid,
                                     uintptr_t base, size_t size,
-                                    const std::string &master_server_addr) {
+                                    const std::string &master_server_addr,
+                                    uint32_t block_size) {
+    if (block_size < 512 || (block_size & (block_size - 1)) != 0) {
+        LOG(ERROR) << "Invalid NoF namespace block_size=" << block_size;
+        return OPERATION_FAILED;
+    }
+
     LOG(INFO) << "Registering SSD: nqn=" << nqn << ",nsid=" << nsid
               << ",traddr=" << traddr << ",trsvcid=" << trsvcid
               << ",master=" << master_server_addr << ",base=" << base
-              << ",size=" << size;
+              << ",size=" << size << ",block_size=" << block_size;
 
     auto err = master_client_.Connect(master_server_addr);
     if (err != ErrorCode::OK) {
@@ -37,6 +43,7 @@ int NoFRegisterClient::set_register(const std::string &nqn, size_t nsid,
     segment.id = generate_uuid();
     segment.name = te_endpoint;
     segment.te_endpoint = te_endpoint;
+    segment.block_size = block_size;
     auto mount_result = master_client_.MountNoFSegment(segment);
     if (!mount_result) {
         LOG(ERROR) << "mount_segment_to_master_failed ";

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -395,6 +395,7 @@ class MasterServiceHATest : public ::testing::Test {
         segment.base = base;
         segment.size = size;
         segment.te_endpoint = std::move(endpoint);
+        segment.block_size = 512;
         return segment;
     }
 #endif

--- a/mooncake-store/tests/master_service/dsl/scenario.cpp
+++ b/mooncake-store/tests/master_service/dsl/scenario.cpp
@@ -2151,6 +2151,7 @@ bool MasterScenario::EnsureService() {
         segment.base = next_segment_base_;
         segment.size = node.capacity;
         segment.te_endpoint = node.endpoint;
+        segment.block_size = 512;
         next_segment_base_ += node.capacity + 4096;
 
         const auto owner = node.owner.empty() ? node.name : node.owner;

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -160,6 +160,7 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         segment.base = kSegmentBase + next_segment_offset_;
         segment.size = size;
         segment.te_endpoint = segment.name;
+        segment.block_size = 512;
         next_segment_offset_ += size + 4096;
 
         UUID client_id = generate_uuid();

--- a/mooncake-store/tests/master_service_test_fixture.h
+++ b/mooncake-store/tests/master_service_test_fixture.h
@@ -328,6 +328,7 @@ class MasterServiceTest : public ::testing::Test {
         segment.base = base;
         segment.size = size;
         segment.te_endpoint = std::move(endpoint);
+        segment.block_size = 512;
         return segment;
     }
 #endif

--- a/mooncake-store/tests/nof_heartbeat_test.cpp
+++ b/mooncake-store/tests/nof_heartbeat_test.cpp
@@ -24,6 +24,7 @@ NoFSegment MakeNoFSegment(std::string name, std::string endpoint,
     segment.base = base;
     segment.size = size;
     segment.te_endpoint = std::move(endpoint);
+    segment.block_size = 512;
     return segment;
 }
 

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -559,6 +559,23 @@ TEST_F(OffsetAllocatorTest, BasicAllocation) {
     EXPECT_NE(handle2->address(), OffsetAllocation::NO_SPACE);
 }
 
+TEST_F(OffsetAllocatorTest, MinimumAlignment) {
+    constexpr uint64_t BASE = 4096;
+    for (uint32 min_alignment_bytes : {512u, 4096u}) {
+        SCOPED_TRACE(min_alignment_bytes);
+        auto allocator = OffsetAllocator::create(BASE, 64 * 1024 * 1024, 16, 16,
+                                                 min_alignment_bytes);
+        auto first = allocator->allocate(513);
+        auto second = allocator->allocate(512);
+        ASSERT_TRUE(first.has_value());
+        ASSERT_TRUE(second.has_value());
+        EXPECT_EQ(first->size(), 513u);
+        EXPECT_EQ(first->address(), BASE);
+        EXPECT_EQ(second->address(),
+                  BASE + (min_alignment_bytes == 512 ? 1024 : 4096));
+    }
+}
+
 // Test allocation failure when out of space
 TEST_F(OffsetAllocatorTest, AllocationFailure) {
     constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024 * 1024;  // 1GB

--- a/mooncake-store/tests/segment_test.cpp
+++ b/mooncake-store/tests/segment_test.cpp
@@ -466,6 +466,7 @@ TEST_F(SegmentTest, NoFUsageSnapshotSurvivesMetricsReset) {
     segment.size = kSegmentSize;
     segment.base = 0x300000000;
     segment.te_endpoint = "nof_usage_snapshot_endpoint";
+    segment.block_size = 512;
     UUID client_id = generate_uuid();
 
     {
@@ -520,6 +521,26 @@ TEST_F(SegmentTest, NoFUsageSnapshotSurvivesMetricsReset) {
     allocator.reset();
     EXPECT_EQ(segment_manager.GetUsage().used_bytes, 0u);
     EXPECT_EQ(segment_manager.GetUsage().capacity_bytes, 0u);
+}
+
+TEST_F(SegmentTest, NoFMountRejectsInvalidBlockSizes) {
+    NoFSegmentManager manager(BufferAllocatorType::OFFSET);
+    const UUID client_id = generate_uuid();
+    auto access = manager.getNoFSegmentAccess();
+    NoFSegment segment;
+    segment.id = generate_uuid();
+    segment.name = "nof_invalid_block_size";
+    segment.size = 16 * 1024 * 1024;
+    segment.te_endpoint = segment.name;
+    for (uint32_t block_size : {0u, 1u, 256u, 513u, 768u, 4095u}) {
+        SCOPED_TRACE(block_size);
+        segment.block_size = block_size;
+        EXPECT_EQ(access.MountSegment(segment, client_id),
+                  ErrorCode::INVALID_PARAMS);
+    }
+    std::vector<MountedNoFSegmentSnapshot> mounted;
+    EXPECT_EQ(access.GetMountedSegments(mounted), ErrorCode::OK);
+    EXPECT_TRUE(mounted.empty());
 }
 
 // MountSegmentDuplicate Tests:

--- a/mooncake-wheel/mooncake/mooncake_ssd_register.py
+++ b/mooncake-wheel/mooncake/mooncake_ssd_register.py
@@ -191,7 +191,7 @@ class MooncakeNoFRegister:
                             continue
 
                         bdev = bdevs[0]
-                        block_size = bdev.get('block_size', 512)
+                        block_size = bdev['block_size']
                         num_blocks = bdev.get('num_blocks', 0)
                         size = block_size * num_blocks
 
@@ -203,12 +203,13 @@ class MooncakeNoFRegister:
                             'trsvcid': int(trsvcid),  # Ensure trsvcid is integer
                             'base': 0,
                             'size': size,
+                            'block_size': block_size,
                             'master_server_address': master_server_address,
                             'metadata_server': ''
                         }
 
                         ssd_configs.append(ssd_config)
-                        logging.info(f"Found SSD: nqn={nqn}, nsid={nsid}, traddr={traddr}, size={size}")
+                        logging.info(f"Found SSD: nqn={nqn}, nsid={nsid}, traddr={traddr}, size={size}, block_size={block_size}")
 
             except Exception as e:
                 logging.error(f"Failed to get SSD info from {ip}: {e}")
@@ -244,7 +245,8 @@ class MooncakeNoFRegister:
                     cfg["trsvcid"],
                     cfg["base"],
                     cfg["size"],
-                    cfg["master_server_address"]
+                    cfg["master_server_address"],
+                    cfg["block_size"]
                 )
 
                 if ret != 0:


### PR DESCRIPTION
## Description

Fixes https://github.com/kvcache-ai/Mooncake/issues/4021

NoF allocations could return offsets that were not aligned to the namespace block size, causing the client to reject I/O during alignment checks.

This PR addresses the problem in two commits:

- Report each namespace's `block_size` from the existing bdev query, or accept an explicit value through the C++/Python registration APIs
- Use the namespace block size as the minimum allocation unit for NoF and reject segments with unaligned bases or sizes

NoF block sizes must be powers of two and at least 512 bytes. The registration APIs now require `block_size`, and the `NoFSegment` RPC schema changes. Masters and clients exchanging this type must be upgraded together.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with analysis, implementation, tests, and build verification.