### PR TITLE
[Bugfix][Store] Report the mounted segment's protocol in buffer descriptors

### DIFF
--- a/mooncake-store/include/allocator.h
+++ b/mooncake-store/include/allocator.h
@@ -74,14 +74,11 @@ class AllocatedBuffer {
     // Forward declaration of the descriptor struct
     struct Descriptor;
 
+    // Defined in allocator.cpp, where BufferAllocatorBase is complete.
     AllocatedBuffer(std::shared_ptr<BufferAllocatorBase> allocator,
                     void* buffer_ptr, std::size_t size,
                     std::optional<offset_allocator::OffsetAllocationHandle>&&
-                        offset_handle = std::nullopt)
-        : allocator_(std::move(allocator)),
-          buffer_ptr_(buffer_ptr),
-          size_(size),
-          offset_handle_(std::move(offset_handle)) {}
+                        offset_handle = std::nullopt);
 
     AllocatedBuffer(std::shared_ptr<BufferAllocatorBase> allocator,
                     const Descriptor& descriptor);
@@ -189,6 +186,14 @@ class BufferAllocatorBase {
     virtual std::string getTransportEndpoint() const = 0;
 
     /**
+     * Protocol the segment behind this allocator was mounted with ("tcp",
+     * "rdma", ...); buffers are stamped with it at construction. Not pure so
+     * that allocators serving no mounted segment (the dummy allocator,
+     * out-of-tree subclasses) keep the transfer default.
+     */
+    virtual std::string getTransferProtocol() const { return "tcp"; }
+
+    /**
      * Returns the largest free region available in this allocator.
      * For CacheLib allocators, this returns kAllocatorUnknownFreeSpace as an
      * approximation. For OffsetAllocator, this returns the actual largest free
@@ -275,10 +280,13 @@ class CachelibBufferAllocator
     : public BufferAllocatorBase,
       public std::enable_shared_from_this<CachelibBufferAllocator> {
    public:
+    // The default keeps older callers compiling; production callers must pass
+    // the mounted segment's protocol. See getTransferProtocol().
     static tl::expected<std::shared_ptr<CachelibBufferAllocator>, ErrorCode>
     Create(std::string segment_name, size_t base, size_t size,
            std::string transport_endpoint,
-           ReplicaType replica_type = ReplicaType::MEMORY);
+           ReplicaType replica_type = ReplicaType::MEMORY,
+           std::string protocol = "tcp");
 
     ~CachelibBufferAllocator() override;
 
@@ -293,6 +301,7 @@ class CachelibBufferAllocator
     std::string getTransportEndpoint() const override {
         return transport_endpoint_;
     }
+    std::string getTransferProtocol() const override { return protocol_; }
 
     /**
      * For CacheLib, return kAllocatorUnknownFreeSpace as we don't have exact
@@ -306,7 +315,7 @@ class CachelibBufferAllocator
    private:
     CachelibBufferAllocator(std::string segment_name, size_t base, size_t size,
                             std::string transport_endpoint,
-                            ReplicaType replica_type);
+                            ReplicaType replica_type, std::string protocol);
 
     std::unique_ptr<AllocatedBuffer> adoptImportedBuffer(
         const LiveAllocation& allocation);
@@ -316,6 +325,7 @@ class CachelibBufferAllocator
     const size_t total_size_;
     const std::string transport_endpoint_;
     const ReplicaType replica_type_;
+    const std::string protocol_;
 
     // metrics - removed allocated_bytes_ member
     // ylt::metric::gauge_t* allocated_bytes_{nullptr};
@@ -331,7 +341,7 @@ class CachelibBufferAllocator
         std::string segment_name, size_t base, size_t size,
         std::string transport_endpoint,
         const std::vector<LiveAllocation>& allocations,
-        ReplicaType replica_type);
+        ReplicaType replica_type, std::string protocol);
 };
 
 struct RestoredCachelibBufferAllocator {
@@ -343,7 +353,8 @@ std::optional<RestoredCachelibBufferAllocator> ImportCachelibBufferAllocator(
     std::string segment_name, size_t base, size_t size,
     std::string transport_endpoint,
     const std::vector<LiveAllocation>& allocations,
-    ReplicaType replica_type = ReplicaType::MEMORY);
+    ReplicaType replica_type = ReplicaType::MEMORY,
+    std::string protocol = "tcp");
 
 /**
  * OffsetBufferAllocator manages memory allocation using the OffsetAllocator
@@ -356,7 +367,8 @@ class OffsetBufferAllocator
    public:
     OffsetBufferAllocator(std::string segment_name, size_t base, size_t size,
                           std::string transport_endpoint,
-                          ReplicaType replica_type = ReplicaType::MEMORY);
+                          ReplicaType replica_type = ReplicaType::MEMORY,
+                          std::string protocol = "tcp");
 
     ~OffsetBufferAllocator() override;
 
@@ -371,6 +383,7 @@ class OffsetBufferAllocator
     std::string getTransportEndpoint() const override {
         return transport_endpoint_;
     }
+    std::string getTransferProtocol() const override { return protocol_; }
 
     /**
      * Returns the actual largest free region from the offset allocator.
@@ -394,6 +407,7 @@ class OffsetBufferAllocator
     const size_t total_size_;
     const std::string transport_endpoint_;
     const ReplicaType replica_type_;
+    const std::string protocol_;
 
     // offset allocator implementation
     std::shared_ptr<offset_allocator::OffsetAllocator> offset_allocator_;
@@ -413,13 +427,15 @@ std::optional<RestoredOffsetBufferAllocator> ImportOffsetBufferAllocator(
     std::string segment_name, size_t base, size_t size,
     std::string transport_endpoint,
     const std::vector<LiveAllocation>& allocations,
-    ReplicaType replica_type = ReplicaType::MEMORY);
+    ReplicaType replica_type = ReplicaType::MEMORY,
+    std::string protocol = "tcp");
 
 tl::expected<std::shared_ptr<BufferAllocatorBase>, ErrorCode>
 CreateBufferAllocator(BufferAllocatorType allocator_type,
                       std::string segment_name, size_t base, size_t size,
                       std::string transport_endpoint,
-                      ReplicaType replica_type = ReplicaType::MEMORY);
+                      ReplicaType replica_type = ReplicaType::MEMORY,
+                      std::string protocol = "tcp");
 
 // The main difference is that it allocates real memory and returns it, while
 // BufferAllocator allocates an address

--- a/mooncake-store/include/segment/region.h
+++ b/mooncake-store/include/segment/region.h
@@ -19,6 +19,7 @@ struct RegionResourceSpec {
     uintptr_t base{0};
     size_t size{0};
     std::string transport_endpoint;
+    std::string protocol;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -61,6 +61,29 @@ std::string AllocatedBuffer::getSegmentName() const noexcept {
     return std::string();
 }
 
+AllocatedBuffer::AllocatedBuffer(
+    std::shared_ptr<BufferAllocatorBase> allocator, void* buffer_ptr,
+    std::size_t size,
+    std::optional<offset_allocator::OffsetAllocationHandle>&& offset_handle)
+    : buffer_ptr_(buffer_ptr),
+      size_(size),
+      offset_handle_(std::move(offset_handle)) {
+    if (allocator) {
+        allocator_ = allocator;
+        // Stamp the protocol of the segment this buffer was allocated from, so
+        // descriptors report the transport actually in use.
+        //
+        // "cxl" is deliberately skipped: it is not a transfer, it marks an
+        // address already offset-encoded by change_to_cxl(). Stamping it from
+        // the allocator would make a plain address look CXL-encoded, and send
+        // deallocate()/get_descriptor() down the CXL path.
+        auto owner_protocol = allocator->getTransferProtocol();
+        if (!owner_protocol.empty() && owner_protocol != "cxl") {
+            protocol = std::move(owner_protocol);
+        }
+    }
+}
+
 AllocatedBuffer::~AllocatedBuffer() {
     // Note: This is an edge case. If the 'weak_ptr' is released, the segment
     // has already been deallocated at this point, and its memory usage details
@@ -136,7 +159,8 @@ std::ostream& operator<<(std::ostream& os, const AllocatedBuffer& buffer) {
 tl::expected<std::shared_ptr<CachelibBufferAllocator>, ErrorCode>
 CachelibBufferAllocator::Create(std::string segment_name, size_t base,
                                 size_t size, std::string transport_endpoint,
-                                ReplicaType replica_type) {
+                                ReplicaType replica_type,
+                                std::string protocol) {
     if (!IsValidCachelibLayout(base, size)) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -146,19 +170,20 @@ CachelibBufferAllocator::Create(std::string segment_name, size_t base,
     // exhaustion follows the process-level fail-fast policy.
     return std::shared_ptr<CachelibBufferAllocator>(new CachelibBufferAllocator(
         std::move(segment_name), base, size, std::move(transport_endpoint),
-        replica_type));
+        replica_type, std::move(protocol)));
 }
 
 tl::expected<std::shared_ptr<BufferAllocatorBase>, ErrorCode>
 CreateBufferAllocator(BufferAllocatorType allocator_type,
                       std::string segment_name, size_t base, size_t size,
-                      std::string transport_endpoint,
-                      ReplicaType replica_type) {
+                      std::string transport_endpoint, ReplicaType replica_type,
+                      std::string protocol) {
     switch (allocator_type) {
         case BufferAllocatorType::CACHELIB: {
             auto allocator = CachelibBufferAllocator::Create(
                 std::move(segment_name), base, size,
-                std::move(transport_endpoint), replica_type);
+                std::move(transport_endpoint), replica_type,
+                std::move(protocol));
             if (!allocator) {
                 return tl::make_unexpected(allocator.error());
             }
@@ -170,7 +195,8 @@ CreateBufferAllocator(BufferAllocatorType allocator_type,
             return std::shared_ptr<BufferAllocatorBase>(
                 std::make_shared<OffsetBufferAllocator>(
                     std::move(segment_name), base, size,
-                    std::move(transport_endpoint), replica_type));
+                    std::move(transport_endpoint), replica_type,
+                    std::move(protocol)));
         default:
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -179,12 +205,14 @@ CreateBufferAllocator(BufferAllocatorType allocator_type,
 CachelibBufferAllocator::CachelibBufferAllocator(std::string segment_name,
                                                  size_t base, size_t size,
                                                  std::string transport_endpoint,
-                                                 ReplicaType replica_type)
+                                                 ReplicaType replica_type,
+                                                 std::string protocol)
     : segment_name_(segment_name),
       base_(base),
       total_size_(size),
       transport_endpoint_(std::move(transport_endpoint)),
-      replica_type_(replica_type) {
+      replica_type_(replica_type),
+      protocol_(std::move(protocol)) {
     VLOG(1) << "initializing_buffer_allocator segment_name=" << segment_name
             << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;
@@ -303,7 +331,8 @@ std::unique_ptr<AllocatedBuffer> CachelibBufferAllocator::adoptImportedBuffer(
 std::optional<RestoredCachelibBufferAllocator> ImportCachelibBufferAllocator(
     std::string segment_name, size_t base, size_t size,
     std::string transport_endpoint,
-    const std::vector<LiveAllocation>& allocations, ReplicaType replica_type) {
+    const std::vector<LiveAllocation>& allocations, ReplicaType replica_type,
+    std::string protocol) {
     if (replica_type != ReplicaType::MEMORY ||
         !IsValidCachelibLayout(base, size)) {
         return std::nullopt;
@@ -322,7 +351,8 @@ std::optional<RestoredCachelibBufferAllocator> ImportCachelibBufferAllocator(
     }
 
     auto created = CachelibBufferAllocator::Create(
-        std::move(segment_name), base, size, transport_endpoint, replica_type);
+        std::move(segment_name), base, size, transport_endpoint, replica_type,
+        std::move(protocol));
     if (!created) {
         return std::nullopt;
     }
@@ -345,12 +375,14 @@ std::optional<RestoredCachelibBufferAllocator> ImportCachelibBufferAllocator(
 OffsetBufferAllocator::OffsetBufferAllocator(std::string segment_name,
                                              size_t base, size_t size,
                                              std::string transport_endpoint,
-                                             ReplicaType replica_type)
+                                             ReplicaType replica_type,
+                                             std::string protocol)
     : segment_name_(segment_name),
       base_(base),
       total_size_(size),
       transport_endpoint_(std::move(transport_endpoint)),
-      replica_type_(replica_type) {
+      replica_type_(replica_type),
+      protocol_(std::move(protocol)) {
     VLOG(1) << "initializing_offset_buffer_allocator segment_name="
             << segment_name << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;
@@ -484,13 +516,15 @@ size_t OffsetBufferAllocator::getLargestFreeRegion() const {
 std::optional<RestoredOffsetBufferAllocator> ImportOffsetBufferAllocator(
     std::string segment_name, size_t base, size_t size,
     std::string transport_endpoint,
-    const std::vector<LiveAllocation>& allocations, ReplicaType replica_type) {
+    const std::vector<LiveAllocation>& allocations, ReplicaType replica_type,
+    std::string protocol) {
     if (base > std::numeric_limits<size_t>::max() - size) {
         return std::nullopt;
     }
     const size_t end = base + size;
     auto allocator = std::make_shared<OffsetBufferAllocator>(
-        std::move(segment_name), base, size, transport_endpoint, replica_type);
+        std::move(segment_name), base, size, transport_endpoint, replica_type,
+        std::move(protocol));
     const auto offset_allocator = allocator->getOffsetAllocator();
 
     std::vector<size_t> order(allocations.size());

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1263,8 +1263,9 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                 continue;
             }
             const RegionResourceSpec spec{
-                restore.segment.id, restore.segment.name, restore.segment.base,
-                restore.segment.size, restore.segment.te_endpoint};
+                restore.segment.id,          restore.segment.name,
+                restore.segment.base,        restore.segment.size,
+                restore.segment.te_endpoint, restore.segment.protocol};
             auto allocations =
                 BuildRegionLiveAllocations(spec, restore.descriptors);
             if (!allocations) {
@@ -1275,7 +1276,8 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                 auto imported = ImportOffsetBufferAllocator(
                     restore.segment.name, restore.segment.base,
                     restore.segment.size, restore.segment.te_endpoint,
-                    *allocations);
+                    *allocations, ReplicaType::MEMORY,
+                    restore.segment.protocol);
                 if (!imported) {
                     return fail_remount(ErrorCode::INVALID_PARAMS);
                 }
@@ -1286,7 +1288,8 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                 auto imported = ImportCachelibBufferAllocator(
                     restore.segment.name, restore.segment.base,
                     restore.segment.size, restore.segment.te_endpoint,
-                    *allocations);
+                    *allocations, ReplicaType::MEMORY,
+                    restore.segment.protocol);
                 if (!imported) {
                     return fail_remount(ErrorCode::INVALID_PARAMS);
                 }

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -251,9 +251,9 @@ ErrorCode ScopedSegmentAccess::MountSegment(
         return ErrorCode::INVALID_PARAMS;
     }
 
-    auto created =
-        CreateBufferAllocator(segment_manager_->memory_allocator_, segment.name,
-                              buffer, size, segment.te_endpoint);
+    auto created = CreateBufferAllocator(
+        segment_manager_->memory_allocator_, segment.name, buffer, size,
+        segment.te_endpoint, ReplicaType::MEMORY, segment.protocol);
     if (!created) {
         return created.error();
     }
@@ -1317,6 +1317,8 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
         }
     }
 
+    // No protocol: NoFSegment carries no transport protocol (NoF replicas are
+    // addressed by endpoint alone), so these buffers keep the transfer default.
     auto created = CreateBufferAllocator(
         nof_segment_manager_->memory_allocator_, segment.name, buffer, size,
         segment.te_endpoint, ReplicaType::NOF_SSD);
@@ -1552,6 +1554,8 @@ ErrorCode SegmentManager::initializeCxlAllocator(const std::string& cxl_path,
               << std::fixed << std::setprecision(2)
               << cxl_size / (1024.0 * 1024 * 1024) << " GB)";
 
+    // No protocol: change_to_cxl() stamps each buffer with "cxl" when it is
+    // handed out; stamping the allocator would mark them before that.
     auto created =
         CreateBufferAllocator(BufferAllocatorType::CACHELIB, cxl_path,
                               DEFAULT_CXL_BASE, cxl_size, cxl_path);

--- a/mooncake-store/src/segment/pool_mount.cpp
+++ b/mooncake-store/src/segment/pool_mount.cpp
@@ -14,8 +14,9 @@ RegionKind ClassifyRegion(const Segment& segment) {
 }
 
 RegionResourceSpec MakeResourceSpec(const Segment& segment) {
-    return RegionResourceSpec{segment.id, segment.name, segment.base,
-                              segment.size, segment.te_endpoint};
+    return RegionResourceSpec{segment.id,          segment.name,
+                              segment.base,        segment.size,
+                              segment.te_endpoint, segment.protocol};
 }
 
 }  // namespace

--- a/mooncake-store/src/segment/region_driver.cpp
+++ b/mooncake-store/src/segment/region_driver.cpp
@@ -215,9 +215,9 @@ tl::expected<PreparedRegionResource, ErrorCode> MemoryRegionDriver::PrepareOpen(
     }
 
     if (live_allocations.empty()) {
-        auto allocator =
-            CreateBufferAllocator(*allocator_type(), spec.name, spec.base,
-                                  spec.size, spec.transport_endpoint);
+        auto allocator = CreateBufferAllocator(
+            *allocator_type(), spec.name, spec.base, spec.size,
+            spec.transport_endpoint, ReplicaType::MEMORY, spec.protocol);
         if (!allocator) {
             return tl::make_unexpected(allocator.error());
         }
@@ -227,7 +227,7 @@ tl::expected<PreparedRegionResource, ErrorCode> MemoryRegionDriver::PrepareOpen(
     if (*allocator_type() == BufferAllocatorType::CACHELIB) {
         auto restored = ImportCachelibBufferAllocator(
             spec.name, spec.base, spec.size, spec.transport_endpoint,
-            live_allocations);
+            live_allocations, ReplicaType::MEMORY, spec.protocol);
         if (!restored) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
@@ -238,7 +238,7 @@ tl::expected<PreparedRegionResource, ErrorCode> MemoryRegionDriver::PrepareOpen(
     if (*allocator_type() == BufferAllocatorType::OFFSET) {
         auto restored = ImportOffsetBufferAllocator(
             spec.name, spec.base, spec.size, spec.transport_endpoint,
-            live_allocations);
+            live_allocations, ReplicaType::MEMORY, spec.protocol);
         if (!restored) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
@@ -307,6 +307,7 @@ tl::expected<RegionDriverRegistry, ErrorCode> CreateRegionDrivers(
         RegionKind::HOST_MEMORY,
         std::make_unique<MemoryRegionDriver>(config.memory_allocator));
     if (config.cxl) {
+        // No protocol: change_to_cxl() stamps each buffer when handed out.
         auto allocator = CreateBufferAllocator(
             BufferAllocatorType::CACHELIB, config.cxl->path, DEFAULT_CXL_BASE,
             config.cxl->size, config.cxl->path);

--- a/mooncake-store/src/serialize/serializer.cpp
+++ b/mooncake-store/src/serialize/serializer.cpp
@@ -1033,7 +1033,8 @@ auto Serializer<OffsetBufferAllocator>::deserialize(const msgpack::object &obj)
             return tl::unexpected(offset_allocator_result.error());
         }
 
-        // Create OffsetBufferAllocator instance
+        // Create OffsetBufferAllocator instance. The snapshot carries no
+        // protocol, so the allocator keeps the transfer default.
         auto allocator = std::make_shared<OffsetBufferAllocator>(
             segment_name, base, total_size, transport_endpoint);
 

--- a/mooncake-store/tests/buffer_allocator_test.cpp
+++ b/mooncake-store/tests/buffer_allocator_test.cpp
@@ -88,6 +88,82 @@ TEST_F(BufferAllocatorTest, AllocateAndDeallocate) {
     }
 }
 
+// Regression: a buffer must report the protocol of the segment it was
+// allocated from, not a hardcoded default. Otherwise descriptors built from
+// these buffers (e.g. /query_key) advertise "tcp" for an RDMA segment.
+TEST_F(BufferAllocatorTest, AllocatedBufferCarriesSegmentProtocol) {
+    const std::string segment_name = "protocol-segment";
+    const size_t size = 1024 * 1024 * 16;  // 16MB (multiple of 4MB)
+    const size_t base = 0x100000000ULL;    // 4GB
+
+    for (const auto& allocator_type : allocator_types_) {
+        auto rdma =
+            CreateBufferAllocator(allocator_type, segment_name, base, size,
+                                  segment_name, ReplicaType::MEMORY, "rdma");
+        ASSERT_TRUE(rdma.has_value());
+        auto bufHandle = (*rdma)->allocate(1024);
+        ASSERT_NE(bufHandle, nullptr);
+        EXPECT_EQ(bufHandle->get_descriptor().protocol_, "rdma");
+
+        // Callers that do not pass a protocol keep the transfer default. A
+        // separate base keeps the two allocators off the same slabs.
+        auto legacy = CreateBufferAllocator(allocator_type, segment_name,
+                                            base + size, size, segment_name);
+        ASSERT_TRUE(legacy.has_value());
+        auto legacyHandle = (*legacy)->allocate(1024);
+        ASSERT_NE(legacyHandle, nullptr);
+        EXPECT_EQ(legacyHandle->get_descriptor().protocol_, "tcp");
+    }
+}
+
+// Regression: a segment mounted as "cxl" without CXL support on the master
+// falls through to the regular allocator. Its buffers are plain addresses
+// until change_to_cxl() runs, so they must not report "cxl": deallocate()
+// would otherwise free the CXL-encoded address instead of the real one.
+TEST_F(BufferAllocatorTest, CxlSegmentProtocolNotStampedOnFreshBuffers) {
+    const std::string segment_name = "cxl-protocol-segment";
+    const size_t size = 1024 * 1024 * 16;  // 16MB (multiple of 4MB)
+    const size_t base = 0x100000000ULL;    // 4GB
+
+    for (const auto& allocator_type : allocator_types_) {
+        auto allocator =
+            CreateBufferAllocator(allocator_type, segment_name, base, size,
+                                  segment_name, ReplicaType::MEMORY, "cxl");
+        ASSERT_TRUE(allocator.has_value());
+        auto bufHandle = (*allocator)->allocate(1024);
+        ASSERT_NE(bufHandle, nullptr);
+        EXPECT_EQ(bufHandle->get_descriptor().protocol_, "tcp");
+        bufHandle.reset();
+    }
+}
+
+// Regression: buffers rebuilt when a segment is remounted must carry the
+// mounted protocol too, otherwise a remount would silently reset it.
+TEST_F(BufferAllocatorTest, ImportedBuffersCarrySegmentProtocol) {
+    constexpr uintptr_t kBase = 0x1C0000000ULL;
+    constexpr size_t kCapacity = 16 * 1024 * 1024;
+    const std::string segment = "protocol-restore";
+    const std::string endpoint = "protocol-restore-endpoint";
+
+    auto original = std::make_shared<OffsetBufferAllocator>(
+        segment, kBase, kCapacity, endpoint, ReplicaType::MEMORY, "rdma");
+    auto first = original->allocate(123);
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first->get_descriptor().protocol_, "rdma");
+
+    const std::vector<AllocatedBuffer::Descriptor> descriptors = {
+        first->get_descriptor()};
+    std::vector<LiveAllocation> allocations = {
+        ToLiveAllocation(kBase, descriptors[0])};
+
+    auto restored =
+        ImportOffsetBufferAllocator(segment, kBase, kCapacity, endpoint,
+                                    allocations, ReplicaType::MEMORY, "rdma");
+    ASSERT_TRUE(restored.has_value());
+    ASSERT_EQ(restored->buffers.size(), descriptors.size());
+    EXPECT_EQ(restored->buffers[0]->get_descriptor().protocol_, "rdma");
+}
+
 // Test multiple allocations within the buffer
 TEST_F(BufferAllocatorTest, AllocateMultiple) {
     for (const auto& allocator_type : allocator_types_) {


### PR DESCRIPTION
/query_key reported protocol_: "tcp" for replicas on an RDMA-mounted segment. The descriptor's protocol comes from AllocatedBuffer::protocol, which defaults to "tcp" and was only ever written by change_to_cxl(), so it never carried the protocol of the segment the buffer was allocated from.

Carry the protocol on the allocator and stamp it when a buffer is constructed:

- BufferAllocatorBase::getTransferProtocol() (defaults to "tcp", deliberately not pure so DummyBufferAllocator and out-of-tree subclasses keep compiling).
- CachelibBufferAllocator / OffsetBufferAllocator keep the protocol they were created with; Create / CreateBufferAllocator / Import* take it as a trailing defaulted parameter so existing callers (tests, benchmarks) are unchanged.
- The AllocatedBuffer ctor moves out of line (BufferAllocatorBase is incomplete in the header) and stamps the protocol from the owning allocator.
- Production call sites pass it through: the segment mount path, the region driver open/adopt paths, and the HA remount / standby-restore imports, which now carry it in RegionResourceSpec.protocol.

"cxl" is never stamped from an allocator. Unlike a transport it marks an address already offset-encoded by change_to_cxl(), which rewrites the pointer in the same call, so it must stay a per-buffer invariant: the CXL allocators are created without a protocol. Taking it from the allocator would let a buffer that has not been offset-encoded advertise "cxl", and deallocate() would then free ptr + DEFAULT_CXL_BASE — reachable by mounting a segment as "cxl" on a master with CXL disabled, which falls through to the regular allocator path.

NoF segments keep the transfer default: NoFSegment has no protocol field (NoF replicas are addressed by endpoint alone). The HA snapshot format carries no protocol either, so allocators rebuilt from it keep the default.

Tests: AllocatedBufferCarriesSegmentProtocol,
CxlSegmentProtocolNotStampedOnFreshBuffers,
ImportedBuffersCarrySegmentProtocol.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)