### PR TITLE
[Store] Add OpLog writer runtime metrics

### DIFF
--- a/mooncake-store/include/ha/oplog/ordered_oplog_writer.h
+++ b/mooncake-store/include/ha/oplog/ordered_oplog_writer.h
@@ -84,6 +84,9 @@ class OrderedOpLogWriter {
     ErrorCode LastError() const;
     std::optional<OrderedOpLogWriterTerminalState> GetTerminalState() const;
     void SetTerminalCallback(TerminalCallback callback);
+    // Called by the service only after installing this writer. Older writers
+    // can no longer publish runtime metrics after this handoff.
+    void ActivateRuntimeMetrics();
     void Start();
     virtual void Stop();
 

--- a/mooncake-store/include/ha_metric_manager.h
+++ b/mooncake-store/include/ha_metric_manager.h
@@ -3,7 +3,9 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <utility>
 
 #include "ylt/metric/counter.hpp"
 #include "ylt/metric/gauge.hpp"
@@ -24,6 +26,23 @@ namespace mooncake {
  */
 class HAMetricManager {
    public:
+    struct WriterRuntimeSnapshot {
+        bool accepting{false};
+        uint64_t retry_count{0};
+        uint64_t retry_delay_ms{0};
+        uint64_t waiting_slots{0};
+        uint64_t committed_queue_depth{0};
+        uint64_t callback_queue_depth{0};
+        uint64_t durable_batch_id{0};
+        uint64_t durable_sequence{0};
+        int64_t last_error{0};
+        std::string terminal_reason;
+        std::optional<std::pair<uint64_t, uint64_t>> stuck_range;
+    };
+
+    void reset_writer_runtime();
+    void update_writer_runtime(const WriterRuntimeSnapshot& snapshot);
+    WriterRuntimeSnapshot get_writer_runtime() const;
     // --- Singleton Access ---
     static HAMetricManager& instance();
 
@@ -247,6 +266,9 @@ class HAMetricManager {
     // State Machine
     ylt::metric::gauge_t standby_state_;
     ylt::metric::counter_t state_transitions_total_;
+
+    mutable std::mutex writer_runtime_mutex_;
+    WriterRuntimeSnapshot writer_runtime_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha_metric_manager.h
+++ b/mooncake-store/include/ha_metric_manager.h
@@ -40,8 +40,12 @@ class HAMetricManager {
         std::optional<std::pair<uint64_t, uint64_t>> stuck_range;
     };
 
-    void reset_writer_runtime();
-    void update_writer_runtime(const WriterRuntimeSnapshot& snapshot);
+    // Activation replaces the observed writer and invalidates earlier owners.
+    // Snapshot retry_count is per writer on input, process cumulative on
+    // output.
+    uint64_t activate_writer_runtime(const WriterRuntimeSnapshot& snapshot);
+    void update_writer_runtime(uint64_t owner,
+                               const WriterRuntimeSnapshot& snapshot);
     WriterRuntimeSnapshot get_writer_runtime() const;
     // --- Singleton Access ---
     static HAMetricManager& instance();
@@ -269,6 +273,8 @@ class HAMetricManager {
 
     mutable std::mutex writer_runtime_mutex_;
     WriterRuntimeSnapshot writer_runtime_;
+    uint64_t writer_runtime_owner_{0};
+    uint64_t writer_retry_base_{0};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
+++ b/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
@@ -46,7 +46,8 @@ struct OrderedOpLogWriter::Impl {
         next_sequence_id = this->config.initial_durable_prefix.last_seq + 1;
     }
 
-    void PublishRuntime() const {
+    void PublishRuntime(bool activate = false) {
+        if (!activate && runtime_owner == 0) return;
         HAMetricManager::WriterRuntimeSnapshot snapshot;
         snapshot.accepting = accepting;
         snapshot.retry_count = retry_count;
@@ -60,7 +61,13 @@ struct OrderedOpLogWriter::Impl {
         snapshot.last_error = static_cast<int64_t>(last_error);
         snapshot.terminal_reason = terminal_reason;
         snapshot.stuck_range = stuck_range;
-        HAMetricManager::instance().update_writer_runtime(snapshot);
+        if (activate) {
+            runtime_owner =
+                HAMetricManager::instance().activate_writer_runtime(snapshot);
+        } else {
+            HAMetricManager::instance().update_writer_runtime(runtime_owner,
+                                                              snapshot);
+        }
     }
 
     void SealCommittedEntriesIfIdle() {
@@ -128,6 +135,7 @@ struct OrderedOpLogWriter::Impl {
     bool callback_stop_requested{false};
     ErrorCode last_error{ErrorCode::OK};
     uint64_t retry_count{0};
+    uint64_t runtime_owner{0};
     uint64_t retry_delay_ms{0};
     std::string terminal_reason;
     std::optional<std::pair<uint64_t, uint64_t>> stuck_range;
@@ -199,10 +207,11 @@ OrderedOpLogWriter::OrderedOpLogWriter(OrderedOpLogWriterConfig config,
                                        WriteBatchFn write_batch,
                                        TerminalCallback terminal_callback)
     : impl_(std::make_unique<Impl>(std::move(config), std::move(write_batch),
-                                   std::move(terminal_callback))) {
-    HAMetricManager::instance().reset_writer_runtime();
+                                   std::move(terminal_callback))) {}
+
+void OrderedOpLogWriter::ActivateRuntimeMetrics() {
     std::lock_guard<std::mutex> lock(impl_->mutex);
-    impl_->PublishRuntime();
+    if (impl_->runtime_owner == 0) impl_->PublishRuntime(true);
 }
 
 OrderedOpLogWriter::~OrderedOpLogWriter() { Stop(); }

--- a/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
+++ b/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
@@ -11,9 +11,7 @@
 #include <vector>
 
 #include "ha/oplog/oplog_test_failpoint.h"
-#ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
 #include "ha_metric_manager.h"
-#endif
 
 namespace mooncake {
 
@@ -46,6 +44,23 @@ struct OrderedOpLogWriter::Impl {
             return;
         }
         next_sequence_id = this->config.initial_durable_prefix.last_seq + 1;
+    }
+
+    void PublishRuntime() const {
+        HAMetricManager::WriterRuntimeSnapshot snapshot;
+        snapshot.accepting = accepting;
+        snapshot.retry_count = retry_count;
+        snapshot.retry_delay_ms = retry_delay_ms;
+        snapshot.waiting_slots = open_waiting_slots;
+        snapshot.committed_queue_depth =
+            committed_entries.size() + ready_entries.size();
+        snapshot.callback_queue_depth = callback_entries.size();
+        snapshot.durable_batch_id = durable_prefix.batch_id;
+        snapshot.durable_sequence = durable_prefix.last_seq;
+        snapshot.last_error = static_cast<int64_t>(last_error);
+        snapshot.terminal_reason = terminal_reason;
+        snapshot.stuck_range = stuck_range;
+        HAMetricManager::instance().update_writer_runtime(snapshot);
     }
 
     void SealCommittedEntriesIfIdle() {
@@ -86,6 +101,13 @@ struct OrderedOpLogWriter::Impl {
                         .count())};
             accepting = false;
             last_error = error;
+            terminal_reason =
+                reason == OrderedOpLogWriterTerminalReason::kRetryTimeout
+                    ? "retry_timeout"
+                : reason == OrderedOpLogWriterTerminalReason::kFenced
+                    ? "fenced"
+                    : "non_retryable_write_error";
+            PublishRuntime();
             callback = terminal_callback;
             state = terminal_state;
         }
@@ -105,6 +127,10 @@ struct OrderedOpLogWriter::Impl {
     bool stop_requested{false};
     bool callback_stop_requested{false};
     ErrorCode last_error{ErrorCode::OK};
+    uint64_t retry_count{0};
+    uint64_t retry_delay_ms{0};
+    std::string terminal_reason;
+    std::optional<std::pair<uint64_t, uint64_t>> stuck_range;
     uint64_t next_reservation_id{1};
     uint64_t next_sequence_id{1};
     DurablePrefix durable_prefix{config.initial_durable_prefix};
@@ -173,7 +199,11 @@ OrderedOpLogWriter::OrderedOpLogWriter(OrderedOpLogWriterConfig config,
                                        WriteBatchFn write_batch,
                                        TerminalCallback terminal_callback)
     : impl_(std::make_unique<Impl>(std::move(config), std::move(write_batch),
-                                   std::move(terminal_callback))) {}
+                                   std::move(terminal_callback))) {
+    HAMetricManager::instance().reset_writer_runtime();
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->PublishRuntime();
+}
 
 OrderedOpLogWriter::~OrderedOpLogWriter() { Stop(); }
 
@@ -192,6 +222,7 @@ OrderedOpLogWriter::Reserve() {
     const uint64_t id = impl_->next_reservation_id++;
     impl_->active_reservations.insert(id);
     ++impl_->open_waiting_slots;
+    impl_->PublishRuntime();
     return Reservation(this, id);
 }
 
@@ -208,6 +239,7 @@ OrderedOpLogWriter::Commit(Reservation&& reservation, OpLogEntry entry,
         --impl_->open_waiting_slots;
         reservation.writer_ = nullptr;
         reservation.id_ = 0;
+        impl_->PublishRuntime();
         return tl::make_unexpected(error);
     };
     if (impl_->terminal_state.has_value()) {
@@ -238,6 +270,7 @@ OrderedOpLogWriter::Commit(Reservation&& reservation, OpLogEntry entry,
         impl_->committed_entries.size() + impl_->ready_entries.size());
 #endif
     impl_->SealCommittedEntriesIfIdle();
+    impl_->PublishRuntime();
     impl_->cv.notify_all();
     return PendingHandle(sequence_id);
 }
@@ -250,6 +283,7 @@ void OrderedOpLogWriter::Abort(Reservation&& reservation) {
     }
     reservation.writer_ = nullptr;
     reservation.id_ = 0;
+    impl_->PublishRuntime();
 }
 
 bool OrderedOpLogWriter::IsAccepting() const {
@@ -309,6 +343,7 @@ void OrderedOpLogWriter::Start() {
                     .set_batch_record_callback_queue_depth(
                         impl_->callback_entries.size());
 #endif
+                impl_->PublishRuntime();
             }
             if (callback_entry.callback) {
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
@@ -345,6 +380,10 @@ void OrderedOpLogWriter::Start() {
                         impl_->committed_entries.size());
 #endif
                 expected_prefix = impl_->durable_prefix;
+                impl_->stuck_range =
+                    std::make_pair(expected_prefix.last_seq + 1,
+                                   expected_prefix.last_seq + entries.size());
+                impl_->PublishRuntime();
             }
 
             OpLogBatchRecord batch;
@@ -415,6 +454,8 @@ void OrderedOpLogWriter::Start() {
                                                  .last_seq = batch.last_seq};
                         impl_->last_error = ErrorCode::OK;
                         impl_->accepting = !impl_->stop_requested;
+                        impl_->retry_delay_ms = 0;
+                        impl_->stuck_range.reset();
                         for (size_t i = 0; i < entries.size(); ++i) {
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
                             entries[i].durable_at = durable_at;
@@ -438,6 +479,7 @@ void OrderedOpLogWriter::Start() {
 #endif
                         impl_->batch_busy = false;
                         impl_->SealCommittedEntriesIfIdle();
+                        impl_->PublishRuntime();
                     }
                     impl_->cv.notify_all();
                     break;
@@ -460,8 +502,11 @@ void OrderedOpLogWriter::Start() {
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
                     HAMetricManager::instance().inc_batch_record_retries();
 #endif
+                    ++impl_->retry_count;
                     impl_->last_error = err;
                     impl_->accepting = false;
+                    impl_->retry_delay_ms = retry_delay.count();
+                    impl_->PublishRuntime();
                     if (!retry_deadline.has_value() &&
                         impl_->config.retry_timeout.count() > 0) {
                         retry_deadline = std::chrono::steady_clock::now() +
@@ -486,6 +531,7 @@ void OrderedOpLogWriter::Stop() {
         std::lock_guard<std::mutex> lock(impl_->mutex);
         impl_->accepting = false;
         impl_->stop_requested = true;
+        impl_->PublishRuntime();
         if (!impl_->running) {
             return;
         }

--- a/mooncake-store/src/ha_metric_manager.cpp
+++ b/mooncake-store/src/ha_metric_manager.cpp
@@ -13,15 +13,21 @@ HAMetricManager& HAMetricManager::instance() {
     return static_instance;
 }
 
-void HAMetricManager::reset_writer_runtime() {
+uint64_t HAMetricManager::activate_writer_runtime(
+    const WriterRuntimeSnapshot& snapshot) {
     std::lock_guard<std::mutex> lock(writer_runtime_mutex_);
-    writer_runtime_ = {};
+    writer_retry_base_ = writer_runtime_.retry_count;
+    writer_runtime_ = snapshot;
+    writer_runtime_.retry_count += writer_retry_base_;
+    return ++writer_runtime_owner_;
 }
 
 void HAMetricManager::update_writer_runtime(
-    const WriterRuntimeSnapshot& snapshot) {
+    uint64_t owner, const WriterRuntimeSnapshot& snapshot) {
     std::lock_guard<std::mutex> lock(writer_runtime_mutex_);
+    if (owner == 0 || owner != writer_runtime_owner_) return;
     writer_runtime_ = snapshot;
+    writer_runtime_.retry_count += writer_retry_base_;
 }
 
 HAMetricManager::WriterRuntimeSnapshot HAMetricManager::get_writer_runtime()
@@ -471,7 +477,19 @@ std::string HAMetricManager::serialize_metrics() {
        << "ha_writer_durable_batch_id " << writer.durable_batch_id << "\n"
        << "# HELP ha_writer_durable_sequence Last durable sequence\n"
        << "# TYPE ha_writer_durable_sequence gauge\n"
-       << "ha_writer_durable_sequence " << writer.durable_sequence << "\n";
+       << "ha_writer_durable_sequence " << writer.durable_sequence << "\n"
+       << "# HELP ha_writer_stuck_first_sequence First sequence of the "
+          "in-flight batch awaiting durability; 0 when absent, not a timeout "
+          "indicator\n"
+       << "# TYPE ha_writer_stuck_first_sequence gauge\n"
+       << "ha_writer_stuck_first_sequence "
+       << (writer.stuck_range ? writer.stuck_range->first : 0) << "\n"
+       << "# HELP ha_writer_stuck_last_sequence Last sequence of the "
+          "in-flight batch awaiting durability; 0 when absent, not a timeout "
+          "indicator\n"
+       << "# TYPE ha_writer_stuck_last_sequence gauge\n"
+       << "ha_writer_stuck_last_sequence "
+       << (writer.stuck_range ? writer.stuck_range->second : 0) << "\n";
     if (!writer.terminal_reason.empty()) {
         ss << "# HELP ha_writer_terminal_reason Current terminal reason\n"
            << "# TYPE ha_writer_terminal_reason gauge\n"

--- a/mooncake-store/src/ha_metric_manager.cpp
+++ b/mooncake-store/src/ha_metric_manager.cpp
@@ -13,6 +13,23 @@ HAMetricManager& HAMetricManager::instance() {
     return static_instance;
 }
 
+void HAMetricManager::reset_writer_runtime() {
+    std::lock_guard<std::mutex> lock(writer_runtime_mutex_);
+    writer_runtime_ = {};
+}
+
+void HAMetricManager::update_writer_runtime(
+    const WriterRuntimeSnapshot& snapshot) {
+    std::lock_guard<std::mutex> lock(writer_runtime_mutex_);
+    writer_runtime_ = snapshot;
+}
+
+HAMetricManager::WriterRuntimeSnapshot HAMetricManager::get_writer_runtime()
+    const {
+    std::lock_guard<std::mutex> lock(writer_runtime_mutex_);
+    return writer_runtime_;
+}
+
 // --- Constructor ---
 HAMetricManager::HAMetricManager()
     // OpLog Sequence Gauges
@@ -423,6 +440,45 @@ std::string HAMetricManager::serialize_metrics() {
 #endif
     serialize_metric(state_transitions_total_);
 
+    const auto writer = get_writer_runtime();
+    ss << "# HELP ha_writer_accepting Whether the batch OpLog writer accepts "
+          "new entries\n"
+       << "# TYPE ha_writer_accepting gauge\n"
+       << "ha_writer_accepting " << (writer.accepting ? 1 : 0) << "\n"
+       << "# HELP ha_writer_retry_count Total writer retries\n"
+       << "# TYPE ha_writer_retry_count counter\n"
+       << "ha_writer_retry_count " << writer.retry_count << "\n"
+       << "# HELP ha_writer_retry_delay_ms Current writer retry delay\n"
+       << "# TYPE ha_writer_retry_delay_ms gauge\n"
+       << "ha_writer_retry_delay_ms " << writer.retry_delay_ms << "\n"
+       << "# HELP ha_writer_waiting_slots Current reserved writer slots\n"
+       << "# TYPE ha_writer_waiting_slots gauge\n"
+       << "ha_writer_waiting_slots " << writer.waiting_slots << "\n"
+       << "# HELP ha_writer_committed_queue_depth Committed writer queue "
+          "depth\n"
+       << "# TYPE ha_writer_committed_queue_depth gauge\n"
+       << "ha_writer_committed_queue_depth " << writer.committed_queue_depth
+       << "\n"
+       << "# HELP ha_writer_callback_queue_depth Callback queue depth\n"
+       << "# TYPE ha_writer_callback_queue_depth gauge\n"
+       << "ha_writer_callback_queue_depth " << writer.callback_queue_depth
+       << "\n"
+       << "# HELP ha_writer_last_error Last writer error code\n"
+       << "# TYPE ha_writer_last_error gauge\n"
+       << "ha_writer_last_error " << writer.last_error << "\n"
+       << "# HELP ha_writer_durable_batch_id Last durable batch ID\n"
+       << "# TYPE ha_writer_durable_batch_id gauge\n"
+       << "ha_writer_durable_batch_id " << writer.durable_batch_id << "\n"
+       << "# HELP ha_writer_durable_sequence Last durable sequence\n"
+       << "# TYPE ha_writer_durable_sequence gauge\n"
+       << "ha_writer_durable_sequence " << writer.durable_sequence << "\n";
+    if (!writer.terminal_reason.empty()) {
+        ss << "# HELP ha_writer_terminal_reason Current terminal reason\n"
+           << "# TYPE ha_writer_terminal_reason gauge\n"
+           << "ha_writer_terminal_reason{reason=\"" << writer.terminal_reason
+           << "\"} 1\n";
+    }
+
     // Histograms
     serialize_metric(oplog_etcd_write_latency_us_);
     serialize_metric(oplog_apply_latency_us_);
@@ -452,6 +508,23 @@ std::string HAMetricManager::get_summary_string() {
     ss << ", etcd_fail=" << get_oplog_etcd_write_failures_total();
     ss << ", watch_disconn=" << get_oplog_watch_disconnections_total();
     ss << ", state=" << get_standby_state();
+    const auto writer = get_writer_runtime();
+    ss << ", writer_accepting=" << (writer.accepting ? "true" : "false")
+       << ", writer_retry_count=" << writer.retry_count
+       << ", writer_retry_delay_ms=" << writer.retry_delay_ms
+       << ", writer_waiting_slots=" << writer.waiting_slots
+       << ", writer_committed_queue=" << writer.committed_queue_depth
+       << ", writer_callback_queue=" << writer.callback_queue_depth
+       << ", writer_durable_batch=" << writer.durable_batch_id
+       << ", writer_durable_seq=" << writer.durable_sequence
+       << ", writer_last_error=" << writer.last_error;
+    if (!writer.terminal_reason.empty()) {
+        ss << ", writer_terminal_reason=" << writer.terminal_reason;
+    }
+    if (writer.stuck_range) {
+        ss << ", writer_stuck_range=" << writer.stuck_range->first << "-"
+           << writer.stuck_range->second;
+    }
     return ss.str();
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -14571,6 +14571,7 @@ ErrorCode MasterService::InitializeBatchOpLogWriter(
     batch_oplog_kv_backend_ = std::move(backend);
     batch_oplog_storage_ = std::move(storage);
     ordered_oplog_writer_ = std::move(writer);
+    ordered_oplog_writer_->ActivateRuntimeMetrics();
     return ErrorCode::OK;
 }
 

--- a/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
@@ -169,6 +169,7 @@ TEST(OrderedOpLogWriterMetricsTest, RuntimeSnapshotTracksAdmission) {
         [](const OpLogBatchRecord&, const DurablePrefix&) {
             return ErrorCode::OK;
         });
+    writer.ActivateRuntimeMetrics();
     auto snapshot = HAMetricManager::instance().get_writer_runtime();
     EXPECT_TRUE(snapshot.accepting);
     EXPECT_EQ(snapshot.waiting_slots, 0);
@@ -180,6 +181,36 @@ TEST(OrderedOpLogWriterMetricsTest, RuntimeSnapshotTracksAdmission) {
     writer.Abort(std::move(*reservation));
     snapshot = HAMetricManager::instance().get_writer_runtime();
     EXPECT_EQ(snapshot.waiting_slots, 0);
+}
+
+TEST(OrderedOpLogWriterMetricsTest,
+     CandidateAndOldDestructorCannotOverwriteOwner) {
+    auto write = [](const OpLogBatchRecord&, const DurablePrefix&) {
+        return ErrorCode::OK;
+    };
+    auto old = std::make_unique<OrderedOpLogWriter>(
+        OrderedOpLogWriterConfig{
+            .initial_durable_prefix = {.batch_id = 1, .last_seq = 10}},
+        write);
+    old->ActivateRuntimeMetrics();
+    auto& metrics = HAMetricManager::instance();
+    {
+        OrderedOpLogWriter rejected({}, write);
+        EXPECT_EQ(metrics.get_writer_runtime().durable_sequence, 10);
+    }
+    EXPECT_TRUE(metrics.get_writer_runtime().accepting);
+    OrderedOpLogWriter replacement(
+        OrderedOpLogWriterConfig{
+            .initial_durable_prefix = {.batch_id = 2, .last_seq = 20}},
+        write);
+    EXPECT_EQ(metrics.get_writer_runtime().durable_sequence, 10);
+    replacement.ActivateRuntimeMetrics();
+    old->Stop();
+    old.reset();
+    EXPECT_TRUE(metrics.get_writer_runtime().accepting);
+    EXPECT_EQ(metrics.get_writer_runtime().durable_sequence, 20);
+    replacement.Stop();
+    EXPECT_FALSE(metrics.get_writer_runtime().accepting);
 }
 
 TEST(OrderedOpLogWriterAdmissionTest, AbortLeavesNoSequenceGap) {

--- a/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
@@ -11,9 +11,7 @@
 #include <thread>
 #include <vector>
 
-#ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
 #include "ha_metric_manager.h"
-#endif
 
 namespace mooncake::test {
 namespace {
@@ -164,6 +162,25 @@ bool WaitForMetric(const std::function<bool()>& predicate) {
 #endif
 
 }  // namespace
+
+TEST(OrderedOpLogWriterMetricsTest, RuntimeSnapshotTracksAdmission) {
+    OrderedOpLogWriter writer(
+        OrderedOpLogWriterConfig{.max_entries_per_batch = 2},
+        [](const OpLogBatchRecord&, const DurablePrefix&) {
+            return ErrorCode::OK;
+        });
+    auto snapshot = HAMetricManager::instance().get_writer_runtime();
+    EXPECT_TRUE(snapshot.accepting);
+    EXPECT_EQ(snapshot.waiting_slots, 0);
+
+    auto reservation = writer.Reserve();
+    ASSERT_TRUE(reservation.has_value());
+    snapshot = HAMetricManager::instance().get_writer_runtime();
+    EXPECT_EQ(snapshot.waiting_slots, 1);
+    writer.Abort(std::move(*reservation));
+    snapshot = HAMetricManager::instance().get_writer_runtime();
+    EXPECT_EQ(snapshot.waiting_slots, 0);
+}
 
 TEST(OrderedOpLogWriterAdmissionTest, AbortLeavesNoSequenceGap) {
     FakeBatchWriter storage;

--- a/mooncake-store/tests/ha/standby/ha_metric_manager_test.cpp
+++ b/mooncake-store/tests/ha/standby/ha_metric_manager_test.cpp
@@ -284,6 +284,57 @@ TEST_F(HAMetricManagerTest, TestConcurrentAccess) {
     EXPECT_EQ(before + kThreads * kIncrementsPerThread, after);
 }
 
+TEST_F(HAMetricManagerTest, WriterOwnershipAndRangeSerialization) {
+    auto& mgr = HAMetricManager::instance();
+    const auto before = mgr.get_writer_runtime().retry_count;
+    HAMetricManager::WriterRuntimeSnapshot first;
+    first.accepting = true;
+    const auto old_owner = mgr.activate_writer_runtime(first);
+    auto serialized = mgr.serialize_metrics();
+    EXPECT_EQ(
+        FindSerializedMetricValue(serialized, "ha_writer_stuck_first_sequence"),
+        0);
+    EXPECT_EQ(
+        FindSerializedMetricValue(serialized, "ha_writer_stuck_last_sequence"),
+        0);
+
+    first.retry_count = 2;
+    first.stuck_range = std::make_pair(11, 15);
+    mgr.update_writer_runtime(old_owner, first);
+    serialized = mgr.serialize_metrics();
+    EXPECT_EQ(
+        FindSerializedMetricValue(serialized, "ha_writer_stuck_first_sequence"),
+        11);
+    EXPECT_EQ(
+        FindSerializedMetricValue(serialized, "ha_writer_stuck_last_sequence"),
+        15);
+    EXPECT_EQ(mgr.get_writer_runtime().retry_count, before + 2);
+
+    first.stuck_range.reset();
+    mgr.update_writer_runtime(old_owner, first);
+    serialized = mgr.serialize_metrics();
+    EXPECT_EQ(
+        FindSerializedMetricValue(serialized, "ha_writer_stuck_first_sequence"),
+        0);
+    EXPECT_EQ(
+        FindSerializedMetricValue(serialized, "ha_writer_stuck_last_sequence"),
+        0);
+
+    HAMetricManager::WriterRuntimeSnapshot second;
+    second.accepting = true;
+    second.durable_sequence = 20;
+    const auto new_owner = mgr.activate_writer_runtime(second);
+    first.accepting = false;
+    first.terminal_reason = "fenced";
+    mgr.update_writer_runtime(old_owner, first);
+    EXPECT_TRUE(mgr.get_writer_runtime().accepting);
+    EXPECT_EQ(mgr.get_writer_runtime().durable_sequence, 20);
+    EXPECT_TRUE(mgr.get_writer_runtime().terminal_reason.empty());
+    second.retry_count = 1;
+    mgr.update_writer_runtime(new_owner, second);
+    EXPECT_EQ(mgr.get_writer_runtime().retry_count, before + 3);
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Description
Expose a single writer runtime snapshot through HA metrics and admin outputs, covering admission, queues, retries, durability, errors, stuck ranges, and terminal reason.

## Module
- [x] mooncake-store

## Type of change
- [x] Feature

## Testing
- pre-commit run --files on all changed files
- git diff --check
- Full CMake build blocked because extern/pybind11 is absent in this checkout.

## Checklist
- [x] Focused diff
- [x] Added unit coverage for admission snapshot

## AI assistance
AI-assisted implementation; human submitter must review every changed line.