### PR TITLE
[Store] Shrink metadata maps after ClearStaleHandles sweeps

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2822,6 +2822,7 @@ tl::expected<void, ErrorCode> MasterService::ClearStaleHandles(
         // hold is capped by kStaleHandleCleanupBatchSize instead of by the
         // size of the shard. The shard may have changed while the lock was
         // released, so every key is looked up and re-classified here.
+        bool erased_in_shard = false;
         for (size_t begin = 0; begin < stale_keys.size();
              begin += kStaleHandleCleanupBatchSize) {
             const size_t end = std::min(begin + kStaleHandleCleanupBatchSize,
@@ -2859,6 +2860,7 @@ tl::expected<void, ErrorCode> MasterService::ClearStaleHandles(
                                             &shard)) {
                         EraseMetadata(tenant_state, it, tenant_it->first,
                                       QuotaEraseMode::kFull, &shard);
+                        erased_in_shard = true;
                     } else {
                         continue;
                     }
@@ -2891,6 +2893,7 @@ tl::expected<void, ErrorCode> MasterService::ClearStaleHandles(
                     }
                     EraseMetadata(tenant_state, it, tenant_it->first,
                                   QuotaEraseMode::kFull, &shard);
+                    erased_in_shard = true;
                 } else {
                     continue;
                 }
@@ -2908,6 +2911,13 @@ tl::expected<void, ErrorCode> MasterService::ClearStaleHandles(
                     tenant_it->second.Empty()) {
                     shard->tenants.erase(tenant_it);
                 }
+            }
+        }
+
+        if (erased_in_shard) {
+            MetadataShardAccessorRW shard(this, i);
+            for (auto& tenant : shard->tenants) {
+                ShrinkBucketsIfSparse(tenant.second.metadata);
             }
         }
     }


### PR DESCRIPTION
## Description

### Background

`std::unordered_map::erase` never returns bucket-array memory — a container that once held millions of entries keeps its high-water bucket array after mass erases (8 bytes/bucket × tens of millions of buckets), so RSS is not released. #3576 introduced `ShrinkBucketsIfSparse` to address this, rehashing a container down via `rehash(size*2)` when its bucket count exceeds 1024 and its load factor drops below 25%.

However, #3576 only invoked it at the end of `BatchEvict` (marking evicted shards with an `evicted_shards` bitset), **missing the `ClearStaleHandles` path, which can also delete keys at a large scale**.

### Observed Symptom

When multiple store nodes share a tenant and one node goes offline:

- The master-side key count keeps dropping as the SSD is unloaded (tens of millions of keys), but **RSS does not drop**;
- When that node recovers and starts writing again, both the key count and RSS **continue to climb further**.

### Root Cause

A store node goes offline → `client_monitor` flags it `BECAME_OFFLINE` → enqueues a `ClientOffboardingJob` → `UnmountSegment` → `ClearInvalidHandles` → `ClearStaleHandles`. This function erases key metadata held by the offline node in per-shard batches via `EraseMetadata`, but at the end it only erases empty tenants — **it never calls `ShrinkBucketsIfSparse`**.

Because multiple stores share the tenant, the offline node only deletes its own subset of keys, so the tenant stays non-empty → the `metadata` map keeps its high-water bucket array → RSS is not released. When the node recovers and writes again, the map grows on top of the high-water baseline → RSS climbs further.

### Fix

Add a shrink pass at the end of `ClearStaleHandles`' shard loop, mirroring the one in `BatchEvict`:

- Introduce a `bool erased_in_shard` flag, set after each of the two synchronous `EraseMetadata` call sites;
- After the shard is fully processed (including the empty_tenants cleanup), if `erased_in_shard` is true, take the write lock and call `ShrinkBucketsIfSparse(metadata)` for each **still-live** tenant.

The write lock is only taken for shards that actually had erasures; `ShrinkBucketsIfSparse` is O(1) — two comparisons and an early return when the map is not sparse — so the overhead is negligible. A fully emptied tenant is already destroyed by `shard->tenants.erase` (its inner map is released along with it), so it neither needs nor can be shrunk — this fix precisely targets the "partially drained" shared tenant.

### Known Limitation

Under the `enable_ha_ && enable_oplog_` path, the actual `EraseMetadata` is deferred to the durable-finalize callback `FinalizeMetadataEraseAfterDurable` and does not occur inside `ClearStaleHandles`, so it is not covered here. The synchronous path (non-HA, or HA without oplog) is covered. Shrinking on the HA path must be added separately in the finalize callback and is left as future work.

**New regression test:**
- `ClearStaleHandlesShrinksSparseMetadataMaps`: reproduces the production scenario of "multiple stores sharing a tenant + partial drain". Two segments share the default tenant; the stale segment holds ~1920 keys to be deleted, while the live segment holds 128 surviving keys to keep the tenant from being erased entirely. Keys are filtered onto a single shard so the `metadata.bucket_count()` crosses the `kShrinkMinBucketCount` shrink threshold; after `PauseReplicaCleanup`, `UnmountSegment(stale)` + `ClearInvalidHandlesForTest` deterministically trigger the sweep. Assertions: `buckets_after < buckets_before / 2` (without the shrink the bucket array stays at its high-water mark and this fails), `buckets_after >= live_keys.size()` (the shrunk map still holds every surviving key), `GetKeyCount() == live_keys.size()` (physical metadata is actually deleted, not merely hidden), and live keys are queryable while stale keys return `OBJECT_NOT_FOUND`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [X] Mooncake Store (`mooncake-store`)
- [ ] Mooncake Conductor (`mooncake-conductor`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
cmake --build . --target master_service_test -j$(nproc)

./mooncake-store/tests/master_service_test \
    --gtest_filter='MasterServiceTest.ClearStaleHandlesShrinksSparseMetadataMaps'
```

**Test results:**
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [X] AI tools were used (specify below)

AI assistance was used for root-cause analysis (reading the `ClearStaleHandles` / `BatchEvict` / `client_monitor` trigger-chain code) and for drafting the fix.