### PR TITLE
[TENT] Read the notify QP's RTR/RTS attributes from EndPointParams

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
@@ -147,6 +147,45 @@ inline int selectQpInPool(const std::vector<QpPoolSegment>& segments,
     return candidate % total_qp;
 }
 
+// Attributes the notification QP takes on its INIT->RTR and RTR->RTS
+// transitions. The data QPs of the same endpoint read these from
+// EndPointParams (RdmaEndPoint::setupOneQP); the notify QP used to hard-code
+// the verbs tutorial values instead, so its retry budget could not be tuned
+// and a dead peer path nominally took 4.096us * 2^18 * 8 ~= 8.6 s to report
+// (about 15 s measured on ConnectX-7) while the data QPs nominally give up in
+// ~0.5 s (about 3.7 s measured). Kept free-standing (no verbs handles) so the
+// mapping can be unit-tested without a device.
+struct NotifyQpRtrAttrs {
+    ibv_mtu path_mtu;
+    uint8_t min_rnr_timer;
+    uint8_t max_dest_rd_atomic;
+};
+
+struct NotifyQpRtsAttrs {
+    uint8_t timeout;
+    uint8_t retry_cnt;
+    uint8_t rnr_retry;
+    uint8_t max_rd_atomic;
+};
+
+// The notify QP only carries SEND/RECV, so one outstanding RDMA read/atomic
+// is all it ever needs; that part stays at 1 regardless of the data-QP value.
+inline NotifyQpRtrAttrs buildNotifyQpRtrAttrs(const EndPointParams& params) {
+    return {params.path_mtu, params.min_rnr_timer, /*max_dest_rd_atomic=*/1};
+}
+
+// The notify QP is the endpoint's only SEND/RECV QP, so it is the only QP
+// that can see RNR NAKs: a burst larger than the receiver's posted RECV slots
+// (kNotifyMaxPendingSends) is ordinary flow control there, not a fault, and
+// must never exhaust a retry budget and retire the endpoint together with its
+// data QPs. rnr_retry therefore stays at 7 (infinite) regardless of
+// send_rnr_count; the RNR *timer* still follows params so a stalled receiver
+// is re-polled as quickly as the data QPs would be.
+inline NotifyQpRtsAttrs buildNotifyQpRtsAttrs(const EndPointParams& params) {
+    return {params.send_timeout, params.send_retry_count,
+            /*rnr_retry=*/7, /*max_rd_atomic=*/1};
+}
+
 struct WorkerParams {
     int num_workers = 6;  // Derived from RdmaParams::num_lanes.
     int max_retry_count = 8;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -56,10 +56,11 @@ static inline const std::string statusToString(
 }
 
 // Forward declaration for notification QP setup
-static int setupNotifyQpConnection(
-    ibv_qp* qp, RdmaContext* ctx, int local_gid_index,
-    const std::string& peer_gid_str, uint16_t peer_lid, uint32_t peer_qp_num,
-    uint16_t pkey_index, uint8_t service_level = 0, uint8_t traffic_class = 0);
+static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
+                                   const EndPointParams& params,
+                                   int local_gid_index,
+                                   const std::string& peer_gid_str,
+                                   uint16_t peer_lid, uint32_t peer_qp_num);
 
 // A peer that reused the same nic path after restarting retires the stale
 // endpoint on the first bootstrap and expects a retry. Older peers also
@@ -565,10 +566,9 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
 
         // Setup notification QP connection if peer supports it
         if (peer_desc.notify_qp_num != 0 && notify_qp_) {
-            rc = setupNotifyQpConnection(
-                notify_qp_, context_, local_address.gid_index, peer_gid,
-                peer_lid, peer_desc.notify_qp_num, params_->pkey_index,
-                params_->service_level, params_->traffic_class);
+            rc = setupNotifyQpConnection(notify_qp_, context_, *params_,
+                                         local_address.gid_index, peer_gid,
+                                         peer_lid, peer_desc.notify_qp_num);
             if (rc) {
                 LOG(WARNING)
                     << "Failed to setup notification QP, notification disabled";
@@ -667,9 +667,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     // Setup notification QP connection if peer supports it
     if (peer_desc.notify_qp_num != 0 && notify_qp_) {
         rc = setupNotifyQpConnection(
-            notify_qp_, context_, local_address_.gid_index, peer_desc.local_gid,
-            peer_desc.local_lid, peer_desc.notify_qp_num, params_->pkey_index,
-            params_->service_level, params_->traffic_class);
+            notify_qp_, context_, *params_, local_address_.gid_index,
+            peer_desc.local_gid, peer_desc.local_lid, peer_desc.notify_qp_num);
         if (rc) {
             notify_connected_ = false;
         } else {
@@ -1119,12 +1118,17 @@ void RdmaEndPoint::repostAllNotifyRecvs() {
     }
 }
 
+// The path MTU, the RNR timer and the timeout/retry budget come from the
+// same EndPointParams the data QPs use (see setupOneQP), so a dead peer path
+// is reported on the notify QP in the time the data QPs take and tuning
+// send_timeout / the retry counts applies to both. The address-vector fields
+// (hop_limit, flow_label, src_path_bits, PSNs) deliberately keep the values
+// this function always used.
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
+                                   const EndPointParams& params,
                                    int local_gid_index,
                                    const std::string& peer_gid_str,
-                                   uint16_t peer_lid, uint32_t peer_qp_num,
-                                   uint16_t pkey_index, uint8_t service_level,
-                                   uint8_t traffic_class) {
+                                   uint16_t peer_lid, uint32_t peer_qp_num) {
     // Reconnect path may call this when QP is already in RTS; force a clean
     // state machine: RESET -> INIT -> RTR -> RTS.
     ibv_qp_attr qp_attr = {};
@@ -1137,7 +1141,7 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
 
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_INIT;
-    qp_attr.pkey_index = pkey_index;
+    qp_attr.pkey_index = params.pkey_index;
     qp_attr.port_num = ctx->portNum();
     qp_attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE;
     ret = ibv_modify_qp(
@@ -1159,23 +1163,24 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
     }
 
     // Modify to RTR
+    const NotifyQpRtrAttrs rtr = buildNotifyQpRtrAttrs(params);
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_RTR;
-    qp_attr.path_mtu = IBV_MTU_4096;
+    qp_attr.path_mtu = rtr.path_mtu;
     qp_attr.dest_qp_num = peer_qp_num;
     qp_attr.rq_psn = 0;
-    qp_attr.max_dest_rd_atomic = 1;
-    qp_attr.min_rnr_timer = 0x12;
+    qp_attr.max_dest_rd_atomic = rtr.max_dest_rd_atomic;
+    qp_attr.min_rnr_timer = rtr.min_rnr_timer;
     qp_attr.ah_attr.is_global = 1;
     qp_attr.ah_attr.dlid = peer_lid;
-    qp_attr.ah_attr.sl = service_level;
+    qp_attr.ah_attr.sl = params.service_level;
     qp_attr.ah_attr.src_path_bits = 0;
     qp_attr.ah_attr.port_num = ctx->portNum();
     memcpy(&qp_attr.ah_attr.grh.dgid, &peer_gid, 16);
     qp_attr.ah_attr.grh.flow_label = 0;
     qp_attr.ah_attr.grh.sgid_index = local_gid_index;
     qp_attr.ah_attr.grh.hop_limit = 255;
-    qp_attr.ah_attr.grh.traffic_class = traffic_class;
+    qp_attr.ah_attr.grh.traffic_class = params.traffic_class;
 
     ret = ibv_modify_qp(qp, &qp_attr,
                         IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
@@ -1187,13 +1192,14 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
     }
 
     // Modify to RTS
+    const NotifyQpRtsAttrs rts = buildNotifyQpRtsAttrs(params);
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_RTS;
     qp_attr.sq_psn = 0;
-    qp_attr.timeout = 0x12;
-    qp_attr.retry_cnt = 7;
-    qp_attr.rnr_retry = 7;
-    qp_attr.max_rd_atomic = 1;
+    qp_attr.timeout = rts.timeout;
+    qp_attr.retry_cnt = rts.retry_cnt;
+    qp_attr.rnr_retry = rts.rnr_retry;
+    qp_attr.max_rd_atomic = rts.max_rd_atomic;
 
     ret = ibv_modify_qp(qp, &qp_attr,
                         IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |

--- a/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
@@ -209,6 +209,51 @@ TEST(EndpointLifecycleTest, NotifyPayloadRejectedWhenLargerThanSlot) {
                                                          too_big, &encoded));
 }
 
+// The notify QP must take its path and retry attributes from EndPointParams
+// like the data QPs do (setupOneQP), not from hard-coded tutorial values:
+// with timeout=0x12 and retry_cnt=7 a dead peer path took ~8.6 s to report
+// on the notify QP while the data QPs of the same endpoint gave up in ~0.5 s,
+// and no configuration could change that.
+TEST(EndpointLifecycleTest, NotifyQpAttrsFollowEndpointParams) {
+    EndPointParams params;
+    params.path_mtu = IBV_MTU_1024;
+    params.min_rnr_timer = 5;
+    params.send_timeout = 20;
+    params.send_retry_count = 3;
+    params.send_rnr_count = 2;
+
+    const NotifyQpRtrAttrs rtr = buildNotifyQpRtrAttrs(params);
+    EXPECT_EQ(rtr.path_mtu, IBV_MTU_1024);
+    EXPECT_EQ(rtr.min_rnr_timer, 5);
+    // SEND/RECV only: one outstanding read/atomic, independent of the
+    // data-QP setting.
+    EXPECT_EQ(rtr.max_dest_rd_atomic, 1);
+
+    const NotifyQpRtsAttrs rts = buildNotifyQpRtsAttrs(params);
+    EXPECT_EQ(rts.timeout, 20);
+    EXPECT_EQ(rts.retry_cnt, 3);
+    // rnr_retry is pinned: RNR NAKs are flow control on the notify QP, not
+    // a fault, so send_rnr_count (2 above) must not reach it.
+    EXPECT_EQ(rts.rnr_retry, 7);
+    EXPECT_EQ(rts.max_rd_atomic, 1);
+}
+
+// With default EndPointParams the notify QP gets the data QPs' budget:
+// timeout 14 (4.096us * 2^14 ~= 67 ms per attempt), 7 retries and the
+// 0.64 ms RNR timer, plus the pinned unbounded RNR retry. The notify QP
+// follows these defaults now, so a change to them must show up here as a
+// deliberate decision.
+TEST(EndpointLifecycleTest, NotifyQpAttrsDefaultsMatchDataQp) {
+    EndPointParams defaults;
+    const NotifyQpRtrAttrs rtr = buildNotifyQpRtrAttrs(defaults);
+    EXPECT_EQ(rtr.path_mtu, IBV_MTU_4096);
+    EXPECT_EQ(rtr.min_rnr_timer, 12);
+    const NotifyQpRtsAttrs rts = buildNotifyQpRtsAttrs(defaults);
+    EXPECT_EQ(rts.timeout, 14);
+    EXPECT_EQ(rts.retry_cnt, 7);
+    EXPECT_EQ(rts.rnr_retry, 7);
+}
+
 TEST(EndpointLifecycleTest, NotifyLocalFaultKeepsEndpointServingData) {
     // A fault confined to the notify QP must not retire the endpoint: doing so
     // moves every data QP to ERR and flushes in-flight transfers.


### PR DESCRIPTION
## Description

An RDMA endpoint has one notification QP next to its data QPs. The data QPs take their path and retry attributes from `EndPointParams` in `setupOneQP()`, so the keys under `transports/rdma/endpoint/` apply to them. `setupNotifyQpConnection()` hard-coded the verbs tutorial values instead, so none of those keys reached the notify QP and the two QP kinds of one endpoint ran on different retry budgets. Reporting a dead peer path took 14.9 s on the notify QP against 3.7 s on the data QPs of the same endpoint.

| attribute | before | after (default) |
| --- | --- | --- |
| `path_mtu` | `IBV_MTU_4096` | `path_mtu` (4096, clamped to the port's active MTU) |
| `min_rnr_timer` | 0x12 (5.12 ms) | `min_rnr_timer` (12: 0.64 ms) |
| `timeout` | 0x12 (1.07 s per attempt) | `send_timeout` (14: 67 ms per attempt) |
| `retry_cnt` | 7 | `send_retry_count` (7) |
| `rnr_retry` | 7 | 7, pinned (see below) |

`buildNotifyQpRtrAttrs()` and `buildNotifyQpRtsAttrs()` in `params.h` map `EndPointParams` to the two attribute sets. They take no verbs handles, like `computeQpPoolSegments()` in the same header, so the mapping is unit-tested without a device. `setupNotifyQpConnection()` takes `const EndPointParams&` in place of the three `pkey_index` / `service_level` / `traffic_class` arguments it already copied out of `params_`. The state machine and the modify masks are unchanged.

`rnr_retry` stays pinned at 7 rather than following `send_rnr_count`, because the notify QP is the endpoint's only SEND/RECV QP and therefore the only one that can see RNR NAKs. A burst larger than the receiver's 256 posted RECV slots is ordinary flow control there, not a fault; if someone lowered that knob, RNR exhaustion on the notify QP would retire the endpoint and flush its data QPs with it. Only the RNR timer follows `min_rnr_timer`.

Deliberately unchanged: the `EndPointParams` defaults; the notify QP's address-vector fields, which keep the values this function always used; and `BootstrapDesc`, so mixed versions interoperate at the default `path_mtu`.

Two consequences worth naming. Following `min_rnr_timer` shortens the RNR retry interval, which took a burst of 2000 standalone notifications from p50 15.3 ms to 1.6 ms. And on the BlueField-3 integrated ConnectX-7 VFs used here the effective dead-path detection time with `timeout=14, retry_cnt=7` is 3.6-3.8 s for both QP kinds, not the 0.54 s the formula gives; the old values measured 14.9 s against a nominal 8.6 s in the same way. The point of this change is that both QP kinds report a dead path in the same time and tune through one key, not that a particular number is reachable - the floor is NIC-dependent and a deployment that needs a shorter one has to measure its own.

This is the second of seven PRs on notification fault tolerance, described in the series RFC (#4061). It applies to `main` on its own and depends on none of them; the later ones rely on the notify QP surfacing a dead path as fast as the data QPs do.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake Conductor (`mooncake-conductor`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Two unit tests, no device needed. `NotifyQpAttrsFollowEndpointParams` gives non-default params and checks that the RTR/RTS attributes follow them while `rnr_retry` stays 7; `NotifyQpAttrsDefaultsMatchDataQp` pins the default set, so a later change to the defaults has to show up here as a deliberate decision. Negative controls: restoring the hard-coded values fails both, and making `rnr_retry` read `send_rnr_count` fails the first.

`ctest` over `mooncake-transfer-engine/tent/tests` with this change on current `main`: 63 of 63, the same count as unpatched `main`, since the two new cases run inside an existing test binary.

Measured with a two-process probe on one host with two BlueField-3 integrated ConnectX-7 VFs over RoCE v2, 2000 transfer-bound plus 2000 standalone notifications per run, before and after, alternating:

| | before | after |
| --- | --- | --- |
| no fault: delivered / duplicates, 3 rounds | 4000/4000, 0 | 4000/4000, 0 |
| no fault: transfer-bound latency p50 / p99 | 168.9-170.4 / 246.9-249.0 us | 170.0-171.9 / 247.0-249.1 us |
| no fault: standalone burst of 2000, p50 | 11.6-16.4 ms | 1.5-1.8 ms |
| target's notify QP forced to ERR: time to the sender's completion error, 2 runs | 14.925 s, 14.344 s | 3.562 s, 3.591 s |
| the same injection during the transfer-bound phase: time to the data QPs' retry exhaustion | 3.74 s | 3.76 s |

So the notify QP reports a dead peer path in 0.95x the time the data QPs take, where it used to take 3.9x, and the normal-path latency is unchanged. Setting `min_rnr_timer=18` on the patched tree brings the burst back to 11.6 ms, which confirms the cause of the third row. The injection hooks and the probe are test-only and not part of this PR.

**Test commands:**
```bash
cmake -S . -B build -G Ninja -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON \
      -DUSE_CUDA=OFF -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DYLT_ENABLE_IBV=ON
cmake --build build
ctest --test-dir build/mooncake-transfer-engine/tent/tests --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable) (tent ctest suite, 63 of 63)
- [x] Manual testing done (describe below) (the before/after table above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) (no TENT doc lists the `transports/rdma/endpoint/` keys today; their effect on the notify QP is documented in `params.h`. A section can be added if reviewers want one.)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not required at 114 insertions; the series RFC is #4061)

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

The code, tests and measurements in this PR were produced with Claude Code as a coding assistant. The author reviewed every change and checked every measurement against the logs.