### PR TITLE
[Store] Skip NoF targets a client reported as unreachable

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -839,6 +839,16 @@ class Client {
     ErrorCode ReadDfsReplica(const std::string& key,
                              const Replica::Descriptor& replica_descriptor,
                              std::vector<Slice>& slices);
+
+    /**
+     * @brief Tell the master that writes to these NoF targets failed from this
+     * client, so it stops allocating on them for us until the report expires.
+     * Master-to-target heartbeats cannot see a client-to-target partition, so
+     * without this the master keeps handing back unusable NoF handles.
+     * Best effort: failures are logged and swallowed. Duplicate and empty
+     * endpoints are dropped, and an empty list issues no RPC.
+     */
+    void ReportUnreachableNoFTargets(std::vector<std::string> te_endpoints);
     tl::expected<uint64_t, ErrorCode> ComputeObjectChecksumForSlices(
         const std::string& object_key, const std::vector<Slice>& slices,
         size_t object_size);

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -465,6 +465,15 @@ class MasterClient {
         const UUID& client_id, int64_t ssd_total_capacity_bytes);
 
     /**
+     * @brief Tells the master this client cannot reach the given NoF targets,
+     * so they are skipped by its subsequent NoF allocations.
+     * @param client_id The reporting client
+     * @param te_endpoints Transfer engine endpoints of the failed targets
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> ReportNoFTargetUnreachable(
+        const UUID& client_id, const std::vector<std::string>& te_endpoints);
+
+    /**
      * @brief Adds multiple new objects to a specified client in batch.
      * @param keys         A list of object keys (names) that were successfully
      * offloaded.

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <set>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
@@ -193,6 +194,8 @@ class MasterService {
     bool IsNoFSegmentMountedForTesting(const UUID& segment_id);
     std::optional<uint32_t> GetNoFHeartbeatFailureCountForTesting(
         const UUID& segment_id);
+    std::set<std::string> GetNoFExcludedSegmentsForTesting(
+        const UUID& client_id);
     [[nodiscard]] TieredStorageUsageSnapshot GetStorageUsageSnapshot() const;
     bool IsTenantQuotaEnabled() const;
     std::vector<TenantQuotaSnapshot> ListTenantQuotaSnapshots() const;
@@ -359,6 +362,20 @@ class MasterService {
      */
     auto GetNoFSegmentsByName(const std::string& segment_name)
         -> tl::expected<std::vector<NoFSegmentOwnerInfo>, ErrorCode>;
+
+    /**
+     * @brief Record that `client_id` could not reach the NoF targets behind
+     * `te_endpoints`. Heartbeat probes only exercise the master-to-target
+     * path, so a client-to-target partition is invisible to them; without
+     * this report the master keeps handing the partitioned client handles it
+     * cannot write to. Reported endpoints are excluded from that client's NoF
+     * allocations until the report expires.
+     * @param client_id The client that observed the I/O failure.
+     * @param te_endpoints Transfer engine endpoints of the failed targets.
+     */
+    auto ReportNoFTargetUnreachable(
+        const UUID& client_id, const std::vector<std::string>& te_endpoints)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Detailed information about a single segment.
@@ -2154,8 +2171,8 @@ class MasterService {
     // Allocate the physical replicas without changing object metadata.  This
     // is used by leased upserts to prove that replacement storage is available
     // before the old metadata is removed.
-    auto AllocateReplicas(const std::string& key, uint64_t value_length,
-                          const ReplicateConfig& config,
+    auto AllocateReplicas(const UUID& client_id, const std::string& key,
+                          uint64_t value_length, const ReplicateConfig& config,
                           const std::string& writer_host_id)
         -> tl::expected<std::vector<Replica>, ErrorCode>;
 
@@ -2210,6 +2227,11 @@ class MasterService {
         const std::string& error_reason);
     bool ProbeNoFSegment(const std::string& te_endpoint,
                          std::string* error_reason);
+
+    // Names of the mounted NoF segments `client_id` currently cannot reach.
+    // Drops expired reports as a side effect. Must not be called while
+    // holding a NoF segment or allocator access guard.
+    std::set<std::string> GetNoFExcludedSegments(const UUID& client_id);
 
     // Pushes an offload mirror for `replica` onto its host client's LocalSSD
     // mailbox. When `mirror_clients` is non-null, the destination client is
@@ -2683,6 +2705,21 @@ class MasterService {
     static constexpr uint64_t kNoFHeartbeatThreadSleepMs = 100;
     mutable std::mutex nof_probe_fn_mutex_;
     NoFProbeFn nof_probe_fn_;
+
+    // NoF targets a client reported as unreachable, mapped to the time the
+    // report expires. Keyed by client because the partition is per client:
+    // the same target stays usable for everyone else.
+    std::mutex nof_unreachable_mutex_;
+    std::unordered_map<
+        UUID,
+        std::unordered_map<std::string, std::chrono::steady_clock::time_point>,
+        boost::hash<UUID>>
+        nof_unreachable_endpoints_;
+    // Reports live for one heartbeat liveness window, the same span the
+    // heartbeat thread waits before unmounting an unresponsive target. After
+    // that the client is allowed to retry the target instead of being pinned
+    // to a stale verdict.
+    const std::chrono::seconds nof_unreachable_ttl_;
 
     // if high availability features enabled
     const bool enable_ha_;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -182,6 +182,9 @@ class WrappedMasterService {
     [[nodiscard]] tl::expected<std::vector<NoFSegmentOwnerInfo>, ErrorCode>
     GetNoFSegmentsByName(const std::string& segment_name);
 
+    tl::expected<void, ErrorCode> ReportNoFTargetUnreachable(
+        const UUID& client_id, const std::vector<std::string>& te_endpoints);
+
     tl::expected<std::string, ErrorCode> GetFsdir();
 
     tl::expected<GetStorageConfigResponse, ErrorCode> GetStorageConfig();

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -255,6 +255,23 @@ struct ReplicaTransferSummary {
     }
 };
 
+// Transfer engine endpoint of a NoF replica, empty for every other type.
+// It is the only NoF target identity carried in a replica descriptor, so it
+// is what a client can name when reporting an unreachable target.
+std::string NoFTargetEndpoint(const Replica::Descriptor& replica) {
+    if (!replica.is_nof_replica()) {
+        return {};
+    }
+    return replica.get_nof_descriptor().buffer_descriptor.transport_endpoint_;
+}
+
+// A failed transfer only says something about client-to-target reachability
+// when the I/O itself failed. INVALID_PARAMS and friends are client-side
+// rejections and must not blocklist the target.
+bool IndicatesUnreachableTarget(ErrorCode error) {
+    return error == ErrorCode::TRANSFER_FAIL;
+}
+
 bool NonDfsTransfersSucceeded(const ReplicaTransferSummary& summary) {
     return summary.successful_memory_transfers ==
                summary.allocated_memory_replicas &&
@@ -1946,6 +1963,7 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
         }
     }
 
+    std::vector<std::string> unreachable_nof_endpoints;
     for (const auto& replica : start_result.value()) {
         if (replica.is_memory_replica() || replica.is_nof_replica()) {
             // Transfer data using allocated handles from all replicas
@@ -1955,11 +1973,16 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
             ErrorCode transfer_err = TransferWrite(replica, slices);
             if (transfer_err != ErrorCode::OK) {
                 transfer_summary.RecordFailure(replica_type, transfer_err);
+                if (IndicatesUnreachableTarget(transfer_err)) {
+                    unreachable_nof_endpoints.push_back(
+                        NoFTargetEndpoint(replica));
+                }
                 continue;
             }
             transfer_summary.RecordSuccess(replica_type);
         }
     }
+    ReportUnreachableNoFTargets(std::move(unreachable_nof_endpoints));
 
     if (transfer_summary.allocated_dfs_replicas > 0 &&
         NonDfsTransfersSucceeded(transfer_summary)) {
@@ -2150,6 +2173,7 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
     }
 
     // Transfer to memory and NoF replicas first.
+    std::vector<std::string> unreachable_nof_endpoints;
     for (const auto& replica : start_result.value()) {
         if (replica.is_memory_replica() || replica.is_nof_replica()) {
             const auto replica_type = replica.is_memory_replica()
@@ -2158,11 +2182,16 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
             ErrorCode transfer_err = TransferWrite(replica, slices);
             if (transfer_err != ErrorCode::OK) {
                 transfer_summary.RecordFailure(replica_type, transfer_err);
+                if (IndicatesUnreachableTarget(transfer_err)) {
+                    unreachable_nof_endpoints.push_back(
+                        NoFTargetEndpoint(replica));
+                }
                 continue;
             }
             transfer_summary.RecordSuccess(replica_type);
         }
     }
+    ReportUnreachableNoFTargets(std::move(unreachable_nof_endpoints));
 
     if (transfer_summary.allocated_dfs_replicas > 0 &&
         NonDfsTransfersSucceeded(transfer_summary)) {
@@ -2295,10 +2324,16 @@ class PutOperation {
     struct PendingTransferRecord {
         ReplicaType replica_type;
         TransferFuture future;
+        // Empty unless this is a NoF transfer. Kept here because the future
+        // outlives the replica descriptor loop that submitted it.
+        std::string te_endpoint;
 
         PendingTransferRecord(ReplicaType type,
-                              TransferFuture&& transfer_future)
-            : replica_type(type), future(std::move(transfer_future)) {}
+                              TransferFuture&& transfer_future,
+                              std::string endpoint = {})
+            : replica_type(type),
+              future(std::move(transfer_future)),
+              te_endpoint(std::move(endpoint)) {}
     };
 
     PutOperation(std::string_view k, const std::vector<Slice>& s)
@@ -2713,6 +2748,7 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
         return;
     }
 
+    std::vector<std::string> unreachable_nof_endpoints;
     for (auto& op : ops) {
         // Skip operations that already failed in previous stages
         if (op.IsResolved()) {
@@ -2776,20 +2812,25 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
                     op.transfer_summary.RecordFailure(replica_type,
                                                       ErrorCode::TRANSFER_FAIL);
                     op.AppendFailureContext(failure_context);
+                    unreachable_nof_endpoints.push_back(
+                        NoFTargetEndpoint(replica));
                     continue;
                 }
 
                 op.pending_transfers.emplace_back(
-                    replica_type, std::move(submit_result.value()));
+                    replica_type, std::move(submit_result.value()),
+                    NoFTargetEndpoint(replica));
             }
         }
 
         VLOG(1) << "Submitted " << op.pending_transfers.size()
                 << " transfers for key " << op.key;
     }
+    ReportUnreachableNoFTargets(std::move(unreachable_nof_endpoints));
 }
 
 void Client::WaitForTransfers(std::vector<PutOperation>& ops) {
+    std::vector<std::string> unreachable_nof_endpoints;
     for (auto& op : ops) {
         // Skip operations that already failed or completed
         if (op.IsResolved()) {
@@ -2805,6 +2846,10 @@ void Client::WaitForTransfers(std::vector<PutOperation>& ops) {
                 std::string error_context =
                     "Transfer " + std::to_string(i) + " failed";
                 op.AppendFailureContext(error_context);
+                if (IndicatesUnreachableTarget(transfer_result)) {
+                    unreachable_nof_endpoints.push_back(
+                        pending_transfer.te_endpoint);
+                }
             } else {
                 op.transfer_summary.RecordSuccess(
                     pending_transfer.replica_type);
@@ -2817,6 +2862,7 @@ void Client::WaitForTransfers(std::vector<PutOperation>& ops) {
                 << "), fail(mem=" << op.transfer_summary.failed_memory_transfers
                 << ", nof=" << op.transfer_summary.failed_nof_transfers << ")";
     }
+    ReportUnreachableNoFTargets(std::move(unreachable_nof_endpoints));
 }
 
 std::vector<ErrorCode> Client::WriteDfsReplicas(
@@ -4060,6 +4106,26 @@ tl::expected<void, ErrorCode> Client::OffloadObjectHeartbeat(
 
 tl::expected<bool, ErrorCode> Client::PollRemoveAll() {
     return master_client_.PollRemoveAll();
+}
+
+void Client::ReportUnreachableNoFTargets(
+    std::vector<std::string> te_endpoints) {
+    std::sort(te_endpoints.begin(), te_endpoints.end());
+    te_endpoints.erase(std::unique(te_endpoints.begin(), te_endpoints.end()),
+                       te_endpoints.end());
+    std::erase_if(te_endpoints,
+                  [](const std::string& endpoint) { return endpoint.empty(); });
+    if (te_endpoints.empty()) {
+        return;
+    }
+    auto response =
+        master_client_.ReportNoFTargetUnreachable(client_id_, te_endpoints);
+    if (!response) {
+        // The write already failed and the caller reports that error; an old
+        // master that does not know this RPC must not turn it into a crash.
+        LOG(WARNING) << "ReportNoFTargetUnreachable failed, error code is "
+                     << response.error();
+    }
 }
 
 tl::expected<void, ErrorCode> Client::ReportSsdCapacity(

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -233,6 +233,11 @@ struct RpcNameTraits<&WrappedMasterService::ReportSsdCapacity> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::ReportNoFTargetUnreachable> {
+    static constexpr const char* value = "ReportNoFTargetUnreachable";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::NotifyOffloadSuccess> {
     static constexpr const char* value = "NotifyOffloadSuccess";
 };
@@ -1083,6 +1088,15 @@ tl::expected<void, ErrorCode> MasterClient::ReportSsdCapacity(
                      ", ssd_total_capacity_bytes=", ssd_total_capacity_bytes);
     return invoke_rpc<&WrappedMasterService::ReportSsdCapacity, void>(
         client_id, ssd_total_capacity_bytes);
+}
+
+tl::expected<void, ErrorCode> MasterClient::ReportNoFTargetUnreachable(
+    const UUID& client_id, const std::vector<std::string>& te_endpoints) {
+    ScopedVLogTimer timer(1, "MasterClient::ReportNoFTargetUnreachable");
+    timer.LogRequest("client_id=", client_id,
+                     ", endpoints=", te_endpoints.size());
+    return invoke_rpc<&WrappedMasterService::ReportNoFTargetUnreachable, void>(
+        client_id, te_endpoints);
 }
 
 tl::expected<void, ErrorCode> MasterClient::NotifyOffloadSuccess(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -211,6 +211,10 @@ MasterService::MasterService(const MasterServiceConfig& config)
           std::chrono::milliseconds(config.nof_heartbeat_probe_timeout_ms)),
       nof_heartbeat_failures_threshold_(
           config.nof_heartbeat_failures_threshold),
+      nof_unreachable_ttl_(std::chrono::seconds(std::max<int64_t>(
+          1,
+          config.nof_heartbeat_interval_sec *
+              static_cast<int64_t>(config.nof_heartbeat_failures_threshold)))),
       enable_ha_(config.enable_ha),
       enable_offload_(config.enable_offload),
       enable_oplog_(config.enable_ha && config.enable_oplog &&
@@ -842,6 +846,11 @@ std::optional<uint32_t> MasterService::GetNoFHeartbeatFailureCountForTesting(
         return std::nullopt;
     }
     return it->second.consecutive_failures;
+}
+
+std::set<std::string> MasterService::GetNoFExcludedSegmentsForTesting(
+    const UUID& client_id) {
+    return GetNoFExcludedSegments(client_id);
 }
 
 TieredStorageUsageSnapshot MasterService::GetStorageUsageSnapshot() const {
@@ -3418,6 +3427,100 @@ auto MasterService::GetNoFSegmentsByName(const std::string& segment_name)
     return nof_segment_manager_.GetSegmentsByName(segment_name);
 }
 
+auto MasterService::ReportNoFTargetUnreachable(
+    const UUID& client_id, const std::vector<std::string>& te_endpoints)
+    -> tl::expected<void, ErrorCode> {
+#ifndef USE_NOF
+    LOG(ERROR) << "client_id=" << client_id << ", error=nof_pool_disabled";
+    (void)te_endpoints;
+    return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+#else
+    const auto now = std::chrono::steady_clock::now();
+    const auto expires_at = now + nof_unreachable_ttl_;
+    size_t recorded = 0;
+    {
+        std::lock_guard<std::mutex> lock(nof_unreachable_mutex_);
+        // Drop reports that already expired so a client that keeps churning
+        // through targets cannot grow the map without bound.
+        for (auto it = nof_unreachable_endpoints_.begin();
+             it != nof_unreachable_endpoints_.end();) {
+            auto& endpoints = it->second;
+            for (auto endpoint_it = endpoints.begin();
+                 endpoint_it != endpoints.end();) {
+                if (endpoint_it->second <= now) {
+                    endpoint_it = endpoints.erase(endpoint_it);
+                } else {
+                    ++endpoint_it;
+                }
+            }
+            if (endpoints.empty()) {
+                it = nof_unreachable_endpoints_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        for (const auto& te_endpoint : te_endpoints) {
+            if (te_endpoint.empty()) {
+                continue;
+            }
+            nof_unreachable_endpoints_[client_id][te_endpoint] = expires_at;
+            ++recorded;
+        }
+    }
+
+    if (recorded == 0) {
+        return {};
+    }
+    LOG(WARNING) << "client_id=" << client_id
+                 << ", action=mark_nof_target_unreachable"
+                 << ", endpoints=" << recorded
+                 << ", ttl_sec=" << nof_unreachable_ttl_.count();
+    return {};
+#endif
+}
+
+std::set<std::string> MasterService::GetNoFExcludedSegments(
+    const UUID& client_id) {
+    std::unordered_set<std::string> unreachable_endpoints;
+    {
+        std::lock_guard<std::mutex> lock(nof_unreachable_mutex_);
+        auto client_it = nof_unreachable_endpoints_.find(client_id);
+        if (client_it == nof_unreachable_endpoints_.end()) {
+            return {};
+        }
+        const auto now = std::chrono::steady_clock::now();
+        auto& endpoints = client_it->second;
+        for (auto it = endpoints.begin(); it != endpoints.end();) {
+            if (it->second <= now) {
+                it = endpoints.erase(it);
+            } else {
+                unreachable_endpoints.insert(it->first);
+                ++it;
+            }
+        }
+        if (endpoints.empty()) {
+            nof_unreachable_endpoints_.erase(client_it);
+        }
+    }
+    if (unreachable_endpoints.empty()) {
+        return {};
+    }
+
+    // Reports name the transfer engine endpoint, which is the only NoF target
+    // identity a client sees in a replica descriptor. Map it back onto the
+    // segment names the allocator understands.
+    std::vector<MountedNoFSegmentSnapshot> mounted_segments;
+    nof_segment_manager_.GetMountedSegmentsSnapshot(mounted_segments);
+    std::set<std::string> excluded_segments;
+    for (const auto& snapshot : mounted_segments) {
+        if (unreachable_endpoints.contains(snapshot.segment.te_endpoint)) {
+            excluded_segments.insert(snapshot.segment.name);
+        }
+    }
+    return excluded_segments;
+}
+
 auto MasterService::GetSegmentsDetail()
     -> tl::expected<std::vector<SegmentDetailInfo>, ErrorCode> {
     ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
@@ -4673,7 +4776,8 @@ MasterService::BatchGetReplicaListForAdmin(const std::vector<std::string>& keys,
     return results;
 }
 
-auto MasterService::AllocateReplicas(const std::string& key,
+auto MasterService::AllocateReplicas(const UUID& client_id,
+                                     const std::string& key,
                                      uint64_t value_length,
                                      const ReplicateConfig& config,
                                      const std::string& writer_host_id)
@@ -4751,6 +4855,14 @@ auto MasterService::AllocateReplicas(const std::string& key,
 #ifdef USE_NOF
     if (config.nof_replica_num > 0 &&
         nof_segment_manager_.getMountedSegmentCount() > 0) {
+        // Heartbeats only prove the master can reach a target. Targets this
+        // client has just failed to write are dropped here, otherwise a
+        // client-to-target partition keeps producing handles the client
+        // cannot use. Resolved before taking the allocator guard because it
+        // reads the mounted segment map under the same segment mutex.
+        std::set<std::string> excluded_segments =
+            GetNoFExcludedSegments(client_id);
+
         ScopedAllocatorAccess allocator_access =
             nof_segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
@@ -4760,7 +4872,7 @@ auto MasterService::AllocateReplicas(const std::string& key,
 
         auto allocation_result = allocation_strategy_->Allocate(
             allocator_manager, value_length, config.nof_replica_num,
-            preferred_segments, std::set<std::string>(), ReplicaType::NOF_SSD);
+            preferred_segments, excluded_segments, ReplicaType::NOF_SSD);
 
         if (!allocation_result.has_value()) {
             VLOG(1) << "Failed to allocate nof replicas for key=" << key
@@ -4964,7 +5076,7 @@ auto MasterService::AllocateAndInsertMetadata(
     }
 
     auto allocation_result =
-        AllocateReplicas(key, value_length, config, writer_host_id);
+        AllocateReplicas(client_id, key, value_length, config, writer_host_id);
     if (!allocation_result) {
         ReleaseTenantQuota(GetBoundTenantQuotaHandle(tenant_state),
                            pending_quota_charge);
@@ -6027,8 +6139,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     if (!quota_result) {
                         return tl::make_unexpected(quota_result.error());
                     }
-                    auto allocation_result = AllocateReplicas(
-                        key, slice_length, merged_config, writer_host_id);
+                    auto allocation_result =
+                        AllocateReplicas(client_id, key, slice_length,
+                                         merged_config, writer_host_id);
                     if (!allocation_result) {
                         ReleaseTenantQuota(quota_account,
                                            replacement_pending_quota_charge);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1608,6 +1608,17 @@ tl::expected<bool, ErrorCode> WrappedMasterService::PollRemoveAll(
     return result;
 }
 
+tl::expected<void, ErrorCode> WrappedMasterService::ReportNoFTargetUnreachable(
+    const UUID& client_id, const std::vector<std::string>& te_endpoints) {
+    ScopedVLogTimer timer(1, "ReportNoFTargetUnreachable");
+    timer.LogRequest("client_id=", client_id,
+                     ", endpoints=", te_endpoints.size());
+    auto result =
+        master_service_.ReportNoFTargetUnreachable(client_id, te_endpoints);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
 tl::expected<void, ErrorCode> WrappedMasterService::ReportSsdCapacity(
     const UUID& client_id, int64_t ssd_total_capacity_bytes) {
     ScopedVLogTimer timer(1, "ReportSsdCapacity");
@@ -1849,6 +1860,9 @@ void RegisterRpcService(
         &mooncake::WrappedMasterService::OffloadObjectHeartbeat>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::ReportSsdCapacity>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::ReportNoFTargetUnreachable>(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::NotifyOffloadSuccess>(

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <limits>
 #include <optional>
+#include <set>
 #include <string>
 #include <thread>
 #include <utility>
@@ -391,6 +392,127 @@ TEST_F(MasterServiceTest, PutEndMemoryDoesNotCompleteNoFReplica) {
     EXPECT_TRUE(final_replica_result->replicas[0].is_memory_replica());
     EXPECT_EQ(final_replica_result->replicas[0].status,
               ReplicaStatus::COMPLETE);
+}
+
+namespace {
+
+// Endpoint of the single NoF replica a PutStart handed out, or empty when no
+// NoF replica was allocated.
+std::string AllocatedNoFEndpoint(
+    const std::vector<Replica::Descriptor>& replicas) {
+    for (const auto& replica : replicas) {
+        if (replica.is_nof_replica()) {
+            return replica.get_nof_descriptor()
+                .buffer_descriptor.transport_endpoint_;
+        }
+    }
+    return {};
+}
+
+}  // namespace
+
+TEST_F(MasterServiceTest, NoFAllocationSkipsTargetUnreachableFromClient) {
+    std::unique_ptr<MasterService> service(new MasterService());
+    NoFSegment partitioned =
+        MakeNoFSegment("nof_partitioned", "nof_partitioned_endpoint");
+    NoFSegment reachable = MakeNoFSegment(
+        "nof_reachable", "nof_reachable_endpoint",
+        kDefaultSegmentBase + 2 * kDefaultSegmentSize, kDefaultSegmentSize);
+    const UUID client_id = generate_uuid();
+    ASSERT_TRUE(service->MountNoFSegment(partitioned, client_id).has_value());
+    ASSERT_TRUE(service->MountNoFSegment(reachable, client_id).has_value());
+
+    ASSERT_TRUE(
+        service
+            ->ReportNoFTargetUnreachable(client_id, {partitioned.te_endpoint})
+            .has_value());
+    EXPECT_EQ(service->GetNoFExcludedSegmentsForTesting(client_id),
+              std::set<std::string>{partitioned.name});
+
+    // The master still reaches the partitioned target, so only the client's
+    // report can steer allocation away from it.
+    ReplicateConfig config;
+    config.replica_num = 0;
+    config.nof_replica_num = 1;
+    for (int i = 0; i < 8; ++i) {
+        const std::string key = "nof_skip_key_" + std::to_string(i);
+        auto put_start_result = service->PutStart(
+            client_id, key, TenantId::Default(), 1024, config);
+        ASSERT_TRUE(put_start_result.has_value()) << "key=" << key;
+        EXPECT_EQ(AllocatedNoFEndpoint(put_start_result.value()),
+                  reachable.te_endpoint)
+            << "key=" << key;
+        ASSERT_TRUE(
+            service
+                ->PutEnd(client_id, key, TenantId::Default(), ReplicaType::ALL)
+                .has_value());
+    }
+}
+
+TEST_F(MasterServiceTest, NoFAllocationFailsWhenEveryTargetIsUnreachable) {
+    std::unique_ptr<MasterService> service(new MasterService());
+    NoFSegment nof_segment = MakeNoFSegment("nof_only", "nof_only_endpoint");
+    const UUID client_id = generate_uuid();
+    ASSERT_TRUE(service->MountNoFSegment(nof_segment, client_id).has_value());
+
+    ReplicateConfig config;
+    config.replica_num = 0;
+    config.nof_replica_num = 1;
+    ASSERT_TRUE(service
+                    ->PutStart(client_id, "nof_before_report",
+                               TenantId::Default(), 1024, config)
+                    .has_value());
+
+    ASSERT_TRUE(
+        service
+            ->ReportNoFTargetUnreachable(client_id, {nof_segment.te_endpoint})
+            .has_value());
+
+    // Failing fast beats handing back a handle the client provably cannot
+    // write to.
+    auto put_start_result = service->PutStart(
+        client_id, "nof_after_report", TenantId::Default(), 1024, config);
+    ASSERT_FALSE(put_start_result.has_value());
+    EXPECT_EQ(put_start_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+}
+
+TEST_F(MasterServiceTest, NoFUnreachableReportIsScopedToReportingClient) {
+    std::unique_ptr<MasterService> service(new MasterService());
+    NoFSegment nof_segment =
+        MakeNoFSegment("nof_shared", "nof_shared_endpoint");
+    const UUID owner_id = generate_uuid();
+    const UUID partitioned_client = generate_uuid();
+    const UUID healthy_client = generate_uuid();
+    ASSERT_TRUE(service->MountNoFSegment(nof_segment, owner_id).has_value());
+
+    ASSERT_TRUE(service
+                    ->ReportNoFTargetUnreachable(partitioned_client,
+                                                 {nof_segment.te_endpoint})
+                    .has_value());
+    EXPECT_TRUE(
+        service->GetNoFExcludedSegmentsForTesting(healthy_client).empty());
+
+    ReplicateConfig config;
+    config.replica_num = 0;
+    config.nof_replica_num = 1;
+    auto put_start_result = service->PutStart(
+        healthy_client, "nof_other_client", TenantId::Default(), 1024, config);
+    ASSERT_TRUE(put_start_result.has_value());
+    EXPECT_EQ(AllocatedNoFEndpoint(put_start_result.value()),
+              nof_segment.te_endpoint);
+}
+
+TEST_F(MasterServiceTest, NoFUnreachableReportIgnoresEmptyEndpoints) {
+    std::unique_ptr<MasterService> service(new MasterService());
+    NoFSegment nof_segment =
+        MakeNoFSegment("nof_empty_report", "nof_empty_report_endpoint");
+    const UUID client_id = generate_uuid();
+    ASSERT_TRUE(service->MountNoFSegment(nof_segment, client_id).has_value());
+
+    ASSERT_TRUE(service->ReportNoFTargetUnreachable(client_id, {}).has_value());
+    ASSERT_TRUE(
+        service->ReportNoFTargetUnreachable(client_id, {""}).has_value());
+    EXPECT_TRUE(service->GetNoFExcludedSegmentsForTesting(client_id).empty());
 }
 
 TEST_F(MasterServiceTest, PartialRevokePreservesPendingSoftPin) {


### PR DESCRIPTION
# Issue #4033 — NoF master keeps allocating space despite client-to-target network partitions

## 1. Root cause

NoF target health was tracked from exactly one vantage point: the master.

`MasterService::NofHeartbeatThreadFunc` (`mooncake-store/src/master_service.cpp`)
walks the mounted NoF segments and calls `ProbeNoFSegment(segment.te_endpoint,
...)`, which reads through the *master's* own connection to the target. A
segment is only unmounted after `nof_heartbeat_failures_threshold` consecutive
failures of that master-to-target probe.

Allocation then trusted that single signal unconditionally. In
`MasterService::AllocateReplicas` the NoF branch called:

```cpp
auto allocation_result = allocation_strategy_->Allocate(
    allocator_manager, value_length, config.nof_replica_num,
    preferred_segments, std::set<std::string>(), ReplicaType::NOF_SSD);
```

The fifth argument is the allocator's `excluded_segments` set, and it was always
empty. The allocation strategy already honours that set (see
`RandomAllocationStrategy::Allocate` in
`mooncake-store/include/allocation_strategy.h`), so the mechanism existed but
nothing ever fed it.

Nothing else closed the loop either: when a client's NoF write failed, the
client recorded the failure locally (`ReplicaTransferSummary::RecordFailure`)
and revoked the put, but never told the master which target had failed. The
master had no per-client reachability state at all.

So when the client-to-target path is partitioned while master-to-target is
healthy, the master's view stays green, `excluded_segments` stays empty, and
every `PutStart` from the partitioned client keeps landing on the target it
cannot reach. The condition persists for the whole partition instead of being
detected once.

## 2. The fix and why

Give the master a second, client-side source of truth and feed it into the
allocator's existing exclusion mechanism.

**Master side** (`master_service.{h,cpp}`)

- New `MasterService::ReportNoFTargetUnreachable(client_id, te_endpoints)`.
  Records `(client, transfer engine endpoint) -> expiry` in
  `nof_unreachable_endpoints_`. Keyed by client because the partition is
  per client: the same target stays perfectly usable for everyone else, so a
  global blocklist would be wrong.
- New private `GetNoFExcludedSegments(client_id)`. Drops expired reports, then
  maps the reported endpoints onto mounted segment *names* via
  `NoFSegmentManager::GetMountedSegmentsSnapshot`. The endpoint is the only NoF
  target identity a client can see in a replica descriptor
  (`NoFDescriptor::buffer_descriptor.transport_endpoint_`), while the allocator
  keys on segment name, so the translation has to happen on the master.
- `AllocateReplicas` now takes `client_id` and passes the resulting set as
  `excluded_segments`. It is resolved *before* `getAllocatorAccess()` is taken,
  because both it and the snapshot read use `NoFSegmentManager::segment_mutex_`
  and re-entering a `std::shared_mutex` on one thread can deadlock against a
  queued writer.

Reports expire after `nof_heartbeat_interval_sec * nof_heartbeat_failures_
threshold` (30s with defaults). That is deliberately the same window the
heartbeat thread waits before declaring a target dead, so no new configuration
flag was introduced: after one liveness window the client retries the target
instead of being pinned to a stale verdict, which is what makes the exclusion
self-healing when the partition ends.

If *every* NoF target is excluded for a client, `PutStart` now fails with
`NO_AVAILABLE_HANDLE` instead of returning a handle. Failing fast beats handing
back storage the client has just proven it cannot write to.

**RPC plumbing** (`rpc_service.{h,cpp}`, `master_client.{h,cpp}`)

`WrappedMasterService::ReportNoFTargetUnreachable` +
`MasterClient::ReportNoFTargetUnreachable`, registered in `RegisterRpcService`.
Modelled on the existing `ReportSsdCapacity` client-to-master report.

**Client side** (`client_service.{h,cpp}`)

`Client::ReportUnreachableNoFTargets` dedups, drops empty endpoints, and issues
one RPC (none at all for an empty list). It is called from every write path
that can observe a NoF I/O failure:

- `Client::Put` and `Client::Upsert` transfer loops
- `Client::SubmitTransfers` (submit failure — for NoF this is the
  "failed to open NoF segment endpoint" path in `transfer_task.cpp`)
- `Client::WaitForTransfers` (completion failure); `PendingTransferRecord`
  gained a `te_endpoint` field because the future outlives the descriptor loop
  that submitted it

Only `ErrorCode::TRANSFER_FAIL` triggers a report (`IndicatesUnreachableTarget`).
`INVALID_PARAMS` and friends are client-side rejections — e.g. the
non-contiguous-slices check in the NoF submit path — and must not blocklist a
healthy target. Memory replicas yield an empty endpoint and are filtered out.
The report is best effort: a failure (including an older master that does not
know the RPC) is logged and swallowed, since the caller already returns the
real write error.

## 3. Files changed

| File | Change |
|---|---|
| `mooncake-store/include/master_service.h` | `ReportNoFTargetUnreachable` decl, `GetNoFExcludedSegments` + per-client state + TTL members, `AllocateReplicas` takes `client_id`, testing accessor |
| `mooncake-store/src/master_service.cpp` | Implementations; NoF allocation passes `excluded_segments`; both `AllocateReplicas` call sites updated |
| `mooncake-store/include/rpc_service.h`, `src/rpc_service.cpp` | RPC wrapper + handler registration |
| `mooncake-store/include/master_client.h`, `src/master_client.cpp` | Client-side RPC stub + `RpcNameTraits` |
| `mooncake-store/include/client_service.h`, `src/client_service.cpp` | `ReportUnreachableNoFTargets`, `NoFTargetEndpoint`, `IndicatesUnreachableTarget`, reporting hooks in the four write paths, `PendingTransferRecord::te_endpoint` |
| `mooncake-store/tests/master_service_test.cpp` | Four tests under `#ifdef USE_NOF` |

## 4. Risk / uncertainty

- **Not built or run here.** The sandbox has no ylt / glog / boost / gtest
  headers and no configured build tree, so nothing was compiled. See section 5
  for what was actually checked. This is the main uncertainty in the change.
- **Not HA-durable by design.** `nof_unreachable_endpoints_` is in-memory only
  and is not part of the master snapshot. After a failover the new master starts
  with a clean slate and clients re-report on their next failed write. Making it
  durable would mean replicating a soft, client-local hint into the snapshot
  codec, which seemed worse than one extra failed write after a failover.
- **Over-reporting is possible.** Any `TRANSFER_FAIL` on a NoF replica
  blocklists that target for that client, even if the real cause was on the
  target rather than the path. The blast radius is bounded: one client, one
  target, one heartbeat liveness window, and the target is still allocated for
  every other client.
- **Availability trade-off.** A client whose only NoF target is excluded now
  gets `NO_AVAILABLE_HANDLE` rather than a handle that fails at write time. That
  is the intended behaviour per the issue, but it does convert a late failure
  into an early one, which callers with `nof_replica_num > 0` and no memory
  replica will see as a `PutStart` error.
- **TTL is derived, not configurable.** Reusing
  `interval * failures_threshold` avoids a new flag but couples two settings.
  If operators need to tune the exclusion window independently, a dedicated
  `nof_client_unreachable_ttl_sec` flag would be the follow-up.
- **The added tests are gated on `USE_NOF`**, which is `OFF` by default, so a
  default CI run does not exercise them.

## 5. How I verified it

Compilation was not possible in this environment (no ylt/glog/boost/gtest, no
build tree), so verification was static:

1. Traced the bug end to end in the source: `NofHeartbeatThreadFunc` ->
   `ProbeNoFSegment` (master-to-target only), and the literal
   `std::set<std::string>()` passed as `excluded_segments` in
   `AllocateReplicas`.
2. Confirmed the allocator honours `excluded_segments` for `ReplicaType::NOF_SSD`
   on every path — single-segment fast path, preferred-segment loop and random
   loop in `RandomAllocationStrategy::Allocate`, plus the shared
   `RankedAllocationStrategy::AllocateRanked` used by the LOCAL_FIRST and
   FREE_RATIO_FIRST strategies.
3. Confirmed the lock ordering: `NoFSegmentManager::GetMountedSegmentsSnapshot`
   takes `segment_mutex_` shared and `getAllocatorAccess()` takes the same
   mutex, so the exclusion set is computed before the allocator guard is
   acquired.
4. Confirmed every `AllocateReplicas` call site
   (`AllocateAndInsertMetadata`, `UpsertStart`) has `client_id` in scope, and
   that `grep` finds no other callers.
5. Checked constructor member-initialiser order against declaration order for
   the new `nof_unreachable_ttl_` member (avoids `-Wreorder`).
6. Checked the new RPC against the existing `ReportSsdCapacity` shape:
   `WrappedMasterService` method, `RpcNameTraits` specialisation,
   `register_handler` entry, `MasterClient` `invoke_rpc` stub —
   `RegisterRpcService` in `rpc_service.cpp` is the only handler registry in the
   tree.
7. Verified `PutStart` accepts `replica_num = 0, nof_replica_num = 1` and that
   `HasExpectedReplicaAllocation` treats it as strict (not
   `FLEXIBLE_DUAL_REPLICA`), which is what makes the
   `NoFAllocationFailsWhenEveryTargetIsUnreachable` expectation correct; also
   that the default heartbeat settings give a 30s TTL, comfortably longer than
   the tests.
8. Ran `git-clang-format --style=file` over the staged diff, applied its
   rewrites, and re-inspected the result (the repo's `pre-commit` formats only
   changed C/C++ lines; `pre-commit` itself is not installed here).

### Tests added (`mooncake-store/tests/master_service_test.cpp`, `#ifdef USE_NOF`)

- `NoFAllocationSkipsTargetUnreachableFromClient` — two mounted NoF targets;
  after reporting one, eight consecutive `PutStart`s all land on the other.
- `NoFAllocationFailsWhenEveryTargetIsUnreachable` — `PutStart` succeeds before
  the report and returns `NO_AVAILABLE_HANDLE` after it.
- `NoFUnreachableReportIsScopedToReportingClient` — a report from one client
  does not affect another client's allocation on the same target.
- `NoFUnreachableReportIgnoresEmptyEndpoints` — empty lists and empty endpoint
  strings record nothing.

Run them with `cmake -DUSE_NOF=ON -DBUILD_UNIT_TESTS=ON` and
`ctest -R master_service_test`.