### PR TITLE
[Bugfix] Fix GIL misuse in TENT Python guard exits

### DIFF
--- a/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
@@ -27,3 +27,13 @@ find_package(
   REQUIRED)
 target_include_directories(tentpy PRIVATE ${Python3_INCLUDE_DIRS})
 target_link_libraries(tentpy PUBLIC tent_link_group)
+
+if(BUILD_UNIT_TESTS)
+  add_test(
+    NAME tent_python_guards_test
+    COMMAND
+      ${CMAKE_COMMAND} -E env "PYTHONPATH=$<TARGET_FILE_DIR:tentpy>"
+      "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/mooncake-common:$<TARGET_FILE_DIR:tent_metrics>:$ENV{LD_LIBRARY_PATH}"
+      ${Python3_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/test_python_guards.py)
+endif()

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -421,7 +421,6 @@ PYBIND11_MODULE(tent, m) {
         .def("__exit__", [](MemoryGuard& self, py::args) {
             py::gil_scoped_release release;
             self.release();
-            return py::none();
         });
 
     py::class_<BatchGuard>(m, "BatchGuard")
@@ -433,7 +432,6 @@ PYBIND11_MODULE(tent, m) {
         .def("__exit__", [](BatchGuard& self, py::args) {
             py::gil_scoped_release release;
             self.release();
-            return py::none();
         });
 
     // -------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/test_python_guards.py
+++ b/mooncake-transfer-engine/tent/tests/test_python_guards.py
@@ -1,0 +1,48 @@
+"""Check that guard exits return safely and preserve Python exceptions."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import tent
+
+
+class PythonGuardTest(unittest.TestCase):
+    def test_context_manager_exits(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "tent.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "metadata_type": "p2p",
+                        "rpc_server_hostname": "127.0.0.1",
+                        "rpc_server_port": 0,
+                        "transports": {
+                            "tcp": {"enable": True},
+                            "hp_tcp": {"enable": False},
+                            "rdma": {"enable": False},
+                            "shm": {"enable": False},
+                        },
+                    }
+                )
+            )
+            engine = tent.TransferEngine(str(config))
+            self.assertTrue(engine.available())
+            for name, allocate in (
+                ("memory", lambda: engine.allocate_memory_guard(4096)),
+                ("batch", lambda: engine.allocate_batch_guard(1)),
+            ):
+                with self.subTest(guard=name, exit="normal"):
+                    with allocate():
+                        pass
+                with self.subTest(guard=name, exit="exception"):
+                    expected = ValueError("exception from the with body")
+                    with self.assertRaises(ValueError) as raised:
+                        with allocate():
+                            raise expected
+                    self.assertIs(raised.exception, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Both `__exit__` lambdas construct `py::none()` while their `py::gil_scoped_release` is still alive, performing a Python reference-count operation without the GIL. When pybind11's GIL refcount assertions are enabled, exiting `with engine.allocate_memory_guard(...)` or `with engine.allocate_batch_guard(...)` can raise `pybind11::handle::inc_ref() PyGILState_Check() failure` and replace an exception raised by the block. With those assertions disabled, the invalid operation may remain silent.

Remove the two explicit returns so the lambdas return `void`: native cleanup still runs without the GIL, and pybind11 converts the return value to `None` after the scope restores the GIL. Add one CPU-only CTest regression covering normal exit and propagation of the original Python exception for both guards.

Open PR and issue searches for the guard names and GIL failure found no duplicate. The adjacent GIL work in #4019 and #3947 changes different bindings. This fix is independent of the pending TCP / HP TCP changes.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake Conductor (`mooncake-conductor`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Standalone build on base `f40474e839d6ba9bb8aa81c63c888a238b5bc09d`, Ubuntu 24.04 / GCC 13 / Python 3.12, Release without LTO. The checked-in pybind11 revision and cached pinned YLT / GTest sources were used. No GPU, remote peer, or external metadata service is needed.

**Test commands:**

```bash
cmake -S . -B build -G Ninja \
  -DCMAKE_BUILD_TYPE=Release -DENABLE_DEBUG_SYMBOLS=OFF \
  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
  -DUSE_TENT=ON -DUSE_CUDA=OFF -DUSE_ETCD=OFF \
  -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF \
  -DTENT_METRICS_ENABLED=OFF
cmake --build build --target tentpy -j2
ctest --test-dir build --output-on-failure --timeout 60 \
  -R '^tent_python_guards_test$'
pre-commit run --files \
  mooncake-transfer-engine/tent/src/python/pybind.cpp \
  mooncake-transfer-engine/tent/src/python/CMakeLists.txt \
  mooncake-transfer-engine/tent/tests/test_python_guards.py
git diff --check
```

**Test results:**

- [x] Unit tests pass (one CTest, four guard/exit subcases)
- [x] Integration tests pass (real local engine through the Python binding)
- [x] Manual testing done: original-code / fixed-code comparison

The original bindings fail all four guard/exit subcases with the GIL assertion;
in both exceptional-exit cases that error replaces the block's `ValueError`.
Restoring only the two-line fix makes the same CTest pass (0.05 seconds).
All hooks passed on the three changed files.

**Regression sensitivity:** The original-code / fixed-code comparison above ran with pybind11's GIL refcount assertions active. The archived standalone `pybind.cpp` compile command uses `-O3` without `-DNDEBUG`. Builds that define `NDEBUG` can disable these assertions, so a passing CTest in that configuration alone does not show that the test detects the original misuse. Deterministic failure reproduction requires `PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF` to be active when compiling the binding. [he-yufeng independently verified](https://github.com/kvcache-ai/Mooncake/pull/4051#pullrequestreview-5185262274) all four subcases failing with the original returns and passing with the fix after explicitly enabling the assertion in the mc-dev build.

## Checklist

- [ ] Human submitter has reviewed every changed line (draft pending this review)
- [x] I have formatted my code using `./scripts/code_format.sh` (PR-scoped hook)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] Documentation update: not applicable; no new API or configuration
- [x] I have added tests to prove my changes are effective
- [ ] RFC: not applicable; two production lines removed, plus a focused regression

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)
