### PR TITLE
[Store] Free NoF heartbeat probe buffers on segment unmount

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -178,6 +178,7 @@ class MasterService {
    public:
     using NoFProbeFn =
         std::function<bool(const std::string&, uint32_t, std::string*)>;
+    using NoFProbeReleaseFn = std::function<void(const std::string&)>;
     using DurableFinalizeCallback =
         std::function<void(const OpLogEntry& durable_entry)>;
     using BatchOpLogWriterFactory =
@@ -189,6 +190,7 @@ class MasterService {
     ~MasterService();
 
     void SetNoFProbeFnForTesting(NoFProbeFn fn);
+    void SetNoFProbeReleaseFnForTesting(NoFProbeReleaseFn fn);
     size_t GetMountedNoFSegmentCountForTesting();
     bool IsNoFSegmentMountedForTesting(const UUID& segment_id);
     std::optional<uint32_t> GetNoFHeartbeatFailureCountForTesting(
@@ -2190,6 +2192,12 @@ class MasterService {
         const std::string& error_reason);
     bool ProbeNoFSegment(const std::string& te_endpoint,
                          std::string* error_reason);
+    // Drops the heartbeat bookkeeping of an unmounted NoF segment and frees
+    // the probe resources its transport endpoint still holds. Both callers
+    // must hold `nof_heartbeat_mutex_`.
+    void EraseNoFHeartbeatStateLocked(const UUID& segment_id);
+    void ReleaseNoFProbeResourcesLocked(
+        const std::vector<std::string>& te_endpoints);
 
     // Pushes an offload mirror for `replica` onto its host client's LocalSSD
     // mailbox. When `mirror_clients` is non-null, the destination client is
@@ -2663,6 +2671,7 @@ class MasterService {
     static constexpr uint64_t kNoFHeartbeatThreadSleepMs = 100;
     mutable std::mutex nof_probe_fn_mutex_;
     NoFProbeFn nof_probe_fn_;
+    NoFProbeReleaseFn nof_probe_release_fn_;
 
     // if high availability features enabled
     const bool enable_ha_;

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -53,10 +53,22 @@ class SpdkWrapper {
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);
 
+    /**
+     * @brief Release the probe resources cached for a transport endpoint.
+     *        Called once the last NoF segment behind @p tr_str is unmounted,
+     *        so that the DMA buffer does not outlive the segment. The call is
+     *        idempotent and skips buffers whose probe request never completed,
+     *        because the device may still write into them.
+     */
+    void ReleaseProbeResources(const std::string &tr_str);
+
    private:
     struct ProbeBuffer {
         void *ptr{nullptr};
         uint32_t size{0};
+        // Set while a probe request holding this buffer is outstanding, so
+        // ReleaseProbeResources never frees memory a pending DMA targets.
+        bool in_flight{false};
 
         ProbeBuffer() = default;
         ProbeBuffer(const ProbeBuffer &) = delete;
@@ -90,6 +102,7 @@ class SpdkWrapper {
     ProbeBuffer *GetOrCreateProbeBuffer(const std::string &tr_str,
                                         uint32_t block_size,
                                         std::string *error_reason);
+    void MarkProbeBufferIdle(const std::string &tr_str);
     ProbeRequestContext *AcquireProbeRequestContext();
     void RecycleProbeRequestContext(ProbeRequestContext *ctx);
     void ReplenishProbeRequestContextPoolLocked(size_t count);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -366,6 +366,9 @@ MasterService::MasterService(const MasterServiceConfig& config)
         return SpdkWrapper::GetInstance().ProbeNofSegment(
             te_endpoint, timeout_ms, error_reason);
     };
+    nof_probe_release_fn_ = [](const std::string& te_endpoint) {
+        SpdkWrapper::GetInstance().ReleaseProbeResources(te_endpoint);
+    };
 #endif
 
     // Offload-on-evict: defer LOCAL_DISK offload to eviction time
@@ -811,6 +814,21 @@ void MasterService::SetNoFProbeFnForTesting(NoFProbeFn fn) {
                        std::string* error_reason) {
         return SpdkWrapper::GetInstance().ProbeNofSegment(
             te_endpoint, timeout_ms, error_reason);
+    };
+#else
+    (void)fn;
+#endif
+}
+
+void MasterService::SetNoFProbeReleaseFnForTesting(NoFProbeReleaseFn fn) {
+#ifdef USE_NOF
+    std::lock_guard<std::mutex> lock(nof_probe_fn_mutex_);
+    if (fn) {
+        nof_probe_release_fn_ = std::move(fn);
+        return;
+    }
+    nof_probe_release_fn_ = [](const std::string& te_endpoint) {
+        SpdkWrapper::GetInstance().ReleaseProbeResources(te_endpoint);
     };
 #else
     (void)fn;
@@ -3279,7 +3297,7 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
     }
     {
         std::lock_guard<std::mutex> lock(nof_heartbeat_mutex_);
-        nof_heartbeat_states_.erase(segment_id);
+        EraseNoFHeartbeatStateLocked(segment_id);
     }
     return {};
 #endif
@@ -12315,6 +12333,49 @@ bool MasterService::ProbeNoFSegment(const std::string& te_endpoint,
 #endif
 }
 
+void MasterService::EraseNoFHeartbeatStateLocked(const UUID& segment_id) {
+    auto it = nof_heartbeat_states_.find(segment_id);
+    if (it == nof_heartbeat_states_.end()) {
+        return;
+    }
+    std::string te_endpoint = std::move(it->second.te_endpoint);
+    nof_heartbeat_states_.erase(it);
+    ReleaseNoFProbeResourcesLocked({te_endpoint});
+}
+
+void MasterService::ReleaseNoFProbeResourcesLocked(
+    const std::vector<std::string>& te_endpoints) {
+    NoFProbeReleaseFn release_fn;
+    {
+        std::lock_guard<std::mutex> lock(nof_probe_fn_mutex_);
+        release_fn = nof_probe_release_fn_;
+    }
+    if (!release_fn) {
+        return;
+    }
+
+    std::unordered_set<std::string> released;
+    for (const auto& te_endpoint : te_endpoints) {
+        if (te_endpoint.empty() || released.contains(te_endpoint)) {
+            continue;
+        }
+        // Several segments may share one transport endpoint; its probe
+        // resources stay alive until the last of them is unmounted.
+        const bool still_tracked =
+            std::any_of(nof_heartbeat_states_.begin(),
+                        nof_heartbeat_states_.end(), [&](const auto& entry) {
+                            return entry.second.te_endpoint == te_endpoint;
+                        });
+        if (still_tracked) {
+            continue;
+        }
+        released.insert(te_endpoint);
+        release_fn(te_endpoint);
+        VLOG(1) << "endpoint=" << te_endpoint
+                << ", action=release_nof_probe_resources";
+    }
+}
+
 bool MasterService::TryUnmountNoFSegmentByHeartbeat(
     const MountedNoFSegmentSnapshot& snapshot,
     const std::string& error_reason) {
@@ -12330,7 +12391,7 @@ bool MasterService::TryUnmountNoFSegmentByHeartbeat(
         if (err == ErrorCode::SEGMENT_NOT_FOUND ||
             err == ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS) {
             std::lock_guard<std::mutex> lock(nof_heartbeat_mutex_);
-            nof_heartbeat_states_.erase(snapshot.segment_id);
+            EraseNoFHeartbeatStateLocked(snapshot.segment_id);
             VLOG(1) << "segment_id=" << snapshot.segment_id
                     << ", action=skip_nof_heartbeat_unmount"
                     << ", reason=" << toString(err);
@@ -12364,7 +12425,7 @@ bool MasterService::TryUnmountNoFSegmentByHeartbeat(
 
     {
         std::lock_guard<std::mutex> lock(nof_heartbeat_mutex_);
-        nof_heartbeat_states_.erase(snapshot.segment_id);
+        EraseNoFHeartbeatStateLocked(snapshot.segment_id);
     }
     MasterMetricManager::instance()
         .inc_nof_segments_unmounted_by_heartbeat_total();
@@ -12422,14 +12483,21 @@ void MasterService::NofHeartbeatThreadFunc() {
                 }
             }
 
+            // Segments can also disappear without going through Unmount, e.g.
+            // when their owning client is offboarded. Collect the endpoints
+            // first and release them once the map no longer references them.
+            std::vector<std::string> stale_endpoints;
             for (auto it = nof_heartbeat_states_.begin();
                  it != nof_heartbeat_states_.end();) {
                 if (!live_segment_ids.contains(it->first)) {
+                    stale_endpoints.push_back(
+                        std::move(it->second.te_endpoint));
                     it = nof_heartbeat_states_.erase(it);
                 } else {
                     ++it;
                 }
             }
+            ReleaseNoFProbeResourcesLocked(stale_endpoints);
 
             if (!ok_segments.empty()) {
                 next_probe_index %= ok_segments.size();

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -406,6 +406,7 @@ SpdkWrapper::ProbeBuffer *SpdkWrapper::GetOrCreateProbeBuffer(
     }
 
     if (probe_buffer->ptr != nullptr && probe_buffer->size == block_size) {
+        probe_buffer->in_flight = true;
         return probe_buffer.get();
     }
 
@@ -424,7 +425,36 @@ SpdkWrapper::ProbeBuffer *SpdkWrapper::GetOrCreateProbeBuffer(
         return nullptr;
     }
     probe_buffer->size = block_size;
+    probe_buffer->in_flight = true;
     return probe_buffer.get();
+}
+
+void SpdkWrapper::MarkProbeBufferIdle(const std::string &tr_str) {
+    std::lock_guard<std::mutex> lock(probe_buffers_mutex_);
+    auto it = probe_buffers_.find(tr_str);
+    if (it != probe_buffers_.end() && it->second) {
+        it->second->in_flight = false;
+    }
+}
+
+void SpdkWrapper::ReleaseProbeResources(const std::string &tr_str) {
+    std::lock_guard<std::mutex> lock(probe_buffers_mutex_);
+    auto it = probe_buffers_.find(tr_str);
+    if (it == probe_buffers_.end()) {
+        return;
+    }
+    if (it->second && it->second->in_flight) {
+        // The last probe never completed, so the controller may still DMA
+        // into this buffer. Keep it until Cleanup() tears the device down.
+        LOG(WARNING) << "endpoint=" << tr_str
+                     << ", action=skip_release_nof_probe_buffer"
+                     << ", reason=probe_in_flight";
+        return;
+    }
+    if (it->second && it->second->ptr) {
+        spdk_free(it->second->ptr);
+    }
+    probe_buffers_.erase(it);
 }
 
 bool SpdkWrapper::ProbeNofSegment(const std::string &tr_str,
@@ -464,6 +494,7 @@ bool SpdkWrapper::ProbeNofSegment(const std::string &tr_str,
                             ProbeReadComplete, probe_ctx);
     if (ret != 0) {
         RecycleProbeRequestContext(probe_ctx);
+        MarkProbeBufferIdle(tr_str);
         if (error_reason) {
             *error_reason = "submit_fail";
         }
@@ -476,6 +507,11 @@ bool SpdkWrapper::ProbeNofSegment(const std::string &tr_str,
            std::chrono::steady_clock::now() < deadline) {
         NvmePollProcessCompletion(seg_handle, 0);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    if (probe_ctx->done.load(std::memory_order_acquire)) {
+        // The request completed, so nothing references the buffer any more.
+        MarkProbeBufferIdle(tr_str);
     }
 
     bool ok = probe_ctx->done.load(std::memory_order_acquire) &&

--- a/mooncake-store/tests/nof_heartbeat_test.cpp
+++ b/mooncake-store/tests/nof_heartbeat_test.cpp
@@ -6,7 +6,9 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <thread>
+#include <vector>
 
 namespace mooncake::test {
 
@@ -216,6 +218,90 @@ TEST_F(NoFHeartbeatTest, OnlyFailedSegmentIsUnmounted) {
     EXPECT_FALSE(service->IsNoFSegmentMountedForTesting(bad_segment.id));
     EXPECT_GE(good_probe_calls.load(), 1);
     EXPECT_GE(bad_probe_calls.load(), 2);
+}
+
+TEST_F(NoFHeartbeatTest, UnmountReleasesNoFProbeResources) {
+    auto service = CreateService(/*heartbeat_interval_sec=*/1,
+                                 /*probe_timeout_ms=*/50,
+                                 /*failure_threshold=*/3);
+    service->SetNoFProbeFnForTesting(
+        [](const std::string&, uint32_t, std::string*) { return true; });
+    std::mutex released_mutex;
+    std::vector<std::string> released_endpoints;
+    service->SetNoFProbeReleaseFnForTesting(
+        [&released_mutex, &released_endpoints](const std::string& endpoint) {
+            std::lock_guard<std::mutex> lock(released_mutex);
+            released_endpoints.push_back(endpoint);
+        });
+
+    UUID client_id = generate_uuid();
+    NoFSegment segment = MakeNoFSegment("nof_seg_release", "nof_release");
+    ASSERT_TRUE(service->MountNoFSegment(segment, client_id).has_value());
+
+    // The heartbeat thread only allocates probe resources once it starts
+    // tracking the segment, so wait until its state exists.
+    ASSERT_TRUE(WaitForCondition(
+        std::chrono::milliseconds(2000), std::chrono::milliseconds(20), [&]() {
+            return service->GetNoFHeartbeatFailureCountForTesting(segment.id)
+                .has_value();
+        }));
+
+    ASSERT_TRUE(service->UnmountNoFSegment(segment.id, client_id).has_value());
+
+    std::vector<std::string> released;
+    {
+        std::lock_guard<std::mutex> lock(released_mutex);
+        released = released_endpoints;
+    }
+    ASSERT_FALSE(released.empty());
+    for (const auto& endpoint : released) {
+        EXPECT_EQ(endpoint, segment.te_endpoint);
+    }
+    EXPECT_FALSE(
+        service->GetNoFHeartbeatFailureCountForTesting(segment.id).has_value());
+}
+
+TEST_F(NoFHeartbeatTest, HeartbeatUnmountReleasesNoFProbeResources) {
+    auto service = CreateService(/*heartbeat_interval_sec=*/1,
+                                 /*probe_timeout_ms=*/50,
+                                 /*failure_threshold=*/2);
+    service->SetNoFProbeFnForTesting(
+        [](const std::string&, uint32_t, std::string* reason) {
+            if (reason) {
+                *reason = "submit_fail";
+            }
+            return false;
+        });
+    std::mutex released_mutex;
+    std::vector<std::string> released_endpoints;
+    service->SetNoFProbeReleaseFnForTesting(
+        [&released_mutex, &released_endpoints](const std::string& endpoint) {
+            std::lock_guard<std::mutex> lock(released_mutex);
+            released_endpoints.push_back(endpoint);
+        });
+
+    UUID client_id = generate_uuid();
+    NoFSegment segment = MakeNoFSegment("nof_seg_release_hb", "nof_release_hb");
+    ASSERT_TRUE(service->MountNoFSegment(segment, client_id).has_value());
+
+    ASSERT_TRUE(WaitForCondition(
+        std::chrono::milliseconds(5000), std::chrono::milliseconds(50),
+        [&]() { return !service->IsNoFSegmentMountedForTesting(segment.id); }));
+    ASSERT_TRUE(WaitForCondition(std::chrono::milliseconds(2000),
+                                 std::chrono::milliseconds(20), [&]() {
+                                     std::lock_guard<std::mutex> lock(
+                                         released_mutex);
+                                     return !released_endpoints.empty();
+                                 }));
+
+    std::vector<std::string> released;
+    {
+        std::lock_guard<std::mutex> lock(released_mutex);
+        released = released_endpoints;
+    }
+    for (const auto& endpoint : released) {
+        EXPECT_EQ(endpoint, segment.te_endpoint);
+    }
 }
 
 TEST_F(NoFHeartbeatTest, ClientExpiryDoesNotUnmountNoFSegment) {


### PR DESCRIPTION
# Issue #4038 — Master retains NoF heartbeat probe resources after segment unmount

## 1. Root cause

The NoF heartbeat probe allocates a per-endpoint SPDK DMA buffer and caches it
forever.

`SpdkWrapper::ProbeNofSegment()` reads one block from the remote namespace to
decide whether a NoF segment is alive. The bounce buffer for that read comes
from `SpdkWrapper::GetOrCreateProbeBuffer()`, which memoizes it in

```cpp
std::map<std::string, std::unique_ptr<ProbeBuffer>> probe_buffers_;  // keyed by te_endpoint
```

The only code that ever frees those buffers is `SpdkWrapper::Cleanup()`, i.e.
process shutdown.

On the master side, unmounting a NoF segment does tear down the heartbeat
bookkeeping — `MasterService::UnmountNoFSegment()`,
`TryUnmountNoFSegmentByHeartbeat()` and the stale-entry sweep in
`NofHeartbeatThreadFunc()` all `nof_heartbeat_states_.erase(segment_id)` — but
nothing told `SpdkWrapper` that the endpoint was gone. So every transport
endpoint the master ever probed kept a hugepage-backed DMA buffer for the
lifetime of the process, even after its segment was unmounted and could never
be probed again.

With mount/unmount churn (clients restarting, NoF nodes rotating, segments
auto-unmounted by the heartbeat itself after a device dies) `probe_buffers_`
grows monotonically, one entry per distinct endpoint, and the DMA pool is
never returned.

## 2. The fix and why

Release the probe resources for a transport endpoint at the moment the master
stops tracking the segment behind it.

**`SpdkWrapper`** gains `ReleaseProbeResources(tr_str)`, which frees the cached
DMA buffer and drops the map entry. It is idempotent, so it is safe on the
repeated/racing unmount paths.

Freeing a DMA buffer is only safe if no NVMe request still targets it.
`ProbeNofSegment()` gives up after `nof_heartbeat_probe_timeout_ms` and returns
`completion_timeout` while the read is still outstanding, so the buffer can
still be written by the controller at that point. A `ProbeBuffer::in_flight`
flag (set when the buffer is handed to a probe, cleared on submit failure and
on completion) makes `ReleaseProbeResources()` skip — and warn about — exactly
those buffers instead of freeing memory a pending DMA targets. They are
reclaimed by `Cleanup()` as before, and reused/cleared if the endpoint is
remounted and probes succeed again.

**`MasterService`** gains a single choke point,
`EraseNoFHeartbeatStateLocked(segment_id)`, which replaces the three raw
`nof_heartbeat_states_.erase(...)` calls, plus
`ReleaseNoFProbeResourcesLocked(endpoints)` used by the heartbeat thread's
stale-entry sweep (that sweep is what catches segments removed out-of-band,
e.g. by client offboarding). Releasing is skipped while any other tracked
segment still names the same endpoint, so a shared endpoint keeps its buffer
until its last segment is gone.

The actual release goes through an injectable `NoFProbeReleaseFn`, mirroring
the existing `NoFProbeFn` hook, so the behaviour is unit-testable without an
SPDK device (`SetNoFProbeReleaseFnForTesting`). Like `nof_probe_fn_`, it is
only wired to `SpdkWrapper` under `USE_NOF`.

## 3. Files changed

| File | Change |
|---|---|
| `mooncake-store/include/spdk/spdk_wrapper.h` | Declare `ReleaseProbeResources` / `MarkProbeBufferIdle`; add `ProbeBuffer::in_flight` |
| `mooncake-store/src/spdk/spdk_wrapper.cpp` | Implement both; set/clear `in_flight` around the probe read |
| `mooncake-store/include/master_service.h` | `NoFProbeReleaseFn` + `nof_probe_release_fn_`, `SetNoFProbeReleaseFnForTesting`, the two new private helpers |
| `mooncake-store/src/master_service.cpp` | Default release fn, testing setter, helper implementations, route the four heartbeat-state erase sites through them |
| `mooncake-store/tests/nof_heartbeat_test.cpp` | Two regression tests |

## 4. Risk / uncertainty

- **Residual retention, deliberately.** If the last probe of an endpoint timed
  out (`completion_timeout`), its buffer is kept rather than freed, because the
  controller may still DMA into it and SPDK keeps hugepages mapped, so a late
  write would silently corrupt whatever is allocated there next. Retention is
  then bounded by the number of distinct endpoints whose final probe hung,
  instead of every endpoint ever probed. Closing that last gap properly needs
  the probe's qpair to be reset/drained, which is a larger change to the
  `OpenNofSegment` handle cache and is out of scope here.
- **Lock ordering.** `EraseNoFHeartbeatStateLocked` runs under
  `nof_heartbeat_mutex_` and reaches `probe_buffers_mutex_`; the release
  callback is copied out from under `nof_probe_fn_mutex_` and invoked outside
  it. No path takes `nof_heartbeat_mutex_` while holding either of the other
  two, so there is no inversion. `ReleaseProbeResources` only holds
  `probe_buffers_mutex_` briefly and never during the probe's polling loop, so
  an RPC-thread unmount cannot stall behind a slow probe.
- **Not verified against real hardware.** The probe path needs `USE_NOF=ON` and
  an NVMe-oF target; neither SPDK nor the project's other build dependencies
  are available in this environment, so the SPDK-side change is reviewed and
  reasoned about, not executed. See below.
- The `in_flight` flag is plain `bool` guarded by `probe_buffers_mutex_`, not
  atomic; every read and write of it is inside that lock.

## 5. How I verified it

- **What I could run.** The two new `MasterService` helpers were extracted into
  a standalone C++20 translation unit with stub types and compiled with
  `g++ -std=c++20 -Wall -Wextra`, then exercised with assertions covering:
  sole-user endpoint is released; endpoint still used by another tracked
  segment is not; it is released once its last user goes away; erasing an
  unknown segment id is a no-op; and the batch path dedups, skips empty
  endpoints and skips still-tracked ones. All assertions pass.
- **What I could not run.** No full build or test-suite run. The repo's
  dependencies (glog, ylt, boost, SPDK) are not installed here, and
  `nof_heartbeat_test` is only built when `USE_NOF=ON`
  (`mooncake-store/tests/CMakeLists.txt:136`). `scripts/code_format.sh` refuses
  to run because it requires clang-format 20 and only 16 is present, so
  formatting was matched to the surrounding code by hand and checked against
  the 80-column limit (no new line exceeds it).
- **Regression tests added** to `mooncake-store/tests/nof_heartbeat_test.cpp`,
  both using the injected release hook:
  - `UnmountReleasesNoFProbeResources` — mount, wait until the heartbeat thread
    tracks the segment, call `UnmountNoFSegment`, assert the endpoint's probe
    resources were released and the heartbeat state is gone. Fails before the
    fix (nothing is ever released).
  - `HeartbeatUnmountReleasesNoFProbeResources` — a permanently failing probe
    drives the auto-unmount path; assert the release also happens there.
  Both snapshot the recorded endpoints under their own mutex before asserting,
  so an assertion never holds that mutex while calling back into the service.
- **Manual review** of every remaining `nof_heartbeat_states_` mutation to
  confirm all four now route through the new helpers, and of the `in_flight`
  state machine for the submit-failure, completion and timeout paths.