### PR TITLE
[BugFix][TENT] Fix ProgressWorker refill test race with dispatch window

### DIFF
--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -91,8 +91,13 @@ class FakeTransport : public Transport {
             fake->poll_counts.push_back(0);
             ++fake->task_count;
         }
+        last_batch_ = batch;
         if (notify_on_submit_) batch->notifyProgress();
         return Status::OK();
+    }
+
+    void notifyLastBatch() {
+        if (last_batch_) last_batch_->notifyProgress();
     }
 
     Status getTransferStatus(SubBatchRef batch, int task_id,
@@ -167,6 +172,7 @@ class FakeTransport : public Transport {
     TransportType self_type_;
     PollStatusFactory poll_status_factory_;
     bool notify_on_submit_;
+    SubBatchRef last_batch_{nullptr};
 };
 
 std::shared_ptr<Config> makeRuntimeQueueConfig(size_t max_dispatch_owners,
@@ -506,8 +512,20 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
+    // Keep the first owner PENDING until after the submit-window assertion.
+    // Otherwise ProgressWorker can observe COMPLETED, refill, and bump
+    // submit_calls to 2 before EXPECT_EQ(..., 1). Same race as #3459.
+    std::atomic<bool> complete_first{false};
     auto fake_rdma = std::make_shared<FakeTransport>(
-        RDMA, FakeTransport::PollStatusFactory{}, true);
+        RDMA,
+        [&complete_first](const Request& request, int) {
+            if (!complete_first.load()) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED,
+                                  request.length};
+        },
+        true);
     installFakeRdma(engine, fake_rdma);
 
     constexpr size_t kReqLen = 4096;
@@ -524,6 +542,9 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
                              makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
             .ok());
     EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    complete_first.store(true);
+    fake_rdma->notifyLastBatch();
 
     const auto deadline =
         std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);


### PR DESCRIPTION
## Description

Fixes an intermittent unit-test race in `RuntimeQueueDispatch.ProgressWorkerRefillsWindowFromTransportNotify` (same class as #3459 / #3460).

`FakeTransport` reported `COMPLETED` and called `notifyProgress()` during `submitTransfer`. With `enable_runtime_queue` forcing a background `ProgressWorker`, the worker could observe a terminal first owner, refill the dispatch window, and bump `submit_calls` to 2 before:

```cpp
EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
```

Seen on `tent-ci (ub-mock)`, e.g. https://github.com/kvcache-ai/Mooncake/actions/runs/34690664385/job/103545262185?pr=4006 (`Which is: 2`, expected `1`, 1 ms). This is a test-synchronization flake, not a production dispatch-window regression.

The test now keeps the first owner `PENDING` until after the single-window assertion, then completes it and re-notifies via `notifyLastBatch()` so refill is still driven by transport notify (`progress_fallback_interval_us=0`).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Debug build of `tent_runtime_queue_dispatch_test` (`USE_TENT=ON`, `USE_CUDA=OFF`, `BUILD_UNIT_TESTS=ON`).

**Test commands:**
```bash
cmake --build build-repro --target tent_runtime_queue_dispatch_test
./build-repro/mooncake-transfer-engine/tent/tests/tent_runtime_queue_dispatch_test --gtest_repeat=20
taskset -c 0,1 ./build-repro/mooncake-transfer-engine/tent/tests/tent_runtime_queue_dispatch_test \
  --gtest_filter=RuntimeQueueDispatch.ProgressWorkerRefillsWindowFromTransportNotify \
  --gtest_repeat=2000 --gtest_brief=1
```

Also rebuilt with a 10ms sleep before `EXPECT_EQ(submit_calls, 1)` (this made the old test fail almost always) and repeated that variant 100 times; all passed. The sleep was not committed.

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- Full `RuntimeQueueDispatch` suite × 20: pass
- `ProgressWorkerRefillsWindowFromTransportNotify` × 2000 on 2 CPUs: pass
- Sleep-amplified variant × 100: pass
- `pre-commit run --files mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp`: pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor was used to inspect the CI failure, implement the test synchronization (same approach as #3460), and draft this PR. Every changed line was reviewed.


Made with [Cursor](https://cursor.com)