### PR TITLE
[TENT] Fall back to the control plane when the RDMA notification channel is unavailable

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -302,8 +302,18 @@ class TransferEngineImpl {
 
     Status cancelTransfer(BatchID batch_id, size_t task_id);
 
+    // Tries every loaded notification transport in slot order. A transport
+    // whose channel is unavailable (endpoint down, no notify QP) is skipped
+    // for the next one, and when all are, the notification goes over the
+    // control-plane RPC the peer answers bootstrap on. Any other error is
+    // returned as is. notification/rpc_fallback=false restores the
+    // first-transport-only behavior.
     Status sendNotification(SegmentID target_id, const Notification& notifi);
 
+    // Drains every loaded notification transport plus the in-process queue,
+    // so a notification lands with the caller no matter which path carried
+    // it. Order is kept within one path only: in a poll, notifications that
+    // took the RPC fallback come after the ones the notify QP carried.
     Status receiveNotification(std::vector<Notification>& notifi_list);
 
     Status probePeerAliveByID(SegmentID target_id);
@@ -485,6 +495,12 @@ class TransferEngineImpl {
 
     Status loadTransports();
 
+    // Control-plane delivery used by sendNotification() once every loaded
+    // notification transport has reported its channel unavailable. Same
+    // wire path as TcpTransport::sendNotification().
+    Status sendNotificationViaRpc(SegmentID target_id,
+                                  const Notification& notifi);
+
     void findStagingPolicy(const Request& req,
                            std::vector<std::string>& policy);
 
@@ -571,6 +587,7 @@ class TransferEngineImpl {
     std::unique_ptr<ProxyManager> staging_proxy_;
     bool merge_requests_;
     std::shared_ptr<const RuntimeConfigSnapshot> runtime_config_snapshot_;
+    bool notify_rpc_fallback_{true};
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -180,8 +180,23 @@ class RdmaTransport : public Transport {
     void registerNotifyQp(uint32_t qp_num,
                           const std::shared_ptr<RdmaEndPoint>& endpoint);
     void unregisterNotifyQp(uint32_t qp_num);
+    // Returns nullptr when no ready endpoint to the peer's device could be
+    // handed out; `failure`, when given, receives why (the segment lookup or
+    // connect() status as is, DeviceNotFound for no enabled context,
+    // InternalError for an allocation failure).
     std::shared_ptr<RdmaEndPoint> getEndpoint(SegmentID target_id,
-                                              int device_id);
+                                              int device_id,
+                                              Status* failure = nullptr);
+
+    // Maps the reason getEndpoint() could not hand out a notify-capable
+    // endpoint to what sendNotification() reports. A bootstrap RPC that
+    // failed means the peer's control plane is unreachable, so the RPC
+    // fallback would only wait out a second timeout on the polling thread:
+    // report RpcServiceError, which TransferEngineImpl does not fall back
+    // on. Everything else (no context, allocation, QP setup) leaves the
+    // control plane reachable and stays DeviceNotFound, i.e. eligible for
+    // the RPC leg.
+    static Status notifyStatusForEndpointFailure(const Status& failure);
 
     // Notification worker thread
     void notifyWorkerThread();

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -363,6 +363,7 @@ Status TransferEngineImpl::construct() {
     CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, rpc_threads_default,
                                                rpc_server_threads));
     merge_requests_ = conf_->get("merge_requests", true);
+    notify_rpc_fallback_ = conf_->get("notification/rpc_fallback", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
@@ -428,6 +429,18 @@ Status TransferEngineImpl::construct() {
     }
 
     CHECK_STATUS(loadTransports());
+
+    // A notification that arrives over the control plane - the RPC fallback
+    // in sendNotification(), or a peer whose only notification path is RPC -
+    // reaches ControlService::onNotify(), which drops it unless a callback is
+    // registered. Queue such notifications in-process so receiveNotification()
+    // hands them out. ControlService keeps a single callback: the TCP
+    // transports register their own in install() below and take over.
+    metadata_->setNotifyCallback([this](const Notification& notifi) -> int {
+        std::lock_guard<std::mutex> lk(local_notifi_mutex_);
+        local_notifi_list_.push_back(notifi);
+        return 0;
+    });
 
     std::string transport_string;
     for (size_t transport_index = 0; transport_index < transport_list_.size();
@@ -649,6 +662,9 @@ Status TransferEngineImpl::deconstruct() {
     progress_worker_.reset();
     local_segment_tracker_.reset();
     if (metadata_) {
+        // The in-process notify callback registered by construct() captures
+        // this engine; the transports already dropped theirs.
+        metadata_->setNotifyCallback(nullptr);
         metadata_->segmentManager().deleteLocal();
         metadata_.reset();
     }
@@ -2800,12 +2816,61 @@ Status TransferEngineImpl::sendNotification(SegmentID target_id,
         local_notifi_list_.push_back(notifi);
         return Status::OK();
     }
+    // Transports are tried in slot order, RDMA before TCP, so with TCP loaded
+    // the fallback is its own RPC-based sendNotification(); the explicit RPC
+    // below is for engines without one. Only a transport whose channel is
+    // unavailable is skipped - the endpoint could not be brought up or the
+    // notification channel on it is gone, so nothing left this host. Any
+    // other error (bad argument, stale cache) is the caller's to see, and a
+    // notification that was posted but lost in flight is out of scope here:
+    // resending it would need receiver-side deduplication first.
+    bool attempted = false;
+    Status status;
     for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
         auto& transport = transport_list_[type];
         if (!transport || !transport->supportNotification()) continue;
-        return transport->sendNotification(target_id, notifi);
+        Status attempt = transport->sendNotification(target_id, notifi);
+        // A transport that advertises notifications without implementing
+        // them (SunriseLink) is not a channel at all.
+        if (attempt.IsNotImplemented()) continue;
+        attempted = true;
+        status = attempt;
+        if (status.ok()) return status;
+        if (!notify_rpc_fallback_ ||
+            !(status.IsRdmaError() || status.IsDeviceNotFound())) {
+            return status;
+        }
+        LOG_EVERY_N(WARNING, 100)
+            << "Notification transport " << transport->getName()
+            << " unavailable for segment " << target_id
+            << ", falling back to the next path (" << google::COUNTER
+            << " so far): " << status.ToString();
     }
-    return Status::InvalidArgument("Notification not supported" LOC_MARK);
+    if (!attempted)
+        return Status::InvalidArgument("Notification not supported" LOC_MARK);
+    // Every loaded notification transport reported its channel unavailable;
+    // the control plane the peer answers bootstrap on is still there.
+    return sendNotificationViaRpc(target_id, notifi);
+}
+
+Status TransferEngineImpl::sendNotificationViaRpc(SegmentID target_id,
+                                                  const Notification& notifi) {
+    return metadata_->segmentManager().withCachedSegment(
+        target_id, [&](SegmentDesc* segment) {
+            auto rpc_server_addr = segment->rpc_server_addr;
+            if (rpc_server_addr.empty()) {
+                return Status::NeedsRefreshCache(
+                    "Empty RPC server addr" LOC_MARK);
+            }
+            auto status = ControlClient::notify(rpc_server_addr, notifi);
+            if (status.IsRpcServiceError()) {
+                // Perhaps rpc_server_addr can be updated in the future
+                return Status::NeedsRefreshCache(
+                    "RPC service error: " + std::string{status.message()} +
+                    LOC_MARK);
+            }
+            return status;
+        });
 }
 
 Status TransferEngineImpl::probePeerAliveByID(SegmentID target_id) {
@@ -2835,12 +2900,30 @@ Status TransferEngineImpl::receiveNotification(
     notifi_list.clear();
     Status status = Status::OK();
     bool has_transport = false;
+    // A notification is queued by whichever transport carried it: the RDMA
+    // transport for its notify QP, the TCP transport for anything that came
+    // over the control plane. Draining only the first transport would strand
+    // the rest. Each one is polled into its own vector because
+    // TcpTransport::receiveNotification() clears its argument first.
     for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
         auto& transport = transport_list_[type];
         if (!transport || !transport->supportNotification()) continue;
+        std::vector<Notification> part;
+        Status part_status = transport->receiveNotification(part);
+        // Advertised but not implemented (SunriseLink): no queue to drain.
+        if (part_status.IsNotImplemented()) continue;
         has_transport = true;
-        status = transport->receiveNotification(notifi_list);
-        break;
+        if (!part_status.ok()) {
+            status = part_status;
+            continue;
+        }
+        if (notifi_list.empty()) {
+            notifi_list.swap(part);
+        } else {
+            notifi_list.insert(notifi_list.end(),
+                               std::make_move_iterator(part.begin()),
+                               std::make_move_iterator(part.end()));
+        }
     }
     // Append self-targeted notifications queued by sendNotification(). They
     // are deliverable even when no transport supports notifications at all,

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -1216,7 +1216,11 @@ bool RdmaEndPoint::sendNotification(const std::string& name,
                notify_pending_count_ < kNotifyMaxPendingSends;
     });
     if (!notify_connected_) {
-        LOG(ERROR) << "Notification QP not connected";
+        // Every send on this endpoint fails the same way until it is
+        // rebuilt, and the caller has a fallback path; one line per hundred
+        // is enough to show it is happening.
+        LOG_EVERY_N(WARNING, 100)
+            << "Notification QP not connected on endpoint " << endpoint_name_;
         return false;
     }
     std::lock_guard<std::mutex> resource_guard(notify_resource_mutex_);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -808,7 +808,8 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
 }
 
 std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
-                                                         int device_id) {
+                                                         int device_id,
+                                                         Status* failure) {
     std::string rpc_server_addr, target_seg_name, target_dev_name,
         target_nic_path_name;
 
@@ -836,6 +837,7 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
 
     if (!status.ok()) {
         LOG(ERROR) << status.ToString();
+        if (failure) *failure = status;
         return nullptr;
     }
 
@@ -849,6 +851,10 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
         }
     }
     if (!context) {
+        if (failure) {
+            *failure =
+                Status::DeviceNotFound("No enabled RDMA context" LOC_MARK);
+        }
         return nullptr;
     }
     std::shared_ptr<RdmaEndPoint> endpoint;
@@ -856,6 +862,10 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
     endpoint = context->endpointStore()->getOrInsert(peer_name);
     if (!endpoint) {
         LOG(ERROR) << "Cannot allocate endpoint " << peer_name;
+        if (failure) {
+            *failure =
+                Status::InternalError("Cannot allocate endpoint" LOC_MARK);
+        }
         return nullptr;
     }
     if (endpoint->status() != RdmaEndPoint::EP_READY) {
@@ -869,21 +879,39 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
                 LOG(ERROR) << "Unable to connect endpoint " << peer_name << ": "
                            << status.ToString();
             }
+            if (failure) *failure = status;
             return nullptr;
         }
     }
     return endpoint;
 }
 
+Status RdmaTransport::notifyStatusForEndpointFailure(const Status& failure) {
+    if (failure.IsRpcServiceError()) {
+        return Status::RpcServiceError(
+            "RDMA notification endpoint bootstrap failed; peer control "
+            "plane unreachable, not falling back to RPC: " +
+            std::string{failure.message()} + LOC_MARK);
+    }
+    return Status::DeviceNotFound("RDMA notification endpoint unavailable: " +
+                                  std::string{failure.message()} + LOC_MARK);
+}
+
 Status RdmaTransport::sendNotification(SegmentID target_id,
                                        const Notification& notify) {
-    auto endpoint = getEndpoint(target_id, LOCAL_SEGMENT_ID);
-    if (!endpoint) {
-        return Status::InternalError(
-            "Endpoint not found for notification" LOC_MARK);
-    }
+    // Both failures below mean nothing left this host. Unless the bootstrap
+    // RPC itself failed (see notifyStatusForEndpointFailure), the engine may
+    // still reach the peer over the control plane, so they are reported with
+    // codes TransferEngineImpl::sendNotification() recognizes as "channel
+    // unavailable" rather than as a generic internal error.
+    Status failure;
+    auto endpoint = getEndpoint(target_id, LOCAL_SEGMENT_ID, &failure);
+    if (!endpoint) return notifyStatusForEndpointFailure(failure);
+    // Notify QP not connected (the peer has none, or it was disabled after a
+    // fault), or the post itself was refused.
     if (!endpoint->sendNotification(notify.name, notify.msg)) {
-        return Status::InternalError("Failed to send notification" LOC_MARK);
+        return Status::RdmaError(
+            "RDMA notification channel unavailable" LOC_MARK);
     }
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -188,6 +188,17 @@ target_include_directories(local_notification_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME local_notification_test COMMAND local_notification_test)
 
+# Notification fallback: an unavailable RDMA notification channel falls back
+# to the next transport and then to the control-plane RPC, and receive drains
+# every transport. Loopback only, no NIC required.
+add_executable(tent_notification_fallback_test notification_fallback_test.cpp)
+target_link_libraries(tent_notification_fallback_test
+                      PRIVATE gtest gtest_main tent_link_group)
+target_include_directories(tent_notification_fallback_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_notification_fallback_test
+         COMMAND tent_notification_fallback_test)
+
 add_executable(transfer_engine_config_override_test
                transfer_engine_config_override_test.cpp)
 target_link_libraries(transfer_engine_config_override_test

--- a/mooncake-transfer-engine/tent/tests/notification_fallback_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/notification_fallback_test.cpp
@@ -1,0 +1,393 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A notification the RDMA channel cannot carry - no endpoint could be
+// brought up, the peer has no notify QP, or the QP was disabled after a
+// fault - used to be dropped with an InternalError. These tests pin the
+// fallback: the engine tries the next notification transport and, with none
+// left, the control-plane RPC; receiveNotification() drains every transport
+// so a notification that arrived over RPC is not stranded in a queue nobody
+// polls. Stand-in transports keep this free of any NIC or metadata server.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/runtime/transfer_engine_impl.h"
+
+namespace mooncake {
+namespace tent {
+
+namespace {
+
+std::shared_ptr<Config> makeConfig(bool rpc_fallback = true) {
+    auto config = std::make_shared<Config>();
+    config->set("metadata_type", "p2p");
+    config->set("rpc_server_hostname", "127.0.0.1");
+    config->set("rpc_server_port", "0");
+    config->set("log_level", "warning");
+    // No real transport: every notification transport in these tests is a
+    // stand-in swapped in after construction, so the fallback order and the
+    // RPC leg are exercised on their own.
+    config->set("transports/tcp/enable", false);
+    config->set("transports/shm/enable", false);
+    config->set("transports/rdma/enable", false);
+    config->set("transports/io_uring/enable", false);
+    config->set("transports/nvlink/enable", false);
+    config->set("transports/mnnvl/enable", false);
+    config->set("transports/gds/enable", false);
+    config->set("transports/ascend_direct/enable", false);
+    config->set("transports/sunrise_link/enable", false);
+    config->set("transports/mpcomm/enable", false);
+    config->set("transports/tpu/enable", false);
+    config->set("transports/ub/enable", false);
+    config->set("enable_progress_worker", false);
+    config->set("enable_runtime_queue", false);
+    config->set("notification/rpc_fallback", rpc_fallback);
+    return config;
+}
+
+// Stands in for a notification transport: sends answer with a fixed status
+// and are recorded, receives hand out whatever the test queued.
+class StubNotifyTransport : public Transport {
+   public:
+    StubNotifyTransport(const char* name, Status send_status)
+        : name_(name), send_status_(send_status) {}
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config>) override {
+        return Status::OK();
+    }
+
+    bool supportNotification() const override { return true; }
+
+    Status sendNotification(SegmentID, const Notification& notifi) override {
+        ++send_calls;
+        sent.push_back(notifi);
+        return send_status_;
+    }
+
+    // Mirrors TcpTransport::receiveNotification(): the argument is cleared
+    // before the queue is swapped in. An engine that hands one vector to
+    // every transport in turn loses everything gathered before this one.
+    Status receiveNotification(std::vector<Notification>& out) override {
+        out.clear();
+        if (!recv_status.ok()) return recv_status;
+        out.swap(queued);
+        return Status::OK();
+    }
+
+    const char* getName() const override { return name_; }
+
+    int send_calls = 0;
+    std::vector<Notification> sent;
+    std::vector<Notification> queued;
+    Status recv_status = Status::OK();
+
+   private:
+    const char* name_;
+    Status send_status_;
+};
+
+Notification makeNotification(const std::string& msg) {
+    Notification notifi;
+    notifi.name = "notification-fallback-test";
+    notifi.msg = msg;
+    return notifi;
+}
+
+// Any non-local segment id. The stand-ins never look at it, and the tests
+// that use it stop before the RPC leg would need a real peer.
+constexpr SegmentID kRemote = 0x1234;
+
+std::shared_ptr<StubNotifyTransport> installStub(TransferEngineImpl& engine,
+                                                 TransportType slot,
+                                                 const char* name,
+                                                 Status send_status) {
+    auto stub = std::make_shared<StubNotifyTransport>(name, send_status);
+    std::string segment_name = engine.getSegmentName();
+    EXPECT_TRUE(stub->install(segment_name, nullptr, nullptr, nullptr).ok());
+    engine.swapTransportForTest(slot, stub);
+    return stub;
+}
+
+}  // namespace
+
+// The RDMA transport (slot RDMA, tried first) reports its channel
+// unavailable; the next notification transport carries the notification.
+// Both codes RdmaTransport::sendNotification() uses for "nothing was posted"
+// must be treated the same.
+TEST(NotificationFallbackTest, FallsBackToNextTransportWhenChannelUnavailable) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    const Status unavailable[] = {
+        Status::RdmaError("RDMA notification channel unavailable"),
+        Status::DeviceNotFound("RDMA notification endpoint unavailable"),
+    };
+    for (const auto& code : unavailable) {
+        auto rdma = installStub(engine, RDMA, "<rdma-unavailable>", code);
+        auto tcp = installStub(engine, TCP, "<tcp-ok>", Status::OK());
+
+        const Status status =
+            engine.sendNotification(kRemote, makeNotification("fallback"));
+        EXPECT_TRUE(status.ok()) << status.ToString();
+        EXPECT_EQ(rdma->send_calls, 1) << code.ToString();
+        ASSERT_EQ(tcp->send_calls, 1) << code.ToString();
+        EXPECT_EQ(tcp->sent[0].msg, "fallback");
+    }
+}
+
+// A transport that rejected the notification, as opposed to one that could
+// not carry it, is the caller's error to see: no other path is tried.
+TEST(NotificationFallbackTest, DoesNotFallBackOnInvalidArgument) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-rejects>",
+                            Status::InvalidArgument("payload too large"));
+    auto tcp = installStub(engine, TCP, "<tcp-ok>", Status::OK());
+
+    const Status status =
+        engine.sendNotification(kRemote, makeNotification("rejected"));
+    EXPECT_TRUE(status.IsInvalidArgument()) << status.ToString();
+    EXPECT_EQ(rdma->send_calls, 1);
+    EXPECT_EQ(tcp->send_calls, 0);
+}
+
+// The RDMA transport reports RpcServiceError when the bootstrap RPC to the
+// peer failed: its control plane is not answering, so neither the next
+// transport nor the engine's own RPC leg is tried - both would only wait
+// out another timeout against the same peer.
+TEST(NotificationFallbackTest, ControlPlaneUnreachableIsReturnedAsIs) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-bootstrap-rpc-failed>",
+                            Status::RpcServiceError("peer control plane "
+                                                    "unreachable"));
+    auto tcp = installStub(engine, TCP, "<tcp-ok>", Status::OK());
+
+    const Status status =
+        engine.sendNotification(kRemote, makeNotification("unreachable"));
+    EXPECT_TRUE(status.IsRpcServiceError()) << status.ToString();
+    EXPECT_EQ(rdma->send_calls, 1);
+    EXPECT_EQ(tcp->send_calls, 0);
+}
+
+// The production chain with TCP loaded is RDMA then TcpTransport, whose own
+// failures are RPC errors, never "channel unavailable". Such an error from
+// the last transport is returned as is; the engine's own RPC leg is not a
+// second attempt at the same peer.
+TEST(NotificationFallbackTest, ReturnsTheLastTransportsErrorInsteadOfRpc) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-unavailable>",
+                            Status::RdmaError("notify QP not connected"));
+    auto tcp = installStub(engine, TCP, "<tcp-rpc-fails>",
+                           Status::RpcServiceError("connection refused"));
+
+    const Status status =
+        engine.sendNotification(kRemote, makeNotification("tcp-failed"));
+    EXPECT_TRUE(status.IsRpcServiceError()) << status.ToString();
+    EXPECT_EQ(rdma->send_calls, 1);
+    EXPECT_EQ(tcp->send_calls, 1);
+}
+
+// Only when every loaded notification transport reports its channel
+// unavailable does the engine make the control-plane RPC itself. kRemote was
+// never opened, so reaching that leg shows up as the segment lookup failing
+// - which is how this test tells it apart from an early return.
+TEST(NotificationFallbackTest, AllTransportsUnavailableReachesTheRpcLeg) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-unavailable>",
+                            Status::RdmaError("notify QP not connected"));
+    auto tcp = installStub(engine, TCP, "<tcp-unavailable>",
+                           Status::DeviceNotFound("no endpoint"));
+
+    const Status status =
+        engine.sendNotification(kRemote, makeNotification("rpc-leg"));
+    EXPECT_TRUE(status.IsInvalidArgument()) << status.ToString();
+    EXPECT_NE(status.message().find("segment handle"), std::string::npos)
+        << status.ToString();
+    EXPECT_EQ(rdma->send_calls, 1);
+    EXPECT_EQ(tcp->send_calls, 1);
+}
+
+// SunriseLink advertises notification support but implements neither send
+// nor receive, so both come back NotImplemented. It must be skipped on the
+// send chain and ignored by the receive drain rather than stop the fallback
+// or turn every empty poll into an error.
+TEST(NotificationFallbackTest, SkipsTransportsThatDoNotImplementNotifications) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-unavailable>",
+                            Status::RdmaError("notify QP not connected"));
+    // Any slot between RDMA and TCP does; the real SunriseLink slot is after
+    // TCP, which would hide the send-chain part of this test.
+    auto stubbed = installStub(engine, SHM, "<advertised-only>",
+                               Status::NotImplemented("not implemented"));
+    stubbed->recv_status = Status::NotImplemented("not implemented");
+    auto tcp = installStub(engine, TCP, "<tcp-ok>", Status::OK());
+
+    const Status status =
+        engine.sendNotification(kRemote, makeNotification("skip"));
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(rdma->send_calls, 1);
+    EXPECT_EQ(stubbed->send_calls, 1);
+    ASSERT_EQ(tcp->send_calls, 1);
+    EXPECT_EQ(tcp->sent[0].msg, "skip");
+
+    tcp->queued = {makeNotification("tcp-0")};
+    std::vector<Notification> received;
+    ASSERT_TRUE(engine.receiveNotification(received).ok());
+    ASSERT_EQ(received.size(), 1u);
+    EXPECT_EQ(received[0].msg, "tcp-0");
+
+    // An empty poll stays a successful empty poll.
+    EXPECT_TRUE(engine.receiveNotification(received).ok());
+    EXPECT_TRUE(received.empty());
+}
+
+// notification/rpc_fallback=false restores the first-transport-only
+// behavior: the unavailable channel's error is returned untouched.
+TEST(NotificationFallbackTest, FallbackCanBeDisabledByConfig) {
+    TransferEngineImpl engine(makeConfig(/*rpc_fallback=*/false));
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-unavailable>",
+                            Status::RdmaError("notify QP not connected"));
+    auto tcp = installStub(engine, TCP, "<tcp-ok>", Status::OK());
+
+    const Status status =
+        engine.sendNotification(kRemote, makeNotification("no-fallback"));
+    EXPECT_TRUE(status.IsRdmaError()) << status.ToString();
+    EXPECT_EQ(rdma->send_calls, 1);
+    EXPECT_EQ(tcp->send_calls, 0);
+}
+
+// One poll hands out what every notification transport queued plus the
+// in-process queue, in slot order, and each notification exactly once. The
+// second stand-in clears its argument the way TcpTransport does, so this
+// also pins that every transport is polled into its own vector.
+TEST(NotificationFallbackTest, ReceiveMergesAllNotificationTransports) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma>", Status::OK());
+    auto tcp = installStub(engine, TCP, "<tcp>", Status::OK());
+    rdma->queued = {makeNotification("rdma-0"), makeNotification("rdma-1")};
+    tcp->queued = {makeNotification("tcp-0"), makeNotification("tcp-1")};
+    ASSERT_TRUE(
+        engine.sendNotification(LOCAL_SEGMENT_ID, makeNotification("local"))
+            .ok());
+
+    std::vector<Notification> received;
+    ASSERT_TRUE(engine.receiveNotification(received).ok());
+    ASSERT_EQ(received.size(), 5u);
+    EXPECT_EQ(received[0].msg, "rdma-0");
+    EXPECT_EQ(received[1].msg, "rdma-1");
+    EXPECT_EQ(received[2].msg, "tcp-0");
+    EXPECT_EQ(received[3].msg, "tcp-1");
+    EXPECT_EQ(received[4].msg, "local");
+
+    // Drained: nothing comes back twice.
+    ASSERT_TRUE(engine.receiveNotification(received).ok());
+    EXPECT_TRUE(received.empty());
+}
+
+// A transport whose queue cannot be read must not stop the drain: what the
+// other paths carried is still handed out, and the error only surfaces on a
+// poll that has nothing to deliver.
+TEST(NotificationFallbackTest, ReceiveKeepsDrainingPastAFailingTransport) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto rdma = installStub(engine, RDMA, "<rdma-broken>", Status::OK());
+    rdma->recv_status = Status::InternalError("notify CQ poll failed");
+    auto tcp = installStub(engine, TCP, "<tcp>", Status::OK());
+    tcp->queued = {makeNotification("tcp-0")};
+    ASSERT_TRUE(
+        engine.sendNotification(LOCAL_SEGMENT_ID, makeNotification("local"))
+            .ok());
+
+    std::vector<Notification> received;
+    ASSERT_TRUE(engine.receiveNotification(received).ok());
+    ASSERT_EQ(received.size(), 2u);
+    EXPECT_EQ(received[0].msg, "tcp-0");
+    EXPECT_EQ(received[1].msg, "local");
+
+    const Status empty = engine.receiveNotification(received);
+    EXPECT_TRUE(empty.IsInternalError()) << empty.ToString();
+    EXPECT_TRUE(received.empty());
+}
+
+// Two engines on loopback, neither with a TCP transport. The sender's only
+// notification transport reports its channel unavailable, so the engine
+// itself makes the control-plane RPC; the receiver, with nothing registered
+// to take RPC notifications, must still hand it out from its next poll.
+TEST(NotificationFallbackTest, RpcNotifyLandsWithoutTcpTransport) {
+    TransferEngineImpl receiver(makeConfig());
+    ASSERT_TRUE(receiver.available());
+    TransferEngineImpl sender(makeConfig());
+    ASSERT_TRUE(sender.available());
+
+    // The receiver has an RDMA transport that never delivers anything; the
+    // notification must not depend on it.
+    auto receiver_rdma =
+        installStub(receiver, RDMA, "<receiver-rdma>", Status::OK());
+    auto sender_rdma =
+        installStub(sender, RDMA, "<sender-rdma-unavailable>",
+                    Status::RdmaError("RDMA notification channel unavailable"));
+
+    SegmentID remote = ~0ull;
+    ASSERT_TRUE(sender.openSegment(remote, receiver.getSegmentName()).ok());
+    ASSERT_NE(remote, LOCAL_SEGMENT_ID);
+
+    const Status status =
+        sender.sendNotification(remote, makeNotification("over-rpc"));
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(sender_rdma->send_calls, 1);
+
+    // The RPC is synchronous, so the notification is queued by the time
+    // sendNotification() returns; the loop only guards against a scheduler
+    // hiccup between the reply and the poll.
+    std::vector<Notification> received;
+    for (int i = 0; i < 100 && received.empty(); ++i) {
+        (void)receiver.receiveNotification(received);
+        if (received.empty())
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_EQ(received.size(), 1u);
+    EXPECT_EQ(received[0].name, "notification-fallback-test");
+    EXPECT_EQ(received[0].msg, "over-rpc");
+    EXPECT_TRUE(receiver_rdma->queued.empty());
+
+    // Delivered exactly once.
+    ASSERT_TRUE(receiver.receiveNotification(received).ok());
+    EXPECT_TRUE(received.empty());
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -200,6 +200,10 @@ class RdmaTransportTestPeer {
                                      uint64_t now_ns) {
         workers.expireTimedOutSlices(ctx, now_ns);
     }
+
+    static Status notifyStatusForEndpointFailure(const Status& failure) {
+        return RdmaTransport::notifyStatusForEndpointFailure(failure);
+    }
 };
 
 // Friend accessor for RdmaContext: TENT reaches libibverbs through a table of
@@ -468,6 +472,35 @@ TEST(RdmaNotifyFaultTriageTest, PathAndPeerFaultsRetireTheEndpoint) {
     // Nothing put this QP in ERR on our side, so the peer or the path did.
     EXPECT_EQ(classify(IBV_WC_WR_FLUSH_ERR, true, true),
               Action::RetireEndpoint);
+}
+
+// A bootstrap RPC that failed says the peer's control plane is not answering,
+// so a notification must not be handed to the RPC fallback: that would only
+// wait out a second RPC timeout on the thread that polls the batch.
+TEST(RdmaNotifyFaultTriageTest, BootstrapRpcFailureNotEligibleForFallback) {
+    const Status mapped = RdmaTransportTestPeer::notifyStatusForEndpointFailure(
+        Status::RpcServiceError("Failed to call RPC function"));
+    EXPECT_TRUE(mapped.IsRpcServiceError()) << mapped.ToString();
+    EXPECT_NE(mapped.message().find("Failed to call RPC function"),
+              std::string_view::npos);
+}
+
+// Every other reason getEndpoint() comes back empty - no enabled context,
+// allocation, QP setup, a stale segment - leaves the control plane reachable,
+// so the engine may still deliver over RPC.
+TEST(RdmaNotifyFaultTriageTest, OtherEndpointFailuresStayEligible) {
+    const Status failures[] = {
+        Status::InternalError("Failed to configure RDMA endpoint"),
+        Status::DeviceNotFound("No enabled RDMA context"),
+        Status::InvalidArgument("Missing peer GID in bootstrap"),
+        Status::NeedsRefreshCache("Empty target segment or device name"),
+    };
+    for (const auto& failure : failures) {
+        const Status mapped =
+            RdmaTransportTestPeer::notifyStatusForEndpointFailure(failure);
+        EXPECT_TRUE(mapped.IsDeviceNotFound())
+            << failure.ToString() << " -> " << mapped.ToString();
+    }
 }
 
 TEST(RdmaNotifyFaultTriageTest, TeardownFlushesStayQuiet) {


### PR DESCRIPTION
## Description

Three failures in `RdmaTransport::sendNotification()` mean nothing left the host: no endpoint could be brought up for the peer, the endpoint has no connected notify QP, or the post was refused. All three surfaced as `InternalError`, which the engine handed back as the final answer, so the notification was simply gone. Two gaps sat behind it: `receiveNotification()` drained only the first transport that supports notifications, so anything the TCP transport had queued from the control plane was never handed out; and no notify callback was registered with `ControlService` unless a TCP transport was loaded, so an RDMA-only engine dropped every RPC-delivered notification.

Measured with a two-process probe: disabling the initiator's notify QP after 500 sends left the target with 500 of 4000 notifications and no END marker, and an initiator loaded without an RDMA transport delivered 0 of 2000 to a target that had one.

Change:

- The three "nothing was posted" cases become `DeviceNotFound` / `RdmaError` instead of `InternalError`. `getEndpoint()` takes an optional `Status* failure` so the reason for a missing endpoint is not lost; the default argument keeps its signature source-compatible.
- `TransferEngineImpl::sendNotification()` tries every loaded notification transport in slot order, skips the ones whose channel is unavailable, and when all are, sends over the control-plane `Notify` RPC the peer already answers bootstrap on - the same wire path `TcpTransport::sendNotification()` uses, and what the classic engine's `rdma_notify_oob_fallback` does. Any other error is returned untouched. A transport that advertises notifications but returns `NotImplemented` is skipped on both the send chain and the receive drain. Each fallback is logged with `LOG_EVERY_N` and a running count.
- One case is deliberately excluded: when the bootstrap failed because the RPC itself failed, the peer's control plane is not answering, so the status is reported as `RpcServiceError` and the engine returns it as is rather than stacking a second RPC timeout on the polling thread. Every other reason still falls back.
- `receiveNotification()` drains every notification transport plus the in-process queue, each into its own vector because `TcpTransport::receiveNotification()` clears its argument. One transport that cannot be read does not stop the drain.
- `construct()` registers an in-process notify callback with `ControlService` before the transports install, so RPC-delivered notifications are queued even without a TCP transport; `deconstruct()` clears it.
- `notification/rpc_fallback` (default true) turns the whole thing off.

Worth knowing: the fallback is a synchronous RPC at call sites that already do one, roughly 67 us on a live peer over loopback; a payload larger than the 64 KB slot now reaches the peer over RPC instead of failing; ordering holds within one path, so notifications that came over RPC are handed out after the ones the notify QP carried in the same poll; and delivery over the fallback needs the receiver to run this change or to have a TCP transport, otherwise the result is what it is today, only no longer reported as an error. Only failures where nothing was posted are covered - a notification lost after a successful post needs receiver-side deduplication first, which comes later in the series. No wire-format and no default timeout change.

This is the third of seven PRs on notification fault tolerance, described in the series RFC (#4061). It applies to `main` on its own, using the in-process notification queue that #3464 added there.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake Conductor (`mooncake-conductor`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

`tent_notification_fallback_test` is new: 10 cases covering the fallback chain (both unavailable statuses), the statuses that must not fall back, the unreachable control plane returned as is, the last transport's error winning over the RPC leg, every transport being unavailable and the RPC leg taking it, the `NotImplemented` skip, the config switch, the merged receive drain, a drain that continues past a failing transport, and an RPC notification landing between two engines that have no TCP transport. Stand-in transports are swapped in through the existing `swapTransportForTest()` hook, so no NIC or metadata server is needed. `RdmaNotifyFaultTriageTest` gains two cases for the bootstrap-failure exclusion.

Negative controls, each reverted afterwards: removing the fallback loop reddens 5 of the new cases; draining only the first transport, 3; dropping the in-process callback and not skipping `NotImplemented`, one each; removing the `RpcServiceError` branch reddens the exclusion case.

`ctest` over `mooncake-transfer-engine/tent/tests` on current `main`: 63 of 63 unpatched, 64 of 64 with this change, which adds one test binary.

Measured on one host with two BlueField-3 integrated ConnectX-7 VFs over RoCE v2, two processes, 2000 transfer-bound plus 2000 standalone notifications per run. The injection hooks and the probe are test-only and not part of this PR.

| Injection | before | after |
|---|---|---|
| none | 4000/4000, 0 duplicates; transfer-bound p50/p99 168.9-170.4 / 246.9-249.0 us | 4000/4000, 0 duplicates; 170.4 / 247.3 us |
| initiator's notify QP disabled after 500 sends | 500 of 4000, 2000 send errors, END never arrived | 4000/4000, 0 duplicates, 0 send errors; standalone p50/p99 67.2 / 120.0 us over RPC |
| initiator loaded without an RDMA transport | 0 of 2000 (queued by the target, never drained) | 2000/2000, 0 duplicates; p50/p99 66.6 / 119.5 us |
| peer frozen before any endpoint exists, two `sendNotification()` calls | 30.009 s, 30.001 s | 30.009 s, 30.001 s, no fallback attempted; without the exclusion above, 90.011 s and 60.001 s |

**Test commands:**
```bash
cmake -S . -B build -G Ninja -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON \
      -DUSE_CUDA=OFF -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DYLT_ENABLE_IBV=ON
cmake --build build
ctest --test-dir build/mooncake-transfer-engine/tent/tests --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable) (tent ctest suite, 64 of 64)
- [x] Manual testing done (describe below) (the before/after table above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) (no TENT design doc covers the notification path; the new key and the fallback semantics are documented in `transfer_engine_impl.h`. A section can be added if reviewers want one.)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (597 insertions, 437 of them tests, so 160 non-test lines; the series RFC is #4061)

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

The code, tests and measurements in this PR were produced with Claude Code as a coding assistant. The author reviewed every change and checked every measurement against the logs.