### PR TITLE
[CI/Build] Enable KV events in wheels with ZeroMQ dependencies

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -111,6 +111,7 @@ jobs:
               exit 1
               ;;
           esac
+          cmake_args="$cmake_args -DENABLE_KV_EVENTS=ON"
 
           {
             echo "VARIANT_FLAG=$variant_flag"

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -208,6 +208,7 @@ elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS
                      liburing-devel \
                      jemalloc-devel \
                      msgpack-devel \
+                     zeromq-devel \
                      libzstd-devel \
                      pkgconf-pkg-config \
                      elfutils-libelf-devel \


### PR DESCRIPTION
## Description

Enable KV events in release wheels and provide the native ZeroMQ development dependency needed to configure those builds on RPM-based manylinux images. With KV events enabled, the current wheel job fails at CMake configuration with `libzmq development files not found` ([failure log](https://github.com/kvcache-ai/Mooncake/actions/runs/34575110794/job/103312539837)).

This carries Ishan Dhanani's original commit `28020985ff84d0afbcfea0e66d88710fa2484e9f` from #4039 unchanged and adds commit `a3c64fe8` with the missing `zeromq-devel` entry in `dependencies.sh`. Compared with #4039, the only additional change is that one dependency-list line. The combined diff is two files and two insertions.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
bash -n dependencies.sh
pre-commit run --files .github/workflows/_build-wheel.yaml dependencies.sh
git diff --check origin/main...HEAD
git merge-tree --write-tree origin/main HEAD
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Local checks passed on macOS: Bash syntax, YAML parsing, Bash syntax for all 12 workflow `run` steps, scoped pre-commit, and diff whitespace. The combined branch merges with the fetched `origin/main` without conflicts. Original commit identity and the two-line combined diff were verified.

A Linux wheel build, repaired-wheel runtime validation, and KV event publication test have not been run for this branch. Hosted CI is pending.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

The original #4039 discloses Opus assistance. Codex prepared the one-line dependency fix, checked the combined diff, and opened this PR. The original commit and author attribution are preserved.