### PR TITLE
[Doc] Fix vLLM PD proxy guidance for the bootstrap-based MooncakeConnector

### DIFF
--- a/docs/source/deployment/integrations/vllm/disagg-prefill-decode.md
+++ b/docs/source/deployment/integrations/vllm/disagg-prefill-decode.md
@@ -67,13 +67,21 @@ vllm serve Qwen/Qwen2.5-7B-Instruct \
 **Proxy Server:**
 
 ```bash
-# In vllm root directory.
-python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
-  --prefiller-host 192.168.0.2 --prefiller-port 8010 \
-  --decoder-host 192.168.0.3 --decoder-port 8020
+# From a vLLM repository checkout. The proxy lives under examples/ and is
+# not included in the pip wheel.
+python examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py \
+  --port 8000 \
+  --prefill http://192.168.0.2:8010 8998 \
+  --decode http://192.168.0.3:8020
 ```
 
-> NOTE: The Mooncake Connector currently uses the proxy from nixl_integration. This will be replaced with a self-developed proxy in the future.
+> NOTE: `MooncakeConnector` requires a router that generates a `transfer_id`
+> and forwards the prefiller bootstrap address to the decoder
+> ([vllm-project/vllm#31034](https://github.com/vllm-project/vllm/pull/31034)).
+> The toy proxy under `tests/v1/kv_connector/nixl_integration/` does not
+> implement this contract: outputs stay correct, but KV caches are silently
+> recomputed on the decoder instead of transferred. The bootstrap port must
+> match the prefiller's `VLLM_MOONCAKE_BOOTSTRAP_PORT` (default: 8998).
 
 Now you can send requests to the proxy server through port 8000.
 

--- a/docs/source/deployment/integrations/vllm/kv-cache-storage.md
+++ b/docs/source/deployment/integrations/vllm/kv-cache-storage.md
@@ -135,8 +135,8 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct \
 Proxy:
 
 ```shell
-python examples/disaggregated/disaggregated_serving/mooncake_connector/mooncake_connector_proxy.py \
-    --prefill http://192.168.0.2:8100 \
+python examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py \
+    --prefill http://192.168.0.2:8100 50052 \
     --decode http://192.168.0.3:8200
 ```
 

--- a/docs/source/deployment/integrations/vllm/vllm-mooncakestoreconnector.md
+++ b/docs/source/deployment/integrations/vllm/vllm-mooncakestoreconnector.md
@@ -123,8 +123,8 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct \
 Proxy:
 
 ```shell
-python examples/disaggregated/disaggregated_serving/mooncake_connector/mooncake_connector_proxy.py \
-    --prefill http://192.168.0.2:8100 \
+python examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py \
+    --prefill http://192.168.0.2:8100 50052 \
     --decode http://192.168.0.3:8200
 ```
 

--- a/docs/source/performance/vllm/vllm-v1-pd-performance.md
+++ b/docs/source/performance/vllm/vllm-v1-pd-performance.md
@@ -78,10 +78,11 @@ VLLM_LOGGING_LEVEL=DEBUG CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 **Proxy (Decoder Node):**
 
 ```bash
-python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
+# From a vLLM repository checkout.
+python examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py \
   --host 0.0.0.0 --port 8000 \
-  --prefiller-host 10.0.28.193 --prefiller-port 8010 \
-  --decoder-host 10.0.28.202 --decoder-port 8020
+  --prefill http://10.0.28.193:8010 8998 \
+  --decode http://10.0.28.202:8020
 ```
 
 ### Benchmark Script


### PR DESCRIPTION
## Description

[vllm-project/vllm#31034](https://github.com/vllm-project/vllm/pull/31034) changed the `MooncakeConnector` router contract: the router must generate a `transfer_id` and forward the prefiller bootstrap address to the decoder; the producer no longer echoes connection parameters in its response.

The docs still point to `tests/v1/kv_connector/nixl_integration/toy_proxy_server.py`, which predates that contract. With current vLLM (verified on v0.29.0), the documented setup silently disables KV transfer — the decoder recomputes prefill KV locally and responses stay correct; the only signal is a `Missing transfer_id` warning on the prefiller.

- `disagg-prefill-decode.md`: use the reference proxy `examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py` (same one vLLM's `mooncake_integration` CI uses); document the `transfer_id`/bootstrap contract and the toy-proxy pitfall.
- `kv-cache-storage.md` / `vllm-mooncakestoreconnector.md`: fix the stale proxy path (moved by [vllm-project/vllm#40759](https://github.com/vllm-project/vllm/pull/40759)) and pass the prefiller's `VLLM_MOONCAKE_BOOTSTRAP_PORT` (`50052`).

## Module

- [x] Docs

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

Verified on vLLM v0.29.0, 1P1D `Qwen/Qwen3.5-4B` (GDN hybrid):

- Toy proxy: no transfer (decoder `kv_transfer_params=None`; prefiller warns `Missing transfer_id`), outputs correct.
- `mooncake_connector_proxy.py` with the documented commands: producer logs `requests done sending` / `Sending to ... done`, consumer logs `pulling kv_caches`.

`sphinx-build -b html` succeeds; pre-commit passes on touched files.

**Test commands:**
```bash
pre-commit run --files docs/source/deployment/integrations/vllm/disagg-prefill-decode.md \
  docs/source/deployment/integrations/vllm/kv-cache-storage.md \
  docs/source/deployment/integrations/vllm/vllm-mooncakestoreconnector.md
```

**Test results:** All hooks pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/kvcache-ai/Mooncake/blob/main/CONTRIBUTING.md) guidelines
- [x] My changes do not affect the main functionality
- [x] I have run pre-commit on the changed files
- [ ] I have added tests that prove my fix is effective or that my feature works

## AI Assistance Disclosure

- [x] AI tools were used to assist with this PR (research, drafting, validation against vLLM v0.29.0)