### PR TITLE
[Store] Rebootstrap standbys behind the compaction floor

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
@@ -16,6 +16,7 @@ class OpLogApplier;
 enum class OpLogBatchStandbyPollDisposition {
     OK,
     RETRYABLE,
+    REBOOTSTRAP_REQUIRED,
     FATAL,
 };
 
@@ -51,6 +52,7 @@ class OpLogBatchStandbyReader {
     std::optional<DurablePrefix> last_observed_prefix_;
     std::optional<DurablePrefix> last_applied_durable_prefix_;
     std::optional<uint64_t> last_scanned_batch_last_seq_;
+    std::optional<uint64_t> compaction_floor_;
     uint64_t last_applied_batch_id_{0};
     bool require_complete_history_{false};
 };

--- a/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
@@ -27,6 +27,7 @@ struct OpLogBatchStandbyPollResult {
     bool durable_prefix_present{false};
     size_t applied_entries{0};
     DurablePrefix durable_prefix{};
+    uint64_t compaction_floor{0};
 };
 
 class OpLogBatchStandbyReader {
@@ -46,13 +47,13 @@ class OpLogBatchStandbyReader {
     }
 
    private:
+    OpLogBatchStandbyPollResult PollBatches(size_t max_batches, uint64_t floor);
     OpLogBatchStorage storage_;
     OpLogApplier& applier_;
     bool batch_format_seen_{false};
     std::optional<DurablePrefix> last_observed_prefix_;
     std::optional<DurablePrefix> last_applied_durable_prefix_;
     std::optional<uint64_t> last_scanned_batch_last_seq_;
-    std::optional<uint64_t> compaction_floor_;
     uint64_t last_applied_batch_id_{0};
     bool require_complete_history_{false};
 };

--- a/mooncake-store/include/ha/oplog/oplog_batch_storage.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_storage.h
@@ -17,6 +17,7 @@ class OpLogBatchStorage {
     ErrorCode ClaimProducerView(ViewVersionId producer_view_version);
     ErrorCode ValidateProducerView(ViewVersionId producer_view_version) const;
     ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const;
+    ErrorCode ReadCompactionFloor(uint64_t& floor) const;
     ErrorCode ReadDurablePrefix(DurablePrefix& prefix);
     ErrorCode WriteBatchAndAdvancePrefix(const OpLogBatchRecord& batch,
                                          const DurablePrefix& expected_prefix);

--- a/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 
 #include <ylt/util/tl/expected.hpp>
@@ -33,7 +34,8 @@ class BatchOpLogSnapshotProvider final {
 
     tl::expected<BatchOpLogSnapshotRestoreResult, ErrorCode> RestoreBaseline(
         StandbyMetadataStore& metadata, StandbySegmentRegistry& registry,
-        OpLogApplier* applier = nullptr, uint64_t minimum_snapshot_batch = 0);
+        OpLogApplier* applier = nullptr, uint64_t minimum_snapshot_batch = 0,
+        std::function<bool()> cancelled = {});
 
    private:
     std::string cluster_id_;

--- a/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
@@ -33,7 +33,7 @@ class BatchOpLogSnapshotProvider final {
 
     tl::expected<BatchOpLogSnapshotRestoreResult, ErrorCode> RestoreBaseline(
         StandbyMetadataStore& metadata, StandbySegmentRegistry& registry,
-        OpLogApplier* applier = nullptr);
+        OpLogApplier* applier = nullptr, uint64_t minimum_snapshot_batch = 0);
 
    private:
     std::string cluster_id_;

--- a/mooncake-store/include/hot_standby_service.h
+++ b/mooncake-store/include/hot_standby_service.h
@@ -66,6 +66,7 @@ struct StandbySyncStatus {
     std::chrono::milliseconds lag_time{0};
     bool is_syncing{false};
     bool is_connected{false};
+    bool is_recovering{false};
     StandbyState state{StandbyState::STOPPED};
     std::chrono::milliseconds time_in_state{0};
     ErrorCode last_error{ErrorCode::OK};
@@ -259,6 +260,7 @@ class HotStandbyService {
      * @brief Main replication loop (runs in background thread)
      */
     void ReplicationLoop();
+    ErrorCode RebootstrapBatchOpLog(uint64_t floor);
 
     /**
      * @brief Verification loop (runs in background thread)
@@ -270,7 +272,7 @@ class HotStandbyService {
     std::unique_ptr<StandbyMetadataStore> metadata_store_;
     std::unique_ptr<SnapshotProvider> snapshot_provider_{
         std::make_unique<NoopSnapshotProvider>()};
-    std::unique_ptr<BatchOpLogSnapshotProvider> batch_oplog_snapshot_provider_;
+    std::shared_ptr<BatchOpLogSnapshotProvider> batch_oplog_snapshot_provider_;
 
     // OpLog replication components
     std::unique_ptr<OpLogApplier> oplog_applier_;
@@ -289,6 +291,7 @@ class HotStandbyService {
     std::atomic<uint64_t> applied_seq_id_{0};
     std::atomic<uint64_t> primary_seq_id_{0};
     std::atomic<ErrorCode> last_error_{ErrorCode::OK};
+    std::atomic<bool> recovering_{false};
 
     // State machine for managing service lifecycle
     StandbyStateMachine state_machine_;

--- a/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
@@ -68,6 +68,21 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
     result.durable_prefix_present = true;
     result.durable_prefix = prefix;
 
+    uint64_t floor = 0;
+    err = storage_.ReadCompactionFloor(floor);
+    if (err == ErrorCode::OK)
+        compaction_floor_ = floor;
+    else if (err != ErrorCode::ETCD_KEY_NOT_EXIST) {
+        SetPollError(result, err, IsRetryableBackendError(err));
+        return result;
+    }
+    if (compaction_floor_ && last_applied_batch_id_ < *compaction_floor_) {
+        result.disposition =
+            OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED;
+        result.error = ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+        return result;
+    }
+
     if (last_observed_prefix_ &&
         (prefix.batch_id < last_observed_prefix_->batch_id ||
          prefix.last_seq < last_observed_prefix_->last_seq ||

--- a/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
@@ -52,8 +52,46 @@ ErrorCode OpLogBatchStandbyReader::SetBaselineCursor(
 OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
     size_t max_batches) {
     OpLogBatchStandbyPollResult result;
+    uint64_t floor = 0;
+    ErrorCode err = storage_.ReadCompactionFloor(floor);
+    if (err != ErrorCode::OK && err != ErrorCode::ETCD_KEY_NOT_EXIST) {
+        SetPollError(result, err, IsRetryableBackendError(err));
+        return result;
+    }
+    if (err == ErrorCode::OK && last_applied_batch_id_ < floor) {
+        result.compaction_floor = floor;
+        result.disposition =
+            OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED;
+        result.error = ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+        return result;
+    }
+    result = PollBatches(max_batches, floor);
+    if (result.disposition == OpLogBatchStandbyPollDisposition::FATAL) {
+        // Pruning may advance after the initial floor read. Classify missing
+        // history against the current floor before declaring corruption.
+        uint64_t current_floor = 0;
+        err = storage_.ReadCompactionFloor(current_floor);
+        if (err == ErrorCode::OK && last_applied_batch_id_ < current_floor) {
+            result.compaction_floor = current_floor;
+            result.disposition =
+                OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED;
+            result.error = ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+        } else if (err == ErrorCode::OK && current_floor > floor &&
+                   current_floor == last_applied_batch_id_) {
+            result = PollBatches(max_batches, current_floor);
+        } else if (err != ErrorCode::OK &&
+                   err != ErrorCode::ETCD_KEY_NOT_EXIST) {
+            SetPollError(result, err, IsRetryableBackendError(err));
+        }
+    }
+    return result;
+}
+
+OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollBatches(
+    size_t max_batches, uint64_t floor) {
+    OpLogBatchStandbyPollResult result;
     DurablePrefix prefix;
-    ErrorCode err = storage_.ReadDurablePrefix(prefix);
+    auto err = storage_.ReadDurablePrefix(prefix);
     if (err == ErrorCode::ETCD_KEY_NOT_EXIST) {
         if (batch_format_seen_) {
             SetPollError(result, ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, false);
@@ -67,21 +105,6 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
     batch_format_seen_ = true;
     result.durable_prefix_present = true;
     result.durable_prefix = prefix;
-
-    uint64_t floor = 0;
-    err = storage_.ReadCompactionFloor(floor);
-    if (err == ErrorCode::OK)
-        compaction_floor_ = floor;
-    else if (err != ErrorCode::ETCD_KEY_NOT_EXIST) {
-        SetPollError(result, err, IsRetryableBackendError(err));
-        return result;
-    }
-    if (compaction_floor_ && last_applied_batch_id_ < *compaction_floor_) {
-        result.disposition =
-            OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED;
-        result.error = ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
-        return result;
-    }
 
     if (last_observed_prefix_ &&
         (prefix.batch_id < last_observed_prefix_->batch_id ||
@@ -101,6 +124,17 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
         } else if (applier_.GetExpectedSequenceId() == 1) {
             last_applied_durable_prefix_ = prefix;
         }
+        return result;
+    }
+
+    // A proven cursor needs no historical batch read: its batch may have
+    // been pruned when the floor equals the durable prefix.
+    if (floor == prefix.batch_id && prefix.batch_id == last_applied_batch_id_ &&
+        last_scanned_batch_last_seq_ == prefix.last_seq &&
+        applier_.GetExpectedSequenceId() > 0 &&
+        applier_.GetExpectedSequenceId() - 1 == prefix.last_seq) {
+        last_observed_prefix_ = prefix;
+        last_applied_durable_prefix_ = prefix;
         return result;
     }
 

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -172,6 +172,21 @@ ErrorCode OpLogBatchStorage::ReadProducerView(
     return ErrorCode::OK;
 }
 
+ErrorCode OpLogBatchStorage::ReadCompactionFloor(uint64_t& floor) const {
+    if (!IsValidClusterId()) return ErrorCode::INVALID_PARAMS;
+    std::string value;
+    const auto err = backend_.Get(
+        "/oplog/" + cluster_id_ + "/snapshot/compaction_floor", value);
+    if (err != ErrorCode::OK) return err;
+    uint64_t parsed = 0;
+    const auto result =
+        std::from_chars(value.data(), value.data() + value.size(), parsed);
+    if (result.ec != std::errc() || result.ptr != value.data() + value.size())
+        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    floor = parsed;
+    return ErrorCode::OK;
+}
+
 ErrorCode OpLogBatchStorage::ClaimProducerView(
     ViewVersionId producer_view_version) {
     if (!IsValidClusterId() || producer_view_version <= 0 ||

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -9,6 +9,7 @@
 
 #include "ha/oplog/oplog_batch_codec.h"
 #include "ha/oplog/oplog_types.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
 #include "ha_metric_manager.h"
 #endif
@@ -176,7 +177,7 @@ ErrorCode OpLogBatchStorage::ReadCompactionFloor(uint64_t& floor) const {
     if (!IsValidClusterId()) return ErrorCode::INVALID_PARAMS;
     std::string value;
     const auto err = backend_.Get(
-        "/oplog/" + cluster_id_ + "/snapshot/compaction_floor", value);
+        ha::BuildBatchOpLogSnapshotCompactionFloorKey(cluster_id_), value);
     if (err != ErrorCode::OK) return err;
     uint64_t parsed = 0;
     const auto result =

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
@@ -129,8 +129,8 @@ void CopyRegistry(const StandbySegmentRegistry& source,
 }
 
 AttemptResult ReplaySuffix(const std::string& cluster_id, HaKvBackend& backend,
-                           OpLogApplier& applier,
-                           const DurablePrefix* baseline) {
+                           OpLogApplier& applier, const DurablePrefix* baseline,
+                           const std::function<bool()>& cancelled) {
     OpLogBatchStandbyReader reader(cluster_id, backend, applier);
     const DurablePrefix start =
         baseline == nullptr ? DurablePrefix{} : *baseline;
@@ -139,6 +139,9 @@ AttemptResult ReplaySuffix(const std::string& cluster_id, HaKvBackend& backend,
     }
 
     for (;;) {
+        if (cancelled && cancelled()) {
+            return Invalid(ErrorCode::ETCD_CTX_CANCELLED);
+        }
         auto poll = reader.PollOnce();
         if (poll.error != ErrorCode::OK) {
             return IsRetryableBackendError(poll.error)
@@ -167,7 +170,9 @@ AttemptResult RestorePointer(
     const std::string& cluster_id, HaKvBackend& backend,
     SnapshotObjectStore& object_store, const std::string& snapshot_root,
     std::string_view pointer_bytes, StandbyMetadataStore& metadata,
-    StandbySegmentRegistry& registry, OpLogApplier* supplied_applier) {
+    StandbySegmentRegistry& registry, OpLogApplier* supplied_applier,
+    const std::function<bool()>& cancelled) {
+    if (cancelled && cancelled()) return Invalid(ErrorCode::ETCD_CTX_CANCELLED);
     auto decoded_descriptor =
         ha::DecodeBatchOpLogSnapshotDescriptor(pointer_bytes);
     if (!decoded_descriptor) {
@@ -240,6 +245,9 @@ AttemptResult RestorePointer(
     applier->Recover(baseline.last_seq);
 
     for (size_t i = 0; i < manifest.object_chunks.size(); ++i) {
+        if (cancelled && cancelled()) {
+            return Invalid(ErrorCode::ETCD_CTX_CANCELLED);
+        }
         const auto& chunk = manifest.object_chunks[i];
         const std::string expected_key =
             ha::BuildBatchOpLogSnapshotObjectChunkKey(
@@ -260,6 +268,9 @@ AttemptResult RestorePointer(
             return Invalid();
         }
         for (const auto& entry : decoded_chunk->objects) {
+            if (cancelled && cancelled()) {
+                return Invalid(ErrorCode::ETCD_CTX_CANCELLED);
+            }
             if (entry.key.empty() || !TenantId(entry.tenant_id).IsValid()) {
                 return Invalid();
             }
@@ -276,7 +287,8 @@ AttemptResult RestorePointer(
         }
     }
 
-    auto suffix = ReplaySuffix(cluster_id, backend, *applier, &baseline);
+    auto suffix =
+        ReplaySuffix(cluster_id, backend, *applier, &baseline, cancelled);
     if (suffix.disposition != AttemptDisposition::kSuccess) {
         return suffix;
     }
@@ -299,7 +311,9 @@ AttemptResult RestoreCompleteOpLog(const std::string& cluster_id,
                                    HaKvBackend& backend,
                                    StandbyMetadataStore& metadata,
                                    StandbySegmentRegistry& registry,
-                                   OpLogApplier* supplied_applier) {
+                                   OpLogApplier* supplied_applier,
+                                   const std::function<bool()>& cancelled) {
+    if (cancelled && cancelled()) return Invalid(ErrorCode::ETCD_CTX_CANCELLED);
     std::unique_ptr<OpLogApplier> owned_applier;
     OpLogApplier* applier = supplied_applier;
     if (applier == nullptr) {
@@ -315,7 +329,8 @@ AttemptResult RestoreCompleteOpLog(const std::string& cluster_id,
         return IsRetryableBackendError(init_error) ? Infrastructure(init_error)
                                                    : Invalid(init_error);
     }
-    auto replay = ReplaySuffix(cluster_id, backend, *applier, nullptr);
+    auto replay =
+        ReplaySuffix(cluster_id, backend, *applier, nullptr, cancelled);
     if (replay.disposition != AttemptDisposition::kSuccess) {
         return replay;
     }
@@ -344,7 +359,8 @@ tl::expected<BatchOpLogSnapshotRestoreResult, ErrorCode>
 BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
                                             StandbySegmentRegistry& registry,
                                             OpLogApplier* applier,
-                                            uint64_t minimum_snapshot_batch) {
+                                            uint64_t minimum_snapshot_batch,
+                                            std::function<bool()> cancelled) {
     metadata.Clear();
     registry.Clear();
     if (!NormalizeAndValidateClusterId(cluster_id_) || cluster_id_.empty() ||
@@ -365,6 +381,8 @@ BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
     for (const std::string& pointer_key :
          {ha::BuildBatchOpLogSnapshotLatestKey(cluster_id_),
           ha::BuildBatchOpLogSnapshotFallbackKey(cluster_id_)}) {
+        if (cancelled && cancelled())
+            return tl::make_unexpected(ErrorCode::ETCD_CTX_CANCELLED);
         std::string pointer_bytes;
         const ErrorCode pointer_error =
             backend_.Get(pointer_key, pointer_bytes);
@@ -380,9 +398,9 @@ BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
             descriptor->last_included_batch_id < minimum_snapshot_batch) {
             continue;
         }
-        auto attempt =
-            RestorePointer(cluster_id_, backend_, object_store_, snapshot_root_,
-                           pointer_bytes, metadata, registry, applier);
+        auto attempt = RestorePointer(cluster_id_, backend_, object_store_,
+                                      snapshot_root_, pointer_bytes, metadata,
+                                      registry, applier, cancelled);
         if (attempt.disposition == AttemptDisposition::kSuccess) {
             return attempt.value;
         }
@@ -401,7 +419,7 @@ BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
         return tl::make_unexpected(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP);
     }
     auto full_replay = RestoreCompleteOpLog(cluster_id_, backend_, metadata,
-                                            registry, applier);
+                                            registry, applier, cancelled);
     if (full_replay.disposition != AttemptDisposition::kSuccess) {
         metadata.Clear();
         registry.Clear();

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
@@ -343,12 +343,23 @@ BatchOpLogSnapshotProvider::BatchOpLogSnapshotProvider(
 tl::expected<BatchOpLogSnapshotRestoreResult, ErrorCode>
 BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
                                             StandbySegmentRegistry& registry,
-                                            OpLogApplier* applier) {
+                                            OpLogApplier* applier,
+                                            uint64_t minimum_snapshot_batch) {
     metadata.Clear();
     registry.Clear();
     if (!NormalizeAndValidateClusterId(cluster_id_) || cluster_id_.empty() ||
         snapshot_root_.empty()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    OpLogBatchStorage storage(cluster_id_, backend_);
+    uint64_t floor = 0;
+    const auto floor_error = storage.ReadCompactionFloor(floor);
+    if (floor_error != ErrorCode::OK &&
+        floor_error != ErrorCode::ETCD_KEY_NOT_EXIST) {
+        return tl::make_unexpected(floor_error);
+    }
+    if (floor_error == ErrorCode::OK) {
+        minimum_snapshot_batch = std::max(minimum_snapshot_batch, floor);
     }
 
     for (const std::string& pointer_key :
@@ -364,6 +375,11 @@ BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
             return tl::make_unexpected(pointer_error);
         }
 
+        auto descriptor = ha::DecodeBatchOpLogSnapshotDescriptor(pointer_bytes);
+        if (!descriptor ||
+            descriptor->last_included_batch_id < minimum_snapshot_batch) {
+            continue;
+        }
         auto attempt =
             RestorePointer(cluster_id_, backend_, object_store_, snapshot_root_,
                            pointer_bytes, metadata, registry, applier);
@@ -381,6 +397,9 @@ BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
         }
     }
 
+    if (minimum_snapshot_batch != 0) {
+        return tl::make_unexpected(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP);
+    }
     auto full_replay = RestoreCompleteOpLog(cluster_id_, backend_, metadata,
                                             registry, applier);
     if (full_replay.disposition != AttemptDisposition::kSuccess) {

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -98,6 +98,7 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
     }
 
     last_error_.store(ErrorCode::OK, std::memory_order_release);
+    recovering_.store(false, std::memory_order_release);
 
     // Trigger START event
     auto result = state_machine_.ProcessEvent(StandbyEvent::START);
@@ -457,16 +458,9 @@ void HotStandbyService::NotifySnapshotStop() {
 StandbySyncStatus HotStandbyService::GetSyncStatus() const {
     StandbySyncStatus status;
 
-    // Get applied sequence ID from OpLogApplier
-    if (oplog_applier_) {
-        uint64_t expected = oplog_applier_->GetExpectedSequenceId();
-        status.applied_seq_id = (expected > 0) ? (expected - 1) : 0;
-        if (status.applied_seq_id == 0) {
-            status.applied_seq_id = applied_seq_id_.load();  // Fallback
-        }
-    } else {
-        status.applied_seq_id = applied_seq_id_.load();
-    }
+    // Callbacks can query status while mutex_ is held or state is swapped.
+    status.applied_seq_id = applied_seq_id_.load();
+    status.is_recovering = recovering_.load(std::memory_order_acquire);
 
     // Primary sequence ID (best-effort): updated by ReplicationLoop via etcd
     // `/latest`.
@@ -493,6 +487,9 @@ StandbySyncStatus HotStandbyService::GetSyncStatus() const {
 }
 
 bool HotStandbyService::IsReadyForPromotion() const {
+    if (recovering_.load(std::memory_order_acquire)) {
+        return false;
+    }
     // Use state machine to check if ready for promotion
     if (!state_machine_.IsReadyForPromotion()) {
         return false;
@@ -671,6 +668,10 @@ ErrorCode HotStandbyService::PreparePromotionLocked(
     uint64_t current_applied_seq_id, PromotionCatchUpPolicy policy) {
     NotifySnapshotPromotion();
     StopReplicationLoop();
+    if (recovering_.load(std::memory_order_acquire)) {
+        state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
+        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    }
     ErrorCode catch_up_err =
         FinalCatchUpForPromotionLocked(current_applied_seq_id, policy);
     if (catch_up_err != ErrorCode::OK) {
@@ -899,8 +900,8 @@ HotStandbyService::BeginBatchOpLogSnapshotCapture() {
     std::unique_lock<std::mutex> service_lock(mutex_);
     auto state = snapshot_capture_state_;
     std::unique_lock<std::mutex> capture_lock(state->mutex);
-    if (!IsRunning() || !batch_standby_reader_ || state->requested ||
-        state->active) {
+    if (!IsRunning() || recovering_.load(std::memory_order_acquire) ||
+        !batch_standby_reader_ || state->requested || state->active) {
         return std::nullopt;
     }
 
@@ -1015,6 +1016,99 @@ void HotStandbyService::SetBatchOpLogSnapshotProvider(
     batch_oplog_snapshot_provider_ = std::move(provider);
 }
 
+ErrorCode HotStandbyService::RebootstrapBatchOpLog(uint64_t floor) {
+    recovering_.store(true, std::memory_order_release);
+    CancelSnapshotCapture();
+    {
+        std::lock_guard<std::mutex> cursor_lock(batch_snapshot_cursor_mutex_);
+        last_applied_batch_snapshot_prefix_.reset();
+    }
+    NotifySyncStatus();
+
+    // Stop/promotion can hold mutex_ while joining this worker. Never block
+    // on that mutex once the worker has been asked to stop.
+    auto lock_while_running = [this](std::unique_lock<std::mutex>& lock) {
+        while (replication_loop_running_.load(std::memory_order_acquire)) {
+            if (lock.try_lock()) {
+                return replication_loop_running_.load(
+                    std::memory_order_acquire);
+            }
+            std::unique_lock<std::mutex> wait_lock(replication_loop_mutex_);
+            replication_loop_cv_.wait_for(
+                wait_lock, std::chrono::milliseconds(1),
+                [this] { return !replication_loop_running_.load(); });
+        }
+        return false;
+    };
+    std::shared_ptr<BatchOpLogSnapshotProvider> provider;
+    {
+        std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+        if (!lock_while_running(lock)) return ErrorCode::ETCD_CTX_CANCELLED;
+        provider = batch_oplog_snapshot_provider_;
+    }
+    if (!provider) return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+
+    auto metadata = std::make_unique<StandbyMetadataStore>();
+    auto applier = std::make_unique<OpLogApplier>(metadata.get(), cluster_id_);
+    StandbySegmentRegistry registry;
+    auto restored =
+        provider->RestoreBaseline(*metadata, registry, applier.get(), floor);
+    if (!restored) return restored.error();
+    auto reader = std::make_unique<OpLogBatchStandbyReader>(
+        cluster_id_, *batch_standby_kv_backend_, *applier);
+    const DurablePrefix baseline{.batch_id = restored->last_applied_batch_id,
+                                 .last_seq = restored->last_applied_seq};
+    auto err = reader->SetBaselineCursor(baseline);
+    if (err != ErrorCode::OK) return err;
+    // Recheck the floor and durable suffix after restoring the candidate.
+    OpLogBatchStandbyPollResult poll;
+    do {
+        if (!replication_loop_running_.load(std::memory_order_acquire)) {
+            return ErrorCode::ETCD_CTX_CANCELLED;
+        }
+        poll = reader->PollOnce();
+        if (poll.error != ErrorCode::OK) return poll.error;
+    } while (poll.durable_prefix_present &&
+             applier->GetExpectedSequenceId() - 1 <
+                 poll.durable_prefix.last_seq);
+    auto cursor = reader->GetLastAppliedDurablePrefix();
+    if (!poll.durable_prefix_present || !cursor ||
+        *cursor != poll.durable_prefix ||
+        cursor->last_seq < applied_seq_id_.load()) {
+        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    }
+    TestFailPoint::Wait("standby_rebootstrap_before_swap");
+    uint64_t current_floor = 0;
+    OpLogBatchStorage storage(cluster_id_, *batch_standby_kv_backend_);
+    err = storage.ReadCompactionFloor(current_floor);
+    if (err != ErrorCode::OK && err != ErrorCode::ETCD_KEY_NOT_EXIST)
+        return err;
+    if (err == ErrorCode::OK &&
+        restored->last_included_batch_id < current_floor) {
+        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    }
+    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+    if (!lock_while_running(lock) || !IsRunning()) {
+        return ErrorCode::ETCD_CTX_CANCELLED;
+    }
+    // Swapping preserves old state until all replacement references exist.
+    // Locals destroy the old reader before its applier and metadata store.
+    metadata_store_.swap(metadata);
+    oplog_applier_.swap(applier);
+    batch_standby_reader_.swap(reader);
+    batch_snapshot_baseline_ = *cursor;
+    batch_snapshot_producer_view_version_ = restored->producer_view_version;
+    {
+        std::lock_guard<std::mutex> cursor_lock(batch_snapshot_cursor_mutex_);
+        last_applied_batch_snapshot_prefix_ = *cursor;
+    }
+    applied_seq_id_.store(cursor->last_seq);
+    primary_seq_id_.store(cursor->last_seq);
+    last_error_.store(ErrorCode::OK);
+    recovering_.store(false, std::memory_order_release);
+    return ErrorCode::OK;
+}
+
 void HotStandbyService::ReplicationLoop() {
     LOG(INFO) << "Replication loop started (OpLog sync)";
 
@@ -1028,6 +1122,7 @@ void HotStandbyService::ReplicationLoop() {
         std::max(retry_base, std::chrono::milliseconds(5000));
     auto retry_delay = retry_base;
     std::optional<std::chrono::steady_clock::time_point> retry_started;
+    uint64_t recovery_floor = 0;
 
     auto wait_for_next_poll = [this](std::chrono::milliseconds delay) {
         std::unique_lock<std::mutex> lock(replication_loop_mutex_);
@@ -1040,6 +1135,20 @@ void HotStandbyService::ReplicationLoop() {
            IsRunning()) {
         if (!IsConnected()) {
             wait_for_next_poll(std::chrono::seconds(1));
+            continue;
+        }
+
+        if (recovering_.load(std::memory_order_acquire)) {
+            const auto error = RebootstrapBatchOpLog(recovery_floor);
+            last_error_.store(error, std::memory_order_release);
+            NotifySyncStatus();
+            if (error != ErrorCode::OK) {
+                wait_for_next_poll(retry_delay);
+                retry_delay = std::min(retry_delay * 2, max_retry_delay);
+            } else {
+                retry_started.reset();
+                retry_delay = retry_base;
+            }
             continue;
         }
 
@@ -1071,12 +1180,9 @@ void HotStandbyService::ReplicationLoop() {
                 const bool made_progress = expected_after > expected_before;
                 if (result.disposition ==
                     OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED) {
-                    LOG(ERROR) << "Batch-record history is below compaction "
-                                  "floor; stopping standby until it is "
-                                  "rebootstrapped";
-                    state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
-                    replication_loop_cv_.notify_all();
-                    break;
+                    recovery_floor = result.compaction_floor;
+                    recovering_.store(true, std::memory_order_release);
+                    continue;
                 }
                 if (result.disposition ==
                     OpLogBatchStandbyPollDisposition::RETRYABLE) {

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -1070,6 +1070,15 @@ void HotStandbyService::ReplicationLoop() {
                 last_error_.store(result.error, std::memory_order_release);
                 const bool made_progress = expected_after > expected_before;
                 if (result.disposition ==
+                    OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED) {
+                    LOG(ERROR) << "Batch-record history is below compaction "
+                                  "floor; stopping standby until it is "
+                                  "rebootstrapped";
+                    state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+                    replication_loop_cv_.notify_all();
+                    break;
+                }
+                if (result.disposition ==
                     OpLogBatchStandbyPollDisposition::RETRYABLE) {
                     const auto now = std::chrono::steady_clock::now();
                     if (!retry_started || made_progress) {

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -1051,8 +1051,10 @@ ErrorCode HotStandbyService::RebootstrapBatchOpLog(uint64_t floor) {
     auto metadata = std::make_unique<StandbyMetadataStore>();
     auto applier = std::make_unique<OpLogApplier>(metadata.get(), cluster_id_);
     StandbySegmentRegistry registry;
-    auto restored =
-        provider->RestoreBaseline(*metadata, registry, applier.get(), floor);
+    auto restored = provider->RestoreBaseline(
+        *metadata, registry, applier.get(), floor, [this] {
+            return !replication_loop_running_.load(std::memory_order_acquire);
+        });
     if (!restored) return restored.error();
     auto reader = std::make_unique<OpLogBatchStandbyReader>(
         cluster_id_, *batch_standby_kv_backend_, *applier);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -259,6 +259,8 @@ add_ha_test(batch_oplog_snapshot_coordinator_test
             ha/snapshot/batch_oplog/coordinator_test.cpp)
 add_ha_test(batch_oplog_snapshot_promotion_test
             ha/snapshot/batch_oplog/promotion_test.cpp)
+add_ha_test(batch_oplog_snapshot_rebootstrap_test
+            ha/snapshot/batch_oplog/rebootstrap_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
@@ -4,6 +4,7 @@
 #include <xxhash.h>
 
 #include <map>
+#include <functional>
 #include <string_view>
 #include <string>
 #include <vector>
@@ -37,6 +38,10 @@ class FakeHaKvBackend : public HaKvBackend {
     }
     ErrorCode Range(std::string_view begin_key, std::string_view end_key,
                     size_t limit, std::vector<KvPair>& kvs) override {
+        if (before_range) {
+            auto callback = std::move(before_range);
+            callback();
+        }
         if (next_range_error_ != ErrorCode::OK) {
             auto error = next_range_error_;
             next_range_error_ = ErrorCode::OK;
@@ -56,6 +61,7 @@ class FakeHaKvBackend : public HaKvBackend {
     ErrorCode Txn(const KvTxn&) override { return ErrorCode::OK; }
 
     int range_calls() const { return range_calls_; }
+    std::function<void()> before_range;
     void Erase(std::string_view key) { values_.erase(std::string(key)); }
     void FailNextGet(ErrorCode error) { next_get_error_ = error; }
     void FailNextRange(ErrorCode error) { next_range_error_ = error; }
@@ -93,6 +99,96 @@ OpLogBatchRecord MakeBatch(uint64_t batch_id, uint64_t first_seq,
 }
 
 }  // namespace
+
+TEST(OpLogBatchStandbyReaderTest, CompactionFloorBoundariesAndDeletion) {
+    FakeHaKvBackend backend;
+    const std::string floor_key = "/oplog/clusterA/snapshot/compaction_floor";
+    backend.Put(BuildDurablePrefixKey("clusterA"),
+                EncodeDurablePrefix({.batch_id = 2, .last_seq = 2}));
+    backend.Put(BuildBatchRecordKey("clusterA", 2),
+                EncodeOpLogBatchRecord(MakeBatch(2, 2, 2)));
+    MockMetadataStore metadata;
+    OpLogApplier applier(&metadata, "clusterA");
+    applier.Recover(2);
+    OpLogBatchStandbyReader reader("clusterA", backend, applier);
+    ASSERT_EQ(ErrorCode::OK,
+              reader.SetBaselineCursor({.batch_id = 2, .last_seq = 2}));
+    EXPECT_EQ(ErrorCode::OK, reader.PollOnce().error);
+    for (const auto* value : {"1", "2", "3", "18446744073709551615"}) {
+        backend.Put(floor_key, value);
+        if (std::string(value) == "2") {
+            backend.Erase(BuildBatchRecordKey("clusterA", 2));
+        }
+        const auto poll = reader.PollOnce();
+        if (std::string(value) == "1" || std::string(value) == "2") {
+            EXPECT_EQ(OpLogBatchStandbyPollDisposition::OK, poll.disposition);
+        } else {
+            EXPECT_EQ(OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED,
+                      poll.disposition);
+            EXPECT_EQ(0u, poll.applied_entries);
+        }
+        EXPECT_EQ(3u, applier.GetExpectedSequenceId());
+    }
+    backend.Erase(floor_key);
+    backend.Put(BuildBatchRecordKey("clusterA", 2),
+                EncodeOpLogBatchRecord(MakeBatch(2, 2, 2)));
+    EXPECT_EQ(ErrorCode::OK, reader.PollOnce().error);
+}
+
+TEST(OpLogBatchStandbyReaderTest, InvalidFloorFailsClosed) {
+    for (const auto* value :
+         {"", "-1", "+1", " 1", "1 ", "1x", "18446744073709551616"}) {
+        SCOPED_TRACE(value);
+        FakeHaKvBackend backend;
+        backend.Put("/oplog/clusterA/snapshot/compaction_floor", value);
+        MockMetadataStore metadata;
+        OpLogApplier applier(&metadata, "clusterA");
+        OpLogBatchStandbyReader reader("clusterA", backend, applier);
+        EXPECT_EQ(OpLogBatchStandbyPollDisposition::FATAL,
+                  reader.PollOnce().disposition);
+    }
+}
+
+TEST(OpLogBatchStandbyReaderTest, FloorAdvancingDuringPollRequiresRebootstrap) {
+    FakeHaKvBackend backend;
+    backend.Put(BuildDurablePrefixKey("clusterA"),
+                EncodeDurablePrefix({.batch_id = 3, .last_seq = 3}));
+    backend.Put(BuildBatchRecordKey("clusterA", 3),
+                EncodeOpLogBatchRecord(MakeBatch(3, 3, 3)));
+    backend.before_range = [&] {
+        backend.Put("/oplog/clusterA/snapshot/compaction_floor", "2");
+    };
+    MockMetadataStore metadata;
+    OpLogApplier applier(&metadata, "clusterA");
+    applier.Recover(1);
+    OpLogBatchStandbyReader reader("clusterA", backend, applier);
+    ASSERT_EQ(ErrorCode::OK,
+              reader.SetBaselineCursor({.batch_id = 1, .last_seq = 1}));
+    const auto result = reader.PollOnce();
+    EXPECT_EQ(OpLogBatchStandbyPollDisposition::REBOOTSTRAP_REQUIRED,
+              result.disposition);
+    EXPECT_EQ(2u, result.compaction_floor);
+    EXPECT_EQ(0u, result.applied_entries);
+    EXPECT_EQ(2u, applier.GetExpectedSequenceId());
+}
+
+TEST(OpLogBatchStandbyReaderTest, FloorDoesNotHideUnknownSuffixGap) {
+    FakeHaKvBackend backend;
+    backend.Put("/oplog/clusterA/snapshot/compaction_floor", "1");
+    backend.Put(BuildDurablePrefixKey("clusterA"),
+                EncodeDurablePrefix({.batch_id = 3, .last_seq = 3}));
+    backend.Put(BuildBatchRecordKey("clusterA", 3),
+                EncodeOpLogBatchRecord(MakeBatch(3, 3, 3)));
+    MockMetadataStore metadata;
+    OpLogApplier applier(&metadata, "clusterA");
+    applier.Recover(1);
+    OpLogBatchStandbyReader reader("clusterA", backend, applier);
+    ASSERT_EQ(ErrorCode::OK,
+              reader.SetBaselineCursor({.batch_id = 1, .last_seq = 1}));
+    EXPECT_EQ(OpLogBatchStandbyPollDisposition::FATAL,
+              reader.PollOnce().disposition);
+    EXPECT_EQ(2u, applier.GetExpectedSequenceId());
+}
 
 TEST(OpLogBatchStandbyReaderTest, MissingPrefixWaitsWithoutLegacyFallback) {
     FakeHaKvBackend backend;

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
@@ -94,6 +94,19 @@ TEST_F(BatchOpLogSnapshotProviderTest, AllAbsentNamespaceIsAnEmptyBaseline) {
     EXPECT_EQ(EncodeDurablePrefix({.batch_id = 0, .last_seq = 0}), prefix);
 }
 
+TEST_F(BatchOpLogSnapshotProviderTest, RestoreHonorsCancellation) {
+    EmptyBackend backend;
+    LocalFileSnapshotObjectStore object_store(root_);
+    BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
+                                        "snapshots");
+    StandbyMetadataStore metadata;
+    StandbySegmentRegistry registry;
+    auto result = provider.RestoreBaseline(metadata, registry, nullptr, 0,
+                                           [] { return true; });
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::ETCD_CTX_CANCELLED, result.error());
+}
+
 TEST_F(BatchOpLogSnapshotProviderTest, EmptyCompleteHistoryIsAValidBaseline) {
     EmptyBackend backend;
     ASSERT_EQ(ErrorCode::OK,

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
@@ -1,6 +1,8 @@
 #include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
 
 #include <gtest/gtest.h>
+#include <cstdlib>
+#include <filesystem>
 
 #include <map>
 #include <string_view>
@@ -59,12 +61,23 @@ class EmptyBackend final : public HaKvBackend {
     std::map<std::string, std::string> values_;
 };
 
+class BatchOpLogSnapshotProviderTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        char pattern[] = "/tmp/mooncake-provider-XXXXXX";
+        const char* root = mkdtemp(pattern);
+        ASSERT_NE(nullptr, root);
+        root_ = root;
+    }
+    void TearDown() override { std::filesystem::remove_all(root_); }
+    std::string root_;
+};
+
 }  // namespace
 
-TEST(BatchOpLogSnapshotProviderTest, AllAbsentNamespaceIsAnEmptyBaseline) {
+TEST_F(BatchOpLogSnapshotProviderTest, AllAbsentNamespaceIsAnEmptyBaseline) {
     EmptyBackend backend;
-    LocalFileSnapshotObjectStore object_store(
-        "/tmp/mooncake-n05-provider-all-absent");
+    LocalFileSnapshotObjectStore object_store(root_);
     BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
                                         "snapshots");
     StandbyMetadataStore metadata;
@@ -81,13 +94,12 @@ TEST(BatchOpLogSnapshotProviderTest, AllAbsentNamespaceIsAnEmptyBaseline) {
     EXPECT_EQ(EncodeDurablePrefix({.batch_id = 0, .last_seq = 0}), prefix);
 }
 
-TEST(BatchOpLogSnapshotProviderTest, EmptyCompleteHistoryIsAValidBaseline) {
+TEST_F(BatchOpLogSnapshotProviderTest, EmptyCompleteHistoryIsAValidBaseline) {
     EmptyBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
                           EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
-    LocalFileSnapshotObjectStore object_store(
-        "/tmp/mooncake-n05-provider-test");
+    LocalFileSnapshotObjectStore object_store(root_);
     BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
                                         "snapshots");
     StandbyMetadataStore metadata;
@@ -102,9 +114,8 @@ TEST(BatchOpLogSnapshotProviderTest, EmptyCompleteHistoryIsAValidBaseline) {
     EXPECT_TRUE(registry.GetAllSegments().empty());
 }
 
-TEST(BatchOpLogSnapshotProviderTest, UsesFallbackWhenLatestIsCorrupt) {
-    const std::string root = "/tmp/mooncake-n05-provider-fallback";
-    LocalFileSnapshotObjectStore object_store(root);
+TEST_F(BatchOpLogSnapshotProviderTest, UsesFallbackWhenLatestIsCorrupt) {
+    LocalFileSnapshotObjectStore object_store(root_);
     EmptyBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
@@ -156,9 +167,8 @@ TEST(BatchOpLogSnapshotProviderTest, UsesFallbackWhenLatestIsCorrupt) {
     EXPECT_EQ(0u, metadata.GetKeyCount());
 }
 
-TEST(BatchOpLogSnapshotProviderTest, ReturnsFinalCursorAfterSuffixReplay) {
-    const std::string root = "/tmp/mooncake-n05-provider-suffix";
-    LocalFileSnapshotObjectStore object_store(root);
+TEST_F(BatchOpLogSnapshotProviderTest, ReturnsFinalCursorAfterSuffixReplay) {
+    LocalFileSnapshotObjectStore object_store(root_);
     EmptyBackend backend;
 
     OpLogBatchRecord suffix_batch;
@@ -227,10 +237,9 @@ TEST(BatchOpLogSnapshotProviderTest, ReturnsFinalCursorAfterSuffixReplay) {
     EXPECT_EQ(2u, result->last_applied_batch_id);
 }
 
-TEST(BatchOpLogSnapshotProviderTest,
-     ReplaysCompleteHistoryAfterBothPointersAreInvalid) {
-    const std::string root = "/tmp/mooncake-n05-provider-complete-oplog";
-    LocalFileSnapshotObjectStore object_store(root);
+TEST_F(BatchOpLogSnapshotProviderTest,
+       ReplaysCompleteHistoryAfterBothPointersAreInvalid) {
+    LocalFileSnapshotObjectStore object_store(root_);
     EmptyBackend backend;
     ASSERT_EQ(
         ErrorCode::OK,

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/rebootstrap_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/rebootstrap_test.cpp
@@ -1,0 +1,309 @@
+#include "hot_standby_service.h"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <map>
+#include <mutex>
+#include <thread>
+
+#include "crc32c.h"
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_batch_codec.h"
+#include "ha/snapshot/batch_oplog/codec.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
+
+namespace mooncake::test {
+namespace {
+
+class MemoryBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = values_.find(std::string(key));
+        if (it == values_.end()) return ErrorCode::ETCD_KEY_NOT_EXIST;
+        value = it->second;
+        return ErrorCode::OK;
+    }
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        values_[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+    ErrorCode Range(std::string_view begin, std::string_view end, size_t limit,
+                    std::vector<KvPair>& output) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        output.clear();
+        for (auto it = values_.lower_bound(std::string(begin));
+             it != values_.end() && it->first < end &&
+             (limit == 0 || output.size() < limit);
+             ++it) {
+            output.push_back({it->first, it->second});
+        }
+        return ErrorCode::OK;
+    }
+    bool SupportsTxn() const override { return true; }
+    ErrorCode Txn(const KvTxn& txn) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& put : txn.puts) values_[put.key] = put.value;
+        return ErrorCode::OK;
+    }
+
+   private:
+    std::mutex mutex_;
+    std::map<std::string, std::string> values_;
+};
+
+template <typename Predicate>
+bool WaitUntil(Predicate predicate) {
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!predicate()) {
+        if (std::chrono::steady_clock::now() >= deadline) return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return true;
+}
+
+class RebootstrapTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        char pattern[] = "/tmp/mooncake-n09-XXXXXX";
+        const auto* directory = mkdtemp(pattern);
+        ASSERT_NE(nullptr, directory);
+        root_ = directory;
+        objects_ = std::make_unique<LocalFileSnapshotObjectStore>(root_);
+        HotStandbyConfig config;
+        config.enable_snapshot_bootstrap = true;
+        config.enable_verification = false;
+        config.oplog_poll_interval_ms = 1;
+        service_ = std::make_unique<HotStandbyService>(config);
+        service_->SetCatchUpBatchKvBackendForTesting(backend_);
+        service_->SetBatchOpLogSnapshotProvider(
+            std::make_unique<BatchOpLogSnapshotProvider>(
+                "n09", *backend_, *objects_, "snapshots"));
+        Publish(1, "old", false);
+        OpLogEntry initial;
+        initial.sequence_id = 1;
+        initial.op_type = OpType::REMOVE;
+        initial.object_key = "absent";
+        OpLogBatchRecord batch;
+        batch.batch_id = batch.first_seq = batch.last_seq = 1;
+        batch.entries = {initial};
+        backend_->Put(BuildBatchRecordKey("n09", 1),
+                      EncodeOpLogBatchRecord(batch));
+        Prefix(1);
+        ASSERT_EQ(ErrorCode::OK, service_->Start("", "", "n09"));
+    }
+    void TearDown() override {
+        ReleaseSwap();
+        service_->Stop();
+        if (armed_) unsetenv("MOONCAKE_TEST_FAILPOINT_DIR");
+        std::filesystem::remove_all(root_);
+    }
+    void Prefix(uint64_t id) {
+        backend_->Put(BuildDurablePrefixKey("n09"),
+                      EncodeDurablePrefix({.batch_id = id, .last_seq = id}));
+    }
+    void Publish(uint64_t id, const std::string& key, bool fallback) {
+        const auto snapshot_id = std::to_string(id) + "-1";
+        const auto segments = EncodeBatchOpLogSnapshotSegments(
+            {{.segment_name = key,
+              .transport_endpoint = key + ":1234",
+              .file_path = ""}});
+        const auto segment_key =
+            ha::BuildBatchOpLogSnapshotSegmentsKey("snapshots", snapshot_id);
+        ASSERT_TRUE(objects_->UploadBuffer(segment_key, segments));
+        const auto chunk = EncodeBatchOpLogSnapshotObjectChunk(
+            0, {{.key = key, .metadata = {}},
+                {.key = "remove-me", .metadata = {}}});
+        const auto chunk_key = ha::BuildBatchOpLogSnapshotObjectChunkKey(
+            "snapshots", snapshot_id, 0);
+        ASSERT_TRUE(objects_->UploadBuffer(chunk_key, chunk));
+        ha::BatchOpLogSnapshotManifest manifest;
+        manifest.snapshot_id = snapshot_id;
+        manifest.last_included_batch_id = id;
+        manifest.last_included_seq = id;
+        manifest.segments = {
+            .key = segment_key,
+            .stored_size = segments.size(),
+            .crc32c = Crc32cValue(segments.data(), segments.size())};
+        manifest.object_chunks = {
+            {.chunk_index = 0,
+             .key = chunk_key,
+             .object_count = 2,
+             .stored_size = chunk.size(),
+             .crc32c = Crc32cValue(chunk.data(), chunk.size())}};
+        const auto bytes = ha::EncodeBatchOpLogSnapshotManifest(manifest);
+        ha::BatchOpLogSnapshotDescriptor descriptor;
+        descriptor.snapshot_id = snapshot_id;
+        descriptor.last_included_batch_id = id;
+        descriptor.last_included_seq = id;
+        descriptor.manifest_key =
+            ha::BuildBatchOpLogSnapshotManifestKey("snapshots", snapshot_id);
+        descriptor.manifest_size = bytes.size();
+        descriptor.manifest_crc32c = Crc32cValue(bytes.data(), bytes.size());
+        ASSERT_TRUE(objects_->UploadString(descriptor.manifest_key, bytes));
+        const auto encoded = ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
+        ASSERT_TRUE(objects_->UploadString(
+            ha::BuildBatchOpLogSnapshotDescriptorKey("snapshots", snapshot_id),
+            encoded));
+        backend_->Put(fallback ? ha::BuildBatchOpLogSnapshotFallbackKey("n09")
+                               : ha::BuildBatchOpLogSnapshotLatestKey("n09"),
+                      encoded);
+    }
+    void Compact() {
+        // Freeze at a complete batch so the reader observes one new history.
+        auto capture = service_->BeginBatchOpLogSnapshotCapture();
+        ASSERT_TRUE(capture);
+        OpLogEntry entry;
+        entry.sequence_id = 4;
+        entry.op_type = OpType::REMOVE;
+        entry.tenant_id = "default";
+        entry.object_key = "remove-me";
+        OpLogBatchRecord batch;
+        batch.batch_id = batch.first_seq = batch.last_seq = 4;
+        batch.entries = {entry};
+        backend_->Put(BuildBatchRecordKey("n09", 4),
+                      EncodeOpLogBatchRecord(batch));
+        Prefix(4);
+        backend_->Put(ha::BuildBatchOpLogSnapshotCompactionFloorKey("n09"),
+                      "3");
+        service_->EndBatchOpLogSnapshotCapture(*capture);
+    }
+    void ExpectOldState() {
+        StandbySnapshot snapshot;
+        ASSERT_TRUE(service_->ExportStandbySnapshot(snapshot));
+        EXPECT_EQ(1u, snapshot.oplog_sequence_id);
+        ASSERT_EQ(2u, snapshot.objects.size());
+        ASSERT_EQ(1u, snapshot.segments.size());
+        EXPECT_EQ("old", snapshot.segments[0].segment_name);
+        EXPECT_FALSE(service_->IsReadyForPromotion());
+        EXPECT_FALSE(service_->BeginBatchOpLogSnapshotCapture());
+        EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS,
+                  service_->Promote());
+    }
+    void ExpectRecovered() {
+        ASSERT_TRUE(WaitUntil([&] {
+            return service_->GetLatestAppliedSequenceId() == 4 &&
+                   !service_->GetSyncStatus().is_recovering;
+        }));
+        EXPECT_TRUE(service_->IsReadyForPromotion());
+        auto handoff = service_->PromoteAndDetachBatchOpLogStore();
+        ASSERT_TRUE(handoff);
+        EXPECT_EQ(4u, handoff->applied_cursor.batch_id);
+        EXPECT_EQ(4u, handoff->applied_cursor.last_seq);
+        EXPECT_EQ(1u, handoff->metadata_store->GetKeyCount());
+        EXPECT_TRUE(handoff->metadata_store->Exists("new"));
+        ASSERT_EQ(1u, handoff->segments.size());
+        EXPECT_EQ("new", handoff->segments[0].segment_name);
+    }
+    void ArmSwap() {
+        setenv("MOONCAKE_TEST_FAILPOINT_DIR", root_.c_str(), 1);
+        armed_ = true;
+        std::ofstream(root_ + "/standby_rebootstrap_before_swap.arm");
+    }
+    void ReleaseSwap() {
+        if (armed_)
+            std::ofstream(root_ + "/standby_rebootstrap_before_swap.release");
+    }
+    std::string root_;
+    bool armed_{false};
+    std::shared_ptr<MemoryBackend> backend_{std::make_shared<MemoryBackend>()};
+    std::unique_ptr<LocalFileSnapshotObjectStore> objects_;
+    std::unique_ptr<HotStandbyService> service_;
+};
+
+TEST_F(RebootstrapTest, CorruptLatestUsesFallbackAndReplaysSuffix) {
+    Publish(3, "new", true);
+    backend_->Put(ha::BuildBatchOpLogSnapshotLatestKey("n09"), "{}");
+    Compact();
+    ExpectRecovered();
+}
+
+TEST_F(RebootstrapTest, NoEligibleSnapshotPreservesStateAndRetriesOnline) {
+    Compact();
+    ASSERT_TRUE(
+        WaitUntil([&] { return service_->GetSyncStatus().is_recovering; }));
+    ExpectOldState();
+    Publish(3, "new", false);
+    ExpectRecovered();
+}
+
+TEST_F(RebootstrapTest, CorruptCandidatePreservesOldStateUntilRepaired) {
+    Publish(3, "new", false);
+    ASSERT_TRUE(objects_->UploadString(
+        ha::BuildBatchOpLogSnapshotObjectChunkKey("snapshots", "3-1", 0),
+        "corrupt"));
+    Compact();
+    ASSERT_TRUE(
+        WaitUntil([&] { return service_->GetSyncStatus().is_recovering; }));
+    ExpectOldState();
+    Publish(3, "new", false);
+    ExpectRecovered();
+}
+
+#ifdef MOONCAKE_ENABLE_TEST_FAILPOINTS
+TEST_F(RebootstrapTest, PromotionDuringSwapFailsClosedThenSucceeds) {
+    ArmSwap();
+    Publish(3, "new", false);
+    Compact();
+    ASSERT_TRUE(WaitUntil([&] {
+        return std::filesystem::exists(root_ +
+                                       "/standby_rebootstrap_before_swap.hit");
+    }));
+    ExpectOldState();
+    ReleaseSwap();
+    ExpectRecovered();
+}
+
+TEST_F(RebootstrapTest, StopDuringSwapDoesNotDeadlockOrInstallCandidate) {
+    ArmSwap();
+    Publish(3, "new", false);
+    Compact();
+    ASSERT_TRUE(WaitUntil([&] {
+        return std::filesystem::exists(root_ +
+                                       "/standby_rebootstrap_before_swap.hit");
+    }));
+    auto stopped = std::async(std::launch::async, [&] { service_->Stop(); });
+    EXPECT_TRUE(WaitUntil(
+        [&] { return service_->GetState() == StandbyState::STOPPED; }));
+    ReleaseSwap();
+    ASSERT_EQ(std::future_status::ready,
+              stopped.wait_for(std::chrono::seconds(5)));
+    EXPECT_EQ(1u, service_->GetLatestAppliedSequenceId());
+    EXPECT_EQ(2u, service_->GetMetadataCount());
+}
+
+TEST_F(RebootstrapTest, FloorAdvancingBeforeSwapRejectsCandidate) {
+    ArmSwap();
+    Publish(3, "new", false);
+    Compact();
+    ASSERT_TRUE(WaitUntil([&] {
+        return std::filesystem::exists(root_ +
+                                       "/standby_rebootstrap_before_swap.hit");
+    }));
+    backend_->Put(ha::BuildBatchOpLogSnapshotCompactionFloorKey("n09"), "4");
+    ReleaseSwap();
+    ASSERT_TRUE(WaitUntil([&] {
+        return !std::filesystem::exists(root_ +
+                                        "/standby_rebootstrap_before_swap.hit");
+    }));
+    ExpectOldState();
+    Publish(4, "new", false);
+    ASSERT_TRUE(WaitUntil([&] {
+        return service_->GetLatestAppliedSequenceId() == 4 &&
+               !service_->GetSyncStatus().is_recovering;
+    }));
+    EXPECT_TRUE(service_->IsReadyForPromotion());
+}
+#endif
+
+}  // namespace
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

Implement N09 compaction-floor awareness and online rebootstrap for batch OpLog standbys, following RFC #3167.

When a standby cursor falls behind `/oplog/<cluster>/snapshot/compaction_floor`, polling returns `REBOOTSTRAP_REQUIRED`. The service pauses normal apply and becomes non-promotable while restoring an eligible latest/fallback snapshot and replaying its suffix into temporary state. Successful recovery atomically replaces the store, registry, applier, reader and cursor; failed attempts retain the old state and retry with backoff.

The reader uses the current floor without retaining deleted keys, rechecks the floor when pruning races with polling, and accepts a proven cursor at the floor even if its historical batch has been deleted. Unknown suffix gaps remain fatal. Promotion and stop are guarded against recovery/swap races.

This PR does not advance the floor, prune batches, or collect snapshot objects. Production pruning remains disabled until all eligible standbys have deployed and validated N09.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Debug build with `BUILD_UNIT_TESTS=ON`, `MOONCAKE_ENABLE_TEST_FAILPOINTS=ON`, `USE_CUDA=OFF`, `USE_ETCD=OFF`, `STORE_USE_ETCD=OFF`, and `WITH_STORE_RUST=OFF`. Tests use an in-memory KV backend and local snapshot objects.

**Test commands:**
```bash
cmake --build build-n09 --target oplog_batch_standby_reader_test batch_oplog_snapshot_provider_test batch_oplog_snapshot_rebootstrap_test hot_standby_service_test batch_oplog_snapshot_promotion_test -j32
ctest --test-dir build-n09 -R '^(oplog_batch_standby_reader_test|batch_oplog_snapshot_provider_test|batch_oplog_snapshot_rebootstrap_test|hot_standby_service_test|batch_oplog_snapshot_promotion_test)$' --output-on-failure
pre-commit run --files $(git diff --name-only --diff-filter=ACMR upstream/main...HEAD)
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

All five test targets pass. Coverage includes absent/deleted/invalid floors, cursor boundaries, unknown gaps, floor advancement during poll and before swap, corrupt latest with healthy fallback, suffix replay, failed recovery preserving old objects/segments, online retry after repair, promotion during recovery, successful promotion after recovery, and stop during swap. PR-scoped pre-commit hooks pass. Real-etcd E2E and production rollout validation have not been run.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Formatting ran through the repository pre-commit hook. Production changes are below 500 LOC excluding tests; related design discussion is RFC #3167. Human review remains pending while this PR is a draft.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with implementation, tests, code review, and this description. The human submitter must review every changed line and be able to defend the change end-to-end before marking it ready for review.
