### PR TITLE
[Bugfix][TE] Fix Ascend LocalCopyEngine stream/context for multi-device async copy

### DIFF
--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/local_copy_engine.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/local_copy_engine.h
@@ -16,6 +16,8 @@
 #ifndef LOCAL_COPY_ENGINE_H
 #define LOCAL_COPY_ENGINE_H
 
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 
 #include <acl/acl.h>
@@ -35,8 +37,8 @@ class LocalCopyEngine {
 
     ~LocalCopyEngine();
 
-    // Initialize the local copy engine. Creates and owns its own ACL stream
-    // for async operations internally.
+    // Initialize the local copy engine. Streams are created lazily per device
+    // under that device's current ACL context (not at Initialize time).
     // transfer_timeout: timeout in milliseconds for sync operations
     // Returns 0 on success, non-zero on failure
     int Initialize(int32_t transfer_timeout);
@@ -76,8 +78,25 @@ class LocalCopyEngine {
                                          aclrtPtrAttributes &src_attrs,
                                          aclrtPtrAttributes &dst_attrs);
 
+    // Return (or lazily create) a stream belonging to the current ACL device
+    // context. The stream must be created while that device's context is
+    // current so aclrtMemcpyAsync does not return 107003.
+    aclrtStream GetOrCreateStreamForCurrentDevice();
+
    private:
-    aclrtStream stream_;
+    // Stream plus the ACL context it was created under. Destroying a stream
+    // requires that same context to be current, otherwise aclrtDestroyStream
+    // can return 107003 (ACL_ERROR_RT_STREAM_CONTEXT).
+    struct DeviceStream {
+        aclrtStream stream = nullptr;
+        aclrtContext context = nullptr;
+    };
+
+    // Per-device streams keyed by ACL device id. A single shared stream is
+    // unsafe across devices because Initialize() may run under device0
+    // context while workers later copy under other device contexts.
+    std::unordered_map<int32_t, DeviceStream> streams_;
+    mutable std::mutex streams_mu_;
     int32_t transfer_timeout_;
     bool initialized_;
 };

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp
@@ -49,11 +49,13 @@ int LocalCopyEngine::Initialize(int32_t transfer_timeout) {
 void LocalCopyEngine::Finalize() {
     std::lock_guard<std::mutex> lock(streams_mu_);
     aclrtContext saved_ctx = nullptr;
-    const bool have_saved =
-        (aclrtGetCurrentContext(&saved_ctx) == ACL_ERROR_NONE &&
-         saved_ctx != nullptr);
-    MAKE_GUARD(ctx_restore, [have_saved, saved_ctx]() {
-        if (have_saved) {
+    if (aclrtGetCurrentContext(&saved_ctx) != ACL_ERROR_NONE) {
+        saved_ctx = nullptr;
+    }
+    // Capture only saved_ctx: MAKE_GUARD is a 2-arg macro, so a
+    // multi-capture lambda would be split on the comma in [].
+    MAKE_GUARD(ctx_restore, [saved_ctx]() {
+        if (saved_ctx != nullptr) {
             (void)aclrtSetCurrentContext(saved_ctx);
         }
     });

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/local_copy_engine.cpp
@@ -33,28 +33,92 @@ constexpr uint32_t kStreamFlags = ACL_STREAM_FAST_LAUNCH | ACL_STREAM_FAST_SYNC;
 }  // namespace
 
 LocalCopyEngine::LocalCopyEngine()
-    : stream_(nullptr), transfer_timeout_(10000), initialized_(false) {}
+    : transfer_timeout_(10000), initialized_(false) {}
 
 LocalCopyEngine::~LocalCopyEngine() { Finalize(); }
 
 int LocalCopyEngine::Initialize(int32_t transfer_timeout) {
     transfer_timeout_ = transfer_timeout;
-    auto ret = aclrtCreateStreamWithConfig(&stream_, 0, kStreamFlags);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(ERROR) << "aclrtCreateStreamWithConfig failed, ret:" << ret
-                   << ", errmsg:" << aclGetRecentErrMsg();
-        return -1;
-    }
+    // Do not create a stream here: initEngines() may still be under a
+    // different device context than the worker threads that later call Copy.
+    // Streams are created lazily in GetOrCreateStreamForCurrentDevice().
     initialized_ = true;
     return 0;
 }
 
 void LocalCopyEngine::Finalize() {
-    if (initialized_ && stream_ != nullptr) {
-        (void)aclrtDestroyStream(stream_);
-        stream_ = nullptr;
+    std::lock_guard<std::mutex> lock(streams_mu_);
+    aclrtContext saved_ctx = nullptr;
+    const bool have_saved =
+        (aclrtGetCurrentContext(&saved_ctx) == ACL_ERROR_NONE &&
+         saved_ctx != nullptr);
+    MAKE_GUARD(ctx_restore, [have_saved, saved_ctx]() {
+        if (have_saved) {
+            (void)aclrtSetCurrentContext(saved_ctx);
+        }
+    });
+
+    for (auto &kv : streams_) {
+        auto &info = kv.second;
+        if (info.stream == nullptr) {
+            continue;
+        }
+        aclError ret = ACL_ERROR_NONE;
+        if (info.context != nullptr) {
+            ret = aclrtSetCurrentContext(info.context);
+        } else {
+            ret = aclrtSetDevice(kv.first);
+        }
+        if (ret != ACL_ERROR_NONE) {
+            LOG(ERROR)
+                << "Failed to switch to device " << kv.first
+                << " context before destroying LocalCopyEngine stream, ret:"
+                << ret << ", errmsg:" << aclGetRecentErrMsg();
+        }
+        (void)aclrtDestroyStream(info.stream);
+        info.stream = nullptr;
+        info.context = nullptr;
     }
+    streams_.clear();
     initialized_ = false;
+}
+
+aclrtStream LocalCopyEngine::GetOrCreateStreamForCurrentDevice() {
+    int32_t device_id = 0;
+    auto ret = aclrtGetDevice(&device_id);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(ERROR) << "aclrtGetDevice failed, ret:" << ret
+                   << ", errmsg:" << aclGetRecentErrMsg();
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(streams_mu_);
+    auto it = streams_.find(device_id);
+    if (it != streams_.end() && it->second.stream != nullptr) {
+        return it->second.stream;
+    }
+
+    aclrtStream stream = nullptr;
+    ret = aclrtCreateStreamWithConfig(&stream, 0, kStreamFlags);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(ERROR) << "aclrtCreateStreamWithConfig failed for device "
+                   << device_id << ", ret:" << ret
+                   << ", errmsg:" << aclGetRecentErrMsg();
+        return nullptr;
+    }
+
+    aclrtContext ctx = nullptr;
+    ret = aclrtGetCurrentContext(&ctx);
+    if (ret != ACL_ERROR_NONE || ctx == nullptr) {
+        LOG(ERROR) << "aclrtGetCurrentContext failed after creating stream for "
+                      "device "
+                   << device_id << ", ret:" << ret
+                   << ", errmsg:" << aclGetRecentErrMsg();
+        ctx = nullptr;
+    }
+    streams_[device_id] = DeviceStream{stream, ctx};
+    VLOG(1) << "Created LocalCopyEngine stream for device " << device_id;
+    return stream;
 }
 
 void LocalCopyEngine::Copy(TransferRequest::OpCode opcode,
@@ -118,6 +182,8 @@ void LocalCopyEngine::Copy(TransferRequest::OpCode opcode,
         ret = CopyWithBatch(opcode, slice_list, kind, batch_num, slice_index);
         if (ret == ACL_ERROR_RT_FEATURE_NOT_SUPPORT) {
             // Fallback to async copy if batch copy is not supported
+            VLOG(1) << "aclrtMemcpyBatch FEATURE_NOT_SUPPORT (207000); "
+                       "falling back to CopyWithAsync";
             CopyWithAsync(opcode, slice_list, kind);
             return;
         }
@@ -243,6 +309,14 @@ void LocalCopyEngine::CopyWithSync(TransferRequest::OpCode opcode,
 void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
                                     const std::vector<Slice *> &slice_list,
                                     aclrtMemcpyKind kind) {
+    aclrtStream stream = GetOrCreateStreamForCurrentDevice();
+    if (stream == nullptr) {
+        for (auto &slice : slice_list) {
+            slice->markFailed();
+        }
+        return;
+    }
+
     std::vector<Slice *> async_list;
     async_list.reserve(slice_list.size());
 
@@ -254,11 +328,11 @@ void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
 
         aclError ret;
         if (opcode == TransferRequest::WRITE) {
-            ret = aclrtMemcpyAsync(remote_ptr, len, local_ptr, len, kind,
-                                   stream_);
+            ret =
+                aclrtMemcpyAsync(remote_ptr, len, local_ptr, len, kind, stream);
         } else {
-            ret = aclrtMemcpyAsync(local_ptr, len, remote_ptr, len, kind,
-                                   stream_);
+            ret =
+                aclrtMemcpyAsync(local_ptr, len, remote_ptr, len, kind, stream);
         }
 
         if (ret != ACL_ERROR_NONE) {
@@ -273,8 +347,7 @@ void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
         return;
     }
 
-    aclError ret =
-        aclrtSynchronizeStreamWithTimeout(stream_, transfer_timeout_);
+    aclError ret = aclrtSynchronizeStreamWithTimeout(stream, transfer_timeout_);
     if (ret == ACL_ERROR_NONE) {
         VLOG(1) << "Copy with aclrtMemcpyAsync suc.";
         for (auto &slice : async_list) {
@@ -282,7 +355,7 @@ void LocalCopyEngine::CopyWithAsync(TransferRequest::OpCode opcode,
         }
     } else {
         LOG(ERROR) << "Memory copy failed, ret:" << ret;
-        (void)aclrtStreamAbort(stream_);
+        (void)aclrtStreamAbort(stream);
         for (auto &slice : async_list) {
             slice->markFailed();
         }


### PR DESCRIPTION
## Description


`LocalCopyEngine` created a single process-wide `stream_` in `Initialize()` during `initEngines()`, still under the device0 ACL context. Worker threads later called `CopyWithAsync` under other devices' contexts, so `aclrtMemcpyAsync` returned **107003** (`ACL_ERROR_RT_STREAM_CONTEXT`).

This PR:

- Replaces the shared stream with **per-device streams** (`unordered_map<device_id, DeviceStream>`), created lazily via `GetOrCreateStreamForCurrentDevice()` while that device's context is current
- Destroys each stream after switching back to the context it was created under, so `aclrtDestroyStream` does not hit the same 107003 mismatch
- Keeps `aclrtMemcpyBatch` **207000** (`FEATURE_NOT_SUPPORT`) fallback to `CopyWithAsync`
- Fixes a compile error vs #3993: `MAKE_GUARD` is a two-argument macro, so `Finalize` captures only `saved_ctx` instead of a multi-capture lambda

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Lima (hixl), source CANN, cmake -DUSE_ASCEND_DIRECT=ON
make ascend_transport
./scripts/code_format.sh --staged
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Lima compiled `local_copy_engine.cpp` and linked `ascend_transport.so` after the `MAKE_GUARD` fix. `./scripts/code_format.sh --staged` left the files unchanged.

NPU 2p dummy-real results from #3993 (devices 0,1): before ~3660× `107003` / `aclrtMemcpyAsync failed`; after rank0/1 exit 0 and zero `107003`. Batch may still return 207000; async fallback is expected and now works across devices.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Production LOC is under the RFC threshold. clang-format-20 applied via `./scripts/code_format.sh --staged`. Treat CI pre-commit as authoritative.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok 4.6 assisted with porting #3993 onto current `main`, the `MAKE_GUARD` compile fix, and this PR. Every changed line was reviewed by the submitter.