### PR TITLE
[TENT] Keep a retiring notify QP published until its completions are drained

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -136,9 +136,31 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     bool sendNotification(const std::string& name, const std::string& msg);
 
-    // Unpublishes the notify QP after a fault confined to it, leaving the data
-    // QPs and the endpoint lifecycle untouched. Notifications stay off for the
-    // remaining lifetime of the endpoint.
+    // Whether the notify QP is connected and not disabled after a fault.
+    bool notifyConnected() const {
+        return notify_connected_.load(std::memory_order_acquire);
+    }
+
+    // One notification WR (send or receive) left the CQ. Called by the
+    // transport for every completion of this endpoint's notify QP.
+    void noteNotifyCompletion() {
+        uint32_t inflight = notify_inflight_.load(std::memory_order_relaxed);
+        while (inflight > 0 &&
+               !notify_inflight_.compare_exchange_weak(
+                   inflight, inflight - 1, std::memory_order_acq_rel,
+                   std::memory_order_relaxed)) {
+        }
+    }
+
+    uint32_t notifyInflight() const {
+        return notify_inflight_.load(std::memory_order_acquire);
+    }
+
+    // Turns notifications off after a fault confined to the notify QP,
+    // leaving the data QPs and the endpoint lifecycle untouched.
+    // Notifications stay off for the remaining lifetime of the endpoint. The
+    // QP itself stays published until deconstruct(), so completions already
+    // in the CQ are still delivered.
     void disableNotification(const std::string& reason);
 
     // Process RECV completion: parse message and add to transport queue
@@ -275,6 +297,11 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     size_t notify_pending_count_ = 0;  // Number of pending sends
     uint64_t notify_send_wr_id_ = 0;   // Circular counter for wr_id
     std::atomic<bool> notify_connected_{false};
+    // Notification WRs posted on the notify QP whose completion has not been
+    // polled yet. finishDestroy() waits for it: the QP must not be destroyed
+    // while completions the peer already saw acknowledged are still in the CQ,
+    // because the provider drops them with the QP.
+    std::atomic<uint32_t> notify_inflight_{0};
 
     // Two-phase destruction constants (matching TE)
     static constexpr double kFinishDestroyTimeoutSec = 30.0;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -171,7 +171,9 @@ class RdmaTransport : public Transport {
     };
 
     // Decides what a failed notification completion costs. Only defined for
-    // error completions; endpoint_ready means the endpoint is still EP_READY.
+    // error completions; endpoint_ready means the endpoint is still EP_READY
+    // and its notifications are still connected (a retiring or disabled
+    // notify QP only flushes from then on).
     static NotifyCompletionAction classifyNotifyCompletion(ibv_wc_status status,
                                                            bool endpoint_alive,
                                                            bool endpoint_ready);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -303,8 +303,10 @@ int RdmaEndPoint::deconstructUnlocked() {
 
     if (result == 0 && !notify_qp_ && !notify_recv_mr_ && !notify_send_mr_ &&
         qp_list_.empty()) {
-        peer_server_name_.clear();
-        peer_nic_name_.clear();
+        // peer_server_name_ / peer_nic_name_ are left alone: the notification
+        // worker reads them from a retiring endpoint it still holds (for the
+        // path health table) without taking lock_, and nothing needs them
+        // cleared - EP_DESTROYED already says the endpoint is gone.
         status_.store(EP_DESTROYED, std::memory_order_release);
         return 0;
     }
@@ -324,12 +326,12 @@ void RdmaEndPoint::beginDestroyNoLock() {
     destroy_start_time_ = getCurrentTimeInNano();
     status_.store(EP_DESTROYING, std::memory_order_release);
 
-    // Stop publishing the endpoint before QPs start flushing. A notification
-    // completion that already locked the weak_ptr may finish safely, while no
-    // later completion can acquire a retiring endpoint.
-    if (notify_qp_) {
-        context_->transport_.unregisterNotifyQp(notify_qp_->qp_num);
-    }
+    // The notify QP stays published until deconstruct(): notifications that
+    // already landed (the sender saw them acked) may still sit in the CQ
+    // unpolled, and the worker can only hand them out while it can find
+    // this endpoint. The flushes that follow the ERR transition stay quiet
+    // because the endpoint is no longer ready; deconstruct() unpublishes
+    // under notify_resource_mutex_ before it frees the buffers.
     {
         std::lock_guard<std::mutex> notify_guard(notify_send_mutex_);
         notify_connected_ = false;
@@ -382,6 +384,12 @@ bool RdmaEndPoint::finishDestroy() {
             break;
         }
     }
+    // The notify QP counts too. Destroying it takes its completions with it,
+    // including notifications the peer already saw acknowledged, so the ERR
+    // transition must be given the time to flush them out first. A QP that
+    // never completes them (a provider that drops WRs on RESET) is covered by
+    // the timeout below.
+    if (!has_outstanding && notifyInflight() != 0) has_outstanding = true;
     if (has_outstanding) {
         double elapsed = (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
         if (elapsed < kFinishDestroyTimeoutSec) {
@@ -574,10 +582,14 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
                     << "Failed to setup notification QP, notification disabled";
                 notify_connected_ = false;
             } else {
-                notify_connected_ = true;
-                repostAllNotifyRecvs();
+                // Published before the first RECV is posted: a peer that
+                // sends the moment its own handshake returns must find this
+                // endpoint, and a completion cannot arrive before the RECVs
+                // are there anyway.
                 context_->transport_.registerNotifyQp(notify_qp_->qp_num,
                                                       shared_from_this());
+                notify_connected_ = true;
+                repostAllNotifyRecvs();
             }
         }
     }
@@ -673,10 +685,10 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
         if (rc) {
             notify_connected_ = false;
         } else {
-            notify_connected_ = true;
-            repostAllNotifyRecvs();
             context_->transport_.registerNotifyQp(notify_qp_->qp_num,
                                                   shared_from_this());
+            notify_connected_ = true;
+            repostAllNotifyRecvs();
         }
     }
 
@@ -1110,7 +1122,9 @@ void RdmaEndPoint::postNotifyRecv(size_t idx) {
     if (ret) {
         LOG(ERROR) << "Failed to post notification recv: " << strerror(abs(ret))
                    << " [" << ret << "]";
+        return;
     }
+    notify_inflight_.fetch_add(1, std::memory_order_release);
 }
 
 void RdmaEndPoint::repostAllNotifyRecvs() {
@@ -1257,12 +1271,21 @@ bool RdmaEndPoint::sendNotification(const std::string& name,
     }
 
     notify_pending_count_++;
+    notify_inflight_.fetch_add(1, std::memory_order_release);
     return true;
 }
 
 bool RdmaEndPoint::handleNotifyRecv(size_t buffer_idx, size_t byte_len) {
     std::lock_guard<std::mutex> resource_guard(notify_resource_mutex_);
-    if (!notify_recv_mr_ || buffer_idx >= kNotifyMaxPendingSends ||
+    if (!notify_recv_mr_) {
+        // The endpoint was deconstructed while this completion was in the
+        // worker's batch. Rare, and not a malformed completion.
+        LOG_EVERY_N(WARNING, 100)
+            << "Notification dropped: endpoint " << endpoint_name_
+            << " was torn down before the completion was handled";
+        return false;
+    }
+    if (buffer_idx >= kNotifyMaxPendingSends ||
         notify_recv_buffer_.size() < (buffer_idx + 1) * kNotifyBufferSize) {
         LOG(ERROR) << "Invalid recv buffer index: " << buffer_idx;
         return false;
@@ -1309,13 +1332,9 @@ void RdmaEndPoint::disableNotification(const std::string& reason) {
     }
     LOG(WARNING) << "Notifications disabled on endpoint " << endpoint_name_
                  << ", data path kept alive: " << reason;
-
-    // Unpublish so the WRs still posted on the dead QP flush silently instead
-    // of re-reporting the same fault once per WR.
-    std::lock_guard<std::mutex> resource_guard(notify_resource_mutex_);
-    if (notify_qp_) {
-        context_->transport_.unregisterNotifyQp(notify_qp_->qp_num);
-    }
+    // The QP stays published: notifications already in the CQ are still
+    // handed out, and the worker keeps the flushes of the posted WRs quiet
+    // now that notify_connected_ is off.
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -957,9 +957,10 @@ int RdmaTransport::processNotifyCompletions() {
 
         // Process each completion
         for (int i = 0; i < completed; ++i) {
-            // Find endpoint by QP number before interpreting errors. A flush
-            // completion after endpoint unpublication is expected during
-            // retirement and should not flood logs.
+            // Find endpoint by QP number before interpreting errors. The QP
+            // stays published while the endpoint retires, so notifications
+            // that landed before the retirement are still handed out; the
+            // flushes that follow are told apart by the endpoint's state.
             std::shared_ptr<RdmaEndPoint> endpoint;
             {
                 RWSpinlock::ReadGuard guard(notify_endpoint_map_lock_);
@@ -969,18 +970,22 @@ int RdmaTransport::processNotifyCompletions() {
                 }
             }
 
+            // Whatever it says, this WR has left the notify QP; the
+            // endpoint's destruction waits for that count to reach zero.
+            if (endpoint) endpoint->noteNotifyCompletion();
+
             if (wc[i].status != IBV_WC_SUCCESS) {
                 // A failed completion leaves this notify QP unusable for good
                 // and only the endpoint lifecycle builds a new one, so left
                 // alone the endpoint stays EP_READY and every later
                 // sendNotification() silently flushes. Retiring it also moves
                 // the data QPs to ERR, so that is reserved for faults which may
-                // mean the peer restarted or the path died. Both acting
-                // branches re-take the notify_endpoint_map_lock_ ReadGuard
-                // released above via unregisterNotifyQp(); the locally held
-                // shared_ptr keeps the endpoint alive across the call.
+                // mean the peer restarted or the path died. A notify QP that
+                // is retiring or already disabled only flushes from here on,
+                // and those completions stay quiet.
                 const bool endpoint_ready =
-                    endpoint && endpoint->status() == RdmaEndPoint::EP_READY;
+                    endpoint && endpoint->status() == RdmaEndPoint::EP_READY &&
+                    endpoint->notifyConnected();
                 auto action = classifyNotifyCompletion(
                     wc[i].status, endpoint != nullptr, endpoint_ready);
                 if (action == NotifyCompletionAction::SkipSilently) continue;

--- a/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
@@ -45,6 +45,16 @@ class EndpointTestAccess {
         endpoint.notify_connected_.store(true, std::memory_order_relaxed);
     }
 
+    static void beginDestroy(RdmaEndPoint& endpoint) {
+        endpoint.beginDestroy();
+    }
+
+    // Stands in for notification WRs posted on the notify QP whose
+    // completions the worker has not polled yet.
+    static void setNotifyInflight(RdmaEndPoint& endpoint, uint32_t count) {
+        endpoint.notify_inflight_.store(count, std::memory_order_release);
+    }
+
     static bool notifyConnected(const RdmaEndPoint& endpoint) {
         return endpoint.notify_connected_.load(std::memory_order_relaxed);
     }
@@ -334,6 +344,33 @@ TEST(EndpointLifecycleTest, ExternalOwnerCanReleaseAfterExplicitDeconstruct) {
 
     endpoint.reset();
     EXPECT_TRUE(weak.expired());
+}
+
+// Destroying the notify QP takes its completions with it, so an endpoint
+// whose notify CQ has not caught up is not finished yet. The data QPs have
+// their own counters; this is the notify side of the same gate.
+TEST(EndpointLifecycleTest, FinishDestroyWaitsForNotifyCompletions) {
+    RdmaEndPoint endpoint;
+    EndpointTestAccess::markConnected(endpoint, "10.0.0.1:12345", "mlx5_0",
+                                      {100, 101});
+    EndpointTestAccess::markNotifyConnected(endpoint);
+    EndpointTestAccess::setNotifyInflight(endpoint, 3);
+    EndpointTestAccess::beginDestroy(endpoint);
+
+    EXPECT_FALSE(endpoint.finishDestroy());
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYING);
+    endpoint.noteNotifyCompletion();
+    endpoint.noteNotifyCompletion();
+    EXPECT_FALSE(endpoint.finishDestroy());
+
+    endpoint.noteNotifyCompletion();
+    EXPECT_EQ(endpoint.notifyInflight(), 0u);
+    // Never below zero, whatever order the completions arrive in.
+    endpoint.noteNotifyCompletion();
+    EXPECT_EQ(endpoint.notifyInflight(), 0u);
+
+    EXPECT_TRUE(endpoint.finishDestroy());
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -482,6 +482,13 @@ TEST(RdmaNotifyFaultTriageTest, TeardownFlushesStayQuiet) {
     // A real fault surfacing after the endpoint is gone has nothing left to
     // act on.
     EXPECT_EQ(classify(IBV_WC_RETRY_EXC_ERR, false, false), Action::ReportOnly);
+    // The notify QP stays published while the endpoint retires, so a real
+    // fault can still arrive on a not-ready endpoint: it is triaged as on any
+    // other live endpoint, and only flushes are skipped.
+    EXPECT_EQ(classify(IBV_WC_RETRY_EXC_ERR, true, false),
+              Action::RetireEndpoint);
+    EXPECT_EQ(classify(IBV_WC_LOC_LEN_ERR, true, false),
+              Action::DisableNotification);
 }
 
 // context_set_ is subscripted by NicID, so it must keep one slot per NIC even


### PR DESCRIPTION
## Description

A notification that has already landed can still be sitting unpolled in the notify CQ: the notify worker drains sixteen completions per pass, and a sender keeps up to its 256-slot window in flight. `beginDestroyNoLock()` removed the notify QP from the transport's QP-number table before moving the QPs to ERR, and `disableNotification()` did the same after a local fault, so those pending completions came back as "unknown QP" in `processNotifyCompletions()` and were dropped. The sender's HCA had been acknowledged, so the sender saw a successful completion and had no reason to resend: the notification was lost with nothing anywhere able to recover it.

This only happens when the retirement is triggered by a thread other than the notify worker - a data-path worker after slice retries, the RPC thread when a peer re-bootstraps, the endpoint store evicting. The worker's own retirement drains the CQ in order and loses nothing.

Change:

- The notify QP stays in the table until `deconstructUnlocked()`, which already unpublishes it under `notify_resource_mutex_` before destroying the QP and freeing the buffers. `handleNotifyRecv()` takes the same mutex before it reads a slot, so handing out a completion while the endpoint retires is safe.
- Flushes stay as quiet as before: the worker now treats a retiring or disabled notify QP as not ready, and `classifyNotifyCompletion()` already skips `IBV_WC_WR_FLUSH_ERR` on a QP that is not ready. A notification still delivered after that point is handed out but its slot is not re-armed, so it costs no work on a QP that can no longer receive.
- `finishDestroy()` waits for the notify QP the way it already waited for the data QPs. Destroying a QP takes its unpolled completions with it, so every posted notification WR is counted and the count has to reach zero first, with the existing 30 s timeout as the backstop. The count is released only once a completion has been consumed - the payload copied out of its slot, or the send and error paths finished - so reaching zero means nothing is left in the worker's hand.
- A consumed RECV slot is re-armed only while the endpoint is ready and its notify QP connected. Both retirement and the local completion error that disables notifications leave the RC QP in ERR, where a replacement work request is wasted: this provider accepts it and flushes it straight back, one that checks the state rejects it and logs. The initial posting in `connect()` and `accept()` is unchanged.
- The QP is published before its first RECV is posted, so a peer that sends the moment its handshake returns cannot land on a QP number the table does not know yet.
- `deconstructUnlocked()` no longer clears `peer_server_name_` / `peer_nic_name_`: the worker reads them off a retiring endpoint without holding `lock_`, and `EP_DESTROYED` already says the endpoint is gone.

One reachability change follows: after `disableNotification()`, a later completion error on that QP now reaches the classifier with the endpoint alive but not ready, where the unpublished QP previously made it `ReportOnly`. A path fault (`IBV_WC_RETRY_EXC_ERR`) therefore retires the endpoint as on any live one and a local fault (`IBV_WC_LOC_LEN_ERR`) disables notifications that are already off; only flushes are skipped. The classifier itself is unchanged.

6 files, 191 insertions, 35 deletions, 71 of the insertions in tests. No configuration, wire or default change.

This is the first of seven PRs on notification fault tolerance, described in the series RFC (#4061); it depends on none of them and closes the one loss the resend PR later in the series cannot cover, because the sender never learns of it.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake Conductor (`mooncake-conductor`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Two new unit tests and two new assertions come with the change. `EndpointLifecycleTest.FinishDestroyWaitsForNotifyCompletions` is new: with notification WRs still outstanding, `finishDestroy()` returns false and the endpoint stays `EP_DESTROYING` until the count drains, and an extra completion does not take it below zero. `EndpointLifecycleTest.NotifyRecvIsRearmedOnlyWhileReady` is new as well and pins the re-arm decision, including the states an endpoint really passes through: ready and connected re-arms, a disabled endpoint that is still `EP_READY` does not, and a retiring one does not. `RdmaNotifyFaultTriageTest.TeardownFlushesStayQuiet` gains two assertions for the reachability change above. Negative controls: dropping the drain gate fails the first case and only that one; forcing the re-arm decision open fails the second and only that one. The lifecycle binary goes from 20 cases to 22.

`ctest` over `mooncake-transfer-engine/tent/tests` with this change alone on current `main`: 63 of 63, the same count as unpatched `main`, since the new cases run inside an existing test binary.

Whether the table entry survives retirement is only observable with a real QP, so it was measured with a two-process probe on one host with two BlueField-3 integrated ConnectX-7 VFs over RoCE v2, 4000 notifications per run, the retirement injected from a detached thread while the notify worker polls. Both arms are `main` plus the same test-only injection hooks, which are not part of this PR:

| | delivered | dropped as unknown QP |
| --- | --- | --- |
| without this change (2 runs) | 3536, 3498 of 4000 | 208, 246 |
| with this change (2 runs) | 3744, 3744 of 4000 | 0, 0 |

The remaining gap to 4000 is sender-side loss, which the resend PR later in the series covers; the two fixes are independent and complementary. Stalling the notify worker for 2 ms and 20 ms after the retirement does not change either arm.

The same rig also counts what the re-arm decision does. Over three runs with the retirement injected, 197 to 251 consumed slots were handed out without a replacement work request, and no post reached the posting path while the QP could no longer receive; with the decision forced open, 198 such posts show up and none are skipped. Delivery, the drain time before the endpoint is destroyed (tens of milliseconds, far from the 30 s backstop) and the absence of dropped or unknown-QP completions are the same either way, so the gate removes work rather than changing behaviour. A run without any fault delivers 4000 of 4000 with no duplicates.

**Test commands:**
```bash
cmake -S . -B build -G Ninja -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON \
      -DUSE_CUDA=OFF -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DYLT_ENABLE_IBV=ON
cmake --build build
ctest --test-dir build/mooncake-transfer-engine/tent/tests --output-on-failure --timeout 600
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable) (tent ctest suite, 63 of 63)
- [x] Manual testing done (describe below) (the injected-retirement runs above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not required at 191 insertions; the series RFC is #4061)

## AI Assistance Disclosure


- [ ] No AI tools were used
- [x] AI tools were used (specify below)

The code, tests and measurements in this PR were produced with Claude Code as a coding assistant. The author reviewed every change and checked every measurement against the logs.