### PR TITLE
[Store] Add WeightRevision metadata registry (RFC #4017 )

### DIFF
--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -17,6 +17,7 @@
 #include "segment.h"
 #include "types.h"
 #include "rpc_types.h"
+#include "weight_management.h"
 #include "master_metric_manager.h"
 #include "store_rpc_client_io_context.h"
 #include "task_manager.h"
@@ -668,6 +669,18 @@ class MasterClient {
     BatchEvictDiskReplica(const std::vector<std::string>& keys,
                           const std::string& tenant_id,
                           ReplicaType replica_type);
+
+    // RFC #4017 PR1
+    [[nodiscard]] tl::expected<BeginWeightImportResponse, ErrorCode>
+    BeginWeightImport(const BeginWeightImportRequest& request);
+    [[nodiscard]] tl::expected<CommitWeightImportResponse, ErrorCode>
+    CommitWeightImport(const CommitWeightImportRequest& request);
+    [[nodiscard]] tl::expected<GetWeightMetadataResponse, ErrorCode>
+    GetWeightMetadata(const GetWeightMetadataRequest& request);
+    [[nodiscard]] tl::expected<ListWeightRevisionsResponse, ErrorCode>
+    ListWeightRevisions(const ListWeightRevisionsRequest& request);
+    [[nodiscard]] tl::expected<UpdateWeightPolicyResponse, ErrorCode>
+    UpdateWeightPolicy(const UpdateWeightPolicyRequest& request);
 
    private:
     /**

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -681,6 +681,10 @@ class MasterClient {
     ListWeightRevisions(const ListWeightRevisionsRequest& request);
     [[nodiscard]] tl::expected<UpdateWeightPolicyResponse, ErrorCode>
     UpdateWeightPolicy(const UpdateWeightPolicyRequest& request);
+    [[nodiscard]] tl::expected<AbortWeightImportResponse, ErrorCode>
+    AbortWeightImport(const AbortWeightImportRequest& request);
+    [[nodiscard]] tl::expected<RemoveWeightRevisionResponse, ErrorCode>
+    RemoveWeightRevision(const RemoveWeightRevisionRequest& request);
 
    private:
     /**

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -39,6 +39,8 @@
 #include "tenant_quota_sharded.h"
 #include "tenant_quota_policy_store.h"
 #include "types.h"
+#include "weight_management.h"
+#include "weight_metadata_store.h"
 #include "master_config.h"
 #include "rpc_types.h"
 #include "replica.h"
@@ -172,6 +174,18 @@ class MasterService {
     tl::expected<std::optional<TenantQuotaSnapshot>, ErrorCode>
     DeleteTenantQuotaPolicy(const TenantId& tenant_id);
     uint64_t GetTenantQuotaAllocatableCapacityBytes();
+
+    // RFC #4017 PR1: revision-level weight metadata registry.
+    tl::expected<BeginWeightImportResponse, ErrorCode> BeginWeightImport(
+        const BeginWeightImportRequest& request);
+    tl::expected<CommitWeightImportResponse, ErrorCode> CommitWeightImport(
+        const CommitWeightImportRequest& request);
+    tl::expected<GetWeightMetadataResponse, ErrorCode> GetWeightMetadata(
+        const GetWeightMetadataRequest& request) const;
+    ListWeightRevisionsResponse ListWeightRevisions(
+        const ListWeightRevisionsRequest& request) const;
+    tl::expected<UpdateWeightPolicyResponse, ErrorCode> UpdateWeightPolicy(
+        const UpdateWeightPolicyRequest& request);
 
     ErrorCode SetBatchOpLogBackendForTesting(
         std::shared_ptr<HaKvBackend> backend);
@@ -2596,6 +2610,7 @@ class MasterService {
     mutable std::mutex tenant_quota_policy_mutex_;
     mutable std::mutex tenant_quota_recompute_mutex_;
     ShardedTenantQuotaTable<1024> tenant_quota_table_;
+    WeightMetadataStore weight_metadata_store_;
 
     // HTTP metadata server pointer for cleanup on client timeout
     // nullptr means cleanup is disabled

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -186,6 +186,10 @@ class MasterService {
         const ListWeightRevisionsRequest& request) const;
     tl::expected<UpdateWeightPolicyResponse, ErrorCode> UpdateWeightPolicy(
         const UpdateWeightPolicyRequest& request);
+    tl::expected<AbortWeightImportResponse, ErrorCode> AbortWeightImport(
+        const AbortWeightImportRequest& request);
+    tl::expected<RemoveWeightRevisionResponse, ErrorCode> RemoveWeightRevision(
+        const RemoveWeightRevisionRequest& request);
 
     ErrorCode SetBatchOpLogBackendForTesting(
         std::shared_ptr<HaKvBackend> backend);

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -342,6 +342,10 @@ class WrappedMasterService {
         const ListWeightRevisionsRequest& request);
     tl::expected<UpdateWeightPolicyResponse, ErrorCode> UpdateWeightPolicy(
         const UpdateWeightPolicyRequest& request);
+    tl::expected<AbortWeightImportResponse, ErrorCode> AbortWeightImport(
+        const AbortWeightImportRequest& request);
+    tl::expected<RemoveWeightRevisionResponse, ErrorCode> RemoveWeightRevision(
+        const RemoveWeightRevisionRequest& request);
 
    private:
     MasterService master_service_;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -331,6 +331,18 @@ class WrappedMasterService {
     bool KvEventsEnabled() const;
     KvEventPublisher::Stats GetKvEventStats() const;
 
+    // RFC #4017 PR1
+    tl::expected<BeginWeightImportResponse, ErrorCode> BeginWeightImport(
+        const BeginWeightImportRequest& request);
+    tl::expected<CommitWeightImportResponse, ErrorCode> CommitWeightImport(
+        const CommitWeightImportRequest& request);
+    tl::expected<GetWeightMetadataResponse, ErrorCode> GetWeightMetadata(
+        const GetWeightMetadataRequest& request);
+    ListWeightRevisionsResponse ListWeightRevisions(
+        const ListWeightRevisionsRequest& request);
+    tl::expected<UpdateWeightPolicyResponse, ErrorCode> UpdateWeightPolicy(
+        const UpdateWeightPolicyRequest& request);
+
    private:
     MasterService master_service_;
 };

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -394,10 +394,10 @@ enum class ErrorCode : int32_t {
     TENANT_NOT_EMPTY = -1702,         ///< Tenant still owns objects or quota.
 
     // Weight revision management errors (Range: -1800 to -1899) — RFC #4017
-    WEIGHT_NOT_FOUND = -1800,          ///< Weight revision not found / not visible.
-    WEIGHT_NOT_READY = -1801,          ///< Weight revision is not READY.
-    WEIGHT_STALE_GENERATION = -1802,   ///< CAS generation mismatch.
-    WEIGHT_CONFLICT = -1803,           ///< Conflicting weight revision state.
+    WEIGHT_NOT_FOUND = -1800,  ///< Weight revision not found / not visible.
+    WEIGHT_NOT_READY = -1801,  ///< Weight revision is not READY.
+    WEIGHT_STALE_GENERATION = -1802,  ///< CAS generation mismatch.
+    WEIGHT_CONFLICT = -1803,          ///< Conflicting weight revision state.
 };
 
 int32_t toInt(ErrorCode errorCode) noexcept;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -392,6 +392,12 @@ enum class ErrorCode : int32_t {
     TENANT_QUOTA_EXCEEDED = -1700,    ///< Tenant memory quota exceeded.
     TENANT_NOT_REGISTERED = -1701,    ///< Tenant has no quota policy.
     TENANT_NOT_EMPTY = -1702,         ///< Tenant still owns objects or quota.
+
+    // Weight revision management errors (Range: -1800 to -1899) — RFC #4017
+    WEIGHT_NOT_FOUND = -1800,          ///< Weight revision not found / not visible.
+    WEIGHT_NOT_READY = -1801,          ///< Weight revision is not READY.
+    WEIGHT_STALE_GENERATION = -1802,   ///< CAS generation mismatch.
+    WEIGHT_CONFLICT = -1803,           ///< Conflicting weight revision state.
 };
 
 int32_t toInt(ErrorCode errorCode) noexcept;

--- a/mooncake-store/include/weight_management.h
+++ b/mooncake-store/include/weight_management.h
@@ -102,12 +102,13 @@ struct WeightRevisionMetadata {
     std::string payload_keys_digest;
     uint64_t payload_count = 0;
     uint64_t logical_payload_bytes = 0;
+    std::vector<std::string> payload_keys;
     std::string operation_id;  // empty = no active operation
 };
 YLT_REFL(WeightRevisionMetadata, identity, availability, observed_residency,
          policy, metadata_generation, manifest_key, manifest_sha256,
          payload_group_id, payload_keys_digest, payload_count,
-         logical_payload_bytes, operation_id);
+         logical_payload_bytes, payload_keys, operation_id);
 
 struct BeginWeightImportRequest {
     WeightRevisionIdentity identity;
@@ -178,6 +179,35 @@ struct UpdateWeightPolicyResponse {
     WeightRevisionMetadata metadata;
 };
 YLT_REFL(UpdateWeightPolicyResponse, metadata);
+
+// Abort an in-flight IMPORTING revision. Optional keys_to_remove lets the
+// caller clean up partially written objects after a failed transfer.
+struct AbortWeightImportRequest {
+    WeightRevisionIdentity identity;
+    uint64_t expected_metadata_generation = 0;
+    std::vector<std::string> keys_to_remove;
+};
+YLT_REFL(AbortWeightImportRequest, identity, expected_metadata_generation,
+         keys_to_remove);
+
+struct AbortWeightImportResponse {
+    WeightRevisionMetadata metadata;
+    std::vector<std::string> removed_keys;
+};
+YLT_REFL(AbortWeightImportResponse, metadata, removed_keys);
+
+// Explicit whole-revision delete (RFC weight_remove subset for PR1).
+struct RemoveWeightRevisionRequest {
+    WeightRevisionIdentity identity;
+    uint64_t expected_metadata_generation = 0;
+};
+YLT_REFL(RemoveWeightRevisionRequest, identity, expected_metadata_generation);
+
+struct RemoveWeightRevisionResponse {
+    WeightRevisionMetadata metadata;
+    std::vector<std::string> removed_keys;
+};
+YLT_REFL(RemoveWeightRevisionResponse, metadata, removed_keys);
 
 inline const char* ToString(WeightAvailabilityState state) {
     switch (state) {

--- a/mooncake-store/include/weight_management.h
+++ b/mooncake-store/include/weight_management.h
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <ylt/struct_pack.hpp>
+
+#include "types.h"
+
+namespace mooncake {
+
+// RFC #4017: revision-level weight management contracts (PR1 subset).
+
+enum class WeightAvailabilityState : uint8_t {
+    IMPORTING = 0,
+    READY = 1,
+    DEGRADED = 2,
+    DELETING = 3,
+    DELETED = 4,
+};
+
+enum class WeightResidencyState : uint8_t {
+    UNKNOWN = 0,
+    HOT = 1,
+    COLD = 2,
+    MIXED = 3,
+    ABSENT = 4,
+};
+
+enum class WeightMigrationMode : uint8_t {
+    PINNED = 0,
+    MANUAL = 1,
+    AUTO = 2,
+};
+
+struct WeightRevisionIdentity {
+    std::string tenant_id = "default";
+    std::string ns = "default";
+    std::string resource_id;
+    std::string revision;
+    uint64_t weight_generation = 0;
+
+    [[nodiscard]] bool IsValid() const {
+        return !resource_id.empty() && !revision.empty();
+    }
+
+    [[nodiscard]] std::string ToKey() const {
+        return tenant_id + "/" + ns + "/" + resource_id + "/" + revision + "/" +
+               std::to_string(weight_generation);
+    }
+
+    bool operator==(const WeightRevisionIdentity& other) const {
+        return tenant_id == other.tenant_id && ns == other.ns &&
+               resource_id == other.resource_id && revision == other.revision &&
+               weight_generation == other.weight_generation;
+    }
+};
+YLT_REFL(WeightRevisionIdentity, tenant_id, ns, resource_id, revision,
+         weight_generation);
+
+struct WeightStoragePolicy {
+    WeightResidencyState preferred_residency = WeightResidencyState::MIXED;
+    double mixed_hot_ratio = 0.5;
+    WeightMigrationMode migration_mode = WeightMigrationMode::AUTO;
+
+    [[nodiscard]] bool IsValid() const {
+        if (mixed_hot_ratio <= 0.0 || mixed_hot_ratio >= 1.0) {
+            return false;
+        }
+        switch (preferred_residency) {
+            case WeightResidencyState::HOT:
+            case WeightResidencyState::COLD:
+            case WeightResidencyState::MIXED:
+                break;
+            default:
+                return false;
+        }
+        switch (migration_mode) {
+            case WeightMigrationMode::PINNED:
+            case WeightMigrationMode::MANUAL:
+            case WeightMigrationMode::AUTO:
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+};
+YLT_REFL(WeightStoragePolicy, preferred_residency, mixed_hot_ratio,
+         migration_mode);
+
+struct WeightRevisionMetadata {
+    WeightRevisionIdentity identity;
+    WeightAvailabilityState availability = WeightAvailabilityState::IMPORTING;
+    WeightResidencyState observed_residency = WeightResidencyState::UNKNOWN;
+    WeightStoragePolicy policy;
+    uint64_t metadata_generation = 1;
+    std::string manifest_key;
+    std::string manifest_sha256;
+    std::string payload_group_id;
+    std::string payload_keys_digest;
+    uint64_t payload_count = 0;
+    uint64_t logical_payload_bytes = 0;
+    std::string operation_id;  // empty = no active operation
+};
+YLT_REFL(WeightRevisionMetadata, identity, availability, observed_residency,
+         policy, metadata_generation, manifest_key, manifest_sha256,
+         payload_group_id, payload_keys_digest, payload_count,
+         logical_payload_bytes, operation_id);
+
+struct BeginWeightImportRequest {
+    WeightRevisionIdentity identity;
+    WeightStoragePolicy policy;
+    std::string payload_group_id;
+};
+YLT_REFL(BeginWeightImportRequest, identity, policy, payload_group_id);
+
+struct BeginWeightImportResponse {
+    WeightRevisionMetadata metadata;
+};
+YLT_REFL(BeginWeightImportResponse, metadata);
+
+struct CommitWeightImportRequest {
+    WeightRevisionIdentity identity;
+    uint64_t expected_metadata_generation = 0;
+    std::string manifest_key;
+    std::string manifest_sha256;
+    std::string payload_keys_digest;
+    uint64_t payload_count = 0;
+    uint64_t logical_payload_bytes = 0;
+    std::vector<std::string> payload_keys;
+};
+YLT_REFL(CommitWeightImportRequest, identity, expected_metadata_generation,
+         manifest_key, manifest_sha256, payload_keys_digest, payload_count,
+         logical_payload_bytes, payload_keys);
+
+struct CommitWeightImportResponse {
+    WeightRevisionMetadata metadata;
+};
+YLT_REFL(CommitWeightImportResponse, metadata);
+
+struct GetWeightMetadataRequest {
+    WeightRevisionIdentity identity;
+};
+YLT_REFL(GetWeightMetadataRequest, identity);
+
+struct GetWeightMetadataResponse {
+    WeightRevisionMetadata metadata;
+};
+YLT_REFL(GetWeightMetadataResponse, metadata);
+
+struct ListWeightRevisionsRequest {
+    std::string tenant_id = "default";
+    std::string ns = "default";
+    std::string resource_id;  // empty = all resources in namespace
+    uint64_t offset = 0;
+    uint64_t limit = 100;
+};
+YLT_REFL(ListWeightRevisionsRequest, tenant_id, ns, resource_id, offset, limit);
+
+struct ListWeightRevisionsResponse {
+    std::vector<WeightRevisionMetadata> revisions;
+    uint64_t next_offset = 0;
+    bool has_more = false;
+};
+YLT_REFL(ListWeightRevisionsResponse, revisions, next_offset, has_more);
+
+struct UpdateWeightPolicyRequest {
+    WeightRevisionIdentity identity;
+    uint64_t expected_metadata_generation = 0;
+    WeightStoragePolicy policy;
+};
+YLT_REFL(UpdateWeightPolicyRequest, identity, expected_metadata_generation,
+         policy);
+
+struct UpdateWeightPolicyResponse {
+    WeightRevisionMetadata metadata;
+};
+YLT_REFL(UpdateWeightPolicyResponse, metadata);
+
+inline const char* ToString(WeightAvailabilityState state) {
+    switch (state) {
+        case WeightAvailabilityState::IMPORTING:
+            return "IMPORTING";
+        case WeightAvailabilityState::READY:
+            return "READY";
+        case WeightAvailabilityState::DEGRADED:
+            return "DEGRADED";
+        case WeightAvailabilityState::DELETING:
+            return "DELETING";
+        case WeightAvailabilityState::DELETED:
+            return "DELETED";
+    }
+    return "UNKNOWN";
+}
+
+inline const char* ToString(WeightResidencyState state) {
+    switch (state) {
+        case WeightResidencyState::UNKNOWN:
+            return "UNKNOWN";
+        case WeightResidencyState::HOT:
+            return "HOT";
+        case WeightResidencyState::COLD:
+            return "COLD";
+        case WeightResidencyState::MIXED:
+            return "MIXED";
+        case WeightResidencyState::ABSENT:
+            return "ABSENT";
+    }
+    return "UNKNOWN";
+}
+
+}  // namespace mooncake

--- a/mooncake-store/include/weight_metadata_store.h
+++ b/mooncake-store/include/weight_metadata_store.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "weight_management.h"
+
+namespace mooncake {
+
+/**
+ * @brief In-memory registry for revision-level weight metadata (RFC #4017 PR1).
+ *
+ * Thread-safe. Does not mutate Store object maps; MasterService performs any
+ * object-existence checks before calling CommitImport.
+ */
+class WeightMetadataStore {
+   public:
+    tl::expected<WeightRevisionMetadata, ErrorCode> BeginImport(
+        const BeginWeightImportRequest& request);
+
+    tl::expected<WeightRevisionMetadata, ErrorCode> CommitImport(
+        const CommitWeightImportRequest& request);
+
+    tl::expected<WeightRevisionMetadata, ErrorCode> Get(
+        const WeightRevisionIdentity& identity) const;
+
+    ListWeightRevisionsResponse List(
+        const ListWeightRevisionsRequest& request) const;
+
+    tl::expected<WeightRevisionMetadata, ErrorCode> UpdatePolicy(
+        const UpdateWeightPolicyRequest& request);
+
+    // Test helper: number of tracked revisions including IMPORTING/DELETED.
+    size_t SizeForTesting() const;
+
+   private:
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, WeightRevisionMetadata> revisions_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/weight_metadata_store.h
+++ b/mooncake-store/include/weight_metadata_store.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <ylt/util/tl/expected.hpp>
@@ -35,8 +36,23 @@ class WeightMetadataStore {
     tl::expected<WeightRevisionMetadata, ErrorCode> UpdatePolicy(
         const UpdateWeightPolicyRequest& request);
 
+    // Abort IMPORTING (or clean up after a failed transfer). Returns the keys
+    // that MasterService should physically remove.
+    tl::expected<std::pair<WeightRevisionMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    AbortImport(const AbortWeightImportRequest& request);
+
+    // Delete a visible or importing revision and return keys to remove.
+    tl::expected<std::pair<WeightRevisionMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    RemoveRevision(const RemoveWeightRevisionRequest& request);
+
     // Test helper: number of tracked revisions including IMPORTING/DELETED.
     size_t SizeForTesting() const;
+
+    // Test helper: read raw metadata including IMPORTING/DELETED.
+    std::optional<WeightRevisionMetadata> GetRawForTesting(
+        const WeightRevisionIdentity& identity) const;
 
    private:
     mutable std::mutex mutex_;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -23,6 +23,8 @@ set(MOONCAKE_STORE_MASTER_SOURCES
     tenant_quota.cpp
     tenant_quota_ledger.cpp
     tenant_quota_policy_store.cpp
+    weight_metadata_store.cpp
+    master_service_weight_management.cpp
     rpc_service.cpp
     master_admin_service.cpp
     offset_allocator.cpp

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -360,6 +360,16 @@ struct RpcNameTraits<&WrappedMasterService::UpdateWeightPolicy> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::AbortWeightImport> {
+    static constexpr const char* value = "AbortWeightImport";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::RemoveWeightRevision> {
+    static constexpr const char* value = "RemoveWeightRevision";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::PollRemoveAll> {
     static constexpr const char* value = "PollRemoveAll";
 };
@@ -1409,6 +1419,19 @@ tl::expected<UpdateWeightPolicyResponse, ErrorCode>
 MasterClient::UpdateWeightPolicy(const UpdateWeightPolicyRequest& request) {
     return invoke_rpc<&WrappedMasterService::UpdateWeightPolicy,
                       UpdateWeightPolicyResponse>(request);
+}
+
+tl::expected<AbortWeightImportResponse, ErrorCode>
+MasterClient::AbortWeightImport(const AbortWeightImportRequest& request) {
+    return invoke_rpc<&WrappedMasterService::AbortWeightImport,
+                      AbortWeightImportResponse>(request);
+}
+
+tl::expected<RemoveWeightRevisionResponse, ErrorCode>
+MasterClient::RemoveWeightRevision(
+    const RemoveWeightRevisionRequest& request) {
+    return invoke_rpc<&WrappedMasterService::RemoveWeightRevision,
+                      RemoveWeightRevisionResponse>(request);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -1428,8 +1428,7 @@ MasterClient::AbortWeightImport(const AbortWeightImportRequest& request) {
 }
 
 tl::expected<RemoveWeightRevisionResponse, ErrorCode>
-MasterClient::RemoveWeightRevision(
-    const RemoveWeightRevisionRequest& request) {
+MasterClient::RemoveWeightRevision(const RemoveWeightRevisionRequest& request) {
     return invoke_rpc<&WrappedMasterService::RemoveWeightRevision,
                       RemoveWeightRevisionResponse>(request);
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -335,6 +335,31 @@ struct RpcNameTraits<&WrappedMasterService::BatchEvictDiskReplica> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BeginWeightImport> {
+    static constexpr const char* value = "BeginWeightImport";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::CommitWeightImport> {
+    static constexpr const char* value = "CommitWeightImport";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::GetWeightMetadata> {
+    static constexpr const char* value = "GetWeightMetadata";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::ListWeightRevisions> {
+    static constexpr const char* value = "ListWeightRevisions";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::UpdateWeightPolicy> {
+    static constexpr const char* value = "UpdateWeightPolicy";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::PollRemoveAll> {
     static constexpr const char* value = "PollRemoveAll";
 };
@@ -1354,6 +1379,36 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchEvictDiskReplica(
             keys.size(), client_id_, keys, tenant_id, replica_type);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
+}
+
+tl::expected<BeginWeightImportResponse, ErrorCode>
+MasterClient::BeginWeightImport(const BeginWeightImportRequest& request) {
+    return invoke_rpc<&WrappedMasterService::BeginWeightImport,
+                      BeginWeightImportResponse>(request);
+}
+
+tl::expected<CommitWeightImportResponse, ErrorCode>
+MasterClient::CommitWeightImport(const CommitWeightImportRequest& request) {
+    return invoke_rpc<&WrappedMasterService::CommitWeightImport,
+                      CommitWeightImportResponse>(request);
+}
+
+tl::expected<GetWeightMetadataResponse, ErrorCode>
+MasterClient::GetWeightMetadata(const GetWeightMetadataRequest& request) {
+    return invoke_rpc<&WrappedMasterService::GetWeightMetadata,
+                      GetWeightMetadataResponse>(request);
+}
+
+tl::expected<ListWeightRevisionsResponse, ErrorCode>
+MasterClient::ListWeightRevisions(const ListWeightRevisionsRequest& request) {
+    return invoke_rpc<&WrappedMasterService::ListWeightRevisions,
+                      ListWeightRevisionsResponse>(request);
+}
+
+tl::expected<UpdateWeightPolicyResponse, ErrorCode>
+MasterClient::UpdateWeightPolicy(const UpdateWeightPolicyRequest& request) {
+    return invoke_rpc<&WrappedMasterService::UpdateWeightPolicy,
+                      UpdateWeightPolicyResponse>(request);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/master_service_weight_management.cpp
+++ b/mooncake-store/src/master_service_weight_management.cpp
@@ -68,4 +68,61 @@ MasterService::UpdateWeightPolicy(const UpdateWeightPolicyRequest& request) {
     return UpdateWeightPolicyResponse{std::move(*metadata)};
 }
 
+namespace {
+
+std::vector<std::string> CollectSuccessfullyRemovedKeys(
+    const std::vector<std::string>& keys,
+    const std::vector<tl::expected<void, ErrorCode>>& results) {
+    std::vector<std::string> removed;
+    removed.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        // OBJECT_NOT_FOUND is fine during cleanup of a partial transfer.
+        if (results[i] || results[i].error() == ErrorCode::OBJECT_NOT_FOUND) {
+            removed.push_back(keys[i]);
+        }
+    }
+    return removed;
+}
+
+}  // namespace
+
+tl::expected<AbortWeightImportResponse, ErrorCode>
+MasterService::AbortWeightImport(const AbortWeightImportRequest& request) {
+    auto result = weight_metadata_store_.AbortImport(request);
+    if (!result) {
+        return tl::make_unexpected(result.error());
+    }
+
+    auto& [metadata, keys] = *result;
+    AbortWeightImportResponse response;
+    response.metadata = std::move(metadata);
+    if (!keys.empty()) {
+        const TenantId tenant_id(request.identity.tenant_id);
+        auto remove_results = BatchRemove(keys, tenant_id, /*force=*/true);
+        response.removed_keys =
+            CollectSuccessfullyRemovedKeys(keys, remove_results);
+    }
+    return response;
+}
+
+tl::expected<RemoveWeightRevisionResponse, ErrorCode>
+MasterService::RemoveWeightRevision(
+    const RemoveWeightRevisionRequest& request) {
+    auto result = weight_metadata_store_.RemoveRevision(request);
+    if (!result) {
+        return tl::make_unexpected(result.error());
+    }
+
+    auto& [metadata, keys] = *result;
+    RemoveWeightRevisionResponse response;
+    response.metadata = std::move(metadata);
+    if (!keys.empty()) {
+        const TenantId tenant_id(request.identity.tenant_id);
+        auto remove_results = BatchRemove(keys, tenant_id, /*force=*/true);
+        response.removed_keys =
+            CollectSuccessfullyRemovedKeys(keys, remove_results);
+    }
+    return response;
+}
+
 }  // namespace mooncake

--- a/mooncake-store/src/master_service_weight_management.cpp
+++ b/mooncake-store/src/master_service_weight_management.cpp
@@ -1,0 +1,71 @@
+#include "master_service.h"
+
+namespace mooncake {
+
+tl::expected<BeginWeightImportResponse, ErrorCode>
+MasterService::BeginWeightImport(const BeginWeightImportRequest& request) {
+    auto metadata = weight_metadata_store_.BeginImport(request);
+    if (!metadata) {
+        return tl::make_unexpected(metadata.error());
+    }
+    return BeginWeightImportResponse{std::move(*metadata)};
+}
+
+tl::expected<CommitWeightImportResponse, ErrorCode>
+MasterService::CommitWeightImport(const CommitWeightImportRequest& request) {
+    if (!request.identity.IsValid() || request.manifest_key.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // PR1: require payload objects and the manifest key to exist before
+    // publishing READY+HOT. Full group-type validation lands in later PRs.
+    const TenantId tenant_id(request.identity.tenant_id);
+    auto manifest_exists = ExistKey(request.manifest_key, tenant_id);
+    if (!manifest_exists) {
+        return tl::make_unexpected(manifest_exists.error());
+    }
+    if (!*manifest_exists) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    for (const auto& payload_key : request.payload_keys) {
+        auto exists = ExistKey(payload_key, tenant_id);
+        if (!exists) {
+            return tl::make_unexpected(exists.error());
+        }
+        if (!*exists) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+    }
+
+    auto metadata = weight_metadata_store_.CommitImport(request);
+    if (!metadata) {
+        return tl::make_unexpected(metadata.error());
+    }
+    return CommitWeightImportResponse{std::move(*metadata)};
+}
+
+tl::expected<GetWeightMetadataResponse, ErrorCode>
+MasterService::GetWeightMetadata(
+    const GetWeightMetadataRequest& request) const {
+    auto metadata = weight_metadata_store_.Get(request.identity);
+    if (!metadata) {
+        return tl::make_unexpected(metadata.error());
+    }
+    return GetWeightMetadataResponse{std::move(*metadata)};
+}
+
+ListWeightRevisionsResponse MasterService::ListWeightRevisions(
+    const ListWeightRevisionsRequest& request) const {
+    return weight_metadata_store_.List(request);
+}
+
+tl::expected<UpdateWeightPolicyResponse, ErrorCode>
+MasterService::UpdateWeightPolicy(const UpdateWeightPolicyRequest& request) {
+    auto metadata = weight_metadata_store_.UpdatePolicy(request);
+    if (!metadata) {
+        return tl::make_unexpected(metadata.error());
+    }
+    return UpdateWeightPolicyResponse{std::move(*metadata)};
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1745,6 +1745,18 @@ WrappedMasterService::UpdateWeightPolicy(
     return master_service_.UpdateWeightPolicy(request);
 }
 
+tl::expected<AbortWeightImportResponse, ErrorCode>
+WrappedMasterService::AbortWeightImport(
+    const AbortWeightImportRequest& request) {
+    return master_service_.AbortWeightImport(request);
+}
+
+tl::expected<RemoveWeightRevisionResponse, ErrorCode>
+WrappedMasterService::RemoveWeightRevision(
+    const RemoveWeightRevisionRequest& request) {
+    return master_service_.RemoveWeightRevision(request);
+}
+
 tl::expected<void, ErrorCode> WrappedMasterService::RestoreFromStandby(
     const std::vector<StandbyObjectEntry>& objects,
     uint64_t initial_oplog_sequence_id,
@@ -1915,6 +1927,11 @@ void RegisterRpcService(
             &wrapped_master_service);
     server
         .register_handler<&mooncake::WrappedMasterService::UpdateWeightPolicy>(
+            &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::AbortWeightImport>(
+        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::RemoveWeightRevision>(
             &wrapped_master_service);
 }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1905,14 +1905,17 @@ void RegisterRpcService(
             &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BeginWeightImport>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::CommitWeightImport>(
-        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::CommitWeightImport>(
+            &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetWeightMetadata>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::ListWeightRevisions>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::UpdateWeightPolicy>(
-        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::ListWeightRevisions>(
+            &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::UpdateWeightPolicy>(
+            &wrapped_master_service);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1716,6 +1716,35 @@ KvEventPublisher::Stats WrappedMasterService::GetKvEventStats() const {
     return master_service_.GetKvEventStats();
 }
 
+tl::expected<BeginWeightImportResponse, ErrorCode>
+WrappedMasterService::BeginWeightImport(
+    const BeginWeightImportRequest& request) {
+    return master_service_.BeginWeightImport(request);
+}
+
+tl::expected<CommitWeightImportResponse, ErrorCode>
+WrappedMasterService::CommitWeightImport(
+    const CommitWeightImportRequest& request) {
+    return master_service_.CommitWeightImport(request);
+}
+
+tl::expected<GetWeightMetadataResponse, ErrorCode>
+WrappedMasterService::GetWeightMetadata(
+    const GetWeightMetadataRequest& request) {
+    return master_service_.GetWeightMetadata(request);
+}
+
+ListWeightRevisionsResponse WrappedMasterService::ListWeightRevisions(
+    const ListWeightRevisionsRequest& request) {
+    return master_service_.ListWeightRevisions(request);
+}
+
+tl::expected<UpdateWeightPolicyResponse, ErrorCode>
+WrappedMasterService::UpdateWeightPolicy(
+    const UpdateWeightPolicyRequest& request) {
+    return master_service_.UpdateWeightPolicy(request);
+}
+
 tl::expected<void, ErrorCode> WrappedMasterService::RestoreFromStandby(
     const std::vector<StandbyObjectEntry>& objects,
     uint64_t initial_oplog_sequence_id,
@@ -1874,6 +1903,16 @@ void RegisterRpcService(
     server
         .register_handler<&mooncake::WrappedMasterService::MarkTaskToComplete>(
             &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BeginWeightImport>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::CommitWeightImport>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::GetWeightMetadata>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::ListWeightRevisions>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::UpdateWeightPolicy>(
+        &wrapped_master_service);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1930,9 +1930,9 @@ void RegisterRpcService(
             &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::AbortWeightImport>(
         &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::RemoveWeightRevision>(
-            &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::RemoveWeightRevision>(
+        &wrapped_master_service);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -79,7 +79,11 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::DFS_PARTIAL_WRITE, "DFS_PARTIAL_WRITE"},
         {ErrorCode::TENANT_QUOTA_EXCEEDED, "TENANT_QUOTA_EXCEEDED"},
         {ErrorCode::TENANT_NOT_REGISTERED, "TENANT_NOT_REGISTERED"},
-        {ErrorCode::TENANT_NOT_EMPTY, "TENANT_NOT_EMPTY"}};
+        {ErrorCode::TENANT_NOT_EMPTY, "TENANT_NOT_EMPTY"},
+        {ErrorCode::WEIGHT_NOT_FOUND, "WEIGHT_NOT_FOUND"},
+        {ErrorCode::WEIGHT_NOT_READY, "WEIGHT_NOT_READY"},
+        {ErrorCode::WEIGHT_STALE_GENERATION, "WEIGHT_STALE_GENERATION"},
+        {ErrorCode::WEIGHT_CONFLICT, "WEIGHT_CONFLICT"}};
 
     auto it = errorCodeMap.find(errorCode);
     static const std::string unknownError = "UNKNOWN_ERROR";

--- a/mooncake-store/src/weight_metadata_store.cpp
+++ b/mooncake-store/src/weight_metadata_store.cpp
@@ -1,8 +1,27 @@
 #include "weight_metadata_store.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 namespace mooncake {
+
+namespace {
+
+std::vector<std::string> UniqueNonEmptyKeys(
+    const std::vector<std::string>& keys) {
+    std::unordered_set<std::string> seen;
+    std::vector<std::string> out;
+    out.reserve(keys.size());
+    for (const auto& key : keys) {
+        if (key.empty() || !seen.insert(key).second) {
+            continue;
+        }
+        out.push_back(key);
+    }
+    return out;
+}
+
+}  // namespace
 
 tl::expected<WeightRevisionMetadata, ErrorCode>
 WeightMetadataStore::BeginImport(const BeginWeightImportRequest& request) {
@@ -78,6 +97,7 @@ WeightMetadataStore::CommitImport(const CommitWeightImportRequest& request) {
     metadata.payload_keys_digest = request.payload_keys_digest;
     metadata.payload_count = request.payload_count;
     metadata.logical_payload_bytes = request.logical_payload_bytes;
+    metadata.payload_keys = request.payload_keys;
     metadata.availability = WeightAvailabilityState::READY;
     metadata.observed_residency = WeightResidencyState::HOT;
     metadata.metadata_generation += 1;
@@ -176,9 +196,94 @@ WeightMetadataStore::UpdatePolicy(const UpdateWeightPolicyRequest& request) {
     return metadata;
 }
 
+tl::expected<std::pair<WeightRevisionMetadata, std::vector<std::string>>,
+             ErrorCode>
+WeightMetadataStore::AbortImport(const AbortWeightImportRequest& request) {
+    if (!request.identity.IsValid()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = revisions_.find(request.identity.ToKey());
+    if (it == revisions_.end()) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_FOUND);
+    }
+
+    auto& metadata = it->second;
+    if (metadata.availability == WeightAvailabilityState::DELETED) {
+        // Idempotent abort after a previous cleanup.
+        return std::make_pair(metadata, std::vector<std::string>{});
+    }
+    if (metadata.availability != WeightAvailabilityState::IMPORTING) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_CONFLICT);
+    }
+    if (request.expected_metadata_generation != 0 &&
+        request.expected_metadata_generation != metadata.metadata_generation) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_STALE_GENERATION);
+    }
+
+    auto keys = UniqueNonEmptyKeys(request.keys_to_remove);
+    metadata.availability = WeightAvailabilityState::DELETED;
+    metadata.observed_residency = WeightResidencyState::UNKNOWN;
+    metadata.operation_id.clear();
+    metadata.metadata_generation += 1;
+    return std::make_pair(metadata, std::move(keys));
+}
+
+tl::expected<std::pair<WeightRevisionMetadata, std::vector<std::string>>,
+             ErrorCode>
+WeightMetadataStore::RemoveRevision(
+    const RemoveWeightRevisionRequest& request) {
+    if (!request.identity.IsValid()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = revisions_.find(request.identity.ToKey());
+    if (it == revisions_.end()) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_FOUND);
+    }
+
+    auto& metadata = it->second;
+    if (metadata.availability == WeightAvailabilityState::DELETED) {
+        return std::make_pair(metadata, std::vector<std::string>{});
+    }
+    if (metadata.availability != WeightAvailabilityState::READY &&
+        metadata.availability != WeightAvailabilityState::DEGRADED &&
+        metadata.availability != WeightAvailabilityState::IMPORTING) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_CONFLICT);
+    }
+    if (request.expected_metadata_generation != 0 &&
+        request.expected_metadata_generation != metadata.metadata_generation) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_STALE_GENERATION);
+    }
+
+    std::vector<std::string> keys = metadata.payload_keys;
+    if (!metadata.manifest_key.empty()) {
+        keys.push_back(metadata.manifest_key);
+    }
+    keys = UniqueNonEmptyKeys(keys);
+
+    metadata.availability = WeightAvailabilityState::DELETED;
+    metadata.observed_residency = WeightResidencyState::UNKNOWN;
+    metadata.operation_id.clear();
+    metadata.metadata_generation += 1;
+    return std::make_pair(metadata, std::move(keys));
+}
+
 size_t WeightMetadataStore::SizeForTesting() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return revisions_.size();
+}
+
+std::optional<WeightRevisionMetadata> WeightMetadataStore::GetRawForTesting(
+    const WeightRevisionIdentity& identity) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = revisions_.find(identity.ToKey());
+    if (it == revisions_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/weight_metadata_store.cpp
+++ b/mooncake-store/src/weight_metadata_store.cpp
@@ -1,0 +1,183 @@
+#include "weight_metadata_store.h"
+
+#include <algorithm>
+
+namespace mooncake {
+
+tl::expected<WeightRevisionMetadata, ErrorCode> WeightMetadataStore::BeginImport(
+    const BeginWeightImportRequest& request) {
+    if (!request.identity.IsValid() || request.payload_group_id.empty() ||
+        !request.policy.IsValid()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    const std::string key = request.identity.ToKey();
+    auto it = revisions_.find(key);
+    if (it != revisions_.end()) {
+        const auto& existing = it->second;
+        if (existing.availability == WeightAvailabilityState::READY ||
+            existing.availability == WeightAvailabilityState::DEGRADED ||
+            existing.availability == WeightAvailabilityState::DELETING) {
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+        if (existing.availability == WeightAvailabilityState::IMPORTING) {
+            // Idempotent retry of the same in-flight import.
+            return existing;
+        }
+        // DELETED tombstone: allow a fresh import with a bumped generation.
+    }
+
+    WeightRevisionMetadata metadata;
+    metadata.identity = request.identity;
+    metadata.availability = WeightAvailabilityState::IMPORTING;
+    metadata.observed_residency = WeightResidencyState::UNKNOWN;
+    metadata.policy = request.policy;
+    metadata.metadata_generation = 1;
+    metadata.payload_group_id = request.payload_group_id;
+    if (it != revisions_.end() &&
+        it->second.availability == WeightAvailabilityState::DELETED) {
+        metadata.metadata_generation = it->second.metadata_generation + 1;
+    }
+    revisions_[key] = metadata;
+    return metadata;
+}
+
+tl::expected<WeightRevisionMetadata, ErrorCode>
+WeightMetadataStore::CommitImport(const CommitWeightImportRequest& request) {
+    if (!request.identity.IsValid() || request.manifest_key.empty() ||
+        request.payload_count == 0 ||
+        request.payload_keys.size() != request.payload_count) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    const std::string key = request.identity.ToKey();
+    auto it = revisions_.find(key);
+    if (it == revisions_.end()) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_FOUND);
+    }
+
+    auto& metadata = it->second;
+    if (metadata.availability == WeightAvailabilityState::READY &&
+        metadata.manifest_key == request.manifest_key &&
+        metadata.payload_keys_digest == request.payload_keys_digest) {
+        // Idempotent commit of an already-published revision.
+        return metadata;
+    }
+    if (metadata.availability != WeightAvailabilityState::IMPORTING) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_CONFLICT);
+    }
+    if (request.expected_metadata_generation != 0 &&
+        request.expected_metadata_generation != metadata.metadata_generation) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_STALE_GENERATION);
+    }
+
+    metadata.manifest_key = request.manifest_key;
+    metadata.manifest_sha256 = request.manifest_sha256;
+    metadata.payload_keys_digest = request.payload_keys_digest;
+    metadata.payload_count = request.payload_count;
+    metadata.logical_payload_bytes = request.logical_payload_bytes;
+    metadata.availability = WeightAvailabilityState::READY;
+    metadata.observed_residency = WeightResidencyState::HOT;
+    metadata.metadata_generation += 1;
+    metadata.operation_id.clear();
+    return metadata;
+}
+
+tl::expected<WeightRevisionMetadata, ErrorCode> WeightMetadataStore::Get(
+    const WeightRevisionIdentity& identity) const {
+    if (!identity.IsValid()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = revisions_.find(identity.ToKey());
+    if (it == revisions_.end()) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_FOUND);
+    }
+    if (it->second.availability == WeightAvailabilityState::IMPORTING ||
+        it->second.availability == WeightAvailabilityState::DELETED) {
+        // IMPORTING/DELETED are invisible to ordinary discovery.
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_FOUND);
+    }
+    return it->second;
+}
+
+ListWeightRevisionsResponse WeightMetadataStore::List(
+    const ListWeightRevisionsRequest& request) const {
+    ListWeightRevisionsResponse response;
+    const uint64_t limit = request.limit == 0 ? 100 : request.limit;
+
+    std::vector<WeightRevisionMetadata> matched;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        matched.reserve(revisions_.size());
+        for (const auto& [_, metadata] : revisions_) {
+            if (metadata.identity.tenant_id != request.tenant_id ||
+                metadata.identity.ns != request.ns) {
+                continue;
+            }
+            if (!request.resource_id.empty() &&
+                metadata.identity.resource_id != request.resource_id) {
+                continue;
+            }
+            if (metadata.availability != WeightAvailabilityState::READY &&
+                metadata.availability != WeightAvailabilityState::DEGRADED) {
+                continue;
+            }
+            matched.push_back(metadata);
+        }
+    }
+
+    std::sort(matched.begin(), matched.end(),
+              [](const WeightRevisionMetadata& a,
+                 const WeightRevisionMetadata& b) {
+                  return a.identity.ToKey() < b.identity.ToKey();
+              });
+
+    if (request.offset >= matched.size()) {
+        response.next_offset = request.offset;
+        response.has_more = false;
+        return response;
+    }
+
+    const size_t start = static_cast<size_t>(request.offset);
+    const size_t end =
+        std::min(matched.size(), start + static_cast<size_t>(limit));
+    response.revisions.assign(matched.begin() + static_cast<std::ptrdiff_t>(start),
+                              matched.begin() + static_cast<std::ptrdiff_t>(end));
+    response.next_offset = static_cast<uint64_t>(end);
+    response.has_more = end < matched.size();
+    return response;
+}
+
+tl::expected<WeightRevisionMetadata, ErrorCode> WeightMetadataStore::UpdatePolicy(
+    const UpdateWeightPolicyRequest& request) {
+    if (!request.identity.IsValid() || !request.policy.IsValid()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = revisions_.find(request.identity.ToKey());
+    if (it == revisions_.end()) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_FOUND);
+    }
+    auto& metadata = it->second;
+    if (metadata.availability != WeightAvailabilityState::READY &&
+        metadata.availability != WeightAvailabilityState::DEGRADED) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_NOT_READY);
+    }
+    if (request.expected_metadata_generation != metadata.metadata_generation) {
+        return tl::make_unexpected(ErrorCode::WEIGHT_STALE_GENERATION);
+    }
+    metadata.policy = request.policy;
+    metadata.metadata_generation += 1;
+    return metadata;
+}
+
+size_t WeightMetadataStore::SizeForTesting() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return revisions_.size();
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/weight_metadata_store.cpp
+++ b/mooncake-store/src/weight_metadata_store.cpp
@@ -4,8 +4,8 @@
 
 namespace mooncake {
 
-tl::expected<WeightRevisionMetadata, ErrorCode> WeightMetadataStore::BeginImport(
-    const BeginWeightImportRequest& request) {
+tl::expected<WeightRevisionMetadata, ErrorCode>
+WeightMetadataStore::BeginImport(const BeginWeightImportRequest& request) {
     if (!request.identity.IsValid() || request.payload_group_id.empty() ||
         !request.policy.IsValid()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -129,11 +129,11 @@ ListWeightRevisionsResponse WeightMetadataStore::List(
         }
     }
 
-    std::sort(matched.begin(), matched.end(),
-              [](const WeightRevisionMetadata& a,
-                 const WeightRevisionMetadata& b) {
-                  return a.identity.ToKey() < b.identity.ToKey();
-              });
+    std::sort(
+        matched.begin(), matched.end(),
+        [](const WeightRevisionMetadata& a, const WeightRevisionMetadata& b) {
+            return a.identity.ToKey() < b.identity.ToKey();
+        });
 
     if (request.offset >= matched.size()) {
         response.next_offset = request.offset;
@@ -144,15 +144,16 @@ ListWeightRevisionsResponse WeightMetadataStore::List(
     const size_t start = static_cast<size_t>(request.offset);
     const size_t end =
         std::min(matched.size(), start + static_cast<size_t>(limit));
-    response.revisions.assign(matched.begin() + static_cast<std::ptrdiff_t>(start),
-                              matched.begin() + static_cast<std::ptrdiff_t>(end));
+    response.revisions.assign(
+        matched.begin() + static_cast<std::ptrdiff_t>(start),
+        matched.begin() + static_cast<std::ptrdiff_t>(end));
     response.next_offset = static_cast<uint64_t>(end);
     response.has_more = end < matched.size();
     return response;
 }
 
-tl::expected<WeightRevisionMetadata, ErrorCode> WeightMetadataStore::UpdatePolicy(
-    const UpdateWeightPolicyRequest& request) {
+tl::expected<WeightRevisionMetadata, ErrorCode>
+WeightMetadataStore::UpdatePolicy(const UpdateWeightPolicyRequest& request) {
     if (!request.identity.IsValid() || !request.policy.IsValid()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -198,6 +198,9 @@ add_store_test(http_metadata_server_test http_metadata_server_test.cpp)
 add_store_test(mmap_arena_test mmap_arena_test.cpp)
 add_store_test(mmap_arena_fallback_test mmap_arena_fallback_test.cpp)
 add_store_test(object_data_type_test object_data_type_test.cpp)
+add_store_test(weight_metadata_store_test weight_metadata_store_test.cpp)
+add_store_test(master_service_weight_import_test
+               master_service_weight_import_test.cpp)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test ha/leadership/high_availability_test.cpp)

--- a/mooncake-store/tests/master_service_weight_import_test.cpp
+++ b/mooncake-store/tests/master_service_weight_import_test.cpp
@@ -193,8 +193,7 @@ TEST_F(MasterServiceWeightImportTest, CommitFailsWhenPayloadMissing) {
     EXPECT_EQ(got.error(), ErrorCode::WEIGHT_NOT_FOUND);
 
     // Failed transfer path: abort IMPORTING and delete partial objects.
-    const std::string partial =
-        "weights/demo/model-b/v1/1/partial-payload";
+    const std::string partial = "weights/demo/model-b/v1/1/partial-payload";
     PutCompletedObject(service, client_id, partial, segment.name,
                        ObjectDataType::WEIGHT, group_id);
 

--- a/mooncake-store/tests/master_service_weight_import_test.cpp
+++ b/mooncake-store/tests/master_service_weight_import_test.cpp
@@ -191,6 +191,80 @@ TEST_F(MasterServiceWeightImportTest, CommitFailsWhenPayloadMissing) {
     auto got = service.GetWeightMetadata(GetWeightMetadataRequest{id});
     ASSERT_FALSE(got.has_value());
     EXPECT_EQ(got.error(), ErrorCode::WEIGHT_NOT_FOUND);
+
+    // Failed transfer path: abort IMPORTING and delete partial objects.
+    const std::string partial =
+        "weights/demo/model-b/v1/1/partial-payload";
+    PutCompletedObject(service, client_id, partial, segment.name,
+                       ObjectDataType::WEIGHT, group_id);
+
+    AbortWeightImportRequest abort_req;
+    abort_req.identity = id;
+    abort_req.expected_metadata_generation = 1;
+    abort_req.keys_to_remove = {partial, manifest};
+    auto aborted = service.AbortWeightImport(abort_req);
+    ASSERT_TRUE(aborted.has_value()) << toString(aborted.error());
+    EXPECT_EQ(aborted->metadata.availability, WeightAvailabilityState::DELETED);
+    EXPECT_FALSE(aborted->removed_keys.empty());
+
+    auto partial_exists = service.ExistKey(partial, TenantId::Default());
+    ASSERT_TRUE(partial_exists.has_value());
+    EXPECT_FALSE(*partial_exists);
+}
+
+TEST_F(MasterServiceWeightImportTest, RemovePublishedRevisionDeletesPayload) {
+    MasterServiceConfig config;
+    MasterService service(config);
+
+    const Segment segment = MakeSegment("weight_remove_segment");
+    const UUID client_id = MountSegment(service, segment);
+
+    const std::string group_id = "weight-group-remove";
+    const std::string payload0 = "weights/demo/model-c/v1/1/payload-0";
+    const std::string manifest = "weights/demo/model-c/v1/1/manifest";
+
+    PutCompletedObject(service, client_id, payload0, segment.name,
+                       ObjectDataType::WEIGHT, group_id);
+    PutCompletedObject(service, client_id, manifest, segment.name,
+                       ObjectDataType::METADATA, group_id);
+
+    WeightRevisionIdentity id = MakeIdentity();
+    id.resource_id = "model-c";
+
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = id;
+    begin_req.payload_group_id = group_id;
+    begin_req.policy.preferred_residency = WeightResidencyState::HOT;
+    begin_req.policy.mixed_hot_ratio = 0.5;
+    begin_req.policy.migration_mode = WeightMigrationMode::MANUAL;
+    ASSERT_TRUE(service.BeginWeightImport(begin_req).has_value());
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = id;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = manifest;
+    commit_req.manifest_sha256 = "sha";
+    commit_req.payload_keys_digest = "digest";
+    commit_req.payload_count = 1;
+    commit_req.logical_payload_bytes = 1024;
+    commit_req.payload_keys = {payload0};
+    ASSERT_TRUE(service.CommitWeightImport(commit_req).has_value());
+
+    RemoveWeightRevisionRequest remove_req;
+    remove_req.identity = id;
+    remove_req.expected_metadata_generation = 2;
+    auto removed = service.RemoveWeightRevision(remove_req);
+    ASSERT_TRUE(removed.has_value()) << toString(removed.error());
+    EXPECT_EQ(removed->metadata.availability, WeightAvailabilityState::DELETED);
+    EXPECT_EQ(removed->removed_keys.size(), 2u);
+
+    auto got = service.GetWeightMetadata(GetWeightMetadataRequest{id});
+    ASSERT_FALSE(got.has_value());
+    EXPECT_EQ(got.error(), ErrorCode::WEIGHT_NOT_FOUND);
+
+    auto payload_exists = service.ExistKey(payload0, TenantId::Default());
+    ASSERT_TRUE(payload_exists.has_value());
+    EXPECT_FALSE(*payload_exists);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_weight_import_test.cpp
+++ b/mooncake-store/tests/master_service_weight_import_test.cpp
@@ -1,0 +1,195 @@
+#include "master_service.h"
+#include "weight_management.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "replica.h"
+#include "types.h"
+
+namespace mooncake::test {
+
+class MasterServiceWeightImportTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("MasterServiceWeightImportTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    static constexpr size_t kSegmentBase = 0x300000000;
+    static constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+
+    Segment MakeSegment(std::string name = "weight_test_segment") const {
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = std::move(name);
+        segment.base = kSegmentBase;
+        segment.size = kSegmentSize;
+        segment.te_endpoint = segment.name;
+        return segment;
+    }
+
+    UUID MountSegment(MasterService& service, const Segment& segment) {
+        UUID client_id = generate_uuid();
+        auto mount = service.MountSegment(segment, client_id);
+        EXPECT_TRUE(mount.has_value()) << toString(mount.error());
+        return client_id;
+    }
+
+    void PutCompletedObject(MasterService& service, const UUID& client_id,
+                            const std::string& key,
+                            const std::string& segment_name,
+                            ObjectDataType data_type,
+                            const std::string& group_id,
+                            uint64_t slice_length = 1024) {
+        ReplicateConfig config;
+        config.replica_num = 1;
+        config.preferred_segment = segment_name;
+        config.data_type = data_type;
+        config.with_hard_pin = true;
+        config.group_ids = std::vector<std::string>{group_id};
+
+        auto put_start = service.PutStart(client_id, key, TenantId::Default(),
+                                          slice_length, config);
+        ASSERT_TRUE(put_start.has_value()) << toString(put_start.error());
+        auto put_end =
+            service.PutEnd(client_id, key, TenantId::Default(),
+                           ReplicaType::MEMORY);
+        ASSERT_TRUE(put_end.has_value()) << toString(put_end.error());
+    }
+
+    WeightRevisionIdentity MakeIdentity() const {
+        WeightRevisionIdentity identity;
+        identity.tenant_id = "default";
+        identity.ns = "demo";
+        identity.resource_id = "model-a";
+        identity.revision = "v1";
+        identity.weight_generation = 1;
+        return identity;
+    }
+};
+
+TEST_F(MasterServiceWeightImportTest, BeginCommitGetListUpdate) {
+    MasterServiceConfig config;
+    MasterService service(config);
+
+    const Segment segment = MakeSegment();
+    const UUID client_id = MountSegment(service, segment);
+
+    const std::string group_id = "weight-group-1";
+    const std::string payload0 = "weights/demo/model-a/v1/1/payload-0";
+    const std::string payload1 = "weights/demo/model-a/v1/1/payload-1";
+    const std::string manifest = "weights/demo/model-a/v1/1/manifest";
+
+    PutCompletedObject(service, client_id, payload0, segment.name,
+                       ObjectDataType::WEIGHT, group_id);
+    PutCompletedObject(service, client_id, payload1, segment.name,
+                       ObjectDataType::WEIGHT, group_id);
+    PutCompletedObject(service, client_id, manifest, segment.name,
+                       ObjectDataType::METADATA, group_id);
+
+    const auto identity = MakeIdentity();
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.payload_group_id = group_id;
+    begin_req.policy.preferred_residency = WeightResidencyState::HOT;
+    begin_req.policy.mixed_hot_ratio = 0.5;
+    begin_req.policy.migration_mode = WeightMigrationMode::MANUAL;
+
+    auto begin = service.BeginWeightImport(begin_req);
+    ASSERT_TRUE(begin.has_value()) << toString(begin.error());
+    EXPECT_EQ(begin->metadata.availability, WeightAvailabilityState::IMPORTING);
+
+    // IMPORTING revisions are not visible via Get/List.
+    auto missing = service.GetWeightMetadata(GetWeightMetadataRequest{identity});
+    ASSERT_FALSE(missing.has_value());
+    EXPECT_EQ(missing.error(), ErrorCode::WEIGHT_NOT_FOUND);
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = identity;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = manifest;
+    commit_req.manifest_sha256 = "sha256-demo";
+    commit_req.payload_keys_digest = "digest-demo";
+    commit_req.payload_count = 2;
+    commit_req.logical_payload_bytes = 2048;
+    commit_req.payload_keys = {payload0, payload1};
+
+    auto commit = service.CommitWeightImport(commit_req);
+    ASSERT_TRUE(commit.has_value()) << toString(commit.error());
+    EXPECT_EQ(commit->metadata.availability, WeightAvailabilityState::READY);
+    EXPECT_EQ(commit->metadata.observed_residency, WeightResidencyState::HOT);
+    EXPECT_EQ(commit->metadata.metadata_generation, 2u);
+
+    auto got = service.GetWeightMetadata(GetWeightMetadataRequest{identity});
+    ASSERT_TRUE(got.has_value()) << toString(got.error());
+    EXPECT_EQ(got->metadata.manifest_key, manifest);
+
+    auto listed = service.ListWeightRevisions(
+        ListWeightRevisionsRequest{"default", "demo", "model-a", 0, 10});
+    ASSERT_EQ(listed.revisions.size(), 1u);
+    EXPECT_EQ(listed.revisions[0].identity.resource_id, "model-a");
+
+    UpdateWeightPolicyRequest update_req;
+    update_req.identity = identity;
+    update_req.expected_metadata_generation = 2;
+    update_req.policy = begin_req.policy;
+    update_req.policy.preferred_residency = WeightResidencyState::COLD;
+    auto updated = service.UpdateWeightPolicy(update_req);
+    ASSERT_TRUE(updated.has_value()) << toString(updated.error());
+    EXPECT_EQ(updated->metadata.policy.preferred_residency,
+              WeightResidencyState::COLD);
+    EXPECT_EQ(updated->metadata.metadata_generation, 3u);
+}
+
+TEST_F(MasterServiceWeightImportTest, CommitFailsWhenPayloadMissing) {
+    MasterServiceConfig config;
+    MasterService service(config);
+
+    const Segment segment = MakeSegment("weight_missing_segment");
+    const UUID client_id = MountSegment(service, segment);
+    const std::string group_id = "weight-group-missing";
+    const std::string manifest = "weights/demo/model-b/v1/1/manifest";
+
+    PutCompletedObject(service, client_id, manifest, segment.name,
+                       ObjectDataType::METADATA, group_id);
+
+    const auto identity = MakeIdentity();
+    // Use a distinct resource so it does not collide with other tests in-process.
+    WeightRevisionIdentity id = identity;
+    id.resource_id = "model-b";
+
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = id;
+    begin_req.payload_group_id = group_id;
+    begin_req.policy.preferred_residency = WeightResidencyState::HOT;
+    begin_req.policy.mixed_hot_ratio = 0.5;
+    begin_req.policy.migration_mode = WeightMigrationMode::MANUAL;
+    ASSERT_TRUE(service.BeginWeightImport(begin_req).has_value());
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = id;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = manifest;
+    commit_req.manifest_sha256 = "sha";
+    commit_req.payload_keys_digest = "digest";
+    commit_req.payload_count = 1;
+    commit_req.logical_payload_bytes = 512;
+    commit_req.payload_keys = {"weights/demo/model-b/v1/1/missing-payload"};
+
+    auto commit = service.CommitWeightImport(commit_req);
+    ASSERT_FALSE(commit.has_value());
+    EXPECT_EQ(commit.error(), ErrorCode::OBJECT_NOT_FOUND);
+
+    // Still not visible because commit never published READY.
+    auto got = service.GetWeightMetadata(GetWeightMetadataRequest{id});
+    ASSERT_FALSE(got.has_value());
+    EXPECT_EQ(got.error(), ErrorCode::WEIGHT_NOT_FOUND);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_weight_import_test.cpp
+++ b/mooncake-store/tests/master_service_weight_import_test.cpp
@@ -57,9 +57,8 @@ class MasterServiceWeightImportTest : public ::testing::Test {
         auto put_start = service.PutStart(client_id, key, TenantId::Default(),
                                           slice_length, config);
         ASSERT_TRUE(put_start.has_value()) << toString(put_start.error());
-        auto put_end =
-            service.PutEnd(client_id, key, TenantId::Default(),
-                           ReplicaType::MEMORY);
+        auto put_end = service.PutEnd(client_id, key, TenantId::Default(),
+                                      ReplicaType::MEMORY);
         ASSERT_TRUE(put_end.has_value()) << toString(put_end.error());
     }
 
@@ -106,7 +105,8 @@ TEST_F(MasterServiceWeightImportTest, BeginCommitGetListUpdate) {
     EXPECT_EQ(begin->metadata.availability, WeightAvailabilityState::IMPORTING);
 
     // IMPORTING revisions are not visible via Get/List.
-    auto missing = service.GetWeightMetadata(GetWeightMetadataRequest{identity});
+    auto missing =
+        service.GetWeightMetadata(GetWeightMetadataRequest{identity});
     ASSERT_FALSE(missing.has_value());
     EXPECT_EQ(missing.error(), ErrorCode::WEIGHT_NOT_FOUND);
 
@@ -160,7 +160,8 @@ TEST_F(MasterServiceWeightImportTest, CommitFailsWhenPayloadMissing) {
                        ObjectDataType::METADATA, group_id);
 
     const auto identity = MakeIdentity();
-    // Use a distinct resource so it does not collide with other tests in-process.
+    // Use a distinct resource so it does not collide with other tests
+    // in-process.
     WeightRevisionIdentity id = identity;
     id.resource_id = "model-b";
 

--- a/mooncake-store/tests/weight_metadata_store_test.cpp
+++ b/mooncake-store/tests/weight_metadata_store_test.cpp
@@ -65,10 +65,12 @@ TEST_F(WeightMetadataStoreTest, BeginCommitGetListUpdateHappyPath) {
     EXPECT_EQ(commit->availability, WeightAvailabilityState::READY);
     EXPECT_EQ(commit->observed_residency, WeightResidencyState::HOT);
     EXPECT_EQ(commit->metadata_generation, 2u);
+    EXPECT_EQ(commit->payload_keys, commit_req.payload_keys);
 
     auto got = store_.Get(identity);
     ASSERT_TRUE(got.has_value());
     EXPECT_EQ(got->manifest_key, commit_req.manifest_key);
+    EXPECT_EQ(got->payload_keys, commit_req.payload_keys);
 
     auto listed = store_.List(
         ListWeightRevisionsRequest{"default", "ns", "model-a", 0, 10});
@@ -144,6 +146,63 @@ TEST_F(WeightMetadataStoreTest, IdempotentBeginWhileImporting) {
     auto again = store_.BeginImport(begin_req);
     ASSERT_TRUE(again.has_value());
     EXPECT_EQ(again->availability, WeightAvailabilityState::IMPORTING);
+}
+
+TEST_F(WeightMetadataStoreTest, AbortImportingCleansUpAndAllowsRetry) {
+    const auto identity = MakeIdentity("model-abort");
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.policy = MakePolicy();
+    begin_req.payload_group_id = "group-abort";
+    ASSERT_TRUE(store_.BeginImport(begin_req).has_value());
+
+    AbortWeightImportRequest abort_req;
+    abort_req.identity = identity;
+    abort_req.expected_metadata_generation = 1;
+    abort_req.keys_to_remove = {"partial-0", "partial-1", "partial-0"};
+    auto aborted = store_.AbortImport(abort_req);
+    ASSERT_TRUE(aborted.has_value());
+    EXPECT_EQ(aborted->first.availability, WeightAvailabilityState::DELETED);
+    EXPECT_EQ(aborted->first.metadata_generation, 2u);
+    ASSERT_EQ(aborted->second.size(), 2u);
+
+    auto raw = store_.GetRawForTesting(identity);
+    ASSERT_TRUE(raw.has_value());
+    EXPECT_EQ(raw->availability, WeightAvailabilityState::DELETED);
+
+    // Fresh import is allowed on the DELETED tombstone.
+    auto again = store_.BeginImport(begin_req);
+    ASSERT_TRUE(again.has_value());
+    EXPECT_EQ(again->availability, WeightAvailabilityState::IMPORTING);
+    EXPECT_EQ(again->metadata_generation, 3u);
+}
+
+TEST_F(WeightMetadataStoreTest, RemoveReadyReturnsStoredPayloadKeys) {
+    const auto identity = MakeIdentity("model-remove");
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.policy = MakePolicy();
+    begin_req.payload_group_id = "group-remove";
+    ASSERT_TRUE(store_.BeginImport(begin_req).has_value());
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = identity;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = "manifest";
+    commit_req.payload_keys_digest = "d";
+    commit_req.payload_count = 2;
+    commit_req.payload_keys = {"p0", "p1"};
+    ASSERT_TRUE(store_.CommitImport(commit_req).has_value());
+
+    RemoveWeightRevisionRequest remove_req;
+    remove_req.identity = identity;
+    remove_req.expected_metadata_generation = 2;
+    auto removed = store_.RemoveRevision(remove_req);
+    ASSERT_TRUE(removed.has_value());
+    EXPECT_EQ(removed->first.availability, WeightAvailabilityState::DELETED);
+    EXPECT_EQ(removed->second,
+              (std::vector<std::string>{"p0", "p1", "manifest"}));
+    EXPECT_EQ(store_.Get(identity).error(), ErrorCode::WEIGHT_NOT_FOUND);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/weight_metadata_store_test.cpp
+++ b/mooncake-store/tests/weight_metadata_store_test.cpp
@@ -46,8 +46,9 @@ TEST_F(WeightMetadataStoreTest, BeginCommitGetListUpdateHappyPath) {
 
     // IMPORTING is invisible to Get/List.
     EXPECT_EQ(store_.Get(identity).error(), ErrorCode::WEIGHT_NOT_FOUND);
-    EXPECT_TRUE(store_.List(ListWeightRevisionsRequest{"default", "ns", "", 0, 10})
-                    .revisions.empty());
+    EXPECT_TRUE(
+        store_.List(ListWeightRevisionsRequest{"default", "ns", "", 0, 10})
+            .revisions.empty());
 
     CommitWeightImportRequest commit_req;
     commit_req.identity = identity;
@@ -69,8 +70,8 @@ TEST_F(WeightMetadataStoreTest, BeginCommitGetListUpdateHappyPath) {
     ASSERT_TRUE(got.has_value());
     EXPECT_EQ(got->manifest_key, commit_req.manifest_key);
 
-    auto listed =
-        store_.List(ListWeightRevisionsRequest{"default", "ns", "model-a", 0, 10});
+    auto listed = store_.List(
+        ListWeightRevisionsRequest{"default", "ns", "model-a", 0, 10});
     ASSERT_EQ(listed.revisions.size(), 1u);
     EXPECT_FALSE(listed.has_more);
 

--- a/mooncake-store/tests/weight_metadata_store_test.cpp
+++ b/mooncake-store/tests/weight_metadata_store_test.cpp
@@ -1,0 +1,148 @@
+#include "weight_metadata_store.h"
+
+#include <gtest/gtest.h>
+
+#include "types.h"
+
+namespace mooncake::test {
+
+class WeightMetadataStoreTest : public ::testing::Test {
+   protected:
+    WeightRevisionIdentity MakeIdentity(const std::string& resource = "model-a",
+                                        const std::string& revision = "v1",
+                                        uint64_t generation = 1) {
+        WeightRevisionIdentity identity;
+        identity.tenant_id = "default";
+        identity.ns = "ns";
+        identity.resource_id = resource;
+        identity.revision = revision;
+        identity.weight_generation = generation;
+        return identity;
+    }
+
+    WeightStoragePolicy MakePolicy() {
+        WeightStoragePolicy policy;
+        policy.preferred_residency = WeightResidencyState::HOT;
+        policy.mixed_hot_ratio = 0.5;
+        policy.migration_mode = WeightMigrationMode::MANUAL;
+        return policy;
+    }
+
+    WeightMetadataStore store_;
+};
+
+TEST_F(WeightMetadataStoreTest, BeginCommitGetListUpdateHappyPath) {
+    const auto identity = MakeIdentity();
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.policy = MakePolicy();
+    begin_req.payload_group_id = "group-1";
+
+    auto begin = store_.BeginImport(begin_req);
+    ASSERT_TRUE(begin.has_value());
+    EXPECT_EQ(begin->availability, WeightAvailabilityState::IMPORTING);
+    EXPECT_EQ(begin->observed_residency, WeightResidencyState::UNKNOWN);
+    EXPECT_EQ(begin->metadata_generation, 1u);
+
+    // IMPORTING is invisible to Get/List.
+    EXPECT_EQ(store_.Get(identity).error(), ErrorCode::WEIGHT_NOT_FOUND);
+    EXPECT_TRUE(store_.List(ListWeightRevisionsRequest{"default", "ns", "", 0, 10})
+                    .revisions.empty());
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = identity;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = "weights/ns/model-a/v1/1/manifest";
+    commit_req.manifest_sha256 = "abc";
+    commit_req.payload_keys_digest = "digest";
+    commit_req.payload_count = 2;
+    commit_req.logical_payload_bytes = 1024;
+    commit_req.payload_keys = {"payload-0", "payload-1"};
+
+    auto commit = store_.CommitImport(commit_req);
+    ASSERT_TRUE(commit.has_value());
+    EXPECT_EQ(commit->availability, WeightAvailabilityState::READY);
+    EXPECT_EQ(commit->observed_residency, WeightResidencyState::HOT);
+    EXPECT_EQ(commit->metadata_generation, 2u);
+
+    auto got = store_.Get(identity);
+    ASSERT_TRUE(got.has_value());
+    EXPECT_EQ(got->manifest_key, commit_req.manifest_key);
+
+    auto listed =
+        store_.List(ListWeightRevisionsRequest{"default", "ns", "model-a", 0, 10});
+    ASSERT_EQ(listed.revisions.size(), 1u);
+    EXPECT_FALSE(listed.has_more);
+
+    UpdateWeightPolicyRequest update_req;
+    update_req.identity = identity;
+    update_req.expected_metadata_generation = 2;
+    update_req.policy = MakePolicy();
+    update_req.policy.preferred_residency = WeightResidencyState::COLD;
+    auto updated = store_.UpdatePolicy(update_req);
+    ASSERT_TRUE(updated.has_value());
+    EXPECT_EQ(updated->policy.preferred_residency, WeightResidencyState::COLD);
+    EXPECT_EQ(updated->metadata_generation, 3u);
+}
+
+TEST_F(WeightMetadataStoreTest, StaleGenerationRejected) {
+    const auto identity = MakeIdentity();
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.policy = MakePolicy();
+    begin_req.payload_group_id = "group-1";
+    ASSERT_TRUE(store_.BeginImport(begin_req).has_value());
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = identity;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = "manifest";
+    commit_req.payload_keys_digest = "d";
+    commit_req.payload_count = 1;
+    commit_req.payload_keys = {"p0"};
+    ASSERT_TRUE(store_.CommitImport(commit_req).has_value());
+
+    UpdateWeightPolicyRequest update_req;
+    update_req.identity = identity;
+    update_req.expected_metadata_generation = 1;  // stale
+    update_req.policy = MakePolicy();
+    auto updated = store_.UpdatePolicy(update_req);
+    ASSERT_FALSE(updated.has_value());
+    EXPECT_EQ(updated.error(), ErrorCode::WEIGHT_STALE_GENERATION);
+}
+
+TEST_F(WeightMetadataStoreTest, DuplicateReadyImportConflicts) {
+    const auto identity = MakeIdentity();
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.policy = MakePolicy();
+    begin_req.payload_group_id = "group-1";
+    ASSERT_TRUE(store_.BeginImport(begin_req).has_value());
+
+    CommitWeightImportRequest commit_req;
+    commit_req.identity = identity;
+    commit_req.expected_metadata_generation = 1;
+    commit_req.manifest_key = "manifest";
+    commit_req.payload_keys_digest = "d";
+    commit_req.payload_count = 1;
+    commit_req.payload_keys = {"p0"};
+    ASSERT_TRUE(store_.CommitImport(commit_req).has_value());
+
+    auto again = store_.BeginImport(begin_req);
+    ASSERT_FALSE(again.has_value());
+    EXPECT_EQ(again.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
+}
+
+TEST_F(WeightMetadataStoreTest, IdempotentBeginWhileImporting) {
+    const auto identity = MakeIdentity();
+    BeginWeightImportRequest begin_req;
+    begin_req.identity = identity;
+    begin_req.policy = MakePolicy();
+    begin_req.payload_group_id = "group-1";
+    ASSERT_TRUE(store_.BeginImport(begin_req).has_value());
+    auto again = store_.BeginImport(begin_req);
+    ASSERT_TRUE(again.has_value());
+    EXPECT_EQ(again->availability, WeightAvailabilityState::IMPORTING);
+}
+
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

Partial implementation of RFC #4017 (revision-level Weight Management), **slice PR1**.

Adds an in-memory `WeightMetadataStore` and Master/client/RPC APIs so a weight revision can be:

1. registered via `BeginWeightImport` (`IMPORTING`, invisible to Get/List)
2. published via `CommitWeightImport` as **READY + HOT** after payload/manifest keys exist
3. discovered via `GetWeightMetadata` / `ListWeightRevisions`
4. policy-updated with generation fencing via `UpdateWeightPolicy`

Related: #4017

### Out of scope for this PR

Python `weight_*` API convergence, HA OpLog/snapshot, residency migration, and revision leases.

### Follow-up plan (3+1)

**PR2 - safe read path + protect managed groups**
1. Revision lease for `weight_get` (TTL; blocks delete / release of existing readable replicas while held; allows creating new replicas)
2. Master + client wiring for lease acquire/release on the get path
3. Managed-group guard so generic `BatchEvict` / single-key `Remove` / cleanup **skip** members of a published weight group (with a skip metric)
4. Tests: get-with-lease vs remove returns BUSY; eviction cannot partially dismantle a READY revision

**PR3 - residency migration**
1. Explicit `weight_migrate` (HOT / COLD / MIXED) with operation records + batched progress
2. AUTO reconciliation under memory pressure (bounded per round, cooldown)

**PR4 (optional / later) - HA + API convergence**
1. Persist weight metadata / leases / operations via OpLog + master snapshot
2. `weight_management_oplog_capability_confirmed` rolling-upgrade gate
3. Converge public API to the RFC `weight_*` surface (remove unmanaged entry points last)

Happy to adjust these boundaries based on maintainer feedback.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Store unit tests added:
#   weight_metadata_store_test
#   master_service_weight_import_test
ctest --test-dir build -R 'weight_metadata_store_test|master_service_weight_import_test' --output-on-failure
```

**Test results:**
- [x] Unit tests added (registry + MasterService mount/put/begin/commit/get/list/update)
- [ ] Integration tests pass (if applicable) - not run in this environment (Windows host without full native Store build)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#4017)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor / Composer assisted with implementing the WeightMetadataStore, Master RPC wiring, and tests against RFC #4017. The submitter reviewed the changes.
