### PR TITLE
[Store] Support DeepSeek-V4.1-Flash Engram with local and Store-backed byte tables

### DIFF
--- a/docs/source/design/store/engram.md
+++ b/docs/source/design/store/engram.md
@@ -58,6 +58,7 @@ Python:
 
 - `EngramStore(layers, store=None)`
 - `populate(layer_id, embedding_buffers, config=ReplicateConfig())`
+- `bind_local(layer_id, embedding_buffers)`
 - `lookup_into(layer_id, row_ids, output)`
 - `remove_from_store(layer_id, force=False)`
 - `get_layer_ids()`
@@ -67,7 +68,32 @@ Python:
 - `get_row_bytes(layer_id)`
 
 The Python `store` argument accepts the existing `MooncakeDistributedStore`
-wrapper, or `None` for metadata-only construction.
+wrapper, or `None` for metadata-only construction or local table binding.
+
+### Local table mode
+
+Construct without a Store client and bind immutable, contiguous `uint8` tables
+before starting lookup workers:
+
+```python
+table = EngramStore({1: layer1})
+heads = [np.memmap(path, mode="r", dtype=np.uint8, shape=(rows, layer1.row_bytes))
+         for path, rows in zip(paths, layer1.table_vocab_sizes)]
+table.bind_local(1, heads)
+table.lookup_into(1, row_ids, output)
+```
+
+This mode copies selected rows directly from CPU-addressable memory into output;
+it performs no Store metadata queries, registration, or network transfers. The
+Python binding retains the supplied list and arrays. Do not change that list,
+modify/resize the arrays, or truncate/unmap their backing files while bound.
+Binding a layer twice, binding with a Store client, and lookup of an unbound
+layer are rejected. C++ callers retain ownership of the bound memory.
+
+Same-host ranks can map the same immutable tmpfs files to share physical pages
+without RDMA. Each rank still owns its staging output. Merely placing data in
+another process on the same host does not make that process's pointers locally
+addressable. Use separate directories for separate model instances.
 
 C++:
 
@@ -97,7 +123,7 @@ It writes output in place and returns `None`. Neither argument is implicitly
 converted. The explicit `layer_id` selects a configured layer; position
 `h` in the last row-ID dimension selects `engram:l{layer_id}:h{h}`.
 
-The caller must register the entire output buffer with the same Store client
+For Store-backed reads, the caller must register the entire output buffer with the same Store client
 before the first nonempty lookup, keep it registered throughout each call, and
 unregister it when finished. `lookup_into` does not allocate, register, or
 unregister output; there is no registration flag or automatic-registration mode.
@@ -142,7 +168,8 @@ the keys written by the failed populate attempt before returning an error.
 
 ## Lookup Flow
 
-Each lookup follows the same simplified backend flow:
+Each Store-backed lookup follows this flow (local mode validates IDs and copies
+rows directly):
 
 1. validate the `row_ids` shape and bounds
 2. build per-head byte ranges for the requested rows

--- a/docs/source/design/store/engram.md
+++ b/docs/source/design/store/engram.md
@@ -95,6 +95,10 @@ without RDMA. Each rank still owns its staging output. Merely placing data in
 another process on the same host does not make that process's pointers locally
 addressable. Use separate directories for separate model instances.
 
+For large memory-mapped tables, consider prefaulting the mappings at startup
+(for example, with Linux `MAP_POPULATE`). Resident file pages can still require
+per-process page-table faults on first access, delaying random row lookups.
+
 C++:
 
 - constructor `EngramStore(const std::map<int, EngramStoreConfig>& layers, std::shared_ptr<PyClient>)`

--- a/docs/source/design/store/engram.md
+++ b/docs/source/design/store/engram.md
@@ -7,99 +7,134 @@ The scope is intentionally narrow:
 - the caller defines the physical table layout
 - the caller uploads one table per head
 - the caller provides precomputed row ids with shape `[B, L, H]`
-- Mooncake returns the selected rows as `[B, L, H, D]`
+- Mooncake writes selected rows into caller-owned `[B, L, H, row_bytes]` memory
 
 Mooncake does not implement tokenizer compression, N-gram hashing, query logic,
 or any other model-side Engram algorithm.
 
 ## Current Backend Boundary
 
-The current implementation is intentionally conservative. It keeps EngramStore
-on top of the existing Store interfaces and does not depend on:
-
-- transfer scatter read
-- grouped transfer task
-- `get_into_range`
-- `batch_query`
-- local direct mapping
-- query cache
-- remote gather control-plane changes
-
-Those optimizations are deferred to follow-up PRs so that the EngramStore backend can
-land first as a small, reviewable unit.
+EngramStore uses the existing `batch_put_from`, `batch_query`, and
+`get_into_ranges` Store interfaces. It stores one object per head and reads only
+the requested byte ranges. Lookup is synchronous; the Python binding releases
+the GIL during I/O. There is no model-specific hashing or GPU execution here.
 
 ## Configuration
 
-`EngramStoreConfig` contains the physical layout for one EngramStore layer:
+`EngramStore` manages all Engram layers of a model. Its constructor accepts a
+map from layer ID to `EngramStoreConfig`; each config describes one layer:
 
 - `table_vocab_sizes`: per-head table sizes `[N_0, N_1, ..., N_{H-1}]`
-- `embedding_dim`: row width `D`
+- `row_bytes`: required positive byte width of each row; the default `0` must be set before constructing the store
 
-For `layer_id`, Mooncake generates one store key per head:
+```python
+layer1 = EngramStoreConfig()
+layer1.table_vocab_sizes = [17, 19]
+layer1.row_bytes = 264
+layer14 = EngramStoreConfig()
+layer14.table_vocab_sizes = [23, 29]
+layer14.row_bytes = 264
+table = EngramStore({1: layer1, 14: layer14}, store)
+```
+
+The constructor copies layouts and creates no stored data. Each layer may have
+different head counts, table sizes and row widths. For `layer_id`, Mooncake
+generates one store key per head:
 
 ```text
 engram:l{layer_id}:h{head_idx}
 ```
 
-Each key stores a `float32` table with shape `[N_h, D]`.
+Each key stores a contiguous `uint8` table with shape `[N_h, row_bytes]`.
+The backend treats rows as opaque bytes. Callers pack and interpret embedding
+values and any quantization scales. For example, a DeepSeek-V4.1 hash-head row
+contains 256 FP8 bytes followed by 8 E8M0 scale bytes, so `row_bytes = 264`.
+There is no dtype mode or configurable key prefix. Models with overlapping layer
+IDs need separate Store deployments or explicit removal before replacement.
 
 ## Public Interface
 
 Python:
 
-- `EngramStore(layer_id, config, store=None)`
-- `populate(embedding_buffers)`
-- `lookup(row_ids)`
-- `remove_from_store(force=False)`
-- `get_table_vocab_sizes()`
-- `get_store_keys()`
-- `get_num_heads()`
-- `get_embedding_dim()`
+- `EngramStore(layers, store=None)`
+- `populate(layer_id, embedding_buffers, config=ReplicateConfig())`
+- `lookup_into(layer_id, row_ids, output)`
+- `remove_from_store(layer_id, force=False)`
+- `get_layer_ids()`
+- `get_table_vocab_sizes(layer_id)`
+- `get_store_keys(layer_id)`
+- `get_num_heads(layer_id)`
+- `get_row_bytes(layer_id)`
 
 The Python `store` argument accepts the existing `MooncakeDistributedStore`
 wrapper, or `None` for metadata-only construction.
 
 C++:
 
-- constructor `EngramStore(int layer_id, const EngramStoreConfig&, std::shared_ptr<PyClient>)`
+- constructor `EngramStore(const std::map<int, EngramStoreConfig>& layers, std::shared_ptr<PyClient>)`
 - `populate(...)`
-- `lookup_rows(...)`
-- `lookup_rows_contiguous(...)`
+- `lookup_into(int layer_id, const int64_t* row_ids, int B, int L, void* output, size_t output_size)`
 - `remove_from_store(...)`
 - metadata getters matching the Python surface
 
 ## Data Contract
 
-Populate expects one NumPy `float32` array per head:
+Populate expects one C-contiguous NumPy `uint8` array per head; it does not
+cast numeric arrays to bytes:
 
 ```text
-embedding_buffers[h].shape == [N_h, D]
+embedding_buffers[h].shape == [N_h, row_bytes]
 ```
 
-Lookup accepts either:
-
-- nested Python lists with logical shape `[B, L, H]`, or
-- a contiguous NumPy `int64` array with shape `[B, L, H]`
-
-Lookup returns:
+`lookup_into` requires a C-contiguous NumPy `int64` row-ID array with shape
+`[B, L, H]` and caller-owned, writable C-contiguous `uint8` output:
 
 ```text
-output.shape == [B, L, H, D]
+output.shape == [B, L, H, row_bytes]
 ```
+
+It writes output in place and returns `None`. Neither argument is implicitly
+converted. The explicit `layer_id` selects a configured layer; position
+`h` in the last row-ID dimension selects `engram:l{layer_id}:h{h}`.
+
+The caller must register the entire output buffer with the same Store client
+before the first nonempty lookup, keep it registered throughout each call, and
+unregister it when finished. `lookup_into` does not allocate, register, or
+unregister output; there is no registration flag or automatic-registration mode.
+An empty batch is a no-op and does not require registration.
+
+```python
+output = np.empty((*row_ids.shape, table.get_row_bytes(layer_id)), dtype=np.uint8)
+assert store.register_buffer(output.ctypes.data, output.nbytes) == 0
+try:
+    table.lookup_into(layer_id, row_ids, output)  # Repeat using this buffer as needed.
+finally:
+    assert store.unregister_buffer(output.ctypes.data) == 0
+```
+
+Store registration does not allocate CUDA pinned memory. SGLang allocates
+persistent pinned host buffers separately, fills them outside CUDA Graph, and
+captures the per-layer H2D copy and dequantization inside the graph. The caller
+must wait for both Store writes and any GPU reads before reusing or releasing
+these buffers.
+
+To store existing floating-point arrays, explicitly expose their bytes, e.g.
+`table.view(np.uint8).reshape(num_rows, row_bytes)`. The caller is responsible for
+the dtype and layout when interpreting lookup results.
 
 ## Populate Flow
 
 Populate follows the existing Store write path:
 
 1. validate that exactly one table is provided for each head
-2. validate that every table matches `[N_h, D]`
+2. validate that every table matches `[N_h, row_bytes]`
 3. verify that the target head-table keys do not already exist
 4. register each embedding table buffer
 5. upload all head tables with `batch_put_from(...)`
 6. unregister the staging buffers
 
-`populate(...)` is defined as a create-only operation for one EngramStore layer. To
-reuse a `layer_id`, first remove the old tables with `remove_from_store(...)`.
+`populate(...)` is defined as a create-only operation for the selected layer. To
+reuse a `layer_id`, first remove that layer's old tables with `remove_from_store(layer_id, ...)`. Other layers are unaffected.
 
 If upload fails after some head tables have already been written, or if publish
 finishes but post-write buffer cleanup fails, the backend best-effort removes
@@ -111,21 +146,23 @@ Each lookup follows the same simplified backend flow:
 
 1. validate the `row_ids` shape and bounds
 2. build per-head byte ranges for the requested rows
-3. issue one `get_into_ranges(...)` call to materialize those rows into the output buffer
+3. query head-table locations with `batch_query(...)`
+4. issue one `get_into_ranges(...)` call to write the rows into the registered output buffer
 
-For NumPy `row_ids`, the binding uses a contiguous fast path and builds ranges
-directly from the input tensor without first converting the entire input into a
-nested C++ container.
+The binding builds ranges directly from contiguous NumPy row IDs.
+It rejects Python lists and implicit dtype or layout conversion.
 
 ## Validation
 
 The backend enforces these invariants:
 
+- the layer map is nonempty, IDs are nonnegative, and operations reject unknown layers
+
 - `table_vocab_sizes` is non-empty and every entry is positive
-- `embedding_dim` is positive
+- `row_bytes` is positive and table/output byte sizes do not overflow
 - `populate(...)` receives exactly one table per head
-- every populated table matches `[N_h, D]`
-- `lookup(...)` receives a non-empty `[B, L, H]` input
+- every populated table matches `[N_h, row_bytes]`
+- `lookup_into(...)` receives matching `[B, L, H]` IDs and registered output
 - every row id satisfies `0 <= row_ids[..., h] < N_h`
 
 ## Validation Status
@@ -142,3 +179,16 @@ This backend is covered by:
 By default, the benchmark exercises `engram_store.populate(...)` directly. Its
 fallback populate paths are gated behind `ENGRAM_ALLOW_POPULATE_FALLBACK=1` so
 they do not silently mask regressions in the current implementation.
+
+## Client Instances and Storage
+
+SGLang shares one EngramStore and one Store client across all Engram layers in
+each rank. Each layer still owns its fixed pinned output buffers for CUDA Graph.
+Different ranks access the same backend keys; creating additional clients or
+EngramStore handles does not replicate table data. Storage replicas are controlled
+by the Store replication configuration used during upload.
+
+Per-rank reads currently duplicate network traffic and fetched rows in staging
+buffers. Reducing that traffic requires a separate optimization such as one reader
+per TP group followed by broadcast, or coordinated shared host buffers. Sharing a
+multi-layer EngramStore instance alone does not deduplicate reads across processes.

--- a/mooncake-integration/store/engram_store_py.cpp
+++ b/mooncake-integration/store/engram_store_py.cpp
@@ -102,6 +102,31 @@ void bind_engram_store(py::module& m) {
         .def_readwrite("row_bytes", &EngramStoreConfig::row_bytes);
 
     py::class_<EngramStore>(m, "EngramStore")
+        .def(
+            "bind_local",
+            [](EngramStore& self, int layer_id, py::list buffers) {
+                const auto rows = self.get_table_vocab_sizes(layer_id);
+                if (py::len(buffers) != rows.size())
+                    throw std::runtime_error(
+                        "Local table count must match heads");
+                std::vector<const void*> pointers;
+                std::vector<size_t> sizes;
+                for (size_t h = 0; h < rows.size(); ++h) {
+                    auto arr = require_embedding_buffer(
+                        buffers[h], rows[h], self.get_row_bytes(layer_id));
+                    pointers.push_back(arr.data());
+                    sizes.push_back(arr.nbytes());
+                }
+                if (self.bind_local(layer_id, pointers, sizes) != 0)
+                    throw std::runtime_error(
+                        "bind_local requires an unbound layer and no Store "
+                        "client");
+            },
+            py::arg("layer_id"), py::arg("embedding_buffers"),
+            py::keep_alive<1, 3>(),
+            "Bind immutable uint8 tables before lookup. Retains the arrays "
+            "without "
+            "copying; do not modify, resize or unmap them while bound.")
         .def("get_layer_ids", &EngramStore::get_layer_ids)
         .def("get_table_vocab_sizes", &EngramStore::get_table_vocab_sizes)
         .def("get_store_keys", &EngramStore::get_store_keys)
@@ -164,7 +189,8 @@ void bind_engram_store(py::module& m) {
             py::arg("layer_id"), py::arg("row_ids").noconvert(),
             py::arg("output").noconvert(),
             "Read into caller-owned uint8 memory. The caller must keep the "
-            "output registered with this Store for the entire call. "
+            "output registered with this Store for Store-backed reads. "
+            "Local bound tables do not require output registration. "
             "This method does not allocate, register, or unregister output.")
         .def(
             "populate",

--- a/mooncake-integration/store/engram_store_py.cpp
+++ b/mooncake-integration/store/engram_store_py.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/stl.h>
 
 #include <cstring>
+#include <limits>
 
 #include "engram/engram_store.h"
 #include "engram/engram_store_config.h"
@@ -16,22 +17,6 @@ namespace {
 
 constexpr char kPyClientCapsuleName[] = "mooncake.PyClient.shared_ptr";
 constexpr char kPyClientCapsuleMethod[] = "_get_pyclient_capsule";
-
-std::vector<std::vector<std::vector<int64_t>>> py_obj_to_vec3d(py::object obj) {
-    std::vector<std::vector<std::vector<int64_t>>> result;
-    for (auto batch_item : obj) {
-        std::vector<std::vector<int64_t>> batch_vec;
-        for (auto token_item : batch_item) {
-            std::vector<int64_t> token_vec;
-            for (auto head_item : token_item) {
-                token_vec.push_back(head_item.cast<int64_t>());
-            }
-            batch_vec.push_back(std::move(token_vec));
-        }
-        result.push_back(std::move(batch_vec));
-    }
-    return result;
-}
 
 std::shared_ptr<PyClient> unwrap_pyclient_capsule(py::object capsule) {
     if (capsule.is_none()) {
@@ -87,81 +72,21 @@ std::shared_ptr<PyClient> unwrap_store(py::object store_obj) {
     }
 }
 
-py::array_t<float> require_embedding_buffer(py::handle buf,
-                                            int64_t expected_rows,
-                                            int expected_cols) {
+py::array require_embedding_buffer(py::handle buf, int64_t rows,
+                                   int row_bytes) {
     if (!py::isinstance<py::array>(buf)) {
         throw std::runtime_error("embedding_buffers must be NumPy arrays");
     }
-
-    auto arr =
-        py::array_t<float, py::array::c_style | py::array::forcecast>::ensure(
-            buf);
-    if (!arr) {
-        throw std::runtime_error("embedding_buffers must be float32 arrays");
+    auto arr = py::reinterpret_borrow<py::array>(buf);
+    if (!arr.dtype().is(py::dtype::of<uint8_t>()) ||
+        !(arr.flags() & py::array::c_style)) {
+        throw std::runtime_error("rows must be contiguous uint8 arrays");
     }
-
-    auto req = arr.request();
-    if (req.ndim != 2) {
-        throw std::runtime_error("each embedding buffer must be 2D [N_h, D]");
-    }
-    if (req.shape[0] != expected_rows || req.shape[1] != expected_cols) {
+    if (arr.ndim() != 2 || arr.shape(0) != rows || arr.shape(1) != row_bytes) {
         throw std::runtime_error(
-            "embedding buffer shape does not match "
-            "get_table_vocab_sizes()/get_embedding_dim()");
+            "embedding buffer must match per-head table shape");
     }
     return arr;
-}
-
-py::array_t<float> lookup_to_numpy(
-    EngramStore& self,
-    const std::vector<std::vector<std::vector<int64_t>>>& row_ids) {
-    if (row_ids.empty() || row_ids[0].empty()) {
-        throw std::runtime_error("row_ids must not be empty");
-    }
-
-    const int B = static_cast<int>(row_ids.size());
-    const int L = static_cast<int>(row_ids[0].size());
-    const int H = self.get_num_heads();
-    const int D = self.get_embedding_dim();
-    py::array_t<float> output({B, L, H, D});
-    auto out_buf = output.request();
-
-    int ret =
-        self.lookup_rows(row_ids, out_buf.ptr, out_buf.size * sizeof(float));
-    if (ret != 0) {
-        throw std::runtime_error("EngramStore lookup failed");
-    }
-    return output;
-}
-
-py::array_t<float> lookup_array_to_numpy(
-    EngramStore& self,
-    const py::array_t<int64_t, py::array::c_style | py::array::forcecast>&
-        row_ids) {
-    auto req = row_ids.request();
-    if (req.ndim != 3) {
-        throw std::runtime_error("row_ids array must have shape [B, L, H]");
-    }
-
-    const int B = static_cast<int>(req.shape[0]);
-    const int L = static_cast<int>(req.shape[1]);
-    const int H = static_cast<int>(req.shape[2]);
-    if (H != self.get_num_heads()) {
-        throw std::runtime_error("row_ids last dimension must match num_heads");
-    }
-
-    const int D = self.get_embedding_dim();
-    py::array_t<float> output({B, L, H, D});
-    auto out_buf = output.request();
-
-    int ret =
-        self.lookup_rows_contiguous(static_cast<const int64_t*>(req.ptr), B, L,
-                                    out_buf.ptr, out_buf.size * sizeof(float));
-    if (ret != 0) {
-        throw std::runtime_error("EngramStore lookup failed");
-    }
-    return output;
 }
 
 }  // namespace
@@ -174,64 +99,87 @@ void bind_engram_store(py::module& m) {
         .def(py::init<>())
         .def_readwrite("table_vocab_sizes",
                        &EngramStoreConfig::table_vocab_sizes)
-        .def_readwrite("embedding_dim", &EngramStoreConfig::embedding_dim);
+        .def_readwrite("row_bytes", &EngramStoreConfig::row_bytes);
 
     py::class_<EngramStore>(m, "EngramStore")
+        .def("get_layer_ids", &EngramStore::get_layer_ids)
         .def("get_table_vocab_sizes", &EngramStore::get_table_vocab_sizes)
         .def("get_store_keys", &EngramStore::get_store_keys)
         .def("get_num_heads", &EngramStore::get_num_heads)
-        .def("get_embedding_dim", &EngramStore::get_embedding_dim)
+        .def("get_row_bytes", &EngramStore::get_row_bytes)
         .def(
             "remove_from_store",
-            [](EngramStore& self, bool force) {
-                int ret = self.remove_from_store(force);
+            [](EngramStore& self, int layer_id, bool force) {
+                int ret = self.remove_from_store(layer_id, force);
                 if (ret < 0) {
                     throw std::runtime_error("remove_from_store failed, rc=" +
                                              std::to_string(ret));
                 }
                 return ret;
             },
-            py::arg("force") = false,
-            "Remove all Mooncake Store tables owned by this EngramStore layer. "
+            py::arg("layer_id"), py::arg("force") = false,
+            "Remove all Mooncake Store tables for the selected layer. "
             "Returns the number of removed head tables; missing keys are "
             "ignored.")
-        .def(py::init([](int layer_id, const EngramStoreConfig& cfg,
+        .def(py::init([](const std::map<int, EngramStoreConfig>& layers,
                          py::object store_obj) {
                  std::shared_ptr<PyClient> store = unwrap_store(store_obj);
-                 return new EngramStore(layer_id, cfg, store);
+                 return new EngramStore(layers, store);
              }),
-             py::arg("layer_id"), py::arg("config"),
-             py::arg("store") = py::none())
+             py::arg("layers"), py::arg("store") = py::none())
         .def(
-            "lookup",
-            [](EngramStore& self, py::object row_ids_obj) {
-                if (py::isinstance<py::array>(row_ids_obj)) {
-                    auto row_ids_array = py::array_t<
-                        int64_t, py::array::c_style |
-                                     py::array::forcecast>::ensure(row_ids_obj);
-                    if (!row_ids_array) {
-                        throw std::runtime_error(
-                            "row_ids array must be convertible to int64");
-                    }
-                    return lookup_array_to_numpy(self, row_ids_array);
+            "lookup_into",
+            [](EngramStore& self, int layer_id,
+               py::array_t<int64_t, py::array::c_style> ids, py::array output) {
+                const int width = self.get_row_bytes(layer_id);
+                if (ids.ndim() != 3 ||
+                    ids.shape(2) != self.get_num_heads(layer_id) ||
+                    ids.shape(0) > std::numeric_limits<int>::max() ||
+                    ids.shape(1) > std::numeric_limits<int>::max() ||
+                    output.ndim() != 4 || output.shape(0) != ids.shape(0) ||
+                    output.shape(1) != ids.shape(1) ||
+                    output.shape(2) != ids.shape(2) ||
+                    output.shape(3) != width || !output.writeable() ||
+                    !(output.flags() & py::array::c_style) ||
+                    !output.dtype().is(py::dtype::of<uint8_t>())) {
+                    throw std::runtime_error(
+                        "lookup_into requires contiguous IDs [B,L,H] and "
+                        "matching writable uint8 output [B,L,H,row_bytes]");
                 }
-                return lookup_to_numpy(self, py_obj_to_vec3d(row_ids_obj));
+                if (ids.size() == 0) return;
+                auto ids_buf = ids.request();
+                auto out_buf = output.request();
+                const int B = static_cast<int>(ids_buf.shape[0]);
+                const int L = static_cast<int>(ids_buf.shape[1]);
+                int ret;
+                {
+                    py::gil_scoped_release release;
+                    ret = self.lookup_into(
+                        layer_id, static_cast<const int64_t*>(ids_buf.ptr), B,
+                        L, out_buf.ptr, out_buf.size * out_buf.itemsize);
+                }
+                if (ret != 0)
+                    throw std::runtime_error("EngramStore lookup_into failed");
             },
-            py::arg("row_ids"),
-            "Lookup embeddings by precomputed row IDs. Returns [B, L, H, D].")
+            py::arg("layer_id"), py::arg("row_ids").noconvert(),
+            py::arg("output").noconvert(),
+            "Read into caller-owned uint8 memory. The caller must keep the "
+            "output registered with this Store for the entire call. "
+            "This method does not allocate, register, or unregister output.")
         .def(
             "populate",
-            [](EngramStore& self, py::list embedding_buffers) {
+            [](EngramStore& self, int layer_id, py::list embedding_buffers,
+               const ReplicateConfig& config) {
                 const std::vector<int64_t> vocab_sizes =
-                    self.get_table_vocab_sizes();
-                const int embed_dim = self.get_embedding_dim();
+                    self.get_table_vocab_sizes(layer_id);
+                const int row_bytes = self.get_row_bytes(layer_id);
                 if (static_cast<size_t>(py::len(embedding_buffers)) !=
                     vocab_sizes.size()) {
                     throw std::runtime_error(
                         "embedding_buffers size must match num_heads");
                 }
 
-                std::vector<py::array_t<float>> arrays;
+                std::vector<py::array> arrays;
                 std::vector<void*> bufs;
                 std::vector<size_t> sizes;
                 arrays.reserve(vocab_sizes.size());
@@ -239,18 +187,20 @@ void bind_engram_store(py::module& m) {
                 sizes.reserve(vocab_sizes.size());
                 for (size_t i = 0; i < vocab_sizes.size(); ++i) {
                     auto arr = require_embedding_buffer(
-                        embedding_buffers[i], vocab_sizes[i], embed_dim);
+                        embedding_buffers[i], vocab_sizes[i], row_bytes);
                     auto req = arr.request();
                     arrays.push_back(arr);
                     bufs.push_back(req.ptr);
-                    sizes.push_back(req.size * sizeof(float));
+                    sizes.push_back(arr.nbytes());
                 }
-                int ret = self.populate(bufs, sizes);
+                py::gil_scoped_release release;
+                int ret = self.populate(layer_id, bufs, sizes, config);
                 if (ret != 0) {
                     throw std::runtime_error("populate failed");
                 }
             },
-            py::arg("embedding_buffers"));
+            py::arg("layer_id"), py::arg("embedding_buffers"),
+            py::arg("config") = ReplicateConfig{});
 }
 
 }  // namespace engram

--- a/mooncake-store/include/engram/engram_store.h
+++ b/mooncake-store/include/engram/engram_store.h
@@ -33,10 +33,16 @@ class EngramStore {
 
     ~EngramStore() = default;
 
+    // Bind immutable caller-owned tables before lookup, without a Store client.
+    // The caller must keep these buffers alive until this EngramStore is
+    // destroyed.
+    int bind_local(int layer_id, const std::vector<const void*>& buffers,
+                   const std::vector<size_t>& sizes);
+
     /**
      * Lookup embedding rows for a batch of precomputed row IDs.
      * @param row_ids [B, L, H] precomputed row IDs, where H == num_heads
-     * The caller must keep output registered with this Store during the call.
+     * Store-backed lookup requires registered output; local lookup does not.
      * @param output [B, L, H, row_bytes] contiguous byte output buffer
      * @param output_size Size of output buffer in bytes
      * @return 0 on success, negative on error
@@ -72,6 +78,7 @@ class EngramStore {
     struct Layer {
         EngramStoreConfig config;
         std::vector<std::string> keys;
+        std::vector<const void*> local_tables;
     };
     const Layer& get_layer(int layer_id) const;
     std::map<int, Layer> layers_;

--- a/mooncake-store/include/engram/engram_store.h
+++ b/mooncake-store/include/engram/engram_store.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "engram/engram_store_config.h"
+#include "replica.h"
 
 namespace mooncake {
 
@@ -14,7 +16,7 @@ class PyClient;
 namespace engram {
 
 /**
- * Mooncake backend for Engram embedding tables.
+ * Mooncake backend for all layers of a model's Engram embedding tables.
  *
  * This class intentionally owns only storage-side concerns:
  * - per-head table naming/layout in Mooncake Store
@@ -26,7 +28,7 @@ namespace engram {
  */
 class EngramStore {
    public:
-    EngramStore(int layer_id, const EngramStoreConfig& config,
+    EngramStore(const std::map<int, EngramStoreConfig>& layers,
                 std::shared_ptr<PyClient> store = nullptr);
 
     ~EngramStore() = default;
@@ -34,49 +36,45 @@ class EngramStore {
     /**
      * Lookup embedding rows for a batch of precomputed row IDs.
      * @param row_ids [B, L, H] precomputed row IDs, where H == num_heads
-     * @param output [B, L, H, D] output buffer
+     * The caller must keep output registered with this Store during the call.
+     * @param output [B, L, H, row_bytes] contiguous byte output buffer
      * @param output_size Size of output buffer in bytes
      * @return 0 on success, negative on error
      */
-    int lookup_rows(
-        const std::vector<std::vector<std::vector<int64_t>>>& row_ids,
-        void* output, size_t output_size) const;
+    int lookup_into(int layer_id, const int64_t* row_ids, int B, int L,
+                    void* output, size_t output_size) const;
+
+    std::vector<int> get_layer_ids() const;
+    std::vector<int64_t> get_table_vocab_sizes(int layer_id) const;
+    std::vector<std::string> get_store_keys(int layer_id) const;
+    int get_num_heads(int layer_id) const;
+    int get_row_bytes(int layer_id) const;
 
     /**
-     * Fast path for contiguous row-id buffers with shape [B, L, H].
-     */
-    int lookup_rows_contiguous(const int64_t* row_ids, int B, int L,
-                               void* output, size_t output_size) const;
-
-    std::vector<int64_t> get_table_vocab_sizes() const;
-    std::vector<std::string> get_store_keys() const;
-    int get_num_heads() const;
-    int get_embedding_dim() const;
-
-    /**
-     * Remove all head tables owned by this EngramStore layer from Mooncake
+     * Remove all head tables owned by the selected layer from Mooncake
      * Store. Missing keys are ignored. Returns the number of removed tables on
      * success, or a negative error code on failure.
      */
-    int remove_from_store(bool force = false);
+    int remove_from_store(int layer_id, bool force = false);
 
     /**
      * Populate Store with per-head embedding tensors.
-     * @param embedding_buffers Buffers for each head [N_h, D]
+     * @param embedding_buffers Byte buffers for each head [N_h, row_bytes]
      * @param buffer_sizes Size in bytes for each buffer
      * @return 0 on success, negative on error
      */
-    int populate(const std::vector<void*>& embedding_buffers,
-                 const std::vector<size_t>& buffer_sizes);
+    int populate(int layer_id, const std::vector<void*>& embedding_buffers,
+                 const std::vector<size_t>& buffer_sizes,
+                 const ReplicateConfig& config = ReplicateConfig{});
 
    private:
-    int lookup_rows_flat(const int64_t* row_ids, int B, int L, void* output,
-                         size_t output_size) const;
-
     std::shared_ptr<PyClient> store_;
-    std::vector<int64_t> table_vocab_sizes_;
-    int embedding_dim_;
-    std::vector<std::string> embed_keys_;
+    struct Layer {
+        EngramStoreConfig config;
+        std::vector<std::string> keys;
+    };
+    const Layer& get_layer(int layer_id) const;
+    std::map<int, Layer> layers_;
 };
 
 }  // namespace engram

--- a/mooncake-store/include/engram/engram_store_config.h
+++ b/mooncake-store/include/engram/engram_store_config.h
@@ -15,7 +15,8 @@ namespace engram {
  */
 struct EngramStoreConfig {
     std::vector<int64_t> table_vocab_sizes = {1024};
-    int embedding_dim = 64;
+    // Required positive width of an opaque byte row; no dtype interpretation.
+    int row_bytes = 0;
 };
 
 }  // namespace engram

--- a/mooncake-store/src/engram/engram_store.cpp
+++ b/mooncake-store/src/engram/engram_store.cpp
@@ -24,7 +24,7 @@ EngramStore::EngramStore(const std::map<int, EngramStoreConfig>& layers,
                 "EngramStore requires nonnegative layer IDs, positive "
                 "row_bytes and nonempty tables");
         }
-        Layer layer{config, {}};
+        Layer layer{config, {}, {}};
         for (size_t h = 0; h < config.table_vocab_sizes.size(); ++h) {
             const int64_t vocab_size = config.table_vocab_sizes[h];
             if (vocab_size <= 0 ||
@@ -49,13 +49,31 @@ const EngramStore::Layer& EngramStore::get_layer(int layer_id) const {
     return it->second;
 }
 
+int EngramStore::bind_local(int layer_id,
+                            const std::vector<const void*>& buffers,
+                            const std::vector<size_t>& sizes) {
+    const auto& layer = get_layer(layer_id);
+    if (store_ || !layer.local_tables.empty() ||
+        buffers.size() != layer.keys.size() || sizes.size() != buffers.size()) {
+        return -1;
+    }
+    for (size_t h = 0; h < buffers.size(); ++h) {
+        if (!buffers[h] ||
+            sizes[h] != static_cast<size_t>(layer.config.table_vocab_sizes[h]) *
+                            layer.config.row_bytes)
+            return -1;
+    }
+    layers_.at(layer_id).local_tables = buffers;
+    return 0;
+}
+
 int EngramStore::lookup_into(int layer_id, const int64_t* row_ids, int B, int L,
                              void* output_buffer, size_t output_size) const {
     const auto& layer = get_layer(layer_id);
     const auto& table_vocab_sizes = layer.config.table_vocab_sizes;
     const auto& embed_keys = layer.keys;
-    if (store_ == nullptr || row_ids == nullptr || output_buffer == nullptr ||
-        B <= 0 || L <= 0) {
+    if ((!store_ && layer.local_tables.empty()) || row_ids == nullptr ||
+        output_buffer == nullptr || B <= 0 || L <= 0) {
         return -1;
     }
 
@@ -80,6 +98,30 @@ int EngramStore::lookup_into(int layer_id, const int64_t* row_ids, int B, int L,
         std::memset(output_buffer, 0, expected_size);
         return -1;
     };
+
+    if (!layer.local_tables.empty()) {
+        // Validate all IDs before touching output. No metadata or transfer
+        // work.
+        for (size_t t = 0; t < token_count; ++t) {
+            for (int h = 0; h < num_heads; ++h) {
+                const auto id = row_ids[t * num_heads + h];
+                if (id < 0 || id >= table_vocab_sizes[h]) return fail_lookup();
+            }
+        }
+        auto* dst = static_cast<char*>(output_buffer);
+        for (size_t t = 0; t < token_count; ++t) {
+            for (int h = 0; h < num_heads; ++h) {
+                const size_t index = t * num_heads + h;
+                const auto* src =
+                    static_cast<const char*>(layer.local_tables[h]);
+                std::memcpy(
+                    dst + index * row_bytes,
+                    src + static_cast<size_t>(row_ids[index]) * row_bytes,
+                    row_bytes);
+            }
+        }
+        return 0;
+    }
 
     std::vector<void*> buffers{output_buffer};
     std::vector<std::vector<std::string>> all_keys(1);

--- a/mooncake-store/src/engram/engram_store.cpp
+++ b/mooncake-store/src/engram/engram_store.cpp
@@ -11,46 +11,56 @@
 namespace mooncake {
 namespace engram {
 
-EngramStore::EngramStore(int layer_id, const EngramStoreConfig& config,
+EngramStore::EngramStore(const std::map<int, EngramStoreConfig>& layers,
                          std::shared_ptr<PyClient> store)
-    : store_(std::move(store)),
-      table_vocab_sizes_(config.table_vocab_sizes),
-      embedding_dim_(config.embedding_dim) {
-    if (table_vocab_sizes_.empty()) {
-        throw std::invalid_argument(
-            "EngramStoreConfig.table_vocab_sizes must not be empty");
+    : store_(std::move(store)) {
+    if (layers.empty()) {
+        throw std::invalid_argument("EngramStore requires at least one layer");
     }
-    if (embedding_dim_ <= 0) {
-        throw std::invalid_argument(
-            "EngramStoreConfig.embedding_dim must be positive");
-    }
-    for (int64_t vocab_size : table_vocab_sizes_) {
-        if (vocab_size <= 0) {
+    for (const auto& [layer_id, config] : layers) {
+        if (layer_id < 0 || config.row_bytes <= 0 ||
+            config.table_vocab_sizes.empty()) {
             throw std::invalid_argument(
-                "EngramStoreConfig.table_vocab_sizes must contain only "
-                "positive values");
+                "EngramStore requires nonnegative layer IDs, positive "
+                "row_bytes and nonempty tables");
         }
-    }
-
-    embed_keys_.reserve(table_vocab_sizes_.size());
-    for (size_t h = 0; h < table_vocab_sizes_.size(); ++h) {
-        std::ostringstream oss;
-        oss << "engram:l" << layer_id << ":h" << h;
-        embed_keys_.push_back(oss.str());
+        Layer layer{config, {}};
+        for (size_t h = 0; h < config.table_vocab_sizes.size(); ++h) {
+            const int64_t vocab_size = config.table_vocab_sizes[h];
+            if (vocab_size <= 0 ||
+                static_cast<uint64_t>(vocab_size) >
+                    std::numeric_limits<size_t>::max() / config.row_bytes) {
+                throw std::invalid_argument("Invalid Engram table size");
+            }
+            std::ostringstream key;
+            key << "engram:l" << layer_id << ":h" << h;
+            layer.keys.push_back(key.str());
+        }
+        layers_.emplace(layer_id, std::move(layer));
     }
 }
 
-int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
-                                  void* output_buffer,
-                                  size_t output_size) const {
+const EngramStore::Layer& EngramStore::get_layer(int layer_id) const {
+    auto it = layers_.find(layer_id);
+    if (it == layers_.end()) {
+        throw std::invalid_argument("Unknown Engram layer: " +
+                                    std::to_string(layer_id));
+    }
+    return it->second;
+}
+
+int EngramStore::lookup_into(int layer_id, const int64_t* row_ids, int B, int L,
+                             void* output_buffer, size_t output_size) const {
+    const auto& layer = get_layer(layer_id);
+    const auto& table_vocab_sizes = layer.config.table_vocab_sizes;
+    const auto& embed_keys = layer.keys;
     if (store_ == nullptr || row_ids == nullptr || output_buffer == nullptr ||
         B <= 0 || L <= 0) {
         return -1;
     }
 
-    const int num_heads = static_cast<int>(table_vocab_sizes_.size());
-    const size_t row_bytes =
-        static_cast<size_t>(embedding_dim_) * sizeof(float);
+    const int num_heads = static_cast<int>(table_vocab_sizes.size());
+    const size_t row_bytes = layer.config.row_bytes;
     const size_t max_size = std::numeric_limits<size_t>::max();
     if (static_cast<size_t>(B) > max_size / static_cast<size_t>(L)) {
         return -1;
@@ -83,7 +93,7 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
     all_sizes[0].reserve(static_cast<size_t>(num_heads));
 
     for (int h = 0; h < num_heads; ++h) {
-        all_keys[0].push_back(embed_keys_[h]);
+        all_keys[0].push_back(embed_keys[h]);
         all_dst_offsets[0].emplace_back();
         all_src_offsets[0].emplace_back();
         all_sizes[0].emplace_back();
@@ -100,7 +110,7 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
             for (int h = 0; h < num_heads; ++h) {
                 const int64_t idx =
                     row_ids[row_offset + static_cast<size_t>(h)];
-                if (idx < 0 || idx >= table_vocab_sizes_[h]) {
+                if (idx < 0 || idx >= table_vocab_sizes[h]) {
                     return fail_lookup();
                 }
                 all_dst_offsets[0][h].push_back(
@@ -112,30 +122,19 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
         }
     }
 
-    const int register_ret =
-        store_->register_buffer(output_buffer, expected_size);
-    if (register_ret != 0) {
-        return fail_lookup();
-    }
-
     mooncake::PyClient::QueryResultCache query_result_cache;
-    auto query_results = store_->batch_query(embed_keys_);
-    if (query_results.size() != embed_keys_.size()) {
-        store_->unregister_buffer(output_buffer);
+    auto query_results = store_->batch_query(embed_keys);
+    if (query_results.size() != embed_keys.size()) {
         return fail_lookup();
     }
-    query_result_cache.reserve(embed_keys_.size());
-    for (size_t i = 0; i < embed_keys_.size(); ++i) {
-        query_result_cache.emplace(embed_keys_[i], query_results[i]);
+    query_result_cache.reserve(embed_keys.size());
+    for (size_t i = 0; i < embed_keys.size(); ++i) {
+        query_result_cache.emplace(embed_keys[i], query_results[i]);
     }
 
     auto results = store_->get_into_ranges(buffers, all_keys, all_dst_offsets,
                                            all_src_offsets, all_sizes,
                                            &query_result_cache);
-    const int unregister_ret = store_->unregister_buffer(output_buffer);
-    if (unregister_ret != 0) {
-        return fail_lookup();
-    }
     if (results.size() != 1 ||
         results[0].size() != static_cast<size_t>(num_heads)) {
         return fail_lookup();
@@ -154,57 +153,30 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
     return 0;
 }
 
-int EngramStore::lookup_rows_contiguous(const int64_t* row_ids, int B, int L,
-                                        void* output_buffer,
-                                        size_t output_size) const {
-    return lookup_rows_flat(row_ids, B, L, output_buffer, output_size);
+std::vector<int> EngramStore::get_layer_ids() const {
+    std::vector<int> ids;
+    for (const auto& [id, layer] : layers_) ids.push_back(id);
+    return ids;
 }
 
-int EngramStore::lookup_rows(
-    const std::vector<std::vector<std::vector<int64_t>>>& row_ids,
-    void* output_buffer, size_t output_size) const {
-    if (store_ == nullptr || output_buffer == nullptr || row_ids.empty() ||
-        row_ids[0].empty()) {
-        return -1;
-    }
-
-    const int B = static_cast<int>(row_ids.size());
-    const int L = static_cast<int>(row_ids[0].size());
-    const int num_heads = static_cast<int>(table_vocab_sizes_.size());
-    std::vector<int64_t> flat_row_ids;
-    flat_row_ids.reserve(static_cast<size_t>(B) * L * num_heads);
-    for (int b = 0; b < B; ++b) {
-        if (static_cast<int>(row_ids[b].size()) != L) {
-            return -1;
-        }
-        for (int l = 0; l < L; ++l) {
-            if (static_cast<int>(row_ids[b][l].size()) != num_heads) {
-                return -1;
-            }
-            flat_row_ids.insert(flat_row_ids.end(), row_ids[b][l].begin(),
-                                row_ids[b][l].end());
-        }
-    }
-
-    return lookup_rows_flat(flat_row_ids.data(), B, L, output_buffer,
-                            output_size);
+std::vector<int64_t> EngramStore::get_table_vocab_sizes(int layer_id) const {
+    return get_layer(layer_id).config.table_vocab_sizes;
 }
 
-std::vector<int64_t> EngramStore::get_table_vocab_sizes() const {
-    return table_vocab_sizes_;
+std::vector<std::string> EngramStore::get_store_keys(int layer_id) const {
+    return get_layer(layer_id).keys;
 }
 
-std::vector<std::string> EngramStore::get_store_keys() const {
-    return embed_keys_;
+int EngramStore::get_num_heads(int layer_id) const {
+    return static_cast<int>(get_layer(layer_id).keys.size());
 }
 
-int EngramStore::get_num_heads() const {
-    return static_cast<int>(table_vocab_sizes_.size());
+int EngramStore::get_row_bytes(int layer_id) const {
+    return get_layer(layer_id).config.row_bytes;
 }
 
-int EngramStore::get_embedding_dim() const { return embedding_dim_; }
-
-int EngramStore::remove_from_store(bool force) {
+int EngramStore::remove_from_store(int layer_id, bool force) {
+    const auto& embed_keys = get_layer(layer_id).keys;
     if (store_ == nullptr) {
         return static_cast<int>(ErrorCode::INVALID_PARAMS);
     }
@@ -214,7 +186,7 @@ int EngramStore::remove_from_store(bool force) {
     int removed = 0;
     int first_error = 0;
 
-    for (const auto& key : embed_keys_) {
+    for (const auto& key : embed_keys) {
         int rc = store_->remove(key, force);
         if (rc == 0) {
             ++removed;
@@ -231,40 +203,45 @@ int EngramStore::remove_from_store(bool force) {
     return first_error != 0 ? first_error : removed;
 }
 
-int EngramStore::populate(const std::vector<void*>& embedding_buffers,
-                          const std::vector<size_t>& buffer_sizes) {
+int EngramStore::populate(int layer_id,
+                          const std::vector<void*>& embedding_buffers,
+                          const std::vector<size_t>& buffer_sizes,
+                          const ReplicateConfig& config) {
+    const auto& layer = get_layer(layer_id);
+    const auto& table_vocab_sizes = layer.config.table_vocab_sizes;
+    const auto& embed_keys = layer.keys;
     if (store_ == nullptr) {
         return -1;
     }
-    if (embedding_buffers.size() != embed_keys_.size() ||
-        buffer_sizes.size() != embed_keys_.size()) {
+    if (embedding_buffers.size() != embed_keys.size() ||
+        buffer_sizes.size() != embed_keys.size()) {
         return -1;
     }
 
     for (size_t i = 0; i < buffer_sizes.size(); ++i) {
-        const size_t expected = static_cast<size_t>(table_vocab_sizes_[i]) *
-                                embedding_dim_ * sizeof(float);
+        const size_t expected =
+            static_cast<size_t>(table_vocab_sizes[i]) * layer.config.row_bytes;
         if (embedding_buffers[i] == nullptr || buffer_sizes[i] != expected) {
             return -1;
         }
     }
 
-    std::vector<int> exists_results = store_->batchIsExist(embed_keys_);
-    if (exists_results.size() != embed_keys_.size()) {
+    std::vector<int> exists_results = store_->batchIsExist(embed_keys);
+    if (exists_results.size() != embed_keys.size()) {
         LOG(ERROR) << "Failed to preflight EngramStore populate key existence";
         return -1;
     }
     for (size_t i = 0; i < exists_results.size(); ++i) {
         const int exists = exists_results[i];
         if (exists < 0) {
-            LOG(ERROR) << "Failed to query EngramStore key '" << embed_keys_[i]
+            LOG(ERROR) << "Failed to query EngramStore key '" << embed_keys[i]
                        << "' before populate, rc=" << exists;
             return -1;
         }
         if (exists != 0) {
             LOG(ERROR)
                 << "EngramStore populate requires empty destination key '"
-                << embed_keys_[i] << "'. Remove the existing layer first.";
+                << embed_keys[i] << "'. Remove the existing layer first.";
             return -1;
         }
     }
@@ -294,10 +271,10 @@ int EngramStore::populate(const std::vector<void*>& embedding_buffers,
         }
     }
 
-    std::vector<int> put_results =
-        store_->batch_put_from(embed_keys_, embedding_buffers, buffer_sizes);
+    std::vector<int> put_results = store_->batch_put_from(
+        embed_keys, embedding_buffers, buffer_sizes, config);
     const bool put_succeeded =
-        put_results.size() == embed_keys_.size() &&
+        put_results.size() == embed_keys.size() &&
         std::all_of(put_results.begin(), put_results.end(),
                     [](int result) { return result == 0; });
 
@@ -306,17 +283,17 @@ int EngramStore::populate(const std::vector<void*>& embedding_buffers,
 
     if (!put_succeeded || unregister_failed) {
         const bool put_results_complete =
-            put_results.size() == embed_keys_.size();
-        for (size_t i = 0; i < embed_keys_.size(); ++i) {
+            put_results.size() == embed_keys.size();
+        for (size_t i = 0; i < embed_keys.size(); ++i) {
             if (put_results_complete && put_results[i] != 0) {
                 continue;
             }
-            int rc = store_->remove(embed_keys_[i], true);
+            int rc = store_->remove(embed_keys[i], true);
             if (rc != 0 &&
                 rc != static_cast<int>(ErrorCode::OBJECT_NOT_FOUND)) {
                 LOG(ERROR)
                     << "Failed to roll back partially populated EngramStore "
-                    << "key '" << embed_keys_[i] << "', rc=" << rc;
+                    << "key '" << embed_keys[i] << "', rc=" << rc;
             }
         }
         if (unregister_failed) {

--- a/scripts/bench_engram_store_27b.py
+++ b/scripts/bench_engram_store_27b.py
@@ -24,6 +24,7 @@ import os
 import sys
 import time
 import uuid
+from contextlib import contextmanager
 
 import numpy as np
 
@@ -46,7 +47,7 @@ BATCH_SIZES = [1, 4, 16, 64, 128, 256]
 NUM_WARMUP = 10
 NUM_ITER = 50
 TABLE_VOCAB_SIZES = [50000] * 8
-EMBEDDING_DIM = 16
+ROW_BYTES = 64
 ALLOW_POPULATE_FALLBACK = (
     os.environ.get("ENGRAM_STORE_ALLOW_POPULATE_FALLBACK", "0") == "1"
 )
@@ -55,7 +56,7 @@ ALLOW_POPULATE_FALLBACK = (
 def create_engram_store_config():
     cfg = store.EngramStoreConfig()
     cfg.table_vocab_sizes = TABLE_VOCAB_SIZES
-    cfg.embedding_dim = EMBEDDING_DIM
+    cfg.row_bytes = ROW_BYTES
     return cfg
 
 
@@ -111,9 +112,7 @@ def populate_store_via_cxl_segment(store_obj, keys, embedding_buffers):
             key = keys[head_idx]
             rc = store_obj.put_from(key, cursor, nbytes)
             if rc != 0:
-                raise RuntimeError(
-                    f"CXL put_from fallback failed for {key}, rc={rc}"
-                )
+                raise RuntimeError(f"CXL put_from fallback failed for {key}, rc={rc}")
             published_keys.append(key)
             cursor += aligned
     except Exception:
@@ -121,17 +120,22 @@ def populate_store_via_cxl_segment(store_obj, keys, embedding_buffers):
         raise
 
 
-def populate_store(engram_store, store_obj):
-    keys = engram_store.get_store_keys()
+def populate_store(engram_store, layer_id, store_obj):
+    keys = engram_store.get_store_keys(layer_id)
     embedding_buffers = []
-    for vocab_size in engram_store.get_table_vocab_sizes():
-        emb = np.random.randn(vocab_size, engram_store.get_embedding_dim()).astype(np.float32)
+    for vocab_size in engram_store.get_table_vocab_sizes(layer_id):
+        emb = np.random.randint(
+            0,
+            256,
+            size=(vocab_size, engram_store.get_row_bytes(layer_id)),
+            dtype=np.uint8,
+        )
         embedding_buffers.append(emb)
 
     t0 = time.perf_counter()
     mode = "engram_store.populate"
     try:
-        engram_store.populate(embedding_buffers)
+        engram_store.populate(layer_id, embedding_buffers)
     except RuntimeError:
         if not ALLOW_POPULATE_FALLBACK:
             raise
@@ -158,32 +162,49 @@ def populate_store(engram_store, store_obj):
     return embedding_buffers, populate_ms, mode
 
 
-def make_row_ids(engram_store, batch_size, seq_len):
+def make_row_ids(engram_store, layer_id, batch_size, seq_len):
     row_ids = []
     for b in range(batch_size):
         batch = []
-        for l in range(seq_len):
+        for pos in range(seq_len):
             token_rows = []
-            for head, vocab_size in enumerate(engram_store.get_table_vocab_sizes()):
-                token_rows.append((b * seq_len + l + head) % vocab_size)
+            for head, vocab_size in enumerate(
+                engram_store.get_table_vocab_sizes(layer_id)
+            ):
+                token_rows.append((b * seq_len + pos + head) % vocab_size)
             batch.append(token_rows)
         row_ids.append(batch)
-    return row_ids
+    return np.asarray(row_ids, dtype=np.int64)
 
 
-def run_benchmark(engram_store, batch_size, num_warmup, num_iter):
+@contextmanager
+def registered_output(store_obj, engram_store, layer_id, row_ids):
+    output = np.empty(
+        (*row_ids.shape, engram_store.get_row_bytes(layer_id)), dtype=np.uint8
+    )
+    if store_obj.register_buffer(output.ctypes.data, output.nbytes) != 0:
+        raise RuntimeError("Could not register benchmark output")
+    try:
+        yield output
+    finally:
+        if store_obj.unregister_buffer(output.ctypes.data) != 0:
+            raise RuntimeError("Could not unregister benchmark output")
+
+
+def run_benchmark(engram_store, layer_id, store_obj, batch_size, num_warmup, num_iter):
     seq_len = 1
-    row_ids = make_row_ids(engram_store, batch_size, seq_len)
+    row_ids = make_row_ids(engram_store, layer_id, batch_size, seq_len)
 
-    for _ in range(num_warmup):
-        engram_store.lookup(row_ids)
+    with registered_output(store_obj, engram_store, layer_id, row_ids) as output:
+        for _ in range(num_warmup):
+            engram_store.lookup_into(layer_id, row_ids, output)
 
-    total_ms_list = []
-    for _ in range(num_iter):
-        t0 = time.perf_counter()
-        engram_store.lookup(row_ids)
-        t1 = time.perf_counter()
-        total_ms_list.append((t1 - t0) * 1000)
+        total_ms_list = []
+        for _ in range(num_iter):
+            t0 = time.perf_counter()
+            engram_store.lookup_into(layer_id, row_ids, output)
+            t1 = time.perf_counter()
+            total_ms_list.append((t1 - t0) * 1000)
 
     total_ms = np.array(total_ms_list)
     mean_total = np.mean(total_ms)
@@ -194,9 +215,8 @@ def run_benchmark(engram_store, batch_size, num_warmup, num_iter):
     bytes_per_request = (
         batch_size
         * seq_len
-        * engram_store.get_num_heads()
-        * engram_store.get_embedding_dim()
-        * 4
+        * engram_store.get_num_heads(layer_id)
+        * engram_store.get_row_bytes(layer_id)
     )
     gbps = (bytes_per_request / 1e9) / (mean_total / 1000)
 
@@ -210,9 +230,10 @@ def run_benchmark(engram_store, batch_size, num_warmup, num_iter):
     }
 
 
-def validate_lookup_correctness(engram_store, embedding_buffers):
-    row_ids = make_row_ids(engram_store, batch_size=1, seq_len=1)
-    output = np.asarray(engram_store.lookup(row_ids))
+def validate_lookup_correctness(engram_store, layer_id, store_obj, embedding_buffers):
+    row_ids = make_row_ids(engram_store, layer_id, batch_size=1, seq_len=1)
+    with registered_output(store_obj, engram_store, layer_id, row_ids) as output:
+        engram_store.lookup_into(layer_id, row_ids, output)
 
     max_abs_err = 0.0
     for head_idx in range(output.shape[2]):
@@ -251,11 +272,15 @@ def main():
     try:
         cfg = create_engram_store_config()
         layer_id = uuid.uuid4().int & 0x7FFFFFFF
-        engram_store = store.EngramStore(layer_id=layer_id, config=cfg, store=store_obj)
-        embedding_buffers, populate_ms, mode = populate_store(engram_store, store_obj)
+        engram_store = store.EngramStore({layer_id: cfg}, store_obj)
+        embedding_buffers, populate_ms, mode = populate_store(
+            engram_store, layer_id, store_obj
+        )
         print(f"Populate mode: {mode}, took {populate_ms:.2f} ms")
 
-        max_abs_err = validate_lookup_correctness(engram_store, embedding_buffers)
+        max_abs_err = validate_lookup_correctness(
+            engram_store, layer_id, store_obj, embedding_buffers
+        )
         print(f"Max abs error: {max_abs_err:.6f}")
 
         print("\nResults:")
@@ -263,7 +288,9 @@ def main():
             f"{'Batch':>8} {'Mean(ms)':>10} {'P50(ms)':>10} {'P99(ms)':>10} {'Tok/s':>12} {'GB/s':>10}"
         )
         for batch_size in BATCH_SIZES:
-            result = run_benchmark(engram_store, batch_size, NUM_WARMUP, NUM_ITER)
+            result = run_benchmark(
+                engram_store, layer_id, store_obj, batch_size, NUM_WARMUP, NUM_ITER
+            )
             print(
                 f"{result['batch_size']:>8} {result['mean_total_ms']:>10.3f} {result['p50_ms']:>10.3f} "
                 f"{result['p99_ms']:>10.3f} {result['tokens_per_sec']:>12.1f} {result['gbps']:>10.3f}"
@@ -271,7 +298,7 @@ def main():
     finally:
         if engram_store is not None:
             try:
-                engram_store.remove_from_store(force=True)
+                engram_store.remove_from_store(layer_id, force=True)
             except Exception as exc:
                 print(f"Warning: failed to clean up benchmark layer: {exc}")
         store_obj.close()

--- a/scripts/test_engram_store.py
+++ b/scripts/test_engram_store.py
@@ -324,6 +324,39 @@ class EngramStoreTestBase(unittest.TestCase):
 
 
 class TestEngramStoreMetadata(EngramStoreTestBase):
+    def test_local_tables_lifetime_and_bounds(self):
+        import gc
+        import weakref
+
+        cfg = self.create_config()
+        cfg.row_bytes = 264
+        table = self.EngramStore({1: cfg, 14: cfg})
+        arrays = [
+            np.arange(n * 264, dtype=np.uint32).astype(np.uint8).reshape(n, 264)
+            for n in cfg.table_vocab_sizes
+        ]
+        expected = np.stack([a[-1].copy() for a in arrays])
+        refs = [weakref.ref(a) for a in arrays]
+        for a in arrays:
+            a.flags.writeable = False
+        table.bind_local(1, arrays)
+        del arrays, a
+        gc.collect()
+        assert all(ref() is not None for ref in refs)
+        ids = (np.array(cfg.table_vocab_sizes, dtype=np.int64) - 1)[None, None]
+        output = np.empty((1, 1, len(cfg.table_vocab_sizes), 264), dtype=np.uint8)
+        table.lookup_into(1, ids, output)  # No Store or registered output.
+        np.testing.assert_array_equal(output[0, 0], expected)
+        with self.assertRaises(RuntimeError):
+            table.lookup_into(14, ids, output)
+        ids[0, 0, 0] += 1
+        with self.assertRaises(RuntimeError):
+            table.lookup_into(1, ids, output)
+        assert not output.any()
+        del table
+        gc.collect()
+        assert all(ref() is None for ref in refs)
+
     def test_creation_and_metadata(self):
         cfg, engram_store = self.create_engram_store()
         self.assertEqual(

--- a/scripts/test_engram_store.py
+++ b/scripts/test_engram_store.py
@@ -5,7 +5,7 @@ Integration tests for the Mooncake EngramStore backend.
 This suite validates:
 1. metadata-only construction and store-backed construction
 2. populate / lookup / remove on the simplified Store interface
-3. Python-list and NumPy row-id lookup paths
+3. caller-owned registered output buffers and strict NumPy inputs
 4. error handling and cleanup behavior
 """
 
@@ -21,6 +21,7 @@ import unittest
 import urllib.error
 import urllib.request
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
@@ -35,7 +36,7 @@ for path in (BUILD_STORE, WHEEL_DIR):
     if path.is_dir() and str(path) not in sys.path:
         sys.path.insert(0, str(path))
 
-from mooncake.mooncake_config import MooncakeConfig
+from mooncake.mooncake_config import MooncakeConfig  # noqa: E402
 
 GLOBAL_STORE = None
 STORE_MODULE = None
@@ -256,14 +257,15 @@ class EngramStoreTestBase(unittest.TestCase):
     def tearDown(self):
         for engram_store in reversed(self._created_engram_stores):
             try:
-                engram_store.remove_from_store(force=True)
+                for layer_id in engram_store.get_layer_ids():
+                    engram_store.remove_from_store(layer_id, force=True)
             except Exception as exc:
                 print(f"Warning: failed to clean up EngramStore test layer: {exc}")
 
     def create_config(self):
         cfg = self.EngramStoreConfig()
         cfg.table_vocab_sizes = [17, 19, 23, 29]
-        cfg.embedding_dim = 8
+        cfg.row_bytes = 32
         return cfg
 
     def create_engram_store(self, layer_id=None, store_marker=Ellipsis):
@@ -272,50 +274,85 @@ class EngramStoreTestBase(unittest.TestCase):
             self._next_layer_id += 1
 
         cfg = self.create_config()
+        self.layer_id = layer_id
         if store_marker is Ellipsis:
-            engram_store = self.EngramStore(layer_id=layer_id, config=cfg, store=self.store)
+            engram_store = self.EngramStore(layers={layer_id: cfg}, store=self.store)
             self._created_engram_stores.append(engram_store)
         elif store_marker is None:
-            engram_store = self.EngramStore(layer_id=layer_id, config=cfg)
+            engram_store = self.EngramStore(layers={layer_id: cfg})
         else:
-            engram_store = self.EngramStore(layer_id=layer_id, config=cfg, store=store_marker)
+            engram_store = self.EngramStore(layers={layer_id: cfg}, store=store_marker)
             self._created_engram_stores.append(engram_store)
         return cfg, engram_store
 
     def make_embedding_tables(self, engram_store):
-        embed_dim = engram_store.get_embedding_dim()
+        row_bytes = engram_store.get_row_bytes(self.layer_id)
         tables = []
-        for head_idx, vocab_size in enumerate(engram_store.get_table_vocab_sizes()):
-            base = np.arange(vocab_size * embed_dim, dtype=np.float32).reshape(
-                vocab_size, embed_dim
+        for head_idx, vocab_size in enumerate(
+            engram_store.get_table_vocab_sizes(self.layer_id)
+        ):
+            base = np.arange(vocab_size * row_bytes, dtype=np.int64).reshape(
+                vocab_size, row_bytes
             )
-            tables.append(base + head_idx * 1000)
+            tables.append((base + head_idx * 37).astype(np.uint8))
         return tables
 
     def populate_store(self, engram_store):
         tables = self.make_embedding_tables(engram_store)
-        engram_store.populate(tables)
+        engram_store.populate(self.layer_id, tables)
         return tables
+
+    @contextmanager
+    def registered_output(self, table, shape, layer_id=None):
+        layer_id = self.layer_id if layer_id is None else layer_id
+        output = np.empty((*shape, table.get_row_bytes(layer_id)), dtype=np.uint8)
+        if output.nbytes:
+            self.assertEqual(
+                self.store.register_buffer(output.ctypes.data, output.nbytes), 0
+            )
+        try:
+            yield output
+        finally:
+            if output.nbytes:
+                self.assertEqual(self.store.unregister_buffer(output.ctypes.data), 0)
+
+    def read_rows(self, table, row_ids):
+        ids = np.asarray(row_ids, dtype=np.int64)
+        with self.registered_output(table, ids.shape) as output:
+            table.lookup_into(self.layer_id, ids, output)
+        return output
 
 
 class TestEngramStoreMetadata(EngramStoreTestBase):
     def test_creation_and_metadata(self):
         cfg, engram_store = self.create_engram_store()
-        self.assertEqual(engram_store.get_num_heads(), len(cfg.table_vocab_sizes))
-        self.assertEqual(engram_store.get_embedding_dim(), cfg.embedding_dim)
-        self.assertEqual(engram_store.get_table_vocab_sizes(), cfg.table_vocab_sizes)
-        self.assertEqual(len(engram_store.get_store_keys()), len(cfg.table_vocab_sizes))
+        self.assertEqual(
+            engram_store.get_num_heads(self.layer_id), len(cfg.table_vocab_sizes)
+        )
+        self.assertEqual(engram_store.get_row_bytes(self.layer_id), cfg.row_bytes)
+        self.assertEqual(
+            engram_store.get_table_vocab_sizes(self.layer_id), cfg.table_vocab_sizes
+        )
+        self.assertEqual(
+            len(engram_store.get_store_keys(self.layer_id)), len(cfg.table_vocab_sizes)
+        )
 
     def test_creation_without_store_keeps_metadata_accessible(self):
         layer_id = self._next_layer_id
-        cfg, engram_store = self.create_engram_store(layer_id=layer_id, store_marker=None)
-        self.assertEqual(engram_store.get_num_heads(), len(cfg.table_vocab_sizes))
-        self.assertEqual(engram_store.get_embedding_dim(), cfg.embedding_dim)
-        self.assertEqual(engram_store.get_store_keys()[0], f"engram:l{layer_id}:h0")
+        cfg, engram_store = self.create_engram_store(
+            layer_id=layer_id, store_marker=None
+        )
+        self.assertEqual(
+            engram_store.get_num_heads(self.layer_id), len(cfg.table_vocab_sizes)
+        )
+        self.assertEqual(engram_store.get_row_bytes(self.layer_id), cfg.row_bytes)
+        self.assertEqual(
+            engram_store.get_store_keys(self.layer_id)[0], f"engram:l{layer_id}:h0"
+        )
 
 
 class TestStorePopulateAndLookup(EngramStoreTestBase):
-    def test_populate_and_lookup_shape_with_python_lists(self):
+    def test_populate_and_lookup_batch_shape(self):
         _, engram_store = self.create_engram_store()
         self.populate_store(engram_store)
 
@@ -323,17 +360,16 @@ class TestStorePopulateAndLookup(EngramStoreTestBase):
             [[0, 1, 2, 3], [4, 5, 6, 7]],
             [[1, 2, 3, 4], [8, 9, 10, 11]],
         ]
-        output = engram_store.lookup(row_ids)
+        output = self.read_rows(engram_store, row_ids)
 
         expected_shape = (
             len(row_ids),
             len(row_ids[0]),
-            engram_store.get_num_heads(),
-            engram_store.get_embedding_dim(),
+            engram_store.get_num_heads(self.layer_id),
+            engram_store.get_row_bytes(self.layer_id),
         )
         self.assertEqual(output.shape, expected_shape)
-        self.assertFalse(np.any(np.isnan(output)))
-        self.assertFalse(np.any(np.isinf(output)))
+        self.assertEqual(output.dtype, np.uint8)
 
     def test_lookup_matches_stored_rows_from_numpy_ids(self):
         _, engram_store = self.create_engram_store()
@@ -342,38 +378,35 @@ class TestStorePopulateAndLookup(EngramStoreTestBase):
         row_ids = np.array(
             [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]], dtype=np.int64
         )
-        output = np.asarray(engram_store.lookup(row_ids))
+        output = np.asarray(self.read_rows(engram_store, row_ids))
 
         for pos in range(row_ids.shape[1]):
-            for head in range(engram_store.get_num_heads()):
+            for head in range(engram_store.get_num_heads(self.layer_id)):
                 idx = row_ids[0, pos, head]
-                np.testing.assert_allclose(output[0, pos, head], tables[head][idx])
+                np.testing.assert_array_equal(output[0, pos, head], tables[head][idx])
 
-    def test_lookup_list_and_numpy_paths_match(self):
-        _, engram_store = self.create_engram_store()
-        self.populate_store(engram_store)
-
-        row_ids_list = [
-            [[0, 1, 2, 3], [4, 5, 6, 7]],
-            [[1, 2, 3, 4], [8, 9, 10, 11]],
-        ]
-        row_ids_numpy = np.asarray(row_ids_list, dtype=np.int64)
-
-        output_from_list = np.asarray(engram_store.lookup(row_ids_list))
-        output_from_numpy = np.asarray(engram_store.lookup(row_ids_numpy))
-        np.testing.assert_allclose(output_from_list, output_from_numpy)
+    def test_lookup_rejects_implicit_input_conversion(self):
+        _, table = self.create_engram_store()
+        self.populate_store(table)
+        ids = np.zeros((1, 2, table.get_num_heads(self.layer_id)), dtype=np.int64)
+        with self.registered_output(table, ids.shape) as output:
+            for bad_ids in (ids.tolist(), ids.astype(np.int32), ids[..., ::-1]):
+                with self.subTest(input_type=type(bad_ids)), self.assertRaises(
+                    TypeError
+                ):
+                    table.lookup_into(self.layer_id, bad_ids, output)
 
     def test_remove_from_store(self):
         _, engram_store = self.create_engram_store()
         self.populate_store(engram_store)
 
-        removed = engram_store.remove_from_store(force=True)
-        self.assertEqual(removed, engram_store.get_num_heads())
+        removed = engram_store.remove_from_store(self.layer_id, force=True)
+        self.assertEqual(removed, engram_store.get_num_heads(self.layer_id))
 
-        for key in engram_store.get_store_keys():
+        for key in engram_store.get_store_keys(self.layer_id):
             self.assertEqual(self.store.is_exist(key), 0)
 
-        self.assertEqual(engram_store.remove_from_store(force=True), 0)
+        self.assertEqual(engram_store.remove_from_store(self.layer_id, force=True), 0)
 
 
 class TestErrorHandling(EngramStoreTestBase):
@@ -381,38 +414,172 @@ class TestErrorHandling(EngramStoreTestBase):
         _, engram_store = self.create_engram_store()
         self.populate_store(engram_store)
         with self.assertRaises(Exception):
-            engram_store.populate(self.make_embedding_tables(engram_store))
+            engram_store.populate(
+                self.layer_id, self.make_embedding_tables(engram_store)
+            )
 
     def test_lookup_rejects_missing_tables(self):
         _, engram_store = self.create_engram_store()
         with self.assertRaises(Exception):
-            engram_store.lookup([[[0, 1, 2, 3]]])
+            self.read_rows(engram_store, [[[0, 1, 2, 3]]])
 
     def test_populate_rejects_wrong_table_shape(self):
         _, engram_store = self.create_engram_store()
         tables = self.make_embedding_tables(engram_store)
         tables[0] = tables[0][:-1]
         with self.assertRaises(Exception):
-            engram_store.populate(tables)
+            engram_store.populate(self.layer_id, tables)
 
-    def test_lookup_rejects_empty_input(self):
-        _, engram_store = self.create_engram_store()
-        self.populate_store(engram_store)
-        with self.assertRaises(Exception):
-            engram_store.lookup([])
+    def test_lookup_empty_batch_is_noop(self):
+        _, table = self.create_engram_store()
+        ids = np.empty((1, 0, table.get_num_heads(self.layer_id)), dtype=np.int64)
+        output = np.empty(
+            (*ids.shape, table.get_row_bytes(self.layer_id)), dtype=np.uint8
+        )
+        self.assertIsNone(table.lookup_into(self.layer_id, ids, output))
 
     def test_lookup_rejects_wrong_head_dimension(self):
         _, engram_store = self.create_engram_store()
         self.populate_store(engram_store)
-        row_ids = np.zeros((1, 1, engram_store.get_num_heads() - 1), dtype=np.int64)
+        row_ids = np.zeros(
+            (1, 1, engram_store.get_num_heads(self.layer_id) - 1), dtype=np.int64
+        )
         with self.assertRaises(Exception):
-            engram_store.lookup(row_ids)
+            self.read_rows(engram_store, row_ids)
 
     def test_lookup_rejects_out_of_range_row_id(self):
         _, engram_store = self.create_engram_store()
         self.populate_store(engram_store)
         with self.assertRaises(Exception):
-            engram_store.lookup([[[999, 1, 2, 3]]])
+            self.read_rows(engram_store, [[[999, 1, 2, 3]]])
+
+
+class TestByteRows(EngramStoreTestBase):
+    def create_config(self):
+        cfg = super().create_config()
+        cfg.row_bytes = 264
+        return cfg
+
+    def test_lookup_and_registered_output(self):
+        cfg, table = self.create_engram_store()
+        buffers = [
+            np.arange(n * cfg.row_bytes, dtype=np.int64).astype(np.uint8).reshape(n, -1)
+            for n in cfg.table_vocab_sizes
+        ]
+        replica = STORE_MODULE.ReplicateConfig()
+        replica.with_hard_pin = True
+        table.populate(self.layer_id, buffers, replica)
+        ids = np.array([[[0, 1, 2, 3], [16, 18, 22, 28], [0, 1, 2, 3]]], dtype=np.int64)
+        expected = np.stack([buffers[h][ids[..., h]] for h in range(4)], axis=2)
+        with self.registered_output(table, ids.shape) as output:
+            for _ in range(3):
+                output.fill(99)
+                self.assertIsNone(table.lookup_into(self.layer_id, ids, output))
+                np.testing.assert_array_equal(output, expected)
+            bad_ids = ids.copy()
+            bad_ids[0, 0, 0] = -1
+            with self.assertRaises(RuntimeError):
+                table.lookup_into(self.layer_id, bad_ids, output)
+            self.assertFalse(output.any())
+            # Failed reads must also preserve the caller's registration.
+            table.lookup_into(self.layer_id, ids, output)
+            np.testing.assert_array_equal(output, expected)
+            with self.assertRaises(RuntimeError):
+                table.lookup_into(self.layer_id, ids, output[..., ::-1])
+            with self.assertRaises(RuntimeError):
+                table.lookup_into(self.layer_id, ids, output.astype(np.float32))
+            with self.assertRaises(RuntimeError):
+                table.lookup_into(self.layer_id, ids, output[..., :-1])
+            output.setflags(write=False)
+            with self.assertRaises(RuntimeError):
+                table.lookup_into(self.layer_id, ids, output)
+
+    def test_populate_does_not_cast(self):
+        cfg, table = self.create_engram_store()
+        buffers = [
+            np.zeros((n, cfg.row_bytes), dtype=np.float32)
+            for n in cfg.table_vocab_sizes
+        ]
+        with self.assertRaises(RuntimeError):
+            table.populate(self.layer_id, buffers)
+        buffers = [
+            np.zeros((n, cfg.row_bytes * 2), dtype=np.uint8)[:, ::2]
+            for n in cfg.table_vocab_sizes
+        ]
+        with self.assertRaises(RuntimeError):
+            table.populate(self.layer_id, buffers)
+
+    def test_row_size_validation(self):
+        cfg = self.create_config()
+        for row_bytes in (0, -1):
+            with self.subTest(row_bytes=row_bytes):
+                cfg.row_bytes = row_bytes
+                with self.assertRaises(ValueError):
+                    self.EngramStore({1: cfg})
+        cfg.row_bytes = 264
+        cfg.table_vocab_sizes = [2**63 - 1]
+        with self.assertRaises(ValueError):
+            self.EngramStore({1: cfg})
+
+
+class TestMultipleLayers(EngramStoreTestBase):
+    def test_layer_isolation_and_shared_backend(self):
+        first, second = self._next_layer_id, self._next_layer_id + 1
+        cfg1 = self.create_config()
+        cfg2 = self.EngramStoreConfig()
+        cfg2.table_vocab_sizes = [7, 11]
+        cfg2.row_bytes = 264
+        configs = {first: cfg1, second: cfg2}
+        table = self.EngramStore(configs, self.store)
+        self._created_engram_stores.append(table)
+        self.assertEqual(table.get_layer_ids(), [first, second])
+        for layer_id, cfg in configs.items():
+            arrays = [
+                np.full(
+                    (n, cfg.row_bytes), h + 31 + (layer_id - first) * 50, dtype=np.uint8
+                )
+                for h, n in enumerate(cfg.table_vocab_sizes)
+            ]
+            table.populate(layer_id, arrays)
+        # A second handle reads the same keys without populating another copy.
+        peer = self.EngramStore(configs, self.store)
+        for layer_id, cfg in configs.items():
+            self.assertEqual(
+                table.get_store_keys(layer_id), peer.get_store_keys(layer_id)
+            )
+            ids = np.zeros((1, 2, len(cfg.table_vocab_sizes)), dtype=np.int64)
+            with self.registered_output(table, ids.shape, layer_id) as output:
+                for reader in (table, peer):
+                    reader.lookup_into(layer_id, ids, output)
+                    for h in range(ids.shape[-1]):
+                        self.assertTrue(
+                            np.all(
+                                output[..., h, :] == h + 31 + (layer_id - first) * 50
+                            )
+                        )
+        table.remove_from_store(first, force=True)
+        ids = np.zeros((1, 1, 2), dtype=np.int64)
+        with self.registered_output(table, ids.shape, second) as output:
+            peer.lookup_into(second, ids, output)
+            self.assertTrue(np.all(output[..., 0, :] == 81))
+            with self.assertRaisesRegex(ValueError, "Unknown Engram layer"):
+                table.lookup_into(second + 1, ids, output)
+            self.assertTrue(np.all(output[..., 0, :] == 81))
+        for operation in (
+            table.get_store_keys,
+            table.get_row_bytes,
+            table.remove_from_store,
+        ):
+            with self.assertRaisesRegex(ValueError, "Unknown Engram layer"):
+                operation(second + 1)
+        with self.assertRaisesRegex(ValueError, "Unknown Engram layer"):
+            table.populate(second + 1, [])
+
+    def test_invalid_layer_configuration(self):
+        with self.assertRaises(ValueError):
+            self.EngramStore({})
+        with self.assertRaises(ValueError):
+            self.EngramStore({-1: self.create_config()})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Update EngramStore to support DeepSeek-V4.1-Flash's multiple Engram layers and FP8 embedding layout. The corresponding SGLang integration, including asynchronous loading and CUDA Graph support, is **https://github.com/sgl-project/sglang/pull/39205**.

This builds on the existing Engram backend discussed in #1372, adding the byte-row and multi-layer API required by this model while reusing Store placement and transport.

### Abstractions and interfaces

- `EngramStoreConfig`: per-head row counts in `table_vocab_sizes` and a required `row_bytes`. Replace the float32-specific mode with opaque bytes. DeepSeek-V4.1-Flash uses **264 bytes per row: 256 FP8 embedding bytes + 8 scale bytes**.
- `EngramStore(layers, store)`: manage all configured layers through one Store client, or bind immutable local tables with `store=None`. Hashing and dequantization remain in the inference framework.
- `bind_local(layer_id, embedding_buffers)`: bind caller-owned contiguous uint8 head tables without a Store client. Lookup copies selected rows directly into the caller output; output registration is unnecessary in this mode. Python retains the buffers for the EngramStore lifetime; buffers must stay immutable.
- `populate(layer_id, embedding_buffers, config)`: upload each head's table, with Store replication/pinning configuration.
- `lookup_into(layer_id, row_ids, output)`: read directly into caller-owned output memory (pre-registered for Store-backed reads). IDs are contiguous int64 `[B,L,H]`; H identifies the head and each element is a row index within that table. Output is writable contiguous uint8 `[B,L,H,row_bytes]`.
- `remove_from_store(layer_id, force=False)`: remove a layer's tables.

This is an API change: existing callers must migrate to explicit layer IDs, byte rows and caller-owned output buffers.

### Storage and embedding loading

Each key `engram:l{layer_id}:h{head_id}` stores one complete, contiguous hash-head table in the Mooncake Store DRAM pool. Object placement and replicas use existing Store mechanisms. Multiple rank-local clients access the same keys without duplicating the backing tables.

Lookup computes `row_id * row_bytes` and uses Store `get_into_ranges` / Transfer Engine to transfer **only the requested rows**, following the client's TCP/RDMA configuration. The synchronous Python binding releases the GIL during reads and does not allocate or register output memory.

In the companion SGLang PR, background workers call `lookup_into` after token hashing to prefetch rows into SGLang's pinned DRAM. Each Engram layer waits for its own read before H2D and dequantization. Prefill and decode CUDA Graphs remain enabled.

Local mode bypasses Store metadata and transport. The companion uploader creates packed read-only files, preferably on tmpfs; local ranks map the same physical pages. This is explicit local binding, not automatic attachment to another Store owner process.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Integration (`mooncake-integration`)
- [x] Docs

## Type of Change

- [x] New feature
- [x] Refactor
- [x] Breaking change
- [x] Documentation update

## Checklist

- [x] Changed code reviewed during development.
- [x] Scoped pre-commit hooks, including staged C/C++ formatting, passed.
- [x] Engram documentation and examples updated.
- [x] Tests added for multi-layer byte tables and caller-owned output.
- Related design discussion: #1372; this change extends the existing adapter, not the Store architecture.

## AI Assistance Disclosure

- [x] AI tools were used: OpenAI Codex assisted with implementation, tests, profiling and PR preparation.

## How Has This Been Tested?

- Mooncake EngramStore tests: **18 passed, 5 subtests passed**.
- SGLang real Store/local + CUDA Graph regression: **16 passed, 3 expected skips** (two optional benchmarks and Store removal in local mode). Covers changing tokens, active/idle transitions, padded graph replay, delayed reads, failure/retry, and reference gather equivalence.
- Both Mooncake modes loaded the full 48-head-table layout (~202.76 GB). Selected checkpoint rows match raw bytes exactly; GPU BF16 dequantization matches the reference exactly.
- Local memory inspection confirms all eight ranks map the same 48 files: summed table PSS is 188.83 GiB, one physical copy.
- The native host baseline and both Mooncake modes passed concurrent serving and 16K-context smoke checks with finite log probabilities. **864/864 formal benchmark requests completed across 54 rounds**, with exact input/output lengths and prefill/decode Graph replay checks.
- Native baseline processes were verified to have Mooncake disabled and shared native host table mappings on all eight ranks. Every Store round produced RDMA reads; every local and baseline round had zero RDMA-read-counter increase. Counters include warmup.
- Scoped pre-commit checks and Mooncake documentation HTML build passed.

These validate embedding numerics and serving behavior; a broader full-model accuracy benchmark is not included.

8× NVIDIA L20Z on one host, **TP8/EP8/DP8 with DP attention**, `mem_fraction_static=0.65`, overlap scheduling disabled, prefill/decode breakable CUDA Graphs enabled. Per-rank prefill chunk: 2048 tokens; context limit: 32768. All three paths use the same prefill Graph sequence cap for each input length: 16384 for 1K/4K inputs, 32768 for 16K inputs to cover generation and mixed DPA batches.

16 requests per round, three rounds; medians below. Fixed synthetic prompts and seed 42, exact token lengths, forced output length, KV prefix cache flushed after warmup. Concurrency 1/4 does not saturate all eight DP attention ranks.

Native baseline: the same SGLang branch with `SGLANG_DSV41_ENGRAM_MOONCAKE_CONFIG` unset, `SGLANG_DSV41_ENGRAM_HOST_TABLE_LAYOUT=shared` and `SGLANG_DSV41_ENGRAM_HOST_TABLE_PIN=1`; GPU gather directly accesses the native shared pinned host table. `SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE=1` applies to all three paths. Native Engram KV prefetch remains at its default off setting. Store: shared tables in a separate same-host owner, actual RDMA reads. Local: shared readonly tmpfs table pages, prefaulted mappings and CPU copies, no Store client or RDMA.

Output throughput; percentage changes are relative to the native baseline:

| Input / output | Concurrency | Native tok/s | Store tok/s | Change | Local tok/s | Change |
|---|---:|---:|---:|---:|---:|---:|
| 1024 / 256 | 1 | 19.53 | 19.27 | -1.4% | 19.45 | -0.4% |
| 1024 / 256 | 4 | 74.65 | 72.55 | -2.8% | 74.20 | -0.6% |
| 4096 / 512 | 1 | 18.81 | 18.06 | -4.0% | 18.64 | -0.9% |
| 4096 / 512 | 4 | 72.50 | 68.28 | -5.8% | 71.81 | -0.9% |
| 16384 / 1024 | 1 | 17.33 | 16.21 | -6.5% | 17.20 | -0.8% |
| 16384 / 1024 | 4 | 68.98 | 63.69 | -7.7% | 68.29 | -1.0% |

Relative to native host, output throughput changes range from -7.7% to -1.4% for Store and -1.0% to -0.4% for local across these workloads.

Latency, TTFT / TPOT in milliseconds:

| Input / output | Concurrency | Native | Store | Local |
|---|---:|---:|---:|---:|
| 1024 / 256 | 1 | 561.70 / 49.19 | 675.15 / 49.42 | 557.42 / 49.43 |
| 1024 / 256 | 4 | 947.19 / 50.05 | 1170.40 / 50.73 | 940.88 / 50.39 |
| 4096 / 512 | 1 | 2150.70 / 49.06 | 3095.99 / 49.42 | 2142.20 / 49.55 |
| 4096 / 512 | 4 | 2715.25 / 49.95 | 4114.39 / 50.59 | 2728.41 / 50.45 |
| 16384 / 1024 | 1 | 8741.21 / 49.20 | 12458.25 / 49.59 | 8691.67 / 49.69 |
| 16384 / 1024 | 4 | 8359.32 / 49.83 | 12756.75 / 50.41 | 8424.15 / 50.40 |

Compared with Store, local primarily improves TTFT; their TPOT remains around 49–51 ms. Native host uses direct GPU gather, whereas both Mooncake paths stage rows in host output and copy them to the GPU per layer. The end-to-end comparison includes those execution-path differences.

Mooncake-only direct random-row `lookup_into` microbenchmark, two layers sequentially, one client (median of ten timed samples; excludes hash/D2H/H2D/model compute and is not a native GPU-gather benchmark):

| Tokens | Store ms | Local ms |
|---:|---:|---:|
| 1 | 0.699 | 0.013 |
| 1024 | 70.698 | 5.250 |
| 2048 | 270.831 | 10.612 |
